### PR TITLE
Remove packed attribute for uint32_t (new GCC-8 warning) 

### DIFF
--- a/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c
+++ b/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c
@@ -58,6 +58,13 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f4xx_hal.h"
 
+#if defined ( __GNUC__ )
+/* In this file __packed is used to signify an unaligned pointer,
+   which GCC doesn't support, so disable it. */
+#undef __packed
+#define __packed
+#endif /* __GNUC__ */
+
 /** @addtogroup STM32F4xx_LL_USB_DRIVER
   * @{
   */

--- a/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
+++ b/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
@@ -58,6 +58,13 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx_hal.h"
 
+#if defined ( __GNUC__ )
+/* In this file __packed is used to signify an unaligned pointer,
+   which GCC doesn't support, so disable it. */
+#undef __packed
+#define __packed
+#endif /* __GNUC__ */
+
 /** @addtogroup STM32F7xx_LL_USB_DRIVER
   * @{
   */

--- a/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c
+++ b/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c
@@ -58,6 +58,13 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_hal.h"
 
+#if defined ( __GNUC__ )
+/* In this file __packed is used to signify an unaligned pointer,
+   which GCC doesn't support, so disable it. */
+#undef __packed
+#define __packed
+#endif /* __GNUC__ */
+
 /** @addtogroup STM32H7xx_LL_USB_DRIVER
   * @{
   */

--- a/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_usb.c
+++ b/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_usb.c
@@ -58,6 +58,13 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32l4xx_hal.h"
 
+#if defined ( __GNUC__ )
+/* In this file __packed is used to signify an unaligned pointer,
+   which GCC doesn't support, so disable it. */
+#undef __packed
+#define __packed
+#endif /* __GNUC__ */
+
 /** @defgroup USB_LL USB Low Layer
   * @brief Low layer module for USB_FS and USB_OTG_FS drivers
   * @{


### PR DESCRIPTION
Supersedes https://github.com/micropython/stm32lib/pull/6