### PR TITLE
F4_HAL/i2c: Fix I2C frequency is faster than specified one.

### DIFF
--- a/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_i2c.h
+++ b/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_i2c.h
@@ -576,10 +576,11 @@ uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
   * @{
   */
 
+#define I2C_CCR_CALCULATION(__PCLK__, __SPEED__, __COEFF__)     (((((__PCLK__) - 1U)/((__SPEED__) * (__COEFF__))) + 1U) & I2C_CCR_CCR)
 #define I2C_FREQRANGE(__PCLK__)                            ((__PCLK__)/1000000U)
 #define I2C_RISE_TIME(__FREQRANGE__, __SPEED__)            (((__SPEED__) <= 100000U) ? ((__FREQRANGE__) + 1U) : ((((__FREQRANGE__) * 300U) / 1000U) + 1U))
-#define I2C_SPEED_STANDARD(__PCLK__, __SPEED__)            (((((__PCLK__)/((__SPEED__) << 1U)) & I2C_CCR_CCR) < 4U)? 4U:((__PCLK__) / ((__SPEED__) << 1U)))
-#define I2C_SPEED_FAST(__PCLK__, __SPEED__, __DUTYCYCLE__) (((__DUTYCYCLE__) == I2C_DUTYCYCLE_2)? ((__PCLK__) / ((__SPEED__) * 3U)) : (((__PCLK__) / ((__SPEED__) * 25U)) | I2C_DUTYCYCLE_16_9))
+#define I2C_SPEED_STANDARD(__PCLK__, __SPEED__)            ((I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 2U) < 4U)? 4U:I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 2U))
+#define I2C_SPEED_FAST(__PCLK__, __SPEED__, __DUTYCYCLE__) (((__DUTYCYCLE__) == I2C_DUTYCYCLE_2)? I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 3U) : (I2C_CCR_CALCULATION((__PCLK__), (__SPEED__), 25U) | I2C_DUTYCYCLE_16_9))
 #define I2C_SPEED(__PCLK__, __SPEED__, __DUTYCYCLE__)      (((__SPEED__) <= 100000U)? (I2C_SPEED_STANDARD((__PCLK__), (__SPEED__))) : \
                                                                   ((I2C_SPEED_FAST((__PCLK__), (__SPEED__), (__DUTYCYCLE__)) & I2C_CCR_CCR) == 0U)? 1U : \
                                                                   ((I2C_SPEED_FAST((__PCLK__), (__SPEED__), (__DUTYCYCLE__))) | I2C_CCR_FS))


### PR DESCRIPTION
This PR fixes following issue.

The actual I2C frequency is faster than specified one and it may exceededs I2C's specification for Fast mode.
Also, pyb.I2C initialize with baudrate=400000 (I2C Fast mode) by default but actual frequency of SCL is faster than 400KHz.
The frequency of SCL should be less than or equal to 400KHz in Fast mode.

### How to reproduce
Execute this code
```
>>> i2c=pyb.I2C(1, pyb.I2C.CONTROLLER)
>>> i2c
I2C(1, I2C.CONTROLLER, baudrate=420000)
>>> i2c = pyb.I2C(1, pyb.I2C.CONTROLLER, baudrate=350000)
>>> i2c
I2C(1, I2C.CONTROLLER, baudrate=420000)
```

### MicroPython Version
v1.19.1

### Environment
NUCLEO-F446RE

### Detail of changes
I2C is initialized by
https://github.com/micropython/micropython/blob/0e8c2204da377e95b5000a3c708891d98cdeb69c/ports/stm32/pyb_i2c.c#L254-L257
but I think current stm32lib has a bug that the frequency is faster than specified one.
This bug is fixed at least v1.24.1 but I couldn't find a release note about this fix.
I backport it from v1.27.1.

After applying this PR, the frequency of SCL is less than 400KHz.

```
>>> i2c=pyb.I2C(1)
>>> i2c
I2C(1, I2C.CONTROLLER, baudrate=336000)
>>> i2c = pyb.I2C(1, pyb.I2C.CONTROLLER, baudrate=350000)
>>> i2c
I2C(1, I2C.CONTROLLER, baudrate=336000)
```