### PR TITLE
stm32lib stm32l4xx_hal_gpio_ex.h: Add #define GPIO_AF14_TIM2 for L4P5.

### DIFF
--- a/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_gpio_ex.h
+++ b/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_gpio_ex.h
@@ -784,6 +784,7 @@
 /**
   * @brief   AF 14 selection
   */
+#define GPIO_AF14_TIM2         ((uint8_t)0x0E)  /* TIM2 Alternate Function mapping   */
 #define GPIO_AF14_TIM15        ((uint8_t)0x0E)  /* TIM15 Alternate Function mapping  */
 #define GPIO_AF14_TIM16        ((uint8_t)0x0E)  /* TIM16 Alternate Function mapping  */
 #define GPIO_AF14_TIM17        ((uint8_t)0x0E)  /* TIM17 Alternate Function mapping  */


### PR DESCRIPTION
On STM32L4P5 and STM32L4Q5 pin PA0 has TIM2_ETR on AF14.
Required definition in stm32l4xx_hal_gpio_ex.h is missing.
It is included for every other L4 part in the file.
PA0-TIM2_ETR is verified as available in the data sheet and STMCUBEMX.

Signed-off-by: Chris Mason <c.mason@inchipdesign.com.au>