### PR TITLE
stm32lib/CMSIS/STM32F4xx/Include/stm32f413xx.h: Add RCC_CSR_BORRSTF

### DIFF
--- a/CMSIS/STM32F4xx/Include/stm32f413xx.h
+++ b/CMSIS/STM32F4xx/Include/stm32f413xx.h
@@ -10067,6 +10067,9 @@ typedef struct
 #define RCC_CSR_RMVF_Pos                   (24U)
 #define RCC_CSR_RMVF_Msk                   (0x1U << RCC_CSR_RMVF_Pos)          /*!< 0x01000000 */
 #define RCC_CSR_RMVF                       RCC_CSR_RMVF_Msk
+#define RCC_CSR_BORRSTF_Pos                (25U)
+#define RCC_CSR_BORRSTF_Msk                (0x1U << RCC_CSR_BORRSTF_Pos)       /*!< 0x02000000 */
+#define RCC_CSR_BORRSTF                    RCC_CSR_BORRSTF_Msk
 #define RCC_CSR_PINRSTF_Pos                (26U)
 #define RCC_CSR_PINRSTF_Msk                (0x1U << RCC_CSR_PINRSTF_Pos)       /*!< 0x04000000 */
 #define RCC_CSR_PINRSTF                    RCC_CSR_PINRSTF_Msk


### PR DESCRIPTION
RCC_CSR_BORRSTF is defined in the STM32F413 Reference Manual but missing from the header file.