### PR TITLE
 Pass USB_OTG_CfgTypeDef by reference.

### DIFF
--- a/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_usb.h
+++ b/STM32F4xx_HAL_Driver/Inc/stm32f4xx_ll_usb.h
@@ -405,8 +405,8 @@ typedef struct
 #define CLEAR_OUT_EP_INTR(__EPNUM__, __INTERRUPT__)         (USBx_OUTEP(__EPNUM__)->DOEPINT = (__INTERRUPT__))
 
 /* Exported functions --------------------------------------------------------*/
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
-HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *Init);
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *Init);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode);
@@ -438,7 +438,7 @@ uint32_t          USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
 uint32_t          USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
 void              USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt);
 
-HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq);
 HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state);

--- a/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_hcd.c
+++ b/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_hcd.c
@@ -148,13 +148,13 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
   __HAL_HCD_DISABLE(hhcd);
 
   /* Init the Core (common init.) */
-  USB_CoreInit(hhcd->Instance, hhcd->Init);
+  USB_CoreInit(hhcd->Instance, &hhcd->Init);
 
   /* Force Host Mode*/
   USB_SetCurrentMode(hhcd->Instance , USB_OTG_HOST_MODE);
 
   /* Init Host */
-  USB_HostInit(hhcd->Instance, hhcd->Init);
+  USB_HostInit(hhcd->Instance, &hhcd->Init);
 
   hhcd->State= HAL_HCD_STATE_READY;
 

--- a/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c
+++ b/STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_pcd.c
@@ -158,7 +158,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  __HAL_PCD_DISABLE(hpcd);
 
  /*Init the Core (common init.) */
- USB_CoreInit(hpcd->Instance, hpcd->Init);
+ USB_CoreInit(hpcd->Instance, &hpcd->Init);
 
  /* Force Device Mode*/
  USB_SetCurrentMode(hpcd->Instance , USB_OTG_DEVICE_MODE);
@@ -192,7 +192,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  }
 
  /* Init Device */
- USB_DevInit(hpcd->Instance, hpcd->Init);
+ USB_DevInit(hpcd->Instance, &hpcd->Init);
 
  hpcd->State= HAL_PCD_STATE_READY;
 

--- a/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c
+++ b/STM32F4xx_HAL_Driver/Src/stm32f4xx_ll_usb.c
@@ -109,9 +109,9 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
-  if (cfg.phy_itface == USB_OTG_ULPI_PHY)
+  if (cfg->phy_itface == USB_OTG_ULPI_PHY)
   {
 
     USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
@@ -121,7 +121,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
     /* Select vbus source */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
-    if(cfg.use_external_vbus == 1U)
+    if(cfg->use_external_vbus == 1U)
     {
       USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
     }
@@ -140,7 +140,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     USBx->GCCFG = USB_OTG_GCCFG_PWRDWN;
   }
 
-  if(cfg.dma_enable == ENABLE)
+  if(cfg->dma_enable == ENABLE)
   {
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_2;
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
@@ -209,7 +209,7 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeT
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t i = 0U;
 
@@ -218,7 +218,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     defined(STM32F412Rx) || defined(STM32F412Cx) || defined(STM32F413xx) || defined(STM32F423xx)
   USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
 
-  if (cfg.vbus_sensing_enable == 0U)
+  if (cfg->vbus_sensing_enable == 0U)
   {
     /* Deactivate VBUS Sensing B */
     USBx->GCCFG &= ~USB_OTG_GCCFG_VBDEN;
@@ -228,7 +228,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     USBx->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
   }
 #else
-  if (cfg.vbus_sensing_enable == 0U)
+  if (cfg->vbus_sensing_enable == 0U)
   {
     USBx->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
   }
@@ -245,9 +245,9 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   /* Device mode configuration */
   USBx_DEVICE->DCFG |= DCFG_FRAME_INTERVAL_80;
 
-  if(cfg.phy_itface  == USB_OTG_ULPI_PHY)
+  if(cfg->phy_itface  == USB_OTG_ULPI_PHY)
   {
-    if(cfg.speed == USB_OTG_SPEED_HIGH)
+    if(cfg->speed == USB_OTG_SPEED_HIGH)
     {
       /* Set High speed phy */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH);
@@ -274,7 +274,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   USBx_DEVICE->DAINT = 0xFFFFFFFFU;
   USBx_DEVICE->DAINTMSK = 0U;
 
-  for (i = 0U; i < cfg.dev_endpoints; i++)
+  for (i = 0U; i < cfg->dev_endpoints; i++)
   {
     if ((USBx_INEP(i)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
     {
@@ -289,7 +289,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     USBx_INEP(i)->DIEPINT  = 0xFFU;
   }
 
-  for (i = 0U; i < cfg.dev_endpoints; i++)
+  for (i = 0U; i < cfg->dev_endpoints; i++)
   {
     if ((USBx_OUTEP(i)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
     {
@@ -306,7 +306,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
   USBx_DEVICE->DIEPMSK &= ~(USB_OTG_DIEPMSK_TXFURM);
 
-  if (cfg.dma_enable == 1U)
+  if (cfg->dma_enable == 1U)
   {
     /*Set threshold parameters */
     USBx_DEVICE->DTHRCTL = (USB_OTG_DTHRCTL_TXTHRLEN_6 | USB_OTG_DTHRCTL_RXTHRLEN_6);
@@ -322,7 +322,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   USBx->GINTSTS = 0xBFFFFFFFU;
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == DISABLE)
+  if (cfg->dma_enable == DISABLE)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
@@ -333,12 +333,12 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
                     USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM|\
                     USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM);
 
-  if(cfg.Sof_enable)
+  if(cfg->Sof_enable)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
   }
 
-  if (cfg.vbus_sensing_enable == ENABLE)
+  if (cfg->vbus_sensing_enable == ENABLE)
   {
     USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT);
   }
@@ -1239,7 +1239,7 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t i;
 
@@ -1257,7 +1257,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
 #endif /* STM32F446xx || STM32F469xx || STM32F479xx || STM32F412Zx || STM32F412Rx || STM32F412Vx || STM32F412Cx || STM32F413xx || STM32F423xx  */
 
   /* Disable the FS/LS support mode only */
-  if((cfg.speed == USB_OTG_SPEED_FULL)&&
+  if((cfg->speed == USB_OTG_SPEED_FULL)&&
      (USBx != USB_OTG_FS))
   {
     USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS;
@@ -1272,7 +1272,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   USB_FlushRxFifo(USBx);
 
   /* Clear all pending HC Interrupts */
-  for (i = 0U; i < cfg.Host_channels; i++)
+  for (i = 0U; i < cfg->Host_channels; i++)
   {
     USBx_HC(i)->HCINT = 0xFFFFFFFFU;
     USBx_HC(i)->HCINTMSK = 0U;
@@ -1305,7 +1305,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   }
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == DISABLE)
+  if (cfg->dma_enable == DISABLE)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }

--- a/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_usb.h
+++ b/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_usb.h
@@ -404,8 +404,8 @@ typedef struct
 #define CLEAR_OUT_EP_INTR(__EPNUM__, __INTERRUPT__)         (USBx_OUTEP(__EPNUM__)->DOEPINT = (__INTERRUPT__))
 
 /* Exported functions --------------------------------------------------------*/
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
-HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *Init);
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *Init);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeTypeDef mode);
@@ -437,7 +437,7 @@ uint32_t          USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
 uint32_t          USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
 void              USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt);
 
-HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq);
 HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state);

--- a/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_hcd.c
+++ b/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_hcd.c
@@ -144,13 +144,13 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
  __HAL_HCD_DISABLE(hhcd);
 
  /*Init the Core (common init.) */
- USB_CoreInit(hhcd->Instance, hhcd->Init);
+ USB_CoreInit(hhcd->Instance, &hhcd->Init);
 
  /* Force Host Mode*/
  USB_SetCurrentMode(hhcd->Instance , USB_OTG_HOST_MODE);
 
  /* Init Host */
- USB_HostInit(hhcd->Instance, hhcd->Init);
+ USB_HostInit(hhcd->Instance, &hhcd->Init);
 
  hhcd->State= HAL_HCD_STATE_READY;
 

--- a/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_pcd.c
+++ b/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_pcd.c
@@ -154,7 +154,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  __HAL_PCD_DISABLE(hpcd);
 
  /*Init the Core (common init.) */
- USB_CoreInit(hpcd->Instance, hpcd->Init);
+ USB_CoreInit(hpcd->Instance, &hpcd->Init);
 
  /* Force Device Mode*/
  USB_SetCurrentMode(hpcd->Instance , USB_OTG_DEVICE_MODE);
@@ -188,7 +188,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  }
 
  /* Init Device */
- USB_DevInit(hpcd->Instance, hpcd->Init);
+ USB_DevInit(hpcd->Instance, &hpcd->Init);
 
  hpcd->State= HAL_PCD_STATE_READY;
 

--- a/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
+++ b/STM32F7xx_HAL_Driver/Src/stm32f7xx_ll_usb.c
@@ -108,9 +108,9 @@ static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx);
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
-  if (cfg.phy_itface == USB_OTG_ULPI_PHY)
+  if (cfg->phy_itface == USB_OTG_ULPI_PHY)
   {
 
     USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
@@ -120,7 +120,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
     /* Select vbus source */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
-    if(cfg.use_external_vbus == 1)
+    if(cfg->use_external_vbus == 1)
     {
       USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
     }
@@ -146,7 +146,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     /* Enables control of a High Speed USB PHY */
     USB_HS_PHYCInit(USBx);
 
-    if(cfg.use_external_vbus == 1)
+    if(cfg->use_external_vbus == 1)
     {
       USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
     }
@@ -167,7 +167,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     USBx->GCCFG = USB_OTG_GCCFG_PWRDWN;
   }
 
-  if(cfg.dma_enable == ENABLE)
+  if(cfg->dma_enable == ENABLE)
   {
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_2;
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
@@ -236,14 +236,14 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_OTG_ModeT
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t i = 0;
 
   /*Activate VBUS Sensing B */
   USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
 
-  if (cfg.vbus_sensing_enable == 0)
+  if (cfg->vbus_sensing_enable == 0)
   {
     /* Deactivate VBUS Sensing B */
     USBx->GCCFG &= ~ USB_OTG_GCCFG_VBDEN;
@@ -259,9 +259,9 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   /* Device mode configuration */
   USBx_DEVICE->DCFG |= DCFG_FRAME_INTERVAL_80;
 
-  if(cfg.phy_itface  == USB_OTG_ULPI_PHY)
+  if(cfg->phy_itface  == USB_OTG_ULPI_PHY)
   {
-    if(cfg.speed == USB_OTG_SPEED_HIGH)
+    if(cfg->speed == USB_OTG_SPEED_HIGH)
     {
       /* Set High speed phy */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH);
@@ -273,9 +273,9 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     }
   }
 
-  else if(cfg.phy_itface  == USB_OTG_HS_EMBEDDED_PHY)
+  else if(cfg->phy_itface  == USB_OTG_HS_EMBEDDED_PHY)
   {
-    if(cfg.speed == USB_OTG_SPEED_HIGH)
+    if(cfg->speed == USB_OTG_SPEED_HIGH)
     {
       /* Set High speed phy */
       USB_SetDevSpeed (USBx , USB_OTG_SPEED_HIGH);
@@ -303,7 +303,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   USBx_DEVICE->DAINT = 0xFFFFFFFF;
   USBx_DEVICE->DAINTMSK = 0;
 
-  for (i = 0; i < cfg.dev_endpoints; i++)
+  for (i = 0; i < cfg->dev_endpoints; i++)
   {
     if ((USBx_INEP(i)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
     {
@@ -318,7 +318,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     USBx_INEP(i)->DIEPINT  = 0xFF;
   }
 
-  for (i = 0; i < cfg.dev_endpoints; i++)
+  for (i = 0; i < cfg->dev_endpoints; i++)
   {
     if ((USBx_OUTEP(i)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
     {
@@ -335,7 +335,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
   USBx_DEVICE->DIEPMSK &= ~(USB_OTG_DIEPMSK_TXFURM);
 
-  if (cfg.dma_enable == 1)
+  if (cfg->dma_enable == 1)
   {
     /*Set threshold parameters */
     USBx_DEVICE->DTHRCTL = (USB_OTG_DTHRCTL_TXTHRLEN_6 | USB_OTG_DTHRCTL_RXTHRLEN_6);
@@ -351,7 +351,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   USBx->GINTSTS = 0xBFFFFFFF;
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == DISABLE)
+  if (cfg->dma_enable == DISABLE)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
@@ -362,12 +362,12 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
                     USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM|\
                     USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM);
 
-  if(cfg.Sof_enable)
+  if(cfg->Sof_enable)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
   }
 
-  if (cfg.vbus_sensing_enable == ENABLE)
+  if (cfg->vbus_sensing_enable == ENABLE)
   {
     USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT);
   }
@@ -1233,7 +1233,7 @@ static HAL_StatusTypeDef USB_HS_PHYCInit(USB_OTG_GlobalTypeDef *USBx)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t i;
 
@@ -1244,7 +1244,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
 
   /* Disable the FS/LS support mode only */
-  if((cfg.speed == USB_OTG_SPEED_FULL)&&
+  if((cfg->speed == USB_OTG_SPEED_FULL)&&
      (USBx != USB_OTG_FS))
   {
     USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS;
@@ -1259,7 +1259,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   USB_FlushRxFifo(USBx);
 
   /* Clear all pending HC Interrupts */
-  for (i = 0; i < cfg.Host_channels; i++)
+  for (i = 0; i < cfg->Host_channels; i++)
   {
     USBx_HC(i)->HCINT = 0xFFFFFFFF;
     USBx_HC(i)->HCINTMSK = 0;
@@ -1292,7 +1292,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   }
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == DISABLE)
+  if (cfg->dma_enable == DISABLE)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }

--- a/STM32G4xx_HAL_Driver/Inc/stm32g4xx_ll_usb.h
+++ b/STM32G4xx_HAL_Driver/Inc/stm32g4xx_ll_usb.h
@@ -182,8 +182,8 @@ typedef struct
   */
 
 
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg);
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode);

--- a/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pcd.c
+++ b/STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_pcd.c
@@ -196,7 +196,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   }
 
   /* Init Device */
-  (void)USB_DevInit(hpcd->Instance, hpcd->Init);
+  (void)USB_DevInit(hpcd->Instance, &hpcd->Init);
 
   hpcd->USB_Address = 0U;
   hpcd->State = HAL_PCD_STATE_READY;

--- a/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_usb.c
+++ b/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_usb.c
@@ -61,7 +61,7 @@
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(USBx);
@@ -151,7 +151,7 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(cfg);

--- a/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_usb.h
+++ b/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_usb.h
@@ -427,8 +427,8 @@ typedef struct
   * @{
   */
 #if defined (USB_OTG_FS) || defined (USB_OTG_HS)
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
-HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg);
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_SetTurnaroundTime(USB_OTG_GlobalTypeDef *USBx, uint32_t hclk, uint8_t speed);
@@ -461,7 +461,7 @@ uint32_t          USB_ReadDevAllInEpInterrupt(USB_OTG_GlobalTypeDef *USBx);
 uint32_t          USB_ReadDevInEPInterrupt(USB_OTG_GlobalTypeDef *USBx, uint8_t epnum);
 void              USB_ClearInterrupts(USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt);
 
-HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx, uint8_t freq);
 HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DriveVbus(USB_OTG_GlobalTypeDef *USBx, uint8_t state);

--- a/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_hcd.c
+++ b/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_hcd.c
@@ -161,13 +161,13 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
   __HAL_HCD_DISABLE(hhcd);
 
   /* Init the Core (common init.) */
-  (void)USB_CoreInit(hhcd->Instance, hhcd->Init);
+  (void)USB_CoreInit(hhcd->Instance, &hhcd->Init);
 
   /* Force Host Mode*/
   (void)USB_SetCurrentMode(hhcd->Instance, USB_HOST_MODE);
 
   /* Init Host */
-  (void)USB_HostInit(hhcd->Instance, hhcd->Init);
+  (void)USB_HostInit(hhcd->Instance, &hhcd->Init);
 
   hhcd->State = HAL_HCD_STATE_READY;
 

--- a/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pcd.c
+++ b/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_pcd.c
@@ -181,7 +181,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   __HAL_PCD_DISABLE(hpcd);
 
   /*Init the Core (common init.) */
-  if (USB_CoreInit(hpcd->Instance, hpcd->Init) != HAL_OK)
+  if (USB_CoreInit(hpcd->Instance, &hpcd->Init) != HAL_OK)
   {
     hpcd->State = HAL_PCD_STATE_ERROR;
     return HAL_ERROR;
@@ -216,7 +216,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   }
 
   /* Init Device */
-  if (USB_DevInit(hpcd->Instance, hpcd->Init) != HAL_OK)
+  if (USB_DevInit(hpcd->Instance, &hpcd->Init) != HAL_OK)
   {
     hpcd->State = HAL_PCD_STATE_ERROR;
     return HAL_ERROR;

--- a/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c
+++ b/STM32H7xx_HAL_Driver/Src/stm32h7xx_ll_usb.c
@@ -86,11 +86,11 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   HAL_StatusTypeDef ret;
 
-  if (cfg.phy_itface == USB_OTG_ULPI_PHY)
+  if (cfg->phy_itface == USB_OTG_ULPI_PHY)
   {
     USBx->GCCFG &= ~(USB_OTG_GCCFG_PWRDWN);
 
@@ -99,7 +99,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
     /* Select vbus source */
     USBx->GUSBCFG &= ~(USB_OTG_GUSBCFG_ULPIEVBUSD | USB_OTG_GUSBCFG_ULPIEVBUSI);
-    if (cfg.use_external_vbus == 1U)
+    if (cfg->use_external_vbus == 1U)
     {
       USBx->GUSBCFG |= USB_OTG_GUSBCFG_ULPIEVBUSD;
     }
@@ -114,7 +114,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     /* Reset after a PHY select and set Host mode */
     ret = USB_CoreReset(USBx);
 
-    if (cfg.battery_charging_enable == 0U)
+    if (cfg->battery_charging_enable == 0U)
     {
       /* Activate the USB Transceiver */
       USBx->GCCFG |= USB_OTG_GCCFG_PWRDWN;
@@ -126,7 +126,7 @@ HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     }
   }
 
-  if (cfg.dma_enable == 1U)
+  if (cfg->dma_enable == 1U)
   {
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_HBSTLEN_2;
     USBx->GAHBCFG |= USB_OTG_GAHBCFG_DMAEN;
@@ -282,7 +282,7 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx, USB_OTG_ModeTy
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   HAL_StatusTypeDef ret = HAL_OK;
   uint32_t USBx_BASE = (uint32_t)USBx;
@@ -294,7 +294,7 @@ HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cf
   }
 
   /* VBUS Sensing setup */
-  if (cfg.vbus_sensing_enable == 0U)
+  if (cfg->vbus_sensing_enable == 0U)
   {
     USBx_DEVICE->DCTL |= USB_OTG_DCTL_SDIS;
 
@@ -317,9 +317,9 @@ HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cf
   /* Device mode configuration */
   USBx_DEVICE->DCFG |= DCFG_FRAME_INTERVAL_80;
 
-  if (cfg.phy_itface == USB_OTG_ULPI_PHY)
+  if (cfg->phy_itface == USB_OTG_ULPI_PHY)
   {
-    if (cfg.speed == USBD_HS_SPEED)
+    if (cfg->speed == USBD_HS_SPEED)
     {
       /* Set Core speed to High speed mode */
       (void)USB_SetDevSpeed(USBx, USB_OTG_SPEED_HIGH);
@@ -352,7 +352,7 @@ HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cf
   USBx_DEVICE->DOEPMSK = 0U;
   USBx_DEVICE->DAINTMSK = 0U;
 
-  for (i = 0U; i < cfg.dev_endpoints; i++)
+  for (i = 0U; i < cfg->dev_endpoints; i++)
   {
     if ((USBx_INEP(i)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
     {
@@ -374,7 +374,7 @@ HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cf
     USBx_INEP(i)->DIEPINT  = 0xFB7FU;
   }
 
-  for (i = 0U; i < cfg.dev_endpoints; i++)
+  for (i = 0U; i < cfg->dev_endpoints; i++)
   {
     if ((USBx_OUTEP(i)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
     {
@@ -405,7 +405,7 @@ HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cf
   USBx->GINTSTS = 0xBFFFFFFFU;
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == 0U)
+  if (cfg->dma_enable == 0U)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
@@ -416,12 +416,12 @@ HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cf
                    USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM |
                    USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM;
 
-  if (cfg.Sof_enable != 0U)
+  if (cfg->Sof_enable != 0U)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
   }
 
-  if (cfg.vbus_sensing_enable == 1U)
+  if (cfg->vbus_sensing_enable == 1U)
   {
     USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT);
   }
@@ -1314,7 +1314,7 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t USBx_BASE = (uint32_t)USBx;
   uint32_t i;
@@ -1331,7 +1331,7 @@ HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
   if ((USBx->CID & (0x1U << 8)) != 0U)
   {
-    if (cfg.speed == USB_OTG_SPEED_FULL)
+    if (cfg->speed == USB_OTG_SPEED_FULL)
     {
       /* Force Device Enumeration to FS/LS mode only */
       USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS;
@@ -1353,7 +1353,7 @@ HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   (void)USB_FlushRxFifo(USBx);
 
   /* Clear all pending HC Interrupts */
-  for (i = 0U; i < cfg.Host_channels; i++)
+  for (i = 0U; i < cfg->Host_channels; i++)
   {
     USBx_HC(i)->HCINT = 0xFFFFFFFFU;
     USBx_HC(i)->HCINTMSK = 0U;
@@ -1386,7 +1386,7 @@ HAL_StatusTypeDef USB_HostInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   }
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == 0U)
+  if (cfg->dma_enable == 0U)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }

--- a/STM32L0xx_HAL_Driver/Inc/stm32l0xx_ll_usb.h
+++ b/STM32L0xx_HAL_Driver/Inc/stm32l0xx_ll_usb.h
@@ -169,8 +169,8 @@ typedef struct
   */
 
 
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg);
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode);

--- a/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
+++ b/STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_pcd.c
@@ -194,7 +194,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   }
 
   /* Init Device */
-  if (USB_DevInit(hpcd->Instance, hpcd->Init) != HAL_OK)
+  if (USB_DevInit(hpcd->Instance, &hpcd->Init) != HAL_OK)
   {
     hpcd->State = HAL_PCD_STATE_ERROR;
     return HAL_ERROR;

--- a/STM32L0xx_HAL_Driver/Src/stm32l0xx_ll_usb.c
+++ b/STM32L0xx_HAL_Driver/Src/stm32l0xx_ll_usb.c
@@ -61,7 +61,7 @@
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(USBx);
@@ -148,7 +148,7 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(cfg);

--- a/STM32L4xx_HAL_Driver/Inc/stm32l4xx_ll_usb.h
+++ b/STM32L4xx_HAL_Driver/Inc/stm32l4xx_ll_usb.h
@@ -506,8 +506,8 @@ typedef struct
 
 /* Exported functions --------------------------------------------------------*/
 #if defined (USB_OTG_FS)
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
-HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef Init);
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *Init);
+HAL_StatusTypeDef USB_DevInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *Init);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_ModeTypeDef mode);
@@ -539,7 +539,7 @@ uint32_t          USB_ReadDevAllInEpInterrupt (USB_OTG_GlobalTypeDef *USBx);
 uint32_t          USB_ReadDevInEPInterrupt (USB_OTG_GlobalTypeDef *USBx , uint8_t epnum);
 void              USB_ClearInterrupts (USB_OTG_GlobalTypeDef *USBx, uint32_t interrupt);
 
-HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_InitFSLSPClkSel(USB_OTG_GlobalTypeDef *USBx , uint8_t freq);
 HAL_StatusTypeDef USB_ResetPort(USB_OTG_GlobalTypeDef *USBx);
 HAL_StatusTypeDef USB_DriveVbus (USB_OTG_GlobalTypeDef *USBx, uint8_t state);
@@ -562,8 +562,8 @@ HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_OTG_GlobalTypeDef *USBx);
 #endif /* USB_OTG_FS */
 
 #if defined (USB)
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef Init);
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef Init);
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *Init);
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *Init);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx , USB_ModeTypeDef mode);

--- a/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_hcd.c
+++ b/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_hcd.c
@@ -151,13 +151,13 @@ HAL_StatusTypeDef HAL_HCD_Init(HCD_HandleTypeDef *hhcd)
  __HAL_HCD_DISABLE(hhcd);
 
  /*Init the Core (common init.) */
- USB_CoreInit(hhcd->Instance, hhcd->Init);
+ USB_CoreInit(hhcd->Instance, &hhcd->Init);
 
  /* Force Host Mode*/
  USB_SetCurrentMode(hhcd->Instance , USB_HOST_MODE);
 
  /* Init Host */
- USB_HostInit(hhcd->Instance, hhcd->Init);
+ USB_HostInit(hhcd->Instance, &hhcd->Init);
 
  hhcd->State= HAL_HCD_STATE_READY;
 

--- a/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd.c
+++ b/STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_pcd.c
@@ -174,7 +174,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   __HAL_PCD_DISABLE(hpcd);
 
   /*Init the Core (common init.) */
-  USB_CoreInit(hpcd->Instance, hpcd->Init);
+  USB_CoreInit(hpcd->Instance, &hpcd->Init);
 
   /* Force Device Mode*/
   USB_SetCurrentMode(hpcd->Instance , USB_DEVICE_MODE);
@@ -206,7 +206,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   }
 
   /* Init Device */
-  USB_DevInit(hpcd->Instance, hpcd->Init);
+  USB_DevInit(hpcd->Instance, &hpcd->Init);
 
   hpcd->USB_Address = 0;
 

--- a/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_usb.c
+++ b/STM32L4xx_HAL_Driver/Src/stm32l4xx_ll_usb.c
@@ -127,7 +127,7 @@ static HAL_StatusTypeDef USB_CoreReset(USB_OTG_GlobalTypeDef *USBx);
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(cfg);
@@ -204,14 +204,14 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_OTG_GlobalTypeDef *USBx , USB_ModeTypeD
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t index = 0;
 
   /*Activate VBUS Sensing B */
   USBx->GCCFG |= USB_OTG_GCCFG_VBDEN;
 
-  if (cfg.vbus_sensing_enable == 0)
+  if (cfg->vbus_sensing_enable == 0)
   {
     /* Deactivate VBUS Sensing B */
     USBx->GCCFG &= ~ USB_OTG_GCCFG_VBDEN;
@@ -240,7 +240,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   USBx_DEVICE->DAINT = 0xFFFFFFFF;
   USBx_DEVICE->DAINTMSK = 0;
 
-  for (index = 0; index < cfg.dev_endpoints; index++)
+  for (index = 0; index < cfg->dev_endpoints; index++)
   {
     if ((USBx_INEP(index)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
     {
@@ -255,7 +255,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
     USBx_INEP(index)->DIEPINT  = 0xFF;
   }
 
-  for (index = 0; index < cfg.dev_endpoints; index++)
+  for (index = 0; index < cfg->dev_endpoints; index++)
   {
     if ((USBx_OUTEP(index)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
     {
@@ -272,7 +272,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
 
   USBx_DEVICE->DIEPMSK &= ~(USB_OTG_DIEPMSK_TXFURM);
 
-  if (cfg.dma_enable == 1)
+  if (cfg->dma_enable == 1)
   {
     /*Set threshold parameters */
     USBx_DEVICE->DTHRCTL = (USB_OTG_DTHRCTL_TXTHRLEN_6 | USB_OTG_DTHRCTL_RXTHRLEN_6);
@@ -288,7 +288,7 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
   USBx->GINTSTS = 0xBFFFFFFF;
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == DISABLE)
+  if (cfg->dma_enable == DISABLE)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
@@ -299,12 +299,12 @@ HAL_StatusTypeDef USB_DevInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef c
                     USB_OTG_GINTMSK_OEPINT   | USB_OTG_GINTMSK_IISOIXFRM|\
                     USB_OTG_GINTMSK_PXFRM_IISOOXFRM | USB_OTG_GINTMSK_WUIM);
 
-  if(cfg.Sof_enable)
+  if(cfg->Sof_enable)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_SOFM;
   }
 
-  if (cfg.vbus_sensing_enable == ENABLE)
+  if (cfg->vbus_sensing_enable == ENABLE)
   {
     USBx->GINTMSK |= (USB_OTG_GINTMSK_SRQIM | USB_OTG_GINTMSK_OTGINT);
   }
@@ -1045,7 +1045,7 @@ HAL_StatusTypeDef USB_EP0_OutStart(USB_OTG_GlobalTypeDef *USBx, uint8_t dma, uin
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, const USB_OTG_CfgTypeDef *cfg)
 {
   uint32_t index = 0;
 
@@ -1053,7 +1053,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   USBx_PCGCCTL = 0;
 
   /* Disable the FS/LS support mode only */
-  if((cfg.speed == USB_OTG_SPEED_FULL)&&
+  if((cfg->speed == USB_OTG_SPEED_FULL)&&
      (USBx != USB_OTG_FS))
   {
     USBx_HOST->HCFG |= USB_OTG_HCFG_FSLSS;
@@ -1068,7 +1068,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   USB_FlushRxFifo(USBx);
 
   /* Clear all pending HC Interrupts */
-  for (index = 0; index < cfg.Host_channels; index++)
+  for (index = 0; index < cfg->Host_channels; index++)
   {
     USBx_HC(index)->HCINT = 0xFFFFFFFF;
     USBx_HC(index)->HCINTMSK = 0;
@@ -1091,7 +1091,7 @@ HAL_StatusTypeDef USB_HostInit (USB_OTG_GlobalTypeDef *USBx, USB_OTG_CfgTypeDef 
   USBx->HPTXFSIZ = (uint32_t )(((0x40 << 16)& USB_OTG_HPTXFSIZ_PTXFD) | 0xE0);
 
   /* Enable the common interrupts */
-  if (cfg.dma_enable == DISABLE)
+  if (cfg->dma_enable == DISABLE)
   {
     USBx->GINTMSK |= USB_OTG_GINTMSK_RXFLVLM;
   }
@@ -1611,7 +1611,7 @@ HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_OTG_GlobalTypeDef *USBx)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* NOTE : - This function is not required by USB Device FS peripheral, it is used
               only by USB OTG FS peripheral.
@@ -1695,7 +1695,7 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx , USB_ModeTypeDef mode)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit (USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit (USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(cfg);

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_usb.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_usb.h
@@ -178,8 +178,8 @@ typedef struct
   */
 
 
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg);
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode);

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pcd.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pcd.c
@@ -194,7 +194,7 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   }
 
   /* Init Device */
-  (void)USB_DevInit(hpcd->Instance, hpcd->Init);
+  (void)USB_DevInit(hpcd->Instance, &hpcd->Init);
 
   hpcd->USB_Address = 0U;
   hpcd->State = HAL_PCD_STATE_READY;

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_usb.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_usb.c
@@ -61,7 +61,7 @@
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(USBx);
@@ -148,7 +148,7 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode)
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
+HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, const USB_CfgTypeDef *cfg)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(cfg);


### PR DESCRIPTION
This updates all HAL libraries to pass USB_OTG_CfgTypeDef by reference. USB_OTG_CfgTypeDef is a large struct that is being passed by value which uses extra stack and bigger code due to the extra copy of the struct.