### PR TITLE
F4_HAL/uart: UART9 and UART10 should be on APB2.

### DIFF
--- a/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_uart.c
+++ b/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_uart.c
@@ -2486,7 +2486,17 @@ static void UART_SetConfig(UART_HandleTypeDef *huart)
   if(huart->Init.OverSampling == UART_OVERSAMPLING_8)
   {
     /*-------------------------- USART BRR Configuration ---------------------*/
-#if defined(USART6)
+#if defined(UART10)
+    if((huart->Instance == USART1) || (huart->Instance == USART6) || (huart->Instance == UART9) || (huart->Instance == UART10))
+    {
+      huart->Instance->BRR = UART_BRR_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
+    }
+#elif defined(UART9)
+    if((huart->Instance == USART1) || (huart->Instance == USART6) || (huart->Instance == UART9))
+    {
+      huart->Instance->BRR = UART_BRR_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
+    }
+#elif defined(USART6)
     if((huart->Instance == USART1) || (huart->Instance == USART6))
     {
       huart->Instance->BRR = UART_BRR_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
@@ -2496,7 +2506,7 @@ static void UART_SetConfig(UART_HandleTypeDef *huart)
     {
       huart->Instance->BRR = UART_BRR_SAMPLING8(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
     }
-#endif /* USART6 */
+#endif /* USART6 UART9 UART10 */
     else
     {
       huart->Instance->BRR = UART_BRR_SAMPLING8(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate);
@@ -2505,7 +2515,17 @@ static void UART_SetConfig(UART_HandleTypeDef *huart)
   else
   {
     /*-------------------------- USART BRR Configuration ---------------------*/
-#if defined(USART6)
+#if defined(UART10)
+    if((huart->Instance == USART1) || (huart->Instance == USART6) || (huart->Instance == UART9) || (huart->Instance == UART10))
+    {
+      huart->Instance->BRR = UART_BRR_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
+    }
+#elif defined(UART9)
+    if((huart->Instance == USART1) || (huart->Instance == USART6) || (huart->Instance == UART9))
+    {
+      huart->Instance->BRR = UART_BRR_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
+    }
+#elif defined(USART6)
     if((huart->Instance == USART1) || (huart->Instance == USART6))
     {
       huart->Instance->BRR = UART_BRR_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
@@ -2515,7 +2535,7 @@ static void UART_SetConfig(UART_HandleTypeDef *huart)
     {
       huart->Instance->BRR = UART_BRR_SAMPLING16(HAL_RCC_GetPCLK2Freq(), huart->Init.BaudRate);
     }
-#endif /* USART6 */
+#endif /* USART6 UART9 UART10 */
     else
     {
       huart->Instance->BRR = UART_BRR_SAMPLING16(HAL_RCC_GetPCLK1Freq(), huart->Init.BaudRate);


### PR DESCRIPTION
UART9 and UART10 are  on APB2, like UART1 and UART6.
Fixes problem with wrong baud rate because APB1 and APB2 run at different clock dates.