### PR TITLE
Import STM32CubeWB v1.23.0 on 23-Sept-2025.

### DIFF
--- a/CMSIS/STM32WBxx/Include/stm32wb10xx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb10xx.h
@@ -1,0 +1,10844 @@
+/**
+  ******************************************************************************
+  * @file    stm32wb10xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for stm32wb10xx devices.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral's registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32wb10xx
+  * @{
+  */
+
+#ifndef __STM32WB10xx_H
+#define __STM32WB10xx_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+/**
+  * @brief Configuration of the Cortex-M4 Processor and Core Peripherals
+  */
+#define __CM4_REV                 1U /*!< Core Revision r0p1                            */
+#define __MPU_PRESENT             1U /*!< M4 provides an MPU                            */
+#define __VTOR_PRESENT            1U /*!< Vector Table Register supported               */
+#define __NVIC_PRIO_BITS          4U /*!< STM32WBxx uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1U /*!< FPU present                                   */
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+  * @brief stm32wb10xx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
+/*!< Interrupt Number Definition for M4 */
+typedef enum
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
+  HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
+  MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
+  BusFault_IRQn                       = -11,    /*!< Cortex-M4 Bus Fault Interrupt                                     */
+  UsageFault_IRQn                     = -10,    /*!< Cortex-M4 Usage Fault Interrupt                                   */
+  SVCall_IRQn                         = -5,     /*!< Cortex-M4 SV Call Interrupt                                       */
+  DebugMonitor_IRQn                   = -4,     /*!< Cortex-M4 Debug Monitor Interrupt                                 */
+  PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
+  SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
+
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
+  TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
+  RTC_WKUP_IRQn                       = 3,      /*!< RTC Wakeup Interrupt                                              */
+  FLASH_IRQn                          = 4,      /*!< FLASH (CFI)  global Interrupt                                     */
+  RCC_IRQn                            = 5,      /*!< RCC Interrupt                                                     */
+  EXTI0_IRQn                          = 6,      /*!< EXTI Line 0 Interrupt                                             */
+  EXTI1_IRQn                          = 7,      /*!< EXTI Line 1 Interrupt                                             */
+  EXTI2_IRQn                          = 8,      /*!< EXTI Line 2 Interrupt                                             */
+  EXTI3_IRQn                          = 9,      /*!< EXTI Line 3 Interrupt                                             */
+  EXTI4_IRQn                          = 10,     /*!< EXTI Line 4 Interrupt                                             */
+  DMA1_Channel1_IRQn                  = 11,     /*!< DMA1 Channel 1 Interrupt                                          */
+  DMA1_Channel2_IRQn                  = 12,     /*!< DMA1 Channel 2 Interrupt                                          */
+  DMA1_Channel3_IRQn                  = 13,     /*!< DMA1 Channel 3 Interrupt                                          */
+  DMA1_Channel4_IRQn                  = 14,     /*!< DMA1 Channel 4 Interrupt                                          */
+  DMA1_Channel5_IRQn                  = 15,     /*!< DMA1 Channel 5 Interrupt                                          */
+  DMA1_Channel6_IRQn                  = 16,     /*!< DMA1 Channel 6 Interrupt                                          */
+  DMA1_Channel7_IRQn                  = 17,     /*!< DMA1 Channel 7 Interrupt                                          */
+  ADC1_IRQn                           = 18,     /*!< ADC1 Interrupt                                                    */
+  C2SEV_PWR_C2H_IRQn                  = 21,     /*!< CPU2 SEV Interrupt                                                */
+  EXTI9_5_IRQn                        = 23,     /*!< EXTI Lines [9:5] Interrupt                                        */
+  TIM1_BRK_IRQn                       = 24,     /*!< TIM1 Break Interrupt                                              */
+  TIM1_UP_IRQn                        = 25,     /*!< TIM1 Update Interrupt                                             */
+  TIM1_TRG_COM_IRQn                   = 26,     /*!< TIM1 Trigger and Communication Interrupts                         */
+  TIM1_CC_IRQn                        = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                           = 28,     /*!< TIM2 Global Interrupt                                             */
+  PKA_IRQn                            = 29,     /*!< PKA Interrupt                                                     */
+  I2C1_EV_IRQn                        = 30,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                        = 31,     /*!< I2C1 Error Interrupt                                              */
+  SPI1_IRQn                           = 34,     /*!< SPI1 Interrupt                                                    */
+  USART1_IRQn                         = 36,     /*!< USART1 Interrupt                                                  */
+  TSC_IRQn                            = 39,     /*!< TSC Interrupt                                                     */
+  EXTI15_10_IRQn                      = 40,     /*!< EXTI Lines1[15:10 ]Interrupts                                     */
+  RTC_Alarm_IRQn                      = 41,     /*!< RTC Alarms (A and B) Interrupt                                    */
+  PWR_SOTF_BLEACT_RFPHASE_IRQn        = 43,     /*!< PWR switching on the fly interrupt
+                                                     PWR end of BLE activity interrupt
+                                                     PWR end of critical radio phase interrupt                         */
+  IPCC_C1_RX_IRQn                     = 44,     /*!< IPCC RX Occupied Interrupt                                        */
+  IPCC_C1_TX_IRQn                     = 45,     /*!< IPCC TX Free Interrupt                                            */
+  HSEM_IRQn                           = 46,     /*!< HSEM Interrupt                                                    */
+  LPTIM1_IRQn                         = 47,     /*!< LPTIM1 Interrupt                                                  */
+  LPTIM2_IRQn                         = 48,     /*!< LPTIM2 Interrupt                                                  */
+  AES2_IRQn                           = 52,     /*!< AES2 Interrupt                                                    */
+  RNG_IRQn                            = 53,     /*!< RNG Interrupt                                                     */
+  FPU_IRQn                            = 54,     /*!< FPU Interrupt                                                     */
+  DMAMUX1_OVR_IRQn                    = 62      /*!< DMAMUX1 overrun Interrupt                                         */
+} IRQn_Type;
+/**
+  * @}
+  */
+
+#include "core_cm4.h"                /* Cortex-M4 processor and core peripherals */
+#include "system_stm32wbxx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC interrupt and status register,             Address offset: 0x00 */
+  __IO uint32_t IER;          /*!< ADC interrupt enable register,                 Address offset: 0x04 */
+  __IO uint32_t CR;           /*!< ADC control register,                          Address offset: 0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC configuration register 1,                  Address offset: 0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC configuration register 2,                  Address offset: 0x10 */
+  __IO uint32_t SMPR;         /*!< ADC sampling time register,                    Address offset: 0x14 */
+       uint32_t RESERVED1;    /*!< Reserved,                                                      0x18 */
+       uint32_t RESERVED2;    /*!< Reserved,                                                      0x1C */
+  __IO uint32_t TR;           /*!< ADC analog watchdog 1 threshold register,      Address offset: 0x20 */
+  __IO uint32_t RESERVED3;    /*!< Reserved,                                                      0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC group regular sequencer register,          Address offset: 0x28 */
+  __IO uint32_t RESERVED4;    /*!< Reserved,                                                      0x2C */
+       uint32_t RESERVED5[4]; /*!< Reserved,                                               0x30 - 0x3C */
+  __IO uint32_t DR;           /*!< ADC group regular data register,               Address offset: 0x40 */
+       uint32_t RESERVED6[23];/*!< Reserved,                                               0x44 - 0x9C */
+  __IO uint32_t RESERVED7;    /*!< Reserved,                                                      0xA0 */
+  __IO uint32_t RESERVED8;    /*!< Reserved,                                                      0xA4 */
+       uint32_t RESERVED9[3]; /*!< Reserved,                                               0xA8 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC Calibration factor register,               Address offset: 0xB4 */
+} ADC_TypeDef;
+
+/* Legacy registers naming */
+#define TR1     TR
+
+
+typedef struct
+{
+  uint32_t      RESERVED1;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x300 */
+  uint32_t      RESERVED2;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CCR;          /*!< ADC common configuration register,             Address offset: ADC1 base address + 0x308 */
+  uint32_t      RESERVED3;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x30C */
+} ADC_Common_TypeDef;
+
+/**
+  * @brief CRC calculation unit
+  */
+typedef struct
+{
+  __IO uint32_t DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint32_t IDR;         /*!< CRC Independent data register,               Address offset: 0x04 */
+  __IO uint32_t CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+       uint32_t RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+typedef struct
+{
+  __IO uint32_t IDCODE;      /*!< MCU device ID code,                          Address offset: 0x00 */
+  __IO uint32_t CR;          /*!< Debug MCU configuration register,            Address offset: 0x04 */
+  uint32_t RESERVED1[13];    /*!< Reserved,                                               0x08-0x38 */
+  __IO uint32_t APB1FZR1;    /*!< Debug MCU CPU1 APB1 freeze register,         Address offset: 0x3C */
+  __IO uint32_t C2APB1FZR1;  /*!< Debug MCU CPU2 APB1 freeze register,         Address offset: 0x40 */
+  __IO uint32_t APB1FZR2;    /*!< Debug MCU CPU1 APB1 freeze register,         Address offset: 0x44 */
+  __IO uint32_t C2APB1FZR2;  /*!< Debug MCU CPU2 APB1 freeze register,         Address offset: 0x48 */
+  __IO uint32_t APB2FZR;     /*!< Debug MCU CPU1 APB2 freeze register,         Address offset: 0x4C */
+  __IO uint32_t C2APB2FZR;   /*!< Debug MCU CPU2 APB2 freeze register,         Address offset: 0x50 */
+} DBGMCU_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+typedef struct
+{
+  __IO uint32_t CCR;         /*!< DMA channel x configuration register        0x00 */
+  __IO uint32_t CNDTR;       /*!< DMA channel x number of data register       0x04 */
+  __IO uint32_t CPAR;        /*!< DMA channel x peripheral address register   0x08 */
+  __IO uint32_t CMAR;        /*!< DMA channel x memory address register       0x0C */
+  uint32_t RESERVED;         /*!< Reserved,                                   0x10 */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< DMA interrupt status register,                 Address offset: 0x00 */
+  __IO uint32_t IFCR;        /*!< DMA interrupt flag clear register,             Address offset: 0x04 */
+} DMA_TypeDef;
+
+/**
+  * @brief DMA Multiplexer
+  */
+typedef struct
+{
+  __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
+} DMAMUX_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
+  __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
+} DMAMUX_ChannelStatus_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
+} DMAMUX_RequestGen_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
+  __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
+} DMAMUX_RequestGenStatus_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;           /*!< FLASH Access control register,                      Address offset: 0x00      */
+  __IO uint32_t RESERVED;      /*!< Reserved,                                           Address offset: 0x04      */
+  __IO uint32_t KEYR;          /*!< FLASH Key register,                                 Address offset: 0x08      */
+  __IO uint32_t OPTKEYR;       /*!< FLASH Option Key register,                          Address offset: 0x0C      */
+  __IO uint32_t SR;            /*!< FLASH Status register,                              Address offset: 0x10      */
+  __IO uint32_t CR;            /*!< FLASH Control register,                             Address offset: 0x14      */
+  __IO uint32_t ECCR;          /*!< FLASH ECC register,                                 Address offset: 0x18      */
+  uint32_t RESERVED1;          /*!< Reserved,                                           Address offset: 0x1C      */
+  __IO uint32_t OPTR;          /*!< FLASH Option register,                              Address offset: 0x20      */
+  __IO uint32_t PCROP1ASR;     /*!< FLASH Bank 1 PCROP area A Start address register,   Address offset: 0x24      */
+  __IO uint32_t PCROP1AER;     /*!< FLASH Bank 1 PCROP area A End address register,     Address offset: 0x28      */
+  __IO uint32_t WRP1AR;        /*!< FLASH Bank 1 WRP area A address register,           Address offset: 0x2C      */
+  __IO uint32_t WRP1BR;        /*!< FLASH Bank 1 WRP area B address register,           Address offset: 0x30      */
+  __IO uint32_t PCROP1BSR;     /*!< FLASH Bank 1 PCROP area B Start address register,   Address offset: 0x34      */
+  __IO uint32_t PCROP1BER;     /*!< FLASH Bank 1 PCROP area B End address register,     Address offset: 0x38      */
+  __IO uint32_t IPCCBR;        /*!< FLASH IPCC data buffer address,                     Address offset: 0x3C      */
+  uint32_t RESERVED2[7];       /*!< Reserved,                                           Address offset: 0x40-0x58 */
+  __IO uint32_t C2ACR;         /*!< FLASH Core MO+ Access Control Register ,            Address offset: 0x5C      */
+  __IO uint32_t C2SR;          /*!< FLASH Core MO+ Status Register,                     Address offset: 0x60      */
+  __IO uint32_t C2CR;          /*!< FLASH Core MO+ Control register,                    Address offset: 0x64      */
+  uint32_t RESERVED3[6];       /*!< Reserved,                                           Address offset: 0x68-0x7C */
+  __IO uint32_t SFR;           /*!< FLASH secure start address,                         Address offset: 0x80      */
+  __IO uint32_t SRRVR;         /*!< FlASH secure SRAM2 start addr and CPU2 reset vector Address offset: 0x84      */
+} FLASH_TypeDef;
+
+/**
+  * @brief General Purpose I/O
+  */
+typedef struct
+{
+  __IO uint32_t MODER;       /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;      /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;     /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;       /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;         /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;         /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;        /*!< GPIO port bit set/reset  register,     Address offset: 0x18      */
+  __IO uint32_t LCKR;        /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];      /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;         /*!< GPIO Bit Reset register,               Address offset: 0x28      */
+} GPIO_TypeDef;
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;          /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;          /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;         /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;          /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR;        /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+/**
+  * @brief LPTIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+} LPTIM_TypeDef;
+
+/**
+  * @brief Power Control
+  */
+typedef struct
+{
+  __IO uint32_t CR1;          /*!< PWR Power Control Register 1,                     Address offset: 0x00 */
+  __IO uint32_t CR2;          /*!< PWR Power Control Register 2,                     Address offset: 0x04 */
+  __IO uint32_t CR3;          /*!< PWR Power Control Register 3,                     Address offset: 0x08 */
+  __IO uint32_t CR4;          /*!< PWR Power Control Register 4,                     Address offset: 0x0C */
+  __IO uint32_t SR1;          /*!< PWR Power Status Register 1,                      Address offset: 0x10 */
+  __IO uint32_t SR2;          /*!< PWR Power Status Register 2,                      Address offset: 0x14 */
+  __IO uint32_t SCR;          /*!< PWR Power Status Reset Register,                  Address offset: 0x18 */
+  __IO uint32_t CR5;          /*!< PWR Power Control Register 5,                     Address offset: 0x1C */
+  __IO uint32_t PUCRA;        /*!< PWR Pull-Up Control Register of port A,           Address offset: 0x20 */
+  __IO uint32_t PDCRA;        /*!< PWR Pull-Down Control Register of port A,         Address offset: 0x24 */
+  __IO uint32_t PUCRB;        /*!< PWR Pull-Up Control Register of port B,           Address offset: 0x28 */
+  __IO uint32_t PDCRB;        /*!< PWR Pull-Down Control Register of port B,         Address offset: 0x2C */
+  __IO uint32_t PUCRC;        /*!< PWR Pull-Up Control Register of port C,           Address offset: 0x30 */
+  __IO uint32_t PDCRC;        /*!< PWR Pull-Down Control Register of port C,         Address offset: 0x34 */
+       uint32_t RESERVED2[2]; /*!< Reserved,                                         Address offset: 0x38-0x3C */
+  __IO uint32_t PUCRE;        /*!< PWR Pull-Up Control Register of port E,           Address offset: 0x40 */
+  __IO uint32_t PDCRE;        /*!< PWR Pull-Down Control Register of port E,         Address offset: 0x44 */
+       uint32_t RESERVED0[4]; /*!< Reserved,                                         Address offset: 0x48-0x54 */
+  __IO uint32_t PUCRH;        /*!< PWR Pull-Up Control Register of port H,           Address offset: 0x58 */
+  __IO uint32_t PDCRH;        /*!< PWR Pull-Down Control Register of port H,         Address offset: 0x5C */
+       uint32_t RESERVED1[8]; /*!< Reserved,                                         Address offset: 0x60-0x7C */
+  __IO uint32_t C2CR1;        /*!< PWR Power Control Register 1 for CPU2,            Address offset: 0x80 */
+  __IO uint32_t C2CR3;        /*!< PWR Power Control Register 3 for CPU2,            Address offset: 0x84 */
+  __IO uint32_t EXTSCR;       /*!< PWR Power Status Reset Register for CPU2,         Address offset: 0x88 */
+} PWR_TypeDef;
+
+/**
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock  Control Register,                                                    Address offset: 0x00 */
+  __IO uint32_t ICSCR;         /*!< RCC Internal Clock Sources Calibration Register,                                Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
+  __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
+       uint32_t RESERVED0[2];  /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
+  __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
+  __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
+  __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
+       uint32_t RESERVED11;    /*!< Reserved,                                                                       Address offset: 0x24 */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
+  __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
+  __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
+  __IO uint32_t APB3RSTR;      /*!< RCC APB3 peripheral reset register,                                             Address offset: 0x44 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
+  __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
+  __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
+  __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
+  __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
+  __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
+  __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
+  __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
+  __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
+  __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
+  __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
+  __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
+  __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
+  __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+  __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
+  __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
+  __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
+  __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
+  __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
+  __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
+  __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
+  __IO uint32_t C2APB3ENR;     /*!< RCC APB3 peripheral CPU2 clocks enable register 1,                              Address offset: 0x164 */
+  __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
+  __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
+  __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
+  __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
+  __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
+  __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
+  __IO uint32_t C2APB3SMENR;   /*!< RCC APB3 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x184 */
+} RCC_TypeDef;
+
+
+
+/**
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t RESERVED;   /*!< Reserved,                                                  Address offset: 0x18 */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset  0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+  __IO uint32_t BKP5R;      /*!< RTC backup register 5,                                     Address offset: 0x64 */
+  __IO uint32_t BKP6R;      /*!< RTC backup register 6,                                     Address offset: 0x68 */
+  __IO uint32_t BKP7R;      /*!< RTC backup register 7,                                     Address offset: 0x6C */
+  __IO uint32_t BKP8R;      /*!< RTC backup register 8,                                     Address offset: 0x70 */
+  __IO uint32_t BKP9R;      /*!< RTC backup register 9,                                     Address offset: 0x74 */
+  __IO uint32_t BKP10R;     /*!< RTC backup register 10,                                    Address offset: 0x78 */
+  __IO uint32_t BKP11R;     /*!< RTC backup register 11,                                    Address offset: 0x7C */
+  __IO uint32_t BKP12R;     /*!< RTC backup register 12,                                    Address offset: 0x80 */
+  __IO uint32_t BKP13R;     /*!< RTC backup register 13,                                    Address offset: 0x84 */
+  __IO uint32_t BKP14R;     /*!< RTC backup register 14,                                    Address offset: 0x88 */
+  __IO uint32_t BKP15R;     /*!< RTC backup register 15,                                    Address offset: 0x8C */
+  __IO uint32_t BKP16R;     /*!< RTC backup register 16,                                    Address offset: 0x90 */
+  __IO uint32_t BKP17R;     /*!< RTC backup register 17,                                    Address offset: 0x94 */
+  __IO uint32_t BKP18R;     /*!< RTC backup register 18,                                    Address offset: 0x98 */
+  __IO uint32_t BKP19R;     /*!< RTC backup register 19,                                    Address offset: 0x9C */
+} RTC_TypeDef;
+
+
+
+
+/**
+  * @brief Serial Peripheral Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1,       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,       Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,          Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,            Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register,  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register,          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register,          Address offset: 0x18 */
+} SPI_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+typedef struct
+{
+  __IO uint32_t MEMRMP;            /*!< SYSCFG memory remap register                                            Address offset: 0x00       */
+  __IO uint32_t CFGR1;             /*!< SYSCFG configuration register 1,                                        Address offset: 0x04       */
+  __IO uint32_t EXTICR[4];         /*!< SYSCFG external interrupt configuration registers,                      Address offset: 0x08-0x14  */
+  __IO uint32_t SCSR;              /*!< SYSCFG SRAM2 control and status register,                               Address offset: 0x18       */
+  __IO uint32_t CFGR2;             /*!< SYSCFG configuration register 2,                                        Address offset: 0x1C       */
+  __IO uint32_t SWPR1;             /*!< SYSCFG SRAM2 write protection register part 1,                          Address offset: 0x20       */
+  __IO uint32_t SKR;               /*!< SYSCFG SRAM2 key register,                                              Address offset: 0x24       */
+  __IO uint32_t SWPR2;             /*!< SYSCFG write protection register part 2,                                Address offset: 0x28       */
+       uint32_t RESERVED1[53];     /*!< Reserved,                                                               Address offset: 0x2C-0xFC  */
+  __IO uint32_t IMR1;              /*!< SYSCFG CPU1 (CORTEX M4) interrupt masks control-status register part 1, Address offset: 0x100      */
+  __IO uint32_t IMR2;              /*!< SYSCFG CPU1 (CORTEX M4) interrupt masks control-status register part 2, Address offset: 0x104      */
+  __IO uint32_t C2IMR1;            /*!< SYSCFG CPU2 (CORTEX M0) interrupt masks control-status register part 1, Address offset: 0x108      */
+  __IO uint32_t C2IMR2;            /*!< SYSCFG CPU2 (CORTEX M0) interrupt masks control-status register part 2, Address offset: 0x10C      */
+  __IO uint32_t SIPCR;             /*!< SYSCFG secure IP control register,                                      Address offset: 0x110      */
+
+} SYSCFG_TypeDef;
+
+/**
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,                   Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,                   Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,          Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,        Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                      Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,            Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1,      Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2,      Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register,      Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                     Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register                       Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare register5,            Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare register6,            Address offset: 0x5C */
+  __IO uint32_t AF1;         /*!< TIM Alternate function option register 1, Address offset: 0x60 */
+  __IO uint32_t AF2;         /*!< TIM Alternate function option register 2, Address offset: 0x64 */
+} TIM_TypeDef;
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< USART Control register 1,                 Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< USART Control register 2,                 Address offset: 0x04 */
+  __IO uint32_t CR3;         /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;         /*!< USART Baud rate register,                 Address offset: 0x0C */
+  __IO uint32_t GTPR;        /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;        /*!< USART Receiver Time Out register,         Address offset: 0x14 */
+  __IO uint32_t RQR;         /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;         /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;         /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;         /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;         /*!< USART Transmit Data register,             Address offset: 0x28 */
+  __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;         /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+
+/**
+  * @brief AES hardware accelerator
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
+  __IO uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
+  __IO uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
+  __IO uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
+  __IO uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
+  __IO uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
+  __IO uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
+  __IO uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
+  __IO uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
+  __IO uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
+  __IO uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
+  __IO uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
+  __IO uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
+  __IO uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
+  __IO uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
+  __IO uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
+  __IO uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
+  __IO uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
+  __IO uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
+  __IO uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
+  __IO uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
+  __IO uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
+  __IO uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x6C */
+} AES_TypeDef;
+
+/**
+  * @brief RNG
+  */
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+/**
+  * @brief Touch Sensing Controller (TSC)
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< TSC control register,                     Address offset: 0x00 */
+  __IO uint32_t IER;           /*!< TSC interrupt enable register,            Address offset: 0x04 */
+  __IO uint32_t ICR;           /*!< TSC interrupt clear register,             Address offset: 0x08 */
+  __IO uint32_t ISR;           /*!< TSC interrupt status register,            Address offset: 0x0C */
+  __IO uint32_t IOHCR;         /*!< TSC I/O hysteresis control register,      Address offset: 0x10 */
+  uint32_t      RESERVED1;     /*!< Reserved,                                 Address offset: 0x14 */
+  __IO uint32_t IOASCR;        /*!< TSC I/O analog switch control register,   Address offset: 0x18 */
+  uint32_t      RESERVED2;     /*!< Reserved,                                 Address offset: 0x1C */
+  __IO uint32_t IOSCR;         /*!< TSC I/O sampling control register,        Address offset: 0x20 */
+  uint32_t      RESERVED3;     /*!< Reserved,                                 Address offset: 0x24 */
+  __IO uint32_t IOCCR;         /*!< TSC I/O channel control register,         Address offset: 0x28 */
+  uint32_t      RESERVED4;     /*!< Reserved,                                 Address offset: 0x2C */
+  __IO uint32_t IOGCSR;        /*!< TSC I/O group control status register,    Address offset: 0x30 */
+  __IO uint32_t IOGXCR[7];     /*!< TSC I/O group x counter register,         Address offset: 0x34-4C */
+} TSC_TypeDef;
+
+/**
+  * @brief Inter-Processor Communication
+  */
+typedef struct
+{
+  __IO uint32_t C1CR;             /*!< Inter-Processor Communication: C1 control register,                  Address offset: 0x000 */
+  __IO uint32_t C1MR ;            /*!< Inter-Processor Communication: C1 mask register,                     Address offset: 0x004 */
+  __IO uint32_t C1SCR;            /*!< Inter-Processor Communication: C1 status set clear register,         Address offset: 0x008 */
+  __IO uint32_t C1TOC2SR;         /*!< Inter-Processor Communication: C1 to processor M4  status register,  Address offset: 0x00C */
+  __IO uint32_t C2CR;             /*!< Inter-Processor Communication: C2 control register,                  Address offset: 0x010 */
+  __IO uint32_t C2MR ;            /*!< Inter-Processor Communication: C2 mask register,                     Address offset: 0x014 */
+  __IO uint32_t C2SCR;            /*!< Inter-Processor Communication: C2 status set clear register,         Address offset: 0x018 */
+  __IO uint32_t C2TOC1SR;         /*!< Inter-Processor Communication: C2 to processor M4 status register,   Address offset: 0x01C */
+} IPCC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR;               /*!< Control register,                                                    Address offset: 0x000 */
+  __IO uint32_t MR;               /*!< Mask register,                                                       Address offset: 0x004 */
+  __IO uint32_t SCR;              /*!< Status set clear register,                                           Address offset: 0x008 */
+  __IO uint32_t SR;               /*!< Status register,                                                     Address offset: 0x00C */
+} IPCC_CommonTypeDef;
+
+/**
+  * @brief Async Interrupts and Events Controller
+  */
+typedef struct
+{
+  __IO uint32_t RTSR1;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x08 */
+  __IO uint32_t PR1;            /*!< EXTI pending register [31:0],                             Address offset: 0x0C */
+  __IO uint32_t RESERVED1[4];   /*!< Reserved,                                                 Address offset: 0x10 - 0x1C */
+  __IO uint32_t RTSR2;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x20 */
+  __IO uint32_t FTSR2;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x24 */
+  __IO uint32_t SWIER2;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x28 */
+  __IO uint32_t PR2;            /*!< EXTI pending register [31:0],                             Address offset: 0x2C */
+  __IO uint32_t RESERVED2[4];   /*!< Reserved,                                                 Address offset: 0x30 - 0x3C */
+  __IO uint32_t RESERVED3[8];   /*!< Reserved,                                                 Address offset: 0x40 - 0x5C */
+  __IO uint32_t RESERVED4[8];   /*!< Reserved,                                                 Address offset: 0x60 - 0x7C */
+  __IO uint32_t IMR1;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x84 */
+  __IO uint32_t RESERVED5[2];   /*!< Reserved,                                                 Address offset: 0x88 - 0x8C */
+  __IO uint32_t IMR2;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x90 */
+  __IO uint32_t EMR2;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x94 */
+  __IO uint32_t RESERVED8[10];  /*!< Reserved,                                                 Address offset: 0x98 - 0xBC */
+  __IO uint32_t C2IMR1;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xC0 */
+  __IO uint32_t C2EMR1;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xC4 */
+  __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
+  __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
+  __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
+} EXTI_TypeDef;
+
+/**
+  * @brief Public Key Accelerator (PKA)
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< PKA control register,                 Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< PKA status register,                  Address offset: 0x04 */
+  __IO uint32_t CLRFR;       /*!< PKA clear flag register,              Address offset: 0x08 */
+  uint32_t  Reserved1[253];  /*!< Reserved                              Address offset: 0x000C-0x03FC*/
+  __IO uint32_t RAM[894];    /*!< PKA RAM,                              Address offset: 0x0400-0x11F4 */
+} PKA_TypeDef;
+
+/**
+  * @brief HW Semaphore HSEM
+  */
+typedef struct
+{
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+} HSEM_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t IER;        /*!< HSEM interrupt enable register ,                Address offset:   0h     */
+  __IO uint32_t ICR;        /*!< HSEM interrupt clear register ,                 Address offset:   4h     */
+  __IO uint32_t ISR;        /*!< HSEM interrupt status register ,                Address offset:   8h     */
+  __IO uint32_t MISR;       /*!< HSEM masked interrupt status register ,         Address offset:   Ch     */
+} HSEM_Common_TypeDef;
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+
+/*!< Boundary memory map */
+#define FLASH_BASE             (0x08000000UL)/*!< FLASH(up to 320KB) base address */
+#define SRAM_BASE              (0x20000000UL)/*!< SRAM(up to 12 KB) base address */
+#define PERIPH_BASE            (0x40000000UL)/*!< Peripheral base address */
+
+/*!< Memory, OTP and Option bytes */
+
+/* Base addresses */
+#define SYSTEM_MEMORY_BASE     (0x1FFF0000UL)  /*!< System Memory : 28Kb (0x1FFF0000 - 0x1FFF6FFF) */
+#define OTP_AREA_BASE          (0x1FFF7000UL)  /*!< OTP area : 1kB (0x1FFF7000 - 0x1FFF73FF)       */
+#define OPTION_BYTE_BASE       (0x1FFF7800UL)  /*!< Option Bytes : 128B (0x1FFF7800 - 0x1FFF787F)   */
+#define ENGI_BYTE_BASE         (0x1FFF7400UL)  /*!< Engi Bytes : 3kB (0x1FFF7400 - 0x1FFF7FFF)     */
+
+#define SRAM1_BASE             SRAM_BASE                 /*!< SRAM1(up to 12 KB) base address */
+#define SRAM2A_BASE            (SRAM_BASE + 0x00030000UL)/*!< SRAM2A(32 KB) base address      */
+#define SRAM2B_BASE            (SRAM_BASE + 0x00038000UL)/*!< SRAM2B(4 KB) base address       */
+
+/* Memory Size */
+#define FLASH_SIZE              (((uint32_t)(*((uint16_t *)FLASHSIZE_BASE)) & (0x07FFUL)) << 10U)
+#define SRAM1_SIZE              0x00003000UL   /*!< SRAM1 default size  : 12 KB */
+#define SRAM2A_SIZE             0x00008000UL   /*!< SRAM2a default size : 32 KB */
+#define SRAM2B_SIZE             0x00001000UL   /*!< SRAM2b default size :  4 KB */
+
+/* End addresses */
+#define SRAM1_END_ADDR         (0x20002FFFUL)  /*!< SRAM1               :  12KB (0x20000000 - 0x20002FFF) */
+#define SRAM2A_END_ADDR        (0x20037FFFUL)  /*!< SRAM2a (backup)     :  32KB (0x20030000 - 0x20037FFF) */
+#define SRAM2B_END_ADDR        (0x20038FFFUL)  /*!< SRAM2b (backup)     :   4KB (0x20038000 - 0x20038FFF) */
+
+#define SYSTEM_MEMORY_END_ADDR (0x1FFF6FFFUL)  /*!< System Memory : 28KB (0x1FFF0000 - 0x1FFF6FFF)  */
+#define OTP_AREA_END_ADDR      (0x1FFF73FFUL)  /*!< OTP area : 1KB (0x1FFF7000 - 0x1FFF73FF)        */
+#define OPTION_BYTE_END_ADDR   (0x1FFF8FFFUL)  /*!< Option Bytes : 4KB (0x1FFF8000 - 0x1FFF8FFF)    */
+#define ENGI_BYTE_END_ADDR     (0x1FFF7FFFUL)  /*!< Engi Bytes : 3kB (0x1FFF7400 - 0x1FFF7FFF)      */
+
+/*!< Peripheral memory map */
+#define APB1PERIPH_BASE       PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000UL)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000UL)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x08000000UL)
+#define AHB4PERIPH_BASE       (PERIPH_BASE + 0x18000000UL)
+#define APB3PERIPH_BASE       (PERIPH_BASE + 0x20000000UL)
+
+/*!< APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x00000000UL)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x00002800UL)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x00002C00UL)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x00003000UL)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x00005400UL)
+#define LPTIM1_BASE           (APB1PERIPH_BASE + 0x00007C00UL)
+#define LPTIM2_BASE           (APB1PERIPH_BASE + 0x00009400UL)
+
+/*!< APB2 peripherals */
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x00000000UL)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x00002400UL)
+#define ADC1_COMMON_BASE      (APB2PERIPH_BASE + 0x00002700UL)
+
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x00002C00UL)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x00003000UL)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x00003800UL)
+
+/*!< AHB1 peripherals */
+#define DMA1_BASE                (AHB1PERIPH_BASE + 0x00000000UL)
+#define DMAMUX1_BASE             (AHB1PERIPH_BASE + 0x00000800UL)
+#define CRC_BASE                 (AHB1PERIPH_BASE + 0x00003000UL)
+#define TSC_BASE                 (AHB1PERIPH_BASE + 0x00004000UL)
+
+#define DMA1_Channel1_BASE       (DMA1_BASE + 0x00000008UL)
+#define DMA1_Channel2_BASE       (DMA1_BASE + 0x0000001CUL)
+#define DMA1_Channel3_BASE       (DMA1_BASE + 0x00000030UL)
+#define DMA1_Channel4_BASE       (DMA1_BASE + 0x00000044UL)
+#define DMA1_Channel5_BASE       (DMA1_BASE + 0x00000058UL)
+#define DMA1_Channel6_BASE       (DMA1_BASE + 0x0000006CUL)
+#define DMA1_Channel7_BASE       (DMA1_BASE + 0x00000080UL)
+
+#define DMAMUX1_Channel0_BASE    (DMAMUX1_BASE)
+#define DMAMUX1_Channel1_BASE    (DMAMUX1_BASE + 0x00000004UL)
+#define DMAMUX1_Channel2_BASE    (DMAMUX1_BASE + 0x00000008UL)
+#define DMAMUX1_Channel3_BASE    (DMAMUX1_BASE + 0x0000000CUL)
+#define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
+#define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
+#define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+
+#define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
+#define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
+#define DMAMUX1_RequestGenerator2_BASE  (DMAMUX1_BASE + 0x00000108UL)
+#define DMAMUX1_RequestGenerator3_BASE  (DMAMUX1_BASE + 0x0000010CUL)
+
+#define DMAMUX1_ChannelStatus_BASE      (DMAMUX1_BASE + 0x00000080UL)
+#define DMAMUX1_RequestGenStatus_BASE   (DMAMUX1_BASE + 0x00000140UL)
+
+/*!< AHB2 peripherals */
+#define IOPORT_BASE         (AHB2PERIPH_BASE + 0x00000000UL)
+#define GPIOA_BASE          (IOPORT_BASE + 0x00000000UL)
+#define GPIOB_BASE          (IOPORT_BASE + 0x00000400UL)
+#define GPIOC_BASE          (IOPORT_BASE + 0x00000800UL)
+#define GPIOE_BASE          (IOPORT_BASE + 0x00001000UL)
+#define GPIOH_BASE          (IOPORT_BASE + 0x00001C00UL)
+
+/*!< AHB Shared peripherals */
+#define RCC_BASE              (AHB4PERIPH_BASE + 0x00000000UL)
+#define PWR_BASE              (AHB4PERIPH_BASE + 0x00000400UL)
+#define EXTI_BASE             (AHB4PERIPH_BASE + 0x00000800UL)
+#define IPCC_BASE             (AHB4PERIPH_BASE + 0x00000C00UL)
+#define RNG_BASE              (AHB4PERIPH_BASE + 0x00001000UL)
+#define HSEM_BASE             (AHB4PERIPH_BASE + 0x00001400UL)
+#define AES2_BASE             (AHB4PERIPH_BASE + 0x00001800UL)
+#define PKA_BASE              (AHB4PERIPH_BASE + 0x00002000UL)
+#define FLASH_REG_BASE        (AHB4PERIPH_BASE + 0x00004000UL)
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           (0xE0042000UL)
+
+
+/*!< AHB3 peripherals */
+
+/*!< Device Electronic Signature */
+#define PACKAGE_BASE          ((uint32_t)0x1FFF7500UL)       /*!< Package data register base address     */
+#define UID64_BASE            ((uint32_t)0x1FFF7580UL)       /*!< 64-bit Unique device Identification    */
+#define UID_BASE              ((uint32_t)0x1FFF7590UL)       /*!< Unique device ID register base address */
+#define FLASHSIZE_BASE        ((uint32_t)0x1FFF75E0UL)       /*!< Flash size data register base address  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+
+/* Peripherals available on APB1 bus */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define LPTIM2              ((LPTIM_TypeDef *) LPTIM2_BASE)
+
+/* Peripherals available on APB2 bus */
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+
+/* Peripherals available on AHB1 bus */
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+
+#define DMAMUX1             ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
+#define DMAMUX1_Channel0    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
+#define DMAMUX1_Channel1    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel1_BASE)
+#define DMAMUX1_Channel2    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel2_BASE)
+#define DMAMUX1_Channel3    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel3_BASE)
+#define DMAMUX1_Channel4    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
+#define DMAMUX1_Channel5    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
+#define DMAMUX1_Channel6    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+
+#define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
+#define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
+#define DMAMUX1_RequestGenerator2  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator2_BASE)
+#define DMAMUX1_RequestGenerator3  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator3_BASE)
+
+#define DMAMUX1_ChannelStatus      ((DMAMUX_ChannelStatus_TypeDef *) DMAMUX1_ChannelStatus_BASE)
+#define DMAMUX1_RequestGenStatus   ((DMAMUX_RequestGenStatus_TypeDef *) DMAMUX1_RequestGenStatus_BASE)
+
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define TSC                 ((TSC_TypeDef *) TSC_BASE)
+
+/* Peripherals available on AHB2 bus */
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOE               ((GPIO_TypeDef *) GPIOE_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) ADC1_COMMON_BASE)
+
+
+/* Peripherals available on AHB shared bus */
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define IPCC                ((IPCC_TypeDef *) IPCC_BASE)
+#define IPCC_C1             ((IPCC_CommonTypeDef *) IPCC_BASE)
+#define IPCC_C2             ((IPCC_CommonTypeDef *) (IPCC_BASE + 0x10U))
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+#define HSEM                ((HSEM_TypeDef *) HSEM_BASE)
+#define HSEM_COMMON         ((HSEM_Common_TypeDef *) (HSEM_BASE + 0x100U))
+#define AES2                ((AES_TypeDef *) AES2_BASE)
+#define PKA                 ((PKA_TypeDef *) PKA_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_REG_BASE)
+
+/* Peripherals available on AHB3 bus */
+
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+
+#define ADC_SUPPORT_2_5_MSPS /* ADC sampling rate 2.5 Msamples/sec */
+
+/********************  Bit definition for ADC_ISR register  *******************/
+#define ADC_ISR_ADRDY_Pos              (0U)
+#define ADC_ISR_ADRDY_Msk              (0x1UL << ADC_ISR_ADRDY_Pos)            /*!< 0x00000001 */
+#define ADC_ISR_ADRDY                  ADC_ISR_ADRDY_Msk                       /*!< ADC ready flag */
+#define ADC_ISR_EOSMP_Pos              (1U)
+#define ADC_ISR_EOSMP_Msk              (0x1UL << ADC_ISR_EOSMP_Pos)            /*!< 0x00000002 */
+#define ADC_ISR_EOSMP                  ADC_ISR_EOSMP_Msk                       /*!< ADC group regular end of sampling flag */
+#define ADC_ISR_EOC_Pos                (2U)
+#define ADC_ISR_EOC_Msk                (0x1UL << ADC_ISR_EOC_Pos)              /*!< 0x00000004 */
+#define ADC_ISR_EOC                    ADC_ISR_EOC_Msk                         /*!< ADC group regular end of unitary conversion flag */
+#define ADC_ISR_EOS_Pos                (3U)
+#define ADC_ISR_EOS_Msk                (0x1UL << ADC_ISR_EOS_Pos)              /*!< 0x00000008 */
+#define ADC_ISR_EOS                    ADC_ISR_EOS_Msk                         /*!< ADC group regular end of sequence conversions flag */
+#define ADC_ISR_OVR_Pos                (4U)
+#define ADC_ISR_OVR_Msk                (0x1UL << ADC_ISR_OVR_Pos)              /*!< 0x00000010 */
+#define ADC_ISR_OVR                    ADC_ISR_OVR_Msk                         /*!< ADC group regular overrun flag */
+#define ADC_ISR_AWD1_Pos               (7U)
+#define ADC_ISR_AWD1_Msk               (0x1UL << ADC_ISR_AWD1_Pos)             /*!< 0x00000080 */
+#define ADC_ISR_AWD1                   ADC_ISR_AWD1_Msk                        /*!< ADC analog watchdog 1 flag */
+#define ADC_ISR_AWD2_Pos               (8U)
+#define ADC_ISR_AWD2_Msk               (0x1UL << ADC_ISR_AWD2_Pos)             /*!< 0x00000100 */
+#define ADC_ISR_AWD2                   ADC_ISR_AWD2_Msk                        /*!< ADC analog watchdog 2 flag */
+#define ADC_ISR_AWD3_Pos               (9U)
+#define ADC_ISR_AWD3_Msk               (0x1UL << ADC_ISR_AWD3_Pos)             /*!< 0x00000200 */
+#define ADC_ISR_AWD3                   ADC_ISR_AWD3_Msk                        /*!< ADC analog watchdog 3 flag */
+#define ADC_ISR_EOCAL_Pos              (11U)
+#define ADC_ISR_EOCAL_Msk              (0x1UL << ADC_ISR_EOCAL_Pos)            /*!< 0x00000800 */
+#define ADC_ISR_EOCAL                  ADC_ISR_EOCAL_Msk                       /*!< ADC end of calibration flag */
+#define ADC_ISR_CCRDY_Pos              (13U)
+#define ADC_ISR_CCRDY_Msk              (0x1UL << ADC_ISR_CCRDY_Pos)            /*!< 0x00002000 */
+#define ADC_ISR_CCRDY                  ADC_ISR_CCRDY_Msk                       /*!< ADC channel configuration ready flag */
+
+/********************  Bit definition for ADC_IER register  *******************/
+#define ADC_IER_ADRDYIE_Pos            (0U)
+#define ADC_IER_ADRDYIE_Msk            (0x1UL << ADC_IER_ADRDYIE_Pos)          /*!< 0x00000001 */
+#define ADC_IER_ADRDYIE                ADC_IER_ADRDYIE_Msk                     /*!< ADC ready interrupt */
+#define ADC_IER_EOSMPIE_Pos            (1U)
+#define ADC_IER_EOSMPIE_Msk            (0x1UL << ADC_IER_EOSMPIE_Pos)          /*!< 0x00000002 */
+#define ADC_IER_EOSMPIE                ADC_IER_EOSMPIE_Msk                     /*!< ADC group regular end of sampling interrupt */
+#define ADC_IER_EOCIE_Pos              (2U)
+#define ADC_IER_EOCIE_Msk              (0x1UL << ADC_IER_EOCIE_Pos)            /*!< 0x00000004 */
+#define ADC_IER_EOCIE                  ADC_IER_EOCIE_Msk                       /*!< ADC group regular end of unitary conversion interrupt */
+#define ADC_IER_EOSIE_Pos              (3U)
+#define ADC_IER_EOSIE_Msk              (0x1UL << ADC_IER_EOSIE_Pos)            /*!< 0x00000008 */
+#define ADC_IER_EOSIE                  ADC_IER_EOSIE_Msk                       /*!< ADC group regular end of sequence conversions interrupt */
+#define ADC_IER_OVRIE_Pos              (4U)
+#define ADC_IER_OVRIE_Msk              (0x1UL << ADC_IER_OVRIE_Pos)            /*!< 0x00000010 */
+#define ADC_IER_OVRIE                  ADC_IER_OVRIE_Msk                       /*!< ADC group regular overrun interrupt */
+#define ADC_IER_AWD1IE_Pos             (7U)
+#define ADC_IER_AWD1IE_Msk             (0x1UL << ADC_IER_AWD1IE_Pos)           /*!< 0x00000080 */
+#define ADC_IER_AWD1IE                 ADC_IER_AWD1IE_Msk                      /*!< ADC analog watchdog 1 interrupt */
+#define ADC_IER_AWD2IE_Pos             (8U)
+#define ADC_IER_AWD2IE_Msk             (0x1UL << ADC_IER_AWD2IE_Pos)           /*!< 0x00000100 */
+#define ADC_IER_AWD2IE                 ADC_IER_AWD2IE_Msk                      /*!< ADC analog watchdog 2 interrupt */
+#define ADC_IER_AWD3IE_Pos             (9U)
+#define ADC_IER_AWD3IE_Msk             (0x1UL << ADC_IER_AWD3IE_Pos)           /*!< 0x00000200 */
+#define ADC_IER_AWD3IE                 ADC_IER_AWD3IE_Msk                      /*!< ADC analog watchdog 3 interrupt */
+#define ADC_IER_EOCALIE_Pos            (11U)
+#define ADC_IER_EOCALIE_Msk            (0x1UL << ADC_IER_EOCALIE_Pos)          /*!< 0x00000800 */
+#define ADC_IER_EOCALIE                ADC_IER_EOCALIE_Msk                     /*!< ADC end of calibration interrupt */
+#define ADC_IER_CCRDYIE_Pos            (13U)
+#define ADC_IER_CCRDYIE_Msk            (0x1UL << ADC_IER_CCRDYIE_Pos)          /*!< 0x00002000 */
+#define ADC_IER_CCRDYIE                ADC_IER_CCRDYIE_Msk                     /*!< ADC channel configuration ready interrupt */
+
+/********************  Bit definition for ADC_CR register  ********************/
+#define ADC_CR_ADEN_Pos                (0U)
+#define ADC_CR_ADEN_Msk                (0x1UL << ADC_CR_ADEN_Pos)              /*!< 0x00000001 */
+#define ADC_CR_ADEN                    ADC_CR_ADEN_Msk                         /*!< ADC enable */
+#define ADC_CR_ADDIS_Pos               (1U)
+#define ADC_CR_ADDIS_Msk               (0x1UL << ADC_CR_ADDIS_Pos)             /*!< 0x00000002 */
+#define ADC_CR_ADDIS                   ADC_CR_ADDIS_Msk                        /*!< ADC disable */
+#define ADC_CR_ADSTART_Pos             (2U)
+#define ADC_CR_ADSTART_Msk             (0x1UL << ADC_CR_ADSTART_Pos)           /*!< 0x00000004 */
+#define ADC_CR_ADSTART                 ADC_CR_ADSTART_Msk                      /*!< ADC group regular conversion start */
+#define ADC_CR_ADSTP_Pos               (4U)
+#define ADC_CR_ADSTP_Msk               (0x1UL << ADC_CR_ADSTP_Pos)             /*!< 0x00000010 */
+#define ADC_CR_ADSTP                   ADC_CR_ADSTP_Msk                        /*!< ADC group regular conversion stop */
+#define ADC_CR_ADVREGEN_Pos            (28U)
+#define ADC_CR_ADVREGEN_Msk            (0x1UL << ADC_CR_ADVREGEN_Pos)          /*!< 0x10000000 */
+#define ADC_CR_ADVREGEN                ADC_CR_ADVREGEN_Msk                     /*!< ADC voltage regulator enable */
+#define ADC_CR_ADCAL_Pos               (31U)
+#define ADC_CR_ADCAL_Msk               (0x1UL << ADC_CR_ADCAL_Pos)             /*!< 0x80000000 */
+#define ADC_CR_ADCAL                   ADC_CR_ADCAL_Msk                        /*!< ADC calibration */
+
+/********************  Bit definition for ADC_CFGR1 register  *****************/
+#define ADC_CFGR1_DMAEN_Pos            (0U)
+#define ADC_CFGR1_DMAEN_Msk            (0x1UL << ADC_CFGR1_DMAEN_Pos)          /*!< 0x00000001 */
+#define ADC_CFGR1_DMAEN                ADC_CFGR1_DMAEN_Msk                     /*!< ADC DMA transfer enable */
+#define ADC_CFGR1_DMACFG_Pos           (1U)
+#define ADC_CFGR1_DMACFG_Msk           (0x1UL << ADC_CFGR1_DMACFG_Pos)         /*!< 0x00000002 */
+#define ADC_CFGR1_DMACFG               ADC_CFGR1_DMACFG_Msk                    /*!< ADC DMA transfer configuration */
+
+#define ADC_CFGR1_SCANDIR_Pos          (2U)
+#define ADC_CFGR1_SCANDIR_Msk          (0x1UL << ADC_CFGR1_SCANDIR_Pos)        /*!< 0x00000004 */
+#define ADC_CFGR1_SCANDIR              ADC_CFGR1_SCANDIR_Msk                   /*!< ADC group regular sequencer scan direction */
+
+#define ADC_CFGR1_RES_Pos              (3U)
+#define ADC_CFGR1_RES_Msk              (0x3UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000018 */
+#define ADC_CFGR1_RES                  ADC_CFGR1_RES_Msk                       /*!< ADC data resolution */
+#define ADC_CFGR1_RES_0                (0x1UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000008 */
+#define ADC_CFGR1_RES_1                (0x2UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000010 */
+
+#define ADC_CFGR1_ALIGN_Pos            (5U)
+#define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
+
+#define ADC_CFGR1_EXTSEL_Pos           (6U)
+#define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
+#define ADC_CFGR1_EXTSEL               ADC_CFGR1_EXTSEL_Msk                    /*!< ADC group regular external trigger source */
+#define ADC_CFGR1_EXTSEL_0             (0x1UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000040 */
+#define ADC_CFGR1_EXTSEL_1             (0x2UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000080 */
+#define ADC_CFGR1_EXTSEL_2             (0x4UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000100 */
+
+#define ADC_CFGR1_EXTEN_Pos            (10U)
+#define ADC_CFGR1_EXTEN_Msk            (0x3UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000C00 */
+#define ADC_CFGR1_EXTEN                ADC_CFGR1_EXTEN_Msk                     /*!< ADC group regular external trigger polarity */
+#define ADC_CFGR1_EXTEN_0              (0x1UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000400 */
+#define ADC_CFGR1_EXTEN_1              (0x2UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000800 */
+
+#define ADC_CFGR1_OVRMOD_Pos           (12U)
+#define ADC_CFGR1_OVRMOD_Msk           (0x1UL << ADC_CFGR1_OVRMOD_Pos)         /*!< 0x00001000 */
+#define ADC_CFGR1_OVRMOD               ADC_CFGR1_OVRMOD_Msk                    /*!< ADC group regular overrun configuration */
+#define ADC_CFGR1_CONT_Pos             (13U)
+#define ADC_CFGR1_CONT_Msk             (0x1UL << ADC_CFGR1_CONT_Pos)           /*!< 0x00002000 */
+#define ADC_CFGR1_CONT                 ADC_CFGR1_CONT_Msk                      /*!< ADC group regular continuous conversion mode */
+#define ADC_CFGR1_WAIT_Pos             (14U)
+#define ADC_CFGR1_WAIT_Msk             (0x1UL << ADC_CFGR1_WAIT_Pos)           /*!< 0x00004000 */
+#define ADC_CFGR1_WAIT                 ADC_CFGR1_WAIT_Msk                      /*!< ADC low power auto wait */
+#define ADC_CFGR1_AUTOFF_Pos           (15U)
+#define ADC_CFGR1_AUTOFF_Msk           (0x1UL << ADC_CFGR1_AUTOFF_Pos)         /*!< 0x00008000 */
+#define ADC_CFGR1_AUTOFF               ADC_CFGR1_AUTOFF_Msk                    /*!< ADC low power auto power off */
+#define ADC_CFGR1_DISCEN_Pos           (16U)
+#define ADC_CFGR1_DISCEN_Msk           (0x1UL << ADC_CFGR1_DISCEN_Pos)         /*!< 0x00010000 */
+#define ADC_CFGR1_DISCEN               ADC_CFGR1_DISCEN_Msk                    /*!< ADC group regular sequencer discontinuous mode */
+#define ADC_CFGR1_CHSELRMOD_Pos        (21U)
+#define ADC_CFGR1_CHSELRMOD_Msk        (0x1UL << ADC_CFGR1_CHSELRMOD_Pos)      /*!< 0x00200000 */
+#define ADC_CFGR1_CHSELRMOD            ADC_CFGR1_CHSELRMOD_Msk                 /*!< ADC group regular sequencer mode */
+
+#define ADC_CFGR1_AWD1SGL_Pos          (22U)
+#define ADC_CFGR1_AWD1SGL_Msk          (0x1UL << ADC_CFGR1_AWD1SGL_Pos)        /*!< 0x00400000 */
+#define ADC_CFGR1_AWD1SGL              ADC_CFGR1_AWD1SGL_Msk                   /*!< ADC analog watchdog 1 monitoring a single channel or all channels */
+#define ADC_CFGR1_AWD1EN_Pos           (23U)
+#define ADC_CFGR1_AWD1EN_Msk           (0x1UL << ADC_CFGR1_AWD1EN_Pos)         /*!< 0x00800000 */
+#define ADC_CFGR1_AWD1EN               ADC_CFGR1_AWD1EN_Msk                    /*!< ADC analog watchdog 1 enable on scope ADC group regular */
+
+#define ADC_CFGR1_AWD1CH_Pos           (26U)
+#define ADC_CFGR1_AWD1CH_Msk           (0x1FUL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x7C000000 */
+#define ADC_CFGR1_AWD1CH               ADC_CFGR1_AWD1CH_Msk                    /*!< ADC analog watchdog 1 monitored channel selection */
+#define ADC_CFGR1_AWD1CH_0             (0x01UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x04000000 */
+#define ADC_CFGR1_AWD1CH_1             (0x02UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x08000000 */
+#define ADC_CFGR1_AWD1CH_2             (0x04UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x10000000 */
+#define ADC_CFGR1_AWD1CH_3             (0x08UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x20000000 */
+#define ADC_CFGR1_AWD1CH_4             (0x10UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x40000000 */
+
+/* Definitions for cohabitation of ADC peripherals 2.5Ms/sec and 5Ms/sec across STM32WB series */
+#define ADC_CFGR_DMAEN_Pos             ADC_CFGR1_DMAEN_Pos
+#define ADC_CFGR_DMAEN_Msk             ADC_CFGR1_DMAEN_Msk
+#define ADC_CFGR_DMAEN                 ADC_CFGR1_DMAEN
+#define ADC_CFGR_DMACFG_Pos            ADC_CFGR1_DMACFG_Pos
+#define ADC_CFGR_DMACFG_Msk            ADC_CFGR1_DMACFG_Msk
+#define ADC_CFGR_DMACFG                ADC_CFGR1_DMACFG
+
+#define ADC_CFGR_SCANDIR_Pos           ADC_CFGR1_SCANDIR_Pos
+#define ADC_CFGR_SCANDIR_Msk           ADC_CFGR1_SCANDIR_Msk
+#define ADC_CFGR_SCANDIR               ADC_CFGR1_SCANDIR
+
+#define ADC_CFGR_RES_Pos               ADC_CFGR1_RES_Pos
+#define ADC_CFGR_RES_Msk               ADC_CFGR1_RES_Msk
+#define ADC_CFGR_RES                   ADC_CFGR1_RES
+#define ADC_CFGR_RES_0                 ADC_CFGR1_RES_0
+#define ADC_CFGR_RES_1                 ADC_CFGR1_RES_1
+
+#define ADC_CFGR_ALIGN_Pos             ADC_CFGR1_ALIGN_Pos
+#define ADC_CFGR_ALIGN_Msk             ADC_CFGR1_ALIGN_Msk
+#define ADC_CFGR_ALIGN                 ADC_CFGR1_ALIGN
+
+#define ADC_CFGR_EXTSEL_Pos            ADC_CFGR1_EXTSEL_Pos
+#define ADC_CFGR_EXTSEL_Msk            ADC_CFGR1_EXTSEL_Msk
+#define ADC_CFGR_EXTSEL                ADC_CFGR1_EXTSEL
+#define ADC_CFGR_EXTSEL_0              ADC_CFGR1_EXTSEL_0
+#define ADC_CFGR_EXTSEL_1              ADC_CFGR1_EXTSEL_1
+#define ADC_CFGR_EXTSEL_2              ADC_CFGR1_EXTSEL_2
+
+#define ADC_CFGR_EXTEN_Pos             ADC_CFGR1_EXTEN_Pos
+#define ADC_CFGR_EXTEN_Msk             ADC_CFGR1_EXTEN_Msk
+#define ADC_CFGR_EXTEN                 ADC_CFGR1_EXTEN
+#define ADC_CFGR_EXTEN_0               ADC_CFGR1_EXTEN_0
+#define ADC_CFGR_EXTEN_1               ADC_CFGR1_EXTEN_1
+
+#define ADC_CFGR_OVRMOD_Pos            ADC_CFGR1_OVRMOD_Pos
+#define ADC_CFGR_OVRMOD_Msk            ADC_CFGR1_OVRMOD_Msk
+#define ADC_CFGR_OVRMOD                ADC_CFGR1_OVRMOD
+#define ADC_CFGR_CONT_Pos              ADC_CFGR1_CONT_Pos
+#define ADC_CFGR_CONT_Msk              ADC_CFGR1_CONT_Msk
+#define ADC_CFGR_CONT                  ADC_CFGR1_CONT
+#define ADC_CFGR_AUTDLY_Pos            ADC_CFGR1_WAIT_Pos
+#define ADC_CFGR_AUTDLY_Msk            ADC_CFGR1_WAIT_Msk
+#define ADC_CFGR_AUTDLY                ADC_CFGR1_WAIT
+#define ADC_CFGR_AUTOFF_Pos            ADC_CFGR1_AUTOFF_Pos
+#define ADC_CFGR_AUTOFF_Msk            ADC_CFGR1_AUTOFF_Msk
+#define ADC_CFGR_AUTOFF                ADC_CFGR1_AUTOFF
+#define ADC_CFGR_DISCEN_Pos            ADC_CFGR1_DISCEN_Pos
+#define ADC_CFGR_DISCEN_Msk            ADC_CFGR1_DISCEN_Msk
+#define ADC_CFGR_DISCEN                ADC_CFGR1_DISCEN
+#define ADC_CFGR_CHSELRMOD_Pos         ADC_CFGR1_CHSELRMOD_Pos
+#define ADC_CFGR_CHSELRMOD_Msk         ADC_CFGR1_CHSELRMOD_Msk
+#define ADC_CFGR_CHSELRMOD             ADC_CFGR1_CHSELRMOD
+
+#define ADC_CFGR_AWD1SGL_Pos           ADC_CFGR1_AWD1SGL_Pos
+#define ADC_CFGR_AWD1SGL_Msk           ADC_CFGR1_AWD1SGL_Msk
+#define ADC_CFGR_AWD1SGL               ADC_CFGR1_AWD1SGL
+#define ADC_CFGR_AWD1EN_Pos            ADC_CFGR1_AWD1EN_Pos
+#define ADC_CFGR_AWD1EN_Msk            ADC_CFGR1_AWD1EN_Msk
+#define ADC_CFGR_AWD1EN                ADC_CFGR1_AWD1EN
+
+#define ADC_CFGR_AWD1CH_Pos            ADC_CFGR1_AWD1CH_Pos
+#define ADC_CFGR_AWD1CH_Msk            ADC_CFGR1_AWD1CH_Msk
+#define ADC_CFGR_AWD1CH                ADC_CFGR1_AWD1CH
+#define ADC_CFGR_AWD1CH_0              ADC_CFGR1_AWD1CH_0
+#define ADC_CFGR_AWD1CH_1              ADC_CFGR1_AWD1CH_1
+#define ADC_CFGR_AWD1CH_2              ADC_CFGR1_AWD1CH_2
+#define ADC_CFGR_AWD1CH_3              ADC_CFGR1_AWD1CH_3
+#define ADC_CFGR_AWD1CH_4              ADC_CFGR1_AWD1CH_4
+
+/********************  Bit definition for ADC_CFGR2 register  *****************/
+#define ADC_CFGR2_LFTRIG_Pos           (29U)
+#define ADC_CFGR2_LFTRIG_Msk           (0x1UL << ADC_CFGR2_LFTRIG_Pos)         /*!< 0x20000000 */
+#define ADC_CFGR2_LFTRIG               ADC_CFGR2_LFTRIG_Msk                    /*!< ADC low frequency trigger mode */
+
+#define ADC_CFGR2_CKMODE_Pos           (30U)
+#define ADC_CFGR2_CKMODE_Msk           (0x3UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0xC0000000 */
+#define ADC_CFGR2_CKMODE               ADC_CFGR2_CKMODE_Msk                    /*!< ADC clock source and prescaler (prescaler only for clock source synchronous) */
+#define ADC_CFGR2_CKMODE_1             (0x2UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x80000000 */
+#define ADC_CFGR2_CKMODE_0             (0x1UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x40000000 */
+
+/********************  Bit definition for ADC_SMPR register  ******************/
+#define ADC_SMPR_SMP1_Pos              (0U)
+#define ADC_SMPR_SMP1_Msk              (0x7UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000007 */
+#define ADC_SMPR_SMP1                  ADC_SMPR_SMP1_Msk                       /*!< ADC group of channels sampling time 1 */
+#define ADC_SMPR_SMP1_0                (0x1UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000001 */
+#define ADC_SMPR_SMP1_1                (0x2UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000002 */
+#define ADC_SMPR_SMP1_2                (0x4UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000004 */
+
+#define ADC_SMPR_SMP2_Pos              (4U)
+#define ADC_SMPR_SMP2_Msk              (0x7UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000070 */
+#define ADC_SMPR_SMP2                  ADC_SMPR_SMP2_Msk                       /*!< ADC group of channels sampling time 2 */
+#define ADC_SMPR_SMP2_0                (0x1UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000010 */
+#define ADC_SMPR_SMP2_1                (0x2UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000020 */
+#define ADC_SMPR_SMP2_2                (0x4UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000040 */
+
+#define ADC_SMPR_SMPSEL_Pos            (8U)
+#define ADC_SMPR_SMPSEL_Msk            (0x7FFFFUL << ADC_SMPR_SMPSEL_Pos)      /*!< 0x07FFFF00 */
+#define ADC_SMPR_SMPSEL                ADC_SMPR_SMPSEL_Msk                     /*!< ADC all channels sampling time selection */
+#define ADC_SMPR_SMPSEL0_Pos           (8U)
+#define ADC_SMPR_SMPSEL0_Msk           (0x1UL << ADC_SMPR_SMPSEL0_Pos)         /*!< 0x00000100 */
+#define ADC_SMPR_SMPSEL0               ADC_SMPR_SMPSEL0_Msk                    /*!< ADC channel 0 sampling time selection */
+#define ADC_SMPR_SMPSEL1_Pos           (9U)
+#define ADC_SMPR_SMPSEL1_Msk           (0x1UL << ADC_SMPR_SMPSEL1_Pos)         /*!< 0x00000200 */
+#define ADC_SMPR_SMPSEL1               ADC_SMPR_SMPSEL1_Msk                    /*!< ADC channel 1 sampling time selection */
+#define ADC_SMPR_SMPSEL2_Pos           (10U)
+#define ADC_SMPR_SMPSEL2_Msk           (0x1UL << ADC_SMPR_SMPSEL2_Pos)         /*!< 0x00000400 */
+#define ADC_SMPR_SMPSEL2               ADC_SMPR_SMPSEL2_Msk                    /*!< ADC channel 2 sampling time selection */
+#define ADC_SMPR_SMPSEL3_Pos           (11U)
+#define ADC_SMPR_SMPSEL3_Msk           (0x1UL << ADC_SMPR_SMPSEL3_Pos)         /*!< 0x00000800 */
+#define ADC_SMPR_SMPSEL3               ADC_SMPR_SMPSEL3_Msk                    /*!< ADC channel 3 sampling time selection */
+#define ADC_SMPR_SMPSEL4_Pos           (12U)
+#define ADC_SMPR_SMPSEL4_Msk           (0x1UL << ADC_SMPR_SMPSEL4_Pos)         /*!< 0x00001000 */
+#define ADC_SMPR_SMPSEL4               ADC_SMPR_SMPSEL4_Msk                    /*!< ADC channel 4 sampling time selection */
+#define ADC_SMPR_SMPSEL5_Pos           (13U)
+#define ADC_SMPR_SMPSEL5_Msk           (0x1UL << ADC_SMPR_SMPSEL5_Pos)         /*!< 0x00002000 */
+#define ADC_SMPR_SMPSEL5               ADC_SMPR_SMPSEL5_Msk                    /*!< ADC channel 5 sampling time selection */
+#define ADC_SMPR_SMPSEL6_Pos           (14U)
+#define ADC_SMPR_SMPSEL6_Msk           (0x1UL << ADC_SMPR_SMPSEL6_Pos)         /*!< 0x00004000 */
+#define ADC_SMPR_SMPSEL6               ADC_SMPR_SMPSEL6_Msk                    /*!< ADC channel 6 sampling time selection */
+#define ADC_SMPR_SMPSEL7_Pos           (15U)
+#define ADC_SMPR_SMPSEL7_Msk           (0x1UL << ADC_SMPR_SMPSEL7_Pos)         /*!< 0x00008000 */
+#define ADC_SMPR_SMPSEL7               ADC_SMPR_SMPSEL7_Msk                    /*!< ADC channel 7 sampling time selection */
+#define ADC_SMPR_SMPSEL8_Pos           (16U)
+#define ADC_SMPR_SMPSEL8_Msk           (0x1UL << ADC_SMPR_SMPSEL8_Pos)         /*!< 0x00010000 */
+#define ADC_SMPR_SMPSEL8               ADC_SMPR_SMPSEL8_Msk                    /*!< ADC channel 8 sampling time selection */
+#define ADC_SMPR_SMPSEL9_Pos           (17U)
+#define ADC_SMPR_SMPSEL9_Msk           (0x1UL << ADC_SMPR_SMPSEL9_Pos)         /*!< 0x00020000 */
+#define ADC_SMPR_SMPSEL9               ADC_SMPR_SMPSEL9_Msk                    /*!< ADC channel 9 sampling time selection */
+#define ADC_SMPR_SMPSEL10_Pos          (18U)
+#define ADC_SMPR_SMPSEL10_Msk          (0x1UL << ADC_SMPR_SMPSEL10_Pos)        /*!< 0x00040000 */
+#define ADC_SMPR_SMPSEL10              ADC_SMPR_SMPSEL10_Msk                   /*!< ADC channel 10 sampling time selection */
+#define ADC_SMPR_SMPSEL11_Pos          (19U)
+#define ADC_SMPR_SMPSEL11_Msk          (0x1UL << ADC_SMPR_SMPSEL11_Pos)        /*!< 0x00080000 */
+#define ADC_SMPR_SMPSEL11              ADC_SMPR_SMPSEL11_Msk                   /*!< ADC channel 11 sampling time selection */
+#define ADC_SMPR_SMPSEL12_Pos          (20U)
+#define ADC_SMPR_SMPSEL12_Msk          (0x1UL << ADC_SMPR_SMPSEL12_Pos)        /*!< 0x00100000 */
+#define ADC_SMPR_SMPSEL12              ADC_SMPR_SMPSEL12_Msk                   /*!< ADC channel 12 sampling time selection */
+#define ADC_SMPR_SMPSEL13_Pos          (21U)
+#define ADC_SMPR_SMPSEL13_Msk          (0x1UL << ADC_SMPR_SMPSEL13_Pos)        /*!< 0x00200000 */
+#define ADC_SMPR_SMPSEL13              ADC_SMPR_SMPSEL13_Msk                   /*!< ADC channel 13 sampling time selection */
+#define ADC_SMPR_SMPSEL14_Pos          (22U)
+#define ADC_SMPR_SMPSEL14_Msk          (0x1UL << ADC_SMPR_SMPSEL14_Pos)        /*!< 0x00400000 */
+#define ADC_SMPR_SMPSEL14              ADC_SMPR_SMPSEL14_Msk                   /*!< ADC channel 14 sampling time selection */
+#define ADC_SMPR_SMPSEL15_Pos          (23U)
+#define ADC_SMPR_SMPSEL15_Msk          (0x1UL << ADC_SMPR_SMPSEL15_Pos)        /*!< 0x00800000 */
+#define ADC_SMPR_SMPSEL15              ADC_SMPR_SMPSEL15_Msk                   /*!< ADC channel 15 sampling time selection */
+#define ADC_SMPR_SMPSEL16_Pos          (24U)
+#define ADC_SMPR_SMPSEL16_Msk          (0x1UL << ADC_SMPR_SMPSEL16_Pos)        /*!< 0x01000000 */
+#define ADC_SMPR_SMPSEL16              ADC_SMPR_SMPSEL16_Msk                   /*!< ADC channel 16 sampling time selection */
+#define ADC_SMPR_SMPSEL17_Pos          (25U)
+#define ADC_SMPR_SMPSEL17_Msk          (0x1UL << ADC_SMPR_SMPSEL17_Pos)        /*!< 0x02000000 */
+#define ADC_SMPR_SMPSEL17              ADC_SMPR_SMPSEL17_Msk                   /*!< ADC channel 17 sampling time selection */
+#define ADC_SMPR_SMPSEL18_Pos          (25U)
+#define ADC_SMPR_SMPSEL18_Msk          (0x1UL << ADC_SMPR_SMPSEL18_Pos)        /*!< 0x04000000 */
+#define ADC_SMPR_SMPSEL18              ADC_SMPR_SMPSEL18_Msk                   /*!< ADC channel 18 sampling time selection */
+
+/********************  Bit definition for ADC_TR register  *******************/
+#define ADC_TR_LT_Pos             (0U)
+#define ADC_TR_LT_Msk             (0xFFFUL << ADC_TR_LT_Pos)         /*!< 0x00000FFF */
+#define ADC_TR_LT                 ADC_TR_LT_Msk                      /*!< ADC analog watchdog 1 threshold low */
+#define ADC_TR_LT_0               (0x001UL << ADC_TR_LT_Pos)         /*!< 0x00000001 */
+#define ADC_TR_LT_1               (0x002UL << ADC_TR_LT_Pos)         /*!< 0x00000002 */
+#define ADC_TR_LT_2               (0x004UL << ADC_TR_LT_Pos)         /*!< 0x00000004 */
+#define ADC_TR_LT_3               (0x008UL << ADC_TR_LT_Pos)         /*!< 0x00000008 */
+#define ADC_TR_LT_4               (0x010UL << ADC_TR_LT_Pos)         /*!< 0x00000010 */
+#define ADC_TR_LT_5               (0x020UL << ADC_TR_LT_Pos)         /*!< 0x00000020 */
+#define ADC_TR_LT_6               (0x040UL << ADC_TR_LT_Pos)         /*!< 0x00000040 */
+#define ADC_TR_LT_7               (0x080UL << ADC_TR_LT_Pos)         /*!< 0x00000080 */
+#define ADC_TR_LT_8               (0x100UL << ADC_TR_LT_Pos)         /*!< 0x00000100 */
+#define ADC_TR_LT_9               (0x200UL << ADC_TR_LT_Pos)         /*!< 0x00000200 */
+#define ADC_TR_LT_10              (0x400UL << ADC_TR_LT_Pos)         /*!< 0x00000400 */
+#define ADC_TR_LT_11              (0x800UL << ADC_TR_LT_Pos)         /*!< 0x00000800 */
+
+#define ADC_TR_HT_Pos             (16U)
+#define ADC_TR_HT_Msk             (0xFFFUL << ADC_TR_HT_Pos)         /*!< 0x0FFF0000 */
+#define ADC_TR_HT                 ADC_TR_HT_Msk                      /*!< ADC Analog watchdog 1 threshold high */
+#define ADC_TR_HT_0               (0x001UL << ADC_TR_HT_Pos)         /*!< 0x00010000 */
+#define ADC_TR_HT_1               (0x002UL << ADC_TR_HT_Pos)         /*!< 0x00020000 */
+#define ADC_TR_HT_2               (0x004UL << ADC_TR_HT_Pos)         /*!< 0x00040000 */
+#define ADC_TR_HT_3               (0x008UL << ADC_TR_HT_Pos)         /*!< 0x00080000 */
+#define ADC_TR_HT_4               (0x010UL << ADC_TR_HT_Pos)         /*!< 0x00100000 */
+#define ADC_TR_HT_5               (0x020UL << ADC_TR_HT_Pos)         /*!< 0x00200000 */
+#define ADC_TR_HT_6               (0x040UL << ADC_TR_HT_Pos)         /*!< 0x00400000 */
+#define ADC_TR_HT_7               (0x080UL << ADC_TR_HT_Pos)         /*!< 0x00800000 */
+#define ADC_TR_HT_8               (0x100UL << ADC_TR_HT_Pos)         /*!< 0x01000000 */
+#define ADC_TR_HT_9               (0x200UL << ADC_TR_HT_Pos)         /*!< 0x02000000 */
+#define ADC_TR_HT_10              (0x400UL << ADC_TR_HT_Pos)         /*!< 0x04000000 */
+#define ADC_TR_HT_11              (0x800UL << ADC_TR_HT_Pos)         /*!< 0x08000000 */
+
+/* Legacy definitions */
+#define ADC_TR1_LT1             ADC_TR_LT
+#define ADC_TR1_LT1_0           ADC_TR_LT_0
+#define ADC_TR1_LT1_1           ADC_TR_LT_1
+#define ADC_TR1_LT1_2           ADC_TR_LT_2
+#define ADC_TR1_LT1_3           ADC_TR_LT_3
+#define ADC_TR1_LT1_4           ADC_TR_LT_4
+#define ADC_TR1_LT1_5           ADC_TR_LT_5
+#define ADC_TR1_LT1_6           ADC_TR_LT_6
+#define ADC_TR1_LT1_7           ADC_TR_LT_7
+#define ADC_TR1_LT1_8           ADC_TR_LT_8
+#define ADC_TR1_LT1_9           ADC_TR_LT_9
+#define ADC_TR1_LT1_10          ADC_TR_LT_10
+#define ADC_TR1_LT1_11          ADC_TR_LT_11
+
+#define ADC_TR1_HT1             ADC_TR_HT
+#define ADC_TR1_HT1_0           ADC_TR_HT_0
+#define ADC_TR1_HT1_1           ADC_TR_HT_1
+#define ADC_TR1_HT1_2           ADC_TR_HT_2
+#define ADC_TR1_HT1_3           ADC_TR_HT_3
+#define ADC_TR1_HT1_4           ADC_TR_HT_4
+#define ADC_TR1_HT1_5           ADC_TR_HT_5
+#define ADC_TR1_HT1_6           ADC_TR_HT_6
+#define ADC_TR1_HT1_7           ADC_TR_HT_7
+#define ADC_TR1_HT1_8           ADC_TR_HT_8
+#define ADC_TR1_HT1_9           ADC_TR_HT_9
+#define ADC_TR1_HT1_10          ADC_TR_HT_10
+#define ADC_TR1_HT1_11          ADC_TR_HT_11
+
+/********************  Bit definition for ADC_CHSELR register  ****************/
+#define ADC_CHSELR_CHSEL_Pos           (0U)
+#define ADC_CHSELR_CHSEL_Msk           (0x7FFFFUL << ADC_CHSELR_CHSEL_Pos)     /*!< 0x0007FFFF */
+#define ADC_CHSELR_CHSEL               ADC_CHSELR_CHSEL_Msk                    /*!< ADC group regular sequencer channels, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL18_Pos         (18U)
+#define ADC_CHSELR_CHSEL18_Msk         (0x1UL << ADC_CHSELR_CHSEL18_Pos)       /*!< 0x00040000 */
+#define ADC_CHSELR_CHSEL18             ADC_CHSELR_CHSEL18_Msk                  /*!< ADC group regular sequencer channel 18, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL17_Pos         (17U)
+#define ADC_CHSELR_CHSEL17_Msk         (0x1UL << ADC_CHSELR_CHSEL17_Pos)       /*!< 0x00020000 */
+#define ADC_CHSELR_CHSEL17             ADC_CHSELR_CHSEL17_Msk                  /*!< ADC group regular sequencer channel 17, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL16_Pos         (16U)
+#define ADC_CHSELR_CHSEL16_Msk         (0x1UL << ADC_CHSELR_CHSEL16_Pos)       /*!< 0x00010000 */
+#define ADC_CHSELR_CHSEL16             ADC_CHSELR_CHSEL16_Msk                  /*!< ADC group regular sequencer channel 16, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL15_Pos         (15U)
+#define ADC_CHSELR_CHSEL15_Msk         (0x1UL << ADC_CHSELR_CHSEL15_Pos)       /*!< 0x00008000 */
+#define ADC_CHSELR_CHSEL15             ADC_CHSELR_CHSEL15_Msk                  /*!< ADC group regular sequencer channel 15, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL14_Pos         (14U)
+#define ADC_CHSELR_CHSEL14_Msk         (0x1UL << ADC_CHSELR_CHSEL14_Pos)       /*!< 0x00004000 */
+#define ADC_CHSELR_CHSEL14             ADC_CHSELR_CHSEL14_Msk                  /*!< ADC group regular sequencer channel 14, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL13_Pos         (13U)
+#define ADC_CHSELR_CHSEL13_Msk         (0x1UL << ADC_CHSELR_CHSEL13_Pos)       /*!< 0x00002000 */
+#define ADC_CHSELR_CHSEL13             ADC_CHSELR_CHSEL13_Msk                  /*!< ADC group regular sequencer channel 13, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL12_Pos         (12U)
+#define ADC_CHSELR_CHSEL12_Msk         (0x1UL << ADC_CHSELR_CHSEL12_Pos)       /*!< 0x00001000 */
+#define ADC_CHSELR_CHSEL12             ADC_CHSELR_CHSEL12_Msk                  /*!< ADC group regular sequencer channel 12, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL11_Pos         (11U)
+#define ADC_CHSELR_CHSEL11_Msk         (0x1UL << ADC_CHSELR_CHSEL11_Pos)       /*!< 0x00000800 */
+#define ADC_CHSELR_CHSEL11             ADC_CHSELR_CHSEL11_Msk                  /*!< ADC group regular sequencer channel 11, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL10_Pos         (10U)
+#define ADC_CHSELR_CHSEL10_Msk         (0x1UL << ADC_CHSELR_CHSEL10_Pos)       /*!< 0x00000400 */
+#define ADC_CHSELR_CHSEL10             ADC_CHSELR_CHSEL10_Msk                  /*!< ADC group regular sequencer channel 10, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL9_Pos          (9U)
+#define ADC_CHSELR_CHSEL9_Msk          (0x1UL << ADC_CHSELR_CHSEL9_Pos)        /*!< 0x00000200 */
+#define ADC_CHSELR_CHSEL9              ADC_CHSELR_CHSEL9_Msk                   /*!< ADC group regular sequencer channel 9, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL8_Pos          (8U)
+#define ADC_CHSELR_CHSEL8_Msk          (0x1UL << ADC_CHSELR_CHSEL8_Pos)        /*!< 0x00000100 */
+#define ADC_CHSELR_CHSEL8              ADC_CHSELR_CHSEL8_Msk                   /*!< ADC group regular sequencer channel 8, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL7_Pos          (7U)
+#define ADC_CHSELR_CHSEL7_Msk          (0x1UL << ADC_CHSELR_CHSEL7_Pos)        /*!< 0x00000080 */
+#define ADC_CHSELR_CHSEL7              ADC_CHSELR_CHSEL7_Msk                   /*!< ADC group regular sequencer channel 7, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL6_Pos          (6U)
+#define ADC_CHSELR_CHSEL6_Msk          (0x1UL << ADC_CHSELR_CHSEL6_Pos)        /*!< 0x00000040 */
+#define ADC_CHSELR_CHSEL6              ADC_CHSELR_CHSEL6_Msk                   /*!< ADC group regular sequencer channel 6, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL5_Pos          (5U)
+#define ADC_CHSELR_CHSEL5_Msk          (0x1UL << ADC_CHSELR_CHSEL5_Pos)        /*!< 0x00000020 */
+#define ADC_CHSELR_CHSEL5              ADC_CHSELR_CHSEL5_Msk                   /*!< ADC group regular sequencer channel 5, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL4_Pos          (4U)
+#define ADC_CHSELR_CHSEL4_Msk          (0x1UL << ADC_CHSELR_CHSEL4_Pos)        /*!< 0x00000010 */
+#define ADC_CHSELR_CHSEL4              ADC_CHSELR_CHSEL4_Msk                   /*!< ADC group regular sequencer channel 4, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL3_Pos          (3U)
+#define ADC_CHSELR_CHSEL3_Msk          (0x1UL << ADC_CHSELR_CHSEL3_Pos)        /*!< 0x00000008 */
+#define ADC_CHSELR_CHSEL3              ADC_CHSELR_CHSEL3_Msk                   /*!< ADC group regular sequencer channel 3, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL2_Pos          (2U)
+#define ADC_CHSELR_CHSEL2_Msk          (0x1UL << ADC_CHSELR_CHSEL2_Pos)        /*!< 0x00000004 */
+#define ADC_CHSELR_CHSEL2              ADC_CHSELR_CHSEL2_Msk                   /*!< ADC group regular sequencer channel 2, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL1_Pos          (1U)
+#define ADC_CHSELR_CHSEL1_Msk          (0x1UL << ADC_CHSELR_CHSEL1_Pos)        /*!< 0x00000002 */
+#define ADC_CHSELR_CHSEL1              ADC_CHSELR_CHSEL1_Msk                   /*!< ADC group regular sequencer channel 1, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL0_Pos          (0U)
+#define ADC_CHSELR_CHSEL0_Msk          (0x1UL << ADC_CHSELR_CHSEL0_Pos)        /*!< 0x00000001 */
+#define ADC_CHSELR_CHSEL0              ADC_CHSELR_CHSEL0_Msk                   /*!< ADC group regular sequencer channel 0, available when ADC_CFGR1_CHSELRMOD is reset */
+
+#define ADC_CHSELR_SQ_ALL_Pos          (0U)
+#define ADC_CHSELR_SQ_ALL_Msk          (0xFFFFFFFFUL << ADC_CHSELR_SQ_ALL_Pos) /*!< 0xFFFFFFFF */
+#define ADC_CHSELR_SQ_ALL              ADC_CHSELR_SQ_ALL_Msk                   /*!< ADC group regular sequencer all ranks, available when ADC_CFGR1_CHSELRMOD is set */
+
+#define ADC_CHSELR_SQ8_Pos             (28U)
+#define ADC_CHSELR_SQ8_Msk             (0xFUL << ADC_CHSELR_SQ8_Pos)           /*!< 0xF0000000 */
+#define ADC_CHSELR_SQ8                 ADC_CHSELR_SQ8_Msk                      /*!< ADC group regular sequencer rank 8, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ8_0               (0x1UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x10000000 */
+#define ADC_CHSELR_SQ8_1               (0x2UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x20000000 */
+#define ADC_CHSELR_SQ8_2               (0x4UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x40000000 */
+#define ADC_CHSELR_SQ8_3               (0x8UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x80000000 */
+
+#define ADC_CHSELR_SQ7_Pos             (24U)
+#define ADC_CHSELR_SQ7_Msk             (0xFUL << ADC_CHSELR_SQ7_Pos)           /*!< 0x0F000000 */
+#define ADC_CHSELR_SQ7                 ADC_CHSELR_SQ7_Msk                      /*!< ADC group regular sequencer rank 7, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ7_0               (0x1UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x01000000 */
+#define ADC_CHSELR_SQ7_1               (0x2UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x02000000 */
+#define ADC_CHSELR_SQ7_2               (0x4UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x04000000 */
+#define ADC_CHSELR_SQ7_3               (0x8UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x08000000 */
+
+#define ADC_CHSELR_SQ6_Pos             (20U)
+#define ADC_CHSELR_SQ6_Msk             (0xFUL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00F00000 */
+#define ADC_CHSELR_SQ6                 ADC_CHSELR_SQ6_Msk                      /*!< ADC group regular sequencer rank 6, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ6_0               (0x1UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00100000 */
+#define ADC_CHSELR_SQ6_1               (0x2UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00200000 */
+#define ADC_CHSELR_SQ6_2               (0x4UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00400000 */
+#define ADC_CHSELR_SQ6_3               (0x8UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00800000 */
+
+#define ADC_CHSELR_SQ5_Pos             (16U)
+#define ADC_CHSELR_SQ5_Msk             (0xFUL << ADC_CHSELR_SQ5_Pos)           /*!< 0x000F0000 */
+#define ADC_CHSELR_SQ5                 ADC_CHSELR_SQ5_Msk                      /*!< ADC group regular sequencer rank 5, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ5_0               (0x1UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00010000 */
+#define ADC_CHSELR_SQ5_1               (0x2UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00020000 */
+#define ADC_CHSELR_SQ5_2               (0x4UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00040000 */
+#define ADC_CHSELR_SQ5_3               (0x8UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00080000 */
+
+#define ADC_CHSELR_SQ4_Pos             (12U)
+#define ADC_CHSELR_SQ4_Msk             (0xFUL << ADC_CHSELR_SQ4_Pos)           /*!< 0x0000F000 */
+#define ADC_CHSELR_SQ4                 ADC_CHSELR_SQ4_Msk                      /*!< ADC group regular sequencer rank 4, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ4_0               (0x1UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00001000 */
+#define ADC_CHSELR_SQ4_1               (0x2UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00002000 */
+#define ADC_CHSELR_SQ4_2               (0x4UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00004000 */
+#define ADC_CHSELR_SQ4_3               (0x8UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00008000 */
+
+#define ADC_CHSELR_SQ3_Pos             (8U)
+#define ADC_CHSELR_SQ3_Msk             (0xFUL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000F00 */
+#define ADC_CHSELR_SQ3                 ADC_CHSELR_SQ3_Msk                      /*!< ADC group regular sequencer rank 3, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ3_0               (0x1UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000100 */
+#define ADC_CHSELR_SQ3_1               (0x2UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000200 */
+#define ADC_CHSELR_SQ3_2               (0x4UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000400 */
+#define ADC_CHSELR_SQ3_3               (0x8UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000800 */
+
+#define ADC_CHSELR_SQ2_Pos             (4U)
+#define ADC_CHSELR_SQ2_Msk             (0xFUL << ADC_CHSELR_SQ2_Pos)           /*!< 0x000000F0 */
+#define ADC_CHSELR_SQ2                 ADC_CHSELR_SQ2_Msk                      /*!< ADC group regular sequencer rank 2, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ2_0               (0x1UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000010 */
+#define ADC_CHSELR_SQ2_1               (0x2UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000020 */
+#define ADC_CHSELR_SQ2_2               (0x4UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000040 */
+#define ADC_CHSELR_SQ2_3               (0x8UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000080 */
+
+#define ADC_CHSELR_SQ1_Pos             (0U)
+#define ADC_CHSELR_SQ1_Msk             (0xFUL << ADC_CHSELR_SQ1_Pos)           /*!< 0x0000000F */
+#define ADC_CHSELR_SQ1                 ADC_CHSELR_SQ1_Msk                      /*!< ADC group regular sequencer rank 1, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ1_0               (0x1UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000001 */
+#define ADC_CHSELR_SQ1_1               (0x2UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000002 */
+#define ADC_CHSELR_SQ1_2               (0x4UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000004 */
+#define ADC_CHSELR_SQ1_3               (0x8UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000008 */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos                (0U)
+#define ADC_DR_DATA_Msk                (0xFFFFUL << ADC_DR_DATA_Pos)           /*!< 0x0000FFFF */
+#define ADC_DR_DATA                    ADC_DR_DATA_Msk                         /*!< ADC group regular conversion data */
+#define ADC_DR_DATA_0                  (0x0001UL << ADC_DR_DATA_Pos)           /*!< 0x00000001 */
+#define ADC_DR_DATA_1                  (0x0002UL << ADC_DR_DATA_Pos)           /*!< 0x00000002 */
+#define ADC_DR_DATA_2                  (0x0004UL << ADC_DR_DATA_Pos)           /*!< 0x00000004 */
+#define ADC_DR_DATA_3                  (0x0008UL << ADC_DR_DATA_Pos)           /*!< 0x00000008 */
+#define ADC_DR_DATA_4                  (0x0010UL << ADC_DR_DATA_Pos)           /*!< 0x00000010 */
+#define ADC_DR_DATA_5                  (0x0020UL << ADC_DR_DATA_Pos)           /*!< 0x00000020 */
+#define ADC_DR_DATA_6                  (0x0040UL << ADC_DR_DATA_Pos)           /*!< 0x00000040 */
+#define ADC_DR_DATA_7                  (0x0080UL << ADC_DR_DATA_Pos)           /*!< 0x00000080 */
+#define ADC_DR_DATA_8                  (0x0100UL << ADC_DR_DATA_Pos)           /*!< 0x00000100 */
+#define ADC_DR_DATA_9                  (0x0200UL << ADC_DR_DATA_Pos)           /*!< 0x00000200 */
+#define ADC_DR_DATA_10                 (0x0400UL << ADC_DR_DATA_Pos)           /*!< 0x00000400 */
+#define ADC_DR_DATA_11                 (0x0800UL << ADC_DR_DATA_Pos)           /*!< 0x00000800 */
+#define ADC_DR_DATA_12                 (0x1000UL << ADC_DR_DATA_Pos)           /*!< 0x00001000 */
+#define ADC_DR_DATA_13                 (0x2000UL << ADC_DR_DATA_Pos)           /*!< 0x00002000 */
+#define ADC_DR_DATA_14                 (0x4000UL << ADC_DR_DATA_Pos)           /*!< 0x00004000 */
+#define ADC_DR_DATA_15                 (0x8000UL << ADC_DR_DATA_Pos)           /*!< 0x00008000 */
+
+/* Definitions for cohabitation of ADC peripherals 2.5Ms/sec and 5Ms/sec across STM32WB series */
+#define ADC_DR_RDATA_Pos               ADC_DR_DATA_Pos
+#define ADC_DR_RDATA_Msk               ADC_DR_DATA_Msk
+#define ADC_DR_RDATA                   ADC_DR_DATA
+
+/********************  Bit definition for ADC_CALFACT register  ***************/
+#define ADC_CALFACT_CALFACT_Pos        (0U)
+#define ADC_CALFACT_CALFACT_Msk        (0x7FUL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x0000007F */
+#define ADC_CALFACT_CALFACT            ADC_CALFACT_CALFACT_Msk                 /*!< ADC calibration factor in single-ended mode */
+#define ADC_CALFACT_CALFACT_0          (0x01UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000001 */
+#define ADC_CALFACT_CALFACT_1          (0x02UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000002 */
+#define ADC_CALFACT_CALFACT_2          (0x04UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000004 */
+#define ADC_CALFACT_CALFACT_3          (0x08UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000008 */
+#define ADC_CALFACT_CALFACT_4          (0x10UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000010 */
+#define ADC_CALFACT_CALFACT_5          (0x20UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000020 */
+#define ADC_CALFACT_CALFACT_6          (0x40UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000040 */
+
+/*************************  ADC Common registers  *****************************/
+/********************  Bit definition for ADC_CCR register  *******************/
+#define ADC_CCR_PRESC_Pos              (18U)
+#define ADC_CCR_PRESC_Msk              (0xFUL << ADC_CCR_PRESC_Pos)            /*!< 0x003C0000 */
+#define ADC_CCR_PRESC                  ADC_CCR_PRESC_Msk                       /*!< ADC common clock prescaler, only for clock source asynchronous */
+#define ADC_CCR_PRESC_0                (0x1UL << ADC_CCR_PRESC_Pos)            /*!< 0x00040000 */
+#define ADC_CCR_PRESC_1                (0x2UL << ADC_CCR_PRESC_Pos)            /*!< 0x00080000 */
+#define ADC_CCR_PRESC_2                (0x4UL << ADC_CCR_PRESC_Pos)            /*!< 0x00100000 */
+#define ADC_CCR_PRESC_3                (0x8UL << ADC_CCR_PRESC_Pos)            /*!< 0x00200000 */
+
+#define ADC_CCR_VREFEN_Pos             (22U)
+#define ADC_CCR_VREFEN_Msk             (0x1UL << ADC_CCR_VREFEN_Pos)           /*!< 0x00400000 */
+#define ADC_CCR_VREFEN                 ADC_CCR_VREFEN_Msk                      /*!< ADC internal path to VrefInt enable */
+#define ADC_CCR_TSEN_Pos               (23U)
+#define ADC_CCR_TSEN_Msk               (0x1UL << ADC_CCR_TSEN_Pos)             /*!< 0x00800000 */
+#define ADC_CCR_TSEN                   ADC_CCR_TSEN_Msk                        /*!< ADC internal path to temperature sensor enable */
+#define ADC_CCR_VBATEN_Pos             (24U)
+#define ADC_CCR_VBATEN_Msk             (0x1UL << ADC_CCR_VBATEN_Pos)           /*!< 0x01000000 */
+#define ADC_CCR_VBATEN                 ADC_CCR_VBATEN_Msk                      /*!< ADC internal path to battery voltage enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos            (0U)
+#define CRC_DR_DR_Msk            (0xFFFFFFFFUL << CRC_DR_DR_Pos)               /*!< 0xFFFFFFFF */
+#define CRC_DR_DR                CRC_DR_DR_Msk                                 /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos          (0U)
+#define CRC_IDR_IDR_Msk          (0xFFFFFFFFUL << CRC_IDR_IDR_Pos)                   /*!< 0x000000FF */
+#define CRC_IDR_IDR              CRC_IDR_IDR_Msk                               /*!< General-purpose 8-bits data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos         (0U)
+#define CRC_CR_RESET_Msk         (0x1UL << CRC_CR_RESET_Pos)                   /*!< 0x00000001 */
+#define CRC_CR_RESET             CRC_CR_RESET_Msk                              /*!< RESET the CRC computation unit bit */
+#define CRC_CR_POLYSIZE_Pos      (3U)
+#define CRC_CR_POLYSIZE_Msk      (0x3UL << CRC_CR_POLYSIZE_Pos)                /*!< 0x00000018 */
+#define CRC_CR_POLYSIZE          CRC_CR_POLYSIZE_Msk                           /*!< Polynomial size bits */
+#define CRC_CR_POLYSIZE_0        (0x1U << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000008 */
+#define CRC_CR_POLYSIZE_1        (0x2U << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000010 */
+#define CRC_CR_REV_IN_Pos        (5U)
+#define CRC_CR_REV_IN_Msk        (0x3UL << CRC_CR_REV_IN_Pos)                  /*!< 0x00000060 */
+#define CRC_CR_REV_IN            CRC_CR_REV_IN_Msk                             /*!< REV_IN Reverse Input Data bits */
+#define CRC_CR_REV_IN_0          (0x1U << CRC_CR_REV_IN_Pos)                   /*!< 0x00000020 */
+#define CRC_CR_REV_IN_1          (0x2U << CRC_CR_REV_IN_Pos)                   /*!< 0x00000040 */
+#define CRC_CR_REV_OUT_Pos       (7U)
+#define CRC_CR_REV_OUT_Msk       (0x1UL << CRC_CR_REV_OUT_Pos)                 /*!< 0x00000080 */
+#define CRC_CR_REV_OUT           CRC_CR_REV_OUT_Msk                            /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define CRC_INIT_INIT_Pos        (0U)
+#define CRC_INIT_INIT_Msk        (0xFFFFFFFFUL << CRC_INIT_INIT_Pos)           /*!< 0xFFFFFFFF */
+#define CRC_INIT_INIT            CRC_INIT_INIT_Msk                             /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define CRC_POL_POL_Pos          (0U)
+#define CRC_POL_POL_Msk          (0xFFFFFFFFUL << CRC_POL_POL_Pos)             /*!< 0xFFFFFFFF */
+#define CRC_POL_POL              CRC_POL_POL_Msk                               /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Advanced Encryption Standard (AES)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for AES_CR register  *********************/
+#define AES_CR_EN_Pos            (0U)
+#define AES_CR_EN_Msk            (0x1UL << AES_CR_EN_Pos)                      /*!< 0x00000001 */
+#define AES_CR_EN                AES_CR_EN_Msk                                 /*!< AES Enable */
+#define AES_CR_DATATYPE_Pos      (1U)
+#define AES_CR_DATATYPE_Msk      (0x3UL << AES_CR_DATATYPE_Pos)                /*!< 0x00000006 */
+#define AES_CR_DATATYPE          AES_CR_DATATYPE_Msk                           /*!< Data type selection */
+#define AES_CR_DATATYPE_0        (0x1U << AES_CR_DATATYPE_Pos)                 /*!< 0x00000002 */
+#define AES_CR_DATATYPE_1        (0x2U << AES_CR_DATATYPE_Pos)                 /*!< 0x00000004 */
+
+#define AES_CR_MODE_Pos          (3U)
+#define AES_CR_MODE_Msk          (0x3UL << AES_CR_MODE_Pos)                    /*!< 0x00000018 */
+#define AES_CR_MODE              AES_CR_MODE_Msk                               /*!< AES Mode Of Operation */
+#define AES_CR_MODE_0            (0x1U << AES_CR_MODE_Pos)                     /*!< 0x00000008 */
+#define AES_CR_MODE_1            (0x2U << AES_CR_MODE_Pos)                     /*!< 0x00000010 */
+
+#define AES_CR_CHMOD_Pos         (5U)
+#define AES_CR_CHMOD_Msk         (0x803UL << AES_CR_CHMOD_Pos)                 /*!< 0x00010060 */
+#define AES_CR_CHMOD             AES_CR_CHMOD_Msk                              /*!< AES Chaining Mode */
+#define AES_CR_CHMOD_0           (0x001U << AES_CR_CHMOD_Pos)                  /*!< 0x00000020 */
+#define AES_CR_CHMOD_1           (0x002U << AES_CR_CHMOD_Pos)                  /*!< 0x00000040 */
+#define AES_CR_CHMOD_2           (0x800U << AES_CR_CHMOD_Pos)                  /*!< 0x00010000 */
+
+#define AES_CR_CCFC_Pos          (7U)
+#define AES_CR_CCFC_Msk          (0x1UL << AES_CR_CCFC_Pos)                    /*!< 0x00000080 */
+#define AES_CR_CCFC              AES_CR_CCFC_Msk                               /*!< Computation Complete Flag Clear */
+#define AES_CR_ERRC_Pos          (8U)
+#define AES_CR_ERRC_Msk          (0x1UL << AES_CR_ERRC_Pos)                    /*!< 0x00000100 */
+#define AES_CR_ERRC              AES_CR_ERRC_Msk                               /*!< Error Clear */
+#define AES_CR_CCFIE_Pos         (9U)
+#define AES_CR_CCFIE_Msk         (0x1UL << AES_CR_CCFIE_Pos)                   /*!< 0x00000200 */
+#define AES_CR_CCFIE             AES_CR_CCFIE_Msk                              /*!< Computation Complete Flag Interrupt Enable */
+#define AES_CR_ERRIE_Pos         (10U)
+#define AES_CR_ERRIE_Msk         (0x1UL << AES_CR_ERRIE_Pos)                   /*!< 0x00000400 */
+#define AES_CR_ERRIE             AES_CR_ERRIE_Msk                              /*!< Error Interrupt Enable */
+#define AES_CR_DMAINEN_Pos       (11U)
+#define AES_CR_DMAINEN_Msk       (0x1UL << AES_CR_DMAINEN_Pos)                 /*!< 0x00000800 */
+#define AES_CR_DMAINEN           AES_CR_DMAINEN_Msk                            /*!< Enable data input phase DMA management  */
+#define AES_CR_DMAOUTEN_Pos      (12U)
+#define AES_CR_DMAOUTEN_Msk      (0x1UL << AES_CR_DMAOUTEN_Pos)                /*!< 0x00001000 */
+#define AES_CR_DMAOUTEN          AES_CR_DMAOUTEN_Msk                           /*!< Enable data output phase DMA management */
+
+#define AES_CR_GCMPH_Pos         (13U)
+#define AES_CR_GCMPH_Msk         (0x3UL << AES_CR_GCMPH_Pos)                   /*!< 0x00006000 */
+#define AES_CR_GCMPH             AES_CR_GCMPH_Msk                              /*!< GCM Phase */
+#define AES_CR_GCMPH_0           (0x1U << AES_CR_GCMPH_Pos)                    /*!< 0x00002000 */
+#define AES_CR_GCMPH_1           (0x2U << AES_CR_GCMPH_Pos)                    /*!< 0x00004000 */
+
+#define AES_CR_KEYSIZE_Pos       (18U)
+#define AES_CR_KEYSIZE_Msk       (0x1UL << AES_CR_KEYSIZE_Pos)                 /*!< 0x00040000 */
+#define AES_CR_KEYSIZE           AES_CR_KEYSIZE_Msk                            /*!< Key size selection */
+
+#define AES_CR_NPBLB_Pos         (20U)
+#define AES_CR_NPBLB_Msk         (0xFUL << AES_CR_NPBLB_Pos)                   /*!< 0x00F00000 */
+#define AES_CR_NPBLB             AES_CR_NPBLB_Msk                              /*!< Number of padding bytes in last payload block */
+#define AES_CR_NPBLB_0           (0x1U << AES_CR_NPBLB_Pos)                    /*!< 0x00100000 */
+#define AES_CR_NPBLB_1           (0x2U << AES_CR_NPBLB_Pos)                    /*!< 0x00200000 */
+#define AES_CR_NPBLB_2           (0x4U << AES_CR_NPBLB_Pos)                    /*!< 0x00400000 */
+#define AES_CR_NPBLB_3           (0x8U << AES_CR_NPBLB_Pos)                    /*!< 0x00800000 */
+
+/*******************  Bit definition for AES_SR register  *********************/
+#define AES_SR_CCF_Pos           (0U)
+#define AES_SR_CCF_Msk           (0x1UL << AES_SR_CCF_Pos)                     /*!< 0x00000001 */
+#define AES_SR_CCF               AES_SR_CCF_Msk                                /*!< Computation Complete Flag */
+#define AES_SR_RDERR_Pos         (1U)
+#define AES_SR_RDERR_Msk         (0x1UL << AES_SR_RDERR_Pos)                   /*!< 0x00000002 */
+#define AES_SR_RDERR             AES_SR_RDERR_Msk                              /*!< Read Error Flag */
+#define AES_SR_WRERR_Pos         (2U)
+#define AES_SR_WRERR_Msk         (0x1UL << AES_SR_WRERR_Pos)                   /*!< 0x00000004 */
+#define AES_SR_WRERR             AES_SR_WRERR_Msk                              /*!< Write Error Flag */
+#define AES_SR_BUSY_Pos          (3U)
+#define AES_SR_BUSY_Msk          (0x1UL << AES_SR_BUSY_Pos)                    /*!< 0x00000008 */
+#define AES_SR_BUSY              AES_SR_BUSY_Msk                               /*!< Busy Flag */
+
+/*******************  Bit definition for AES_DINR register  *******************/
+#define AES_DINR_Pos             (0U)
+#define AES_DINR_Msk             (0xFFFFFFFFUL << AES_DINR_Pos)                /*!< 0xFFFFFFFF */
+#define AES_DINR                 AES_DINR_Msk                                  /*!< AES Data Input Register */
+
+/*******************  Bit definition for AES_DOUTR register  ******************/
+#define AES_DOUTR_Pos            (0U)
+#define AES_DOUTR_Msk            (0xFFFFFFFFUL << AES_DOUTR_Pos)               /*!< 0xFFFFFFFF */
+#define AES_DOUTR                AES_DOUTR_Msk                                 /*!< AES Data Output Register */
+
+/*******************  Bit definition for AES_KEYR0 register  ******************/
+#define AES_KEYR0_Pos            (0U)
+#define AES_KEYR0_Msk            (0xFFFFFFFFUL << AES_KEYR0_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR0                AES_KEYR0_Msk                                 /*!< AES Key Register 0 */
+
+/*******************  Bit definition for AES_KEYR1 register  ******************/
+#define AES_KEYR1_Pos            (0U)
+#define AES_KEYR1_Msk            (0xFFFFFFFFUL << AES_KEYR1_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR1                AES_KEYR1_Msk                                 /*!< AES Key Register 1 */
+
+/*******************  Bit definition for AES_KEYR2 register  ******************/
+#define AES_KEYR2_Pos            (0U)
+#define AES_KEYR2_Msk            (0xFFFFFFFFUL << AES_KEYR2_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR2                AES_KEYR2_Msk                                 /*!< AES Key Register 2 */
+
+/*******************  Bit definition for AES_KEYR3 register  ******************/
+#define AES_KEYR3_Pos            (0U)
+#define AES_KEYR3_Msk            (0xFFFFFFFFUL << AES_KEYR3_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR3                AES_KEYR3_Msk                                 /*!< AES Key Register 3 */
+
+/*******************  Bit definition for AES_KEYR4 register  ******************/
+#define AES_KEYR4_Pos            (0U)
+#define AES_KEYR4_Msk            (0xFFFFFFFFUL << AES_KEYR4_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR4                AES_KEYR4_Msk                                 /*!< AES Key Register 4 */
+
+/*******************  Bit definition for AES_KEYR5 register  ******************/
+#define AES_KEYR5_Pos            (0U)
+#define AES_KEYR5_Msk            (0xFFFFFFFFUL << AES_KEYR5_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR5                AES_KEYR5_Msk                                 /*!< AES Key Register 5 */
+
+/*******************  Bit definition for AES_KEYR6 register  ******************/
+#define AES_KEYR6_Pos            (0U)
+#define AES_KEYR6_Msk            (0xFFFFFFFFUL << AES_KEYR6_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR6                AES_KEYR6_Msk                                 /*!< AES Key Register 6 */
+
+/*******************  Bit definition for AES_KEYR7 register  ******************/
+#define AES_KEYR7_Pos            (0U)
+#define AES_KEYR7_Msk            (0xFFFFFFFFUL << AES_KEYR7_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR7                AES_KEYR7_Msk                                 /*!< AES Key Register 7 */
+
+/*******************  Bit definition for AES_IVR0 register   ******************/
+#define AES_IVR0_Pos             (0U)
+#define AES_IVR0_Msk             (0xFFFFFFFFUL << AES_IVR0_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR0                 AES_IVR0_Msk                                  /*!< AES Initialization Vector Register 0 */
+
+/*******************  Bit definition for AES_IVR1 register   ******************/
+#define AES_IVR1_Pos             (0U)
+#define AES_IVR1_Msk             (0xFFFFFFFFUL << AES_IVR1_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR1                 AES_IVR1_Msk                                  /*!< AES Initialization Vector Register 1 */
+
+/*******************  Bit definition for AES_IVR2 register   ******************/
+#define AES_IVR2_Pos             (0U)
+#define AES_IVR2_Msk             (0xFFFFFFFFUL << AES_IVR2_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR2                 AES_IVR2_Msk                                  /*!< AES Initialization Vector Register 2 */
+
+/*******************  Bit definition for AES_IVR3 register   ******************/
+#define AES_IVR3_Pos             (0U)
+#define AES_IVR3_Msk             (0xFFFFFFFFUL << AES_IVR3_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR3                 AES_IVR3_Msk                                  /*!< AES Initialization Vector Register 3 */
+
+/*******************  Bit definition for AES_SUSP0R register  ******************/
+#define AES_SUSP0R_Pos           (0U)
+#define AES_SUSP0R_Msk           (0xFFFFFFFFUL << AES_SUSP0R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP0R               AES_SUSP0R_Msk                                /*!< AES Suspend registers 0 */
+
+/*******************  Bit definition for AES_SUSP1R register  ******************/
+#define AES_SUSP1R_Pos           (0U)
+#define AES_SUSP1R_Msk           (0xFFFFFFFFUL << AES_SUSP1R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP1R               AES_SUSP1R_Msk                                /*!< AES Suspend registers 1 */
+
+/*******************  Bit definition for AES_SUSP2R register  ******************/
+#define AES_SUSP2R_Pos           (0U)
+#define AES_SUSP2R_Msk           (0xFFFFFFFFUL << AES_SUSP2R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP2R               AES_SUSP2R_Msk                                /*!< AES Suspend registers 2 */
+
+/*******************  Bit definition for AES_SUSP3R register  ******************/
+#define AES_SUSP3R_Pos           (0U)
+#define AES_SUSP3R_Msk           (0xFFFFFFFFUL << AES_SUSP3R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP3R               AES_SUSP3R_Msk                                /*!< AES Suspend registers 3 */
+
+/*******************  Bit definition for AES_SUSP4R register  ******************/
+#define AES_SUSP4R_Pos           (0U)
+#define AES_SUSP4R_Msk           (0xFFFFFFFFUL << AES_SUSP4R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP4R               AES_SUSP4R_Msk                                /*!< AES Suspend registers 4 */
+
+/*******************  Bit definition for AES_SUSP5R register  ******************/
+#define AES_SUSP5R_Pos           (0U)
+#define AES_SUSP5R_Msk           (0xFFFFFFFFUL << AES_SUSP5R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP5R               AES_SUSP5R_Msk                                /*!< AES Suspend registers 5 */
+
+/*******************  Bit definition for AES_SUSP6R register  ******************/
+#define AES_SUSP6R_Pos           (0U)
+#define AES_SUSP6R_Msk           (0xFFFFFFFFUL << AES_SUSP6R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP6R               AES_SUSP6R_Msk                                /*!< AES Suspend registers 6 */
+
+/*******************  Bit definition for AES_SUSP7R register  ******************/
+#define AES_SUSP7R_Pos           (0U)
+#define AES_SUSP7R_Msk           (0xFFFFFFFFUL << AES_SUSP7R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP7R               AES_SUSP7R_Msk                                /*!< AES Suspend registers 7 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define DMA_ISR_GIF1_Pos       (0U)
+#define DMA_ISR_GIF1_Msk       (0x1UL << DMA_ISR_GIF1_Pos)                     /*!< 0x00000001 */
+#define DMA_ISR_GIF1           DMA_ISR_GIF1_Msk                                /*!< Channel 1 Global interrupt flag */
+#define DMA_ISR_TCIF1_Pos      (1U)
+#define DMA_ISR_TCIF1_Msk      (0x1UL << DMA_ISR_TCIF1_Pos)                    /*!< 0x00000002 */
+#define DMA_ISR_TCIF1          DMA_ISR_TCIF1_Msk                               /*!< Channel 1 Transfer Complete flag */
+#define DMA_ISR_HTIF1_Pos      (2U)
+#define DMA_ISR_HTIF1_Msk      (0x1UL << DMA_ISR_HTIF1_Pos)                    /*!< 0x00000004 */
+#define DMA_ISR_HTIF1          DMA_ISR_HTIF1_Msk                               /*!< Channel 1 Half Transfer flag */
+#define DMA_ISR_TEIF1_Pos      (3U)
+#define DMA_ISR_TEIF1_Msk      (0x1UL << DMA_ISR_TEIF1_Pos)                    /*!< 0x00000008 */
+#define DMA_ISR_TEIF1          DMA_ISR_TEIF1_Msk                               /*!< Channel 1 Transfer Error flag */
+#define DMA_ISR_GIF2_Pos       (4U)
+#define DMA_ISR_GIF2_Msk       (0x1UL << DMA_ISR_GIF2_Pos)                     /*!< 0x00000010 */
+#define DMA_ISR_GIF2           DMA_ISR_GIF2_Msk                                /*!< Channel 2 Global interrupt flag */
+#define DMA_ISR_TCIF2_Pos      (5U)
+#define DMA_ISR_TCIF2_Msk      (0x1UL << DMA_ISR_TCIF2_Pos)                    /*!< 0x00000020 */
+#define DMA_ISR_TCIF2          DMA_ISR_TCIF2_Msk                               /*!< Channel 2 Transfer Complete flag */
+#define DMA_ISR_HTIF2_Pos      (6U)
+#define DMA_ISR_HTIF2_Msk      (0x1UL << DMA_ISR_HTIF2_Pos)                    /*!< 0x00000040 */
+#define DMA_ISR_HTIF2          DMA_ISR_HTIF2_Msk                               /*!< Channel 2 Half Transfer flag */
+#define DMA_ISR_TEIF2_Pos      (7U)
+#define DMA_ISR_TEIF2_Msk      (0x1UL << DMA_ISR_TEIF2_Pos)                    /*!< 0x00000080 */
+#define DMA_ISR_TEIF2          DMA_ISR_TEIF2_Msk                               /*!< Channel 2 Transfer Error flag */
+#define DMA_ISR_GIF3_Pos       (8U)
+#define DMA_ISR_GIF3_Msk       (0x1UL << DMA_ISR_GIF3_Pos)                     /*!< 0x00000100 */
+#define DMA_ISR_GIF3           DMA_ISR_GIF3_Msk                                /*!< Channel 3 Global interrupt flag */
+#define DMA_ISR_TCIF3_Pos      (9U)
+#define DMA_ISR_TCIF3_Msk      (0x1UL << DMA_ISR_TCIF3_Pos)                    /*!< 0x00000200 */
+#define DMA_ISR_TCIF3          DMA_ISR_TCIF3_Msk                               /*!< Channel 3 Transfer Complete flag */
+#define DMA_ISR_HTIF3_Pos      (10U)
+#define DMA_ISR_HTIF3_Msk      (0x1UL << DMA_ISR_HTIF3_Pos)                    /*!< 0x00000400 */
+#define DMA_ISR_HTIF3          DMA_ISR_HTIF3_Msk                               /*!< Channel 3 Half Transfer flag */
+#define DMA_ISR_TEIF3_Pos      (11U)
+#define DMA_ISR_TEIF3_Msk      (0x1UL << DMA_ISR_TEIF3_Pos)                    /*!< 0x00000800 */
+#define DMA_ISR_TEIF3          DMA_ISR_TEIF3_Msk                               /*!< Channel 3 Transfer Error flag */
+#define DMA_ISR_GIF4_Pos       (12U)
+#define DMA_ISR_GIF4_Msk       (0x1UL << DMA_ISR_GIF4_Pos)                     /*!< 0x00001000 */
+#define DMA_ISR_GIF4           DMA_ISR_GIF4_Msk                                /*!< Channel 4 Global interrupt flag */
+#define DMA_ISR_TCIF4_Pos      (13U)
+#define DMA_ISR_TCIF4_Msk      (0x1UL << DMA_ISR_TCIF4_Pos)                    /*!< 0x00002000 */
+#define DMA_ISR_TCIF4          DMA_ISR_TCIF4_Msk                               /*!< Channel 4 Transfer Complete flag */
+#define DMA_ISR_HTIF4_Pos      (14U)
+#define DMA_ISR_HTIF4_Msk      (0x1UL << DMA_ISR_HTIF4_Pos)                    /*!< 0x00004000 */
+#define DMA_ISR_HTIF4          DMA_ISR_HTIF4_Msk                               /*!< Channel 4 Half Transfer flag */
+#define DMA_ISR_TEIF4_Pos      (15U)
+#define DMA_ISR_TEIF4_Msk      (0x1UL << DMA_ISR_TEIF4_Pos)                    /*!< 0x00008000 */
+#define DMA_ISR_TEIF4          DMA_ISR_TEIF4_Msk                               /*!< Channel 4 Transfer Error flag */
+#define DMA_ISR_GIF5_Pos       (16U)
+#define DMA_ISR_GIF5_Msk       (0x1UL << DMA_ISR_GIF5_Pos)                     /*!< 0x00010000 */
+#define DMA_ISR_GIF5           DMA_ISR_GIF5_Msk                                /*!< Channel 5 Global interrupt flag */
+#define DMA_ISR_TCIF5_Pos      (17U)
+#define DMA_ISR_TCIF5_Msk      (0x1UL << DMA_ISR_TCIF5_Pos)                    /*!< 0x00020000 */
+#define DMA_ISR_TCIF5          DMA_ISR_TCIF5_Msk                               /*!< Channel 5 Transfer Complete flag */
+#define DMA_ISR_HTIF5_Pos      (18U)
+#define DMA_ISR_HTIF5_Msk      (0x1UL << DMA_ISR_HTIF5_Pos)                    /*!< 0x00040000 */
+#define DMA_ISR_HTIF5          DMA_ISR_HTIF5_Msk                               /*!< Channel 5 Half Transfer flag */
+#define DMA_ISR_TEIF5_Pos      (19U)
+#define DMA_ISR_TEIF5_Msk      (0x1UL << DMA_ISR_TEIF5_Pos)                    /*!< 0x00080000 */
+#define DMA_ISR_TEIF5          DMA_ISR_TEIF5_Msk                               /*!< Channel 5 Transfer Error flag */
+#define DMA_ISR_GIF6_Pos       (20U)
+#define DMA_ISR_GIF6_Msk       (0x1UL << DMA_ISR_GIF6_Pos)                     /*!< 0x00100000 */
+#define DMA_ISR_GIF6           DMA_ISR_GIF6_Msk                                /*!< Channel 6 Global interrupt flag */
+#define DMA_ISR_TCIF6_Pos      (21U)
+#define DMA_ISR_TCIF6_Msk      (0x1UL << DMA_ISR_TCIF6_Pos)                    /*!< 0x00200000 */
+#define DMA_ISR_TCIF6          DMA_ISR_TCIF6_Msk                               /*!< Channel 6 Transfer Complete flag */
+#define DMA_ISR_HTIF6_Pos      (22U)
+#define DMA_ISR_HTIF6_Msk      (0x1UL << DMA_ISR_HTIF6_Pos)                    /*!< 0x00400000 */
+#define DMA_ISR_HTIF6          DMA_ISR_HTIF6_Msk                               /*!< Channel 6 Half Transfer flag */
+#define DMA_ISR_TEIF6_Pos      (23U)
+#define DMA_ISR_TEIF6_Msk      (0x1UL << DMA_ISR_TEIF6_Pos)                    /*!< 0x00800000 */
+#define DMA_ISR_TEIF6          DMA_ISR_TEIF6_Msk                               /*!< Channel 6 Transfer Error flag */
+#define DMA_ISR_GIF7_Pos       (24U)
+#define DMA_ISR_GIF7_Msk       (0x1UL << DMA_ISR_GIF7_Pos)                     /*!< 0x01000000 */
+#define DMA_ISR_GIF7           DMA_ISR_GIF7_Msk                                /*!< Channel 7 Global interrupt flag */
+#define DMA_ISR_TCIF7_Pos      (25U)
+#define DMA_ISR_TCIF7_Msk      (0x1UL << DMA_ISR_TCIF7_Pos)                    /*!< 0x02000000 */
+#define DMA_ISR_TCIF7          DMA_ISR_TCIF7_Msk                               /*!< Channel 7 Transfer Complete flag */
+#define DMA_ISR_HTIF7_Pos      (26U)
+#define DMA_ISR_HTIF7_Msk      (0x1UL << DMA_ISR_HTIF7_Pos)                    /*!< 0x04000000 */
+#define DMA_ISR_HTIF7          DMA_ISR_HTIF7_Msk                               /*!< Channel 7 Half Transfer flag */
+#define DMA_ISR_TEIF7_Pos      (27U)
+#define DMA_ISR_TEIF7_Msk      (0x1UL << DMA_ISR_TEIF7_Pos)                    /*!< 0x08000000 */
+#define DMA_ISR_TEIF7          DMA_ISR_TEIF7_Msk                               /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define DMA_IFCR_CGIF1_Pos     (0U)
+#define DMA_IFCR_CGIF1_Msk     (0x1UL << DMA_IFCR_CGIF1_Pos)                   /*!< 0x00000001 */
+#define DMA_IFCR_CGIF1         DMA_IFCR_CGIF1_Msk                              /*!< Channel 1 Global interrupt clear */
+#define DMA_IFCR_CTCIF1_Pos    (1U)
+#define DMA_IFCR_CTCIF1_Msk    (0x1UL << DMA_IFCR_CTCIF1_Pos)                  /*!< 0x00000002 */
+#define DMA_IFCR_CTCIF1        DMA_IFCR_CTCIF1_Msk                             /*!< Channel 1 Transfer Complete clear */
+#define DMA_IFCR_CHTIF1_Pos    (2U)
+#define DMA_IFCR_CHTIF1_Msk    (0x1UL << DMA_IFCR_CHTIF1_Pos)                  /*!< 0x00000004 */
+#define DMA_IFCR_CHTIF1        DMA_IFCR_CHTIF1_Msk                             /*!< Channel 1 Half Transfer clear */
+#define DMA_IFCR_CTEIF1_Pos    (3U)
+#define DMA_IFCR_CTEIF1_Msk    (0x1UL << DMA_IFCR_CTEIF1_Pos)                  /*!< 0x00000008 */
+#define DMA_IFCR_CTEIF1        DMA_IFCR_CTEIF1_Msk                             /*!< Channel 1 Transfer Error clear */
+#define DMA_IFCR_CGIF2_Pos     (4U)
+#define DMA_IFCR_CGIF2_Msk     (0x1UL << DMA_IFCR_CGIF2_Pos)                   /*!< 0x00000010 */
+#define DMA_IFCR_CGIF2         DMA_IFCR_CGIF2_Msk                              /*!< Channel 2 Global interrupt clear */
+#define DMA_IFCR_CTCIF2_Pos    (5U)
+#define DMA_IFCR_CTCIF2_Msk    (0x1UL << DMA_IFCR_CTCIF2_Pos)                  /*!< 0x00000020 */
+#define DMA_IFCR_CTCIF2        DMA_IFCR_CTCIF2_Msk                             /*!< Channel 2 Transfer Complete clear */
+#define DMA_IFCR_CHTIF2_Pos    (6U)
+#define DMA_IFCR_CHTIF2_Msk    (0x1UL << DMA_IFCR_CHTIF2_Pos)                  /*!< 0x00000040 */
+#define DMA_IFCR_CHTIF2        DMA_IFCR_CHTIF2_Msk                             /*!< Channel 2 Half Transfer clear */
+#define DMA_IFCR_CTEIF2_Pos    (7U)
+#define DMA_IFCR_CTEIF2_Msk    (0x1UL << DMA_IFCR_CTEIF2_Pos)                  /*!< 0x00000080 */
+#define DMA_IFCR_CTEIF2        DMA_IFCR_CTEIF2_Msk                             /*!< Channel 2 Transfer Error clear */
+#define DMA_IFCR_CGIF3_Pos     (8U)
+#define DMA_IFCR_CGIF3_Msk     (0x1UL << DMA_IFCR_CGIF3_Pos)                   /*!< 0x00000100 */
+#define DMA_IFCR_CGIF3         DMA_IFCR_CGIF3_Msk                              /*!< Channel 3 Global interrupt clear */
+#define DMA_IFCR_CTCIF3_Pos    (9U)
+#define DMA_IFCR_CTCIF3_Msk    (0x1UL << DMA_IFCR_CTCIF3_Pos)                  /*!< 0x00000200 */
+#define DMA_IFCR_CTCIF3        DMA_IFCR_CTCIF3_Msk                             /*!< Channel 3 Transfer Complete clear */
+#define DMA_IFCR_CHTIF3_Pos    (10U)
+#define DMA_IFCR_CHTIF3_Msk    (0x1UL << DMA_IFCR_CHTIF3_Pos)                  /*!< 0x00000400 */
+#define DMA_IFCR_CHTIF3        DMA_IFCR_CHTIF3_Msk                             /*!< Channel 3 Half Transfer clear */
+#define DMA_IFCR_CTEIF3_Pos    (11U)
+#define DMA_IFCR_CTEIF3_Msk    (0x1UL << DMA_IFCR_CTEIF3_Pos)                  /*!< 0x00000800 */
+#define DMA_IFCR_CTEIF3        DMA_IFCR_CTEIF3_Msk                             /*!< Channel 3 Transfer Error clear */
+#define DMA_IFCR_CGIF4_Pos     (12U)
+#define DMA_IFCR_CGIF4_Msk     (0x1UL << DMA_IFCR_CGIF4_Pos)                   /*!< 0x00001000 */
+#define DMA_IFCR_CGIF4         DMA_IFCR_CGIF4_Msk                              /*!< Channel 4 Global interrupt clear */
+#define DMA_IFCR_CTCIF4_Pos    (13U)
+#define DMA_IFCR_CTCIF4_Msk    (0x1UL << DMA_IFCR_CTCIF4_Pos)                  /*!< 0x00002000 */
+#define DMA_IFCR_CTCIF4        DMA_IFCR_CTCIF4_Msk                             /*!< Channel 4 Transfer Complete clear */
+#define DMA_IFCR_CHTIF4_Pos    (14U)
+#define DMA_IFCR_CHTIF4_Msk    (0x1UL << DMA_IFCR_CHTIF4_Pos)                  /*!< 0x00004000 */
+#define DMA_IFCR_CHTIF4        DMA_IFCR_CHTIF4_Msk                             /*!< Channel 4 Half Transfer clear */
+#define DMA_IFCR_CTEIF4_Pos    (15U)
+#define DMA_IFCR_CTEIF4_Msk    (0x1UL << DMA_IFCR_CTEIF4_Pos)                  /*!< 0x00008000 */
+#define DMA_IFCR_CTEIF4        DMA_IFCR_CTEIF4_Msk                             /*!< Channel 4 Transfer Error clear */
+#define DMA_IFCR_CGIF5_Pos     (16U)
+#define DMA_IFCR_CGIF5_Msk     (0x1UL << DMA_IFCR_CGIF5_Pos)                   /*!< 0x00010000 */
+#define DMA_IFCR_CGIF5         DMA_IFCR_CGIF5_Msk                              /*!< Channel 5 Global interrupt clear */
+#define DMA_IFCR_CTCIF5_Pos    (17U)
+#define DMA_IFCR_CTCIF5_Msk    (0x1UL << DMA_IFCR_CTCIF5_Pos)                  /*!< 0x00020000 */
+#define DMA_IFCR_CTCIF5        DMA_IFCR_CTCIF5_Msk                             /*!< Channel 5 Transfer Complete clear */
+#define DMA_IFCR_CHTIF5_Pos    (18U)
+#define DMA_IFCR_CHTIF5_Msk    (0x1UL << DMA_IFCR_CHTIF5_Pos)                  /*!< 0x00040000 */
+#define DMA_IFCR_CHTIF5        DMA_IFCR_CHTIF5_Msk                             /*!< Channel 5 Half Transfer clear */
+#define DMA_IFCR_CTEIF5_Pos    (19U)
+#define DMA_IFCR_CTEIF5_Msk    (0x1UL << DMA_IFCR_CTEIF5_Pos)                  /*!< 0x00080000 */
+#define DMA_IFCR_CTEIF5        DMA_IFCR_CTEIF5_Msk                             /*!< Channel 5 Transfer Error clear */
+#define DMA_IFCR_CGIF6_Pos     (20U)
+#define DMA_IFCR_CGIF6_Msk     (0x1UL << DMA_IFCR_CGIF6_Pos)                   /*!< 0x00100000 */
+#define DMA_IFCR_CGIF6         DMA_IFCR_CGIF6_Msk                              /*!< Channel 6 Global interrupt clear */
+#define DMA_IFCR_CTCIF6_Pos    (21U)
+#define DMA_IFCR_CTCIF6_Msk    (0x1UL << DMA_IFCR_CTCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_IFCR_CTCIF6        DMA_IFCR_CTCIF6_Msk                             /*!< Channel 6 Transfer Complete clear */
+#define DMA_IFCR_CHTIF6_Pos    (22U)
+#define DMA_IFCR_CHTIF6_Msk    (0x1UL << DMA_IFCR_CHTIF6_Pos)                  /*!< 0x00400000 */
+#define DMA_IFCR_CHTIF6        DMA_IFCR_CHTIF6_Msk                             /*!< Channel 6 Half Transfer clear */
+#define DMA_IFCR_CTEIF6_Pos    (23U)
+#define DMA_IFCR_CTEIF6_Msk    (0x1UL << DMA_IFCR_CTEIF6_Pos)                  /*!< 0x00800000 */
+#define DMA_IFCR_CTEIF6        DMA_IFCR_CTEIF6_Msk                             /*!< Channel 6 Transfer Error clear */
+#define DMA_IFCR_CGIF7_Pos     (24U)
+#define DMA_IFCR_CGIF7_Msk     (0x1UL << DMA_IFCR_CGIF7_Pos)                   /*!< 0x01000000 */
+#define DMA_IFCR_CGIF7         DMA_IFCR_CGIF7_Msk                              /*!< Channel 7 Global interrupt clear */
+#define DMA_IFCR_CTCIF7_Pos    (25U)
+#define DMA_IFCR_CTCIF7_Msk    (0x1UL << DMA_IFCR_CTCIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_IFCR_CTCIF7        DMA_IFCR_CTCIF7_Msk                             /*!< Channel 7 Transfer Complete clear */
+#define DMA_IFCR_CHTIF7_Pos    (26U)
+#define DMA_IFCR_CHTIF7_Msk    (0x1UL << DMA_IFCR_CHTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_IFCR_CHTIF7        DMA_IFCR_CHTIF7_Msk                             /*!< Channel 7 Half Transfer clear */
+#define DMA_IFCR_CTEIF7_Pos    (27U)
+#define DMA_IFCR_CTEIF7_Msk    (0x1UL << DMA_IFCR_CTEIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_IFCR_CTEIF7        DMA_IFCR_CTEIF7_Msk                             /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define DMA_CCR_EN_Pos         (0U)
+#define DMA_CCR_EN_Msk         (0x1UL << DMA_CCR_EN_Pos)                       /*!< 0x00000001 */
+#define DMA_CCR_EN             DMA_CCR_EN_Msk                                  /*!< Channel enable                      */
+#define DMA_CCR_TCIE_Pos       (1U)
+#define DMA_CCR_TCIE_Msk       (0x1UL << DMA_CCR_TCIE_Pos)                     /*!< 0x00000002 */
+#define DMA_CCR_TCIE           DMA_CCR_TCIE_Msk                                /*!< Transfer complete interrupt enable  */
+#define DMA_CCR_HTIE_Pos       (2U)
+#define DMA_CCR_HTIE_Msk       (0x1UL << DMA_CCR_HTIE_Pos)                     /*!< 0x00000004 */
+#define DMA_CCR_HTIE           DMA_CCR_HTIE_Msk                                /*!< Half Transfer interrupt enable      */
+#define DMA_CCR_TEIE_Pos       (3U)
+#define DMA_CCR_TEIE_Msk       (0x1UL << DMA_CCR_TEIE_Pos)                     /*!< 0x00000008 */
+#define DMA_CCR_TEIE           DMA_CCR_TEIE_Msk                                /*!< Transfer error interrupt enable     */
+#define DMA_CCR_DIR_Pos        (4U)
+#define DMA_CCR_DIR_Msk        (0x1UL << DMA_CCR_DIR_Pos)                      /*!< 0x00000010 */
+#define DMA_CCR_DIR            DMA_CCR_DIR_Msk                                 /*!< Data transfer direction             */
+#define DMA_CCR_CIRC_Pos       (5U)
+#define DMA_CCR_CIRC_Msk       (0x1UL << DMA_CCR_CIRC_Pos)                     /*!< 0x00000020 */
+#define DMA_CCR_CIRC           DMA_CCR_CIRC_Msk                                /*!< Circular mode                       */
+#define DMA_CCR_PINC_Pos       (6U)
+#define DMA_CCR_PINC_Msk       (0x1UL << DMA_CCR_PINC_Pos)                     /*!< 0x00000040 */
+#define DMA_CCR_PINC           DMA_CCR_PINC_Msk                                /*!< Peripheral increment mode           */
+#define DMA_CCR_MINC_Pos       (7U)
+#define DMA_CCR_MINC_Msk       (0x1UL << DMA_CCR_MINC_Pos)                     /*!< 0x00000080 */
+#define DMA_CCR_MINC           DMA_CCR_MINC_Msk                                /*!< Memory increment mode               */
+
+#define DMA_CCR_PSIZE_Pos      (8U)
+#define DMA_CCR_PSIZE_Msk      (0x3UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000300 */
+#define DMA_CCR_PSIZE          DMA_CCR_PSIZE_Msk                               /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define DMA_CCR_PSIZE_0        (0x1U << DMA_CCR_PSIZE_Pos)                     /*!< 0x00000100 */
+#define DMA_CCR_PSIZE_1        (0x2U << DMA_CCR_PSIZE_Pos)                     /*!< 0x00000200 */
+
+#define DMA_CCR_MSIZE_Pos      (10U)
+#define DMA_CCR_MSIZE_Msk      (0x3UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000C00 */
+#define DMA_CCR_MSIZE          DMA_CCR_MSIZE_Msk                               /*!< MSIZE[1:0] bits (Memory size)       */
+#define DMA_CCR_MSIZE_0        (0x1U << DMA_CCR_MSIZE_Pos)                     /*!< 0x00000400 */
+#define DMA_CCR_MSIZE_1        (0x2U << DMA_CCR_MSIZE_Pos)                     /*!< 0x00000800 */
+
+#define DMA_CCR_PL_Pos         (12U)
+#define DMA_CCR_PL_Msk         (0x3UL << DMA_CCR_PL_Pos)                       /*!< 0x00003000 */
+#define DMA_CCR_PL             DMA_CCR_PL_Msk                                  /*!< PL[1:0] bits(Channel Priority level)*/
+#define DMA_CCR_PL_0           (0x1U << DMA_CCR_PL_Pos)                        /*!< 0x00001000 */
+#define DMA_CCR_PL_1           (0x2U << DMA_CCR_PL_Pos)                        /*!< 0x00002000 */
+
+#define DMA_CCR_MEM2MEM_Pos    (14U)
+#define DMA_CCR_MEM2MEM_Msk    (0x1UL << DMA_CCR_MEM2MEM_Pos)                  /*!< 0x00004000 */
+#define DMA_CCR_MEM2MEM        DMA_CCR_MEM2MEM_Msk                             /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define DMA_CNDTR_NDT_Pos      (0U)
+#define DMA_CNDTR_NDT_Msk      (0xFFFFUL << DMA_CNDTR_NDT_Pos)                 /*!< 0x0000FFFF */
+#define DMA_CNDTR_NDT          DMA_CNDTR_NDT_Msk                               /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define DMA_CPAR_PA_Pos        (0U)
+#define DMA_CPAR_PA_Msk        (0xFFFFFFFFUL << DMA_CPAR_PA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CPAR_PA            DMA_CPAR_PA_Msk                                 /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define DMA_CMAR_MA_Pos        (0U)
+#define DMA_CMAR_MA_Msk        (0xFFFFFFFFUL << DMA_CMAR_MA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CMAR_MA            DMA_CMAR_MA_Msk                                 /*!< Memory Address                      */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMAMUX Controller                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMAMUX_CxCR register  **************/
+#define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
+#define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk       /*!< DMA Request ID                       */
+#define DMAMUX_CxCR_DMAREQ_ID_0                (0x01U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_CxCR_DMAREQ_ID_1                (0x02U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_CxCR_DMAREQ_ID_2                (0x04U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_CxCR_DMAREQ_ID_3                (0x08U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_CxCR_DMAREQ_ID_4                (0x10U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_CxCR_DMAREQ_ID_5                (0x20U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
+#define DMAMUX_CxCR_SOIE_Pos                   (8U)
+#define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos) /*!< 0x00000100 */
+#define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk            /*!< Synchro overrun interrupt enable     */
+#define DMAMUX_CxCR_EGE_Pos                    (9U)
+#define DMAMUX_CxCR_EGE_Msk                    (0x1UL << DMAMUX_CxCR_EGE_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CxCR_EGE                        DMAMUX_CxCR_EGE_Msk             /*!< Event generation interrupt enable    */
+#define DMAMUX_CxCR_SE_Pos                     (16U)
+#define DMAMUX_CxCR_SE_Msk                     (0x1UL << DMAMUX_CxCR_SE_Pos)   /*!< 0x00010000 */
+#define DMAMUX_CxCR_SE                         DMAMUX_CxCR_SE_Msk              /*!< Synchronization enable               */
+#define DMAMUX_CxCR_SPOL_Pos                   (17U)
+#define DMAMUX_CxCR_SPOL_Msk                   (0x3UL << DMAMUX_CxCR_SPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_CxCR_SPOL                       DMAMUX_CxCR_SPOL_Msk            /*!< Synchronization polarity             */
+#define DMAMUX_CxCR_SPOL_0                     (0x1U << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00020000 */
+#define DMAMUX_CxCR_SPOL_1                     (0x2U << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00040000 */
+#define DMAMUX_CxCR_NBREQ_Pos                  (19U)
+#define DMAMUX_CxCR_NBREQ_Msk                  (0x1FUL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_CxCR_NBREQ                      DMAMUX_CxCR_NBREQ_Msk           /*!< Number of request                    */
+#define DMAMUX_CxCR_NBREQ_0                    (0x01U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_CxCR_NBREQ_1                    (0x02U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_CxCR_NBREQ_2                    (0x04U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_CxCR_NBREQ_3                    (0x08U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_CxCR_NBREQ_4                    (0x10U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00800000 */
+#define DMAMUX_CxCR_SYNC_ID_Pos                (24U)
+#define DMAMUX_CxCR_SYNC_ID_Msk                (0x1FUL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x1F000000 */
+#define DMAMUX_CxCR_SYNC_ID                    DMAMUX_CxCR_SYNC_ID_Msk         /*!< Synchronization ID                   */
+#define DMAMUX_CxCR_SYNC_ID_0                  (0x01U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x01000000 */
+#define DMAMUX_CxCR_SYNC_ID_1                  (0x02U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x02000000 */
+#define DMAMUX_CxCR_SYNC_ID_2                  (0x04U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x04000000 */
+#define DMAMUX_CxCR_SYNC_ID_3                  (0x08U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x08000000 */
+#define DMAMUX_CxCR_SYNC_ID_4                  (0x10U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x10000000 */
+
+/*******************  Bits definition for DMAMUX_CSR register  **************/
+#define DMAMUX_CSR_SOF0_Pos                    (0U)
+#define DMAMUX_CSR_SOF0_Msk                    (0x1UL << DMAMUX_CSR_SOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CSR_SOF0                        DMAMUX_CSR_SOF0_Msk             /*!< Synchronization Overrun Flag 0       */
+#define DMAMUX_CSR_SOF1_Pos                    (1U)
+#define DMAMUX_CSR_SOF1_Msk                    (0x1UL << DMAMUX_CSR_SOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CSR_SOF1                        DMAMUX_CSR_SOF1_Msk             /*!< Synchronization Overrun Flag 1       */
+#define DMAMUX_CSR_SOF2_Pos                    (2U)
+#define DMAMUX_CSR_SOF2_Msk                    (0x1UL << DMAMUX_CSR_SOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CSR_SOF2                        DMAMUX_CSR_SOF2_Msk             /*!< Synchronization Overrun Flag 2       */
+#define DMAMUX_CSR_SOF3_Pos                    (3U)
+#define DMAMUX_CSR_SOF3_Msk                    (0x1UL << DMAMUX_CSR_SOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CSR_SOF3                        DMAMUX_CSR_SOF3_Msk             /*!< Synchronization Overrun Flag 3       */
+#define DMAMUX_CSR_SOF4_Pos                    (4U)
+#define DMAMUX_CSR_SOF4_Msk                    (0x1UL << DMAMUX_CSR_SOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CSR_SOF4                        DMAMUX_CSR_SOF4_Msk             /*!< Synchronization Overrun Flag 4       */
+#define DMAMUX_CSR_SOF5_Pos                    (5U)
+#define DMAMUX_CSR_SOF5_Msk                    (0x1UL << DMAMUX_CSR_SOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CSR_SOF5                        DMAMUX_CSR_SOF5_Msk             /*!< Synchronization Overrun Flag 5       */
+#define DMAMUX_CSR_SOF6_Pos                    (6U)
+#define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+
+/********************  Bits definition for DMAMUX_CFR register  **************/
+#define DMAMUX_CFR_CSOF0_Pos                   (0U)
+#define DMAMUX_CFR_CSOF0_Msk                   (0x1UL << DMAMUX_CFR_CSOF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_CFR_CSOF0                       DMAMUX_CFR_CSOF0_Msk            /*!< Clear Overrun Flag 0                 */
+#define DMAMUX_CFR_CSOF1_Pos                   (1U)
+#define DMAMUX_CFR_CSOF1_Msk                   (0x1UL << DMAMUX_CFR_CSOF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_CFR_CSOF1                       DMAMUX_CFR_CSOF1_Msk            /*!< Clear Overrun Flag 1                 */
+#define DMAMUX_CFR_CSOF2_Pos                   (2U)
+#define DMAMUX_CFR_CSOF2_Msk                   (0x1UL << DMAMUX_CFR_CSOF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_CFR_CSOF2                       DMAMUX_CFR_CSOF2_Msk            /*!< Clear Overrun Flag 2                 */
+#define DMAMUX_CFR_CSOF3_Pos                   (3U)
+#define DMAMUX_CFR_CSOF3_Msk                   (0x1UL << DMAMUX_CFR_CSOF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_CFR_CSOF3                       DMAMUX_CFR_CSOF3_Msk            /*!< Clear Overrun Flag 3                 */
+#define DMAMUX_CFR_CSOF4_Pos                   (4U)
+#define DMAMUX_CFR_CSOF4_Msk                   (0x1UL << DMAMUX_CFR_CSOF4_Pos) /*!< 0x00000010 */
+#define DMAMUX_CFR_CSOF4                       DMAMUX_CFR_CSOF4_Msk            /*!< Clear Overrun Flag 4                 */
+#define DMAMUX_CFR_CSOF5_Pos                   (5U)
+#define DMAMUX_CFR_CSOF5_Msk                   (0x1UL << DMAMUX_CFR_CSOF5_Pos) /*!< 0x00000020 */
+#define DMAMUX_CFR_CSOF5                       DMAMUX_CFR_CSOF5_Msk            /*!< Clear Overrun Flag 5                 */
+#define DMAMUX_CFR_CSOF6_Pos                   (6U)
+#define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos) /*!< 0x00000040 */
+#define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk            /*!< Clear Overrun Flag 6                 */
+
+/********************  Bits definition for DMAMUX_RGxCR register  ************/
+#define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
+#define DMAMUX_RGxCR_SIG_ID_Msk                (0x1FUL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x0000001F */
+#define DMAMUX_RGxCR_SIG_ID                    DMAMUX_RGxCR_SIG_ID_Msk         /*!< Signal ID                            */
+#define DMAMUX_RGxCR_SIG_ID_0                  (0x01U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGxCR_SIG_ID_1                  (0x02U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGxCR_SIG_ID_2                  (0x04U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGxCR_SIG_ID_3                  (0x08U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGxCR_SIG_ID_4                  (0x10U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_RGxCR_OIE_Pos                   (8U)
+#define DMAMUX_RGxCR_OIE_Msk                   (0x1UL << DMAMUX_RGxCR_OIE_Pos) /*!< 0x00000100 */
+#define DMAMUX_RGxCR_OIE                       DMAMUX_RGxCR_OIE_Msk            /*!< Overrun interrupt enable             */
+#define DMAMUX_RGxCR_GE_Pos                    (16U)
+#define DMAMUX_RGxCR_GE_Msk                    (0x1UL << DMAMUX_RGxCR_GE_Pos)  /*!< 0x00010000 */
+#define DMAMUX_RGxCR_GE                        DMAMUX_RGxCR_GE_Msk             /*!< Generation enable                    */
+#define DMAMUX_RGxCR_GPOL_Pos                  (17U)
+#define DMAMUX_RGxCR_GPOL_Msk                  (0x3UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_RGxCR_GPOL                      DMAMUX_RGxCR_GPOL_Msk           /*!< Generation polarity                  */
+#define DMAMUX_RGxCR_GPOL_0                    (0x1U << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00020000 */
+#define DMAMUX_RGxCR_GPOL_1                    (0x2U << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00040000 */
+#define DMAMUX_RGxCR_GNBREQ_Pos                (19U)
+#define DMAMUX_RGxCR_GNBREQ_Msk                (0x1FUL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_RGxCR_GNBREQ                    DMAMUX_RGxCR_GNBREQ_Msk          /*!< Number of request                    */
+#define DMAMUX_RGxCR_GNBREQ_0                  (0x01U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_RGxCR_GNBREQ_1                  (0x02U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_RGxCR_GNBREQ_2                  (0x04U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_RGxCR_GNBREQ_3                  (0x08U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_RGxCR_GNBREQ_4                  (0x10U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00800000 */
+
+/********************  Bits definition for DMAMUX_RGSR register  **************/
+#define DMAMUX_RGSR_OF0_Pos                    (0U)
+#define DMAMUX_RGSR_OF0_Msk                    (0x1UL << DMAMUX_RGSR_OF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_RGSR_OF0                        DMAMUX_RGSR_OF0_Msk             /*!< Overrun flag 0                       */
+#define DMAMUX_RGSR_OF1_Pos                    (1U)
+#define DMAMUX_RGSR_OF1_Msk                    (0x1UL << DMAMUX_RGSR_OF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_RGSR_OF1                        DMAMUX_RGSR_OF1_Msk             /*!< Overrun flag 1                       */
+#define DMAMUX_RGSR_OF2_Pos                    (2U)
+#define DMAMUX_RGSR_OF2_Msk                    (0x1UL << DMAMUX_RGSR_OF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_RGSR_OF2                        DMAMUX_RGSR_OF2_Msk             /*!< Overrun flag 2                       */
+#define DMAMUX_RGSR_OF3_Pos                    (3U)
+#define DMAMUX_RGSR_OF3_Msk                    (0x1UL << DMAMUX_RGSR_OF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_RGSR_OF3                        DMAMUX_RGSR_OF3_Msk             /*!< Overrun flag 3                       */
+
+/********************  Bits definition for DMAMUX_RGCFR register  **************/
+#define DMAMUX_RGCFR_COF0_Pos                  (0U)
+#define DMAMUX_RGCFR_COF0_Msk                  (0x1UL << DMAMUX_RGCFR_COF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGCFR_COF0                      DMAMUX_RGCFR_COF0_Msk           /*!< Clear Overrun flag 0                 */
+#define DMAMUX_RGCFR_COF1_Pos                  (1U)
+#define DMAMUX_RGCFR_COF1_Msk                  (0x1UL << DMAMUX_RGCFR_COF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGCFR_COF1                      DMAMUX_RGCFR_COF1_Msk           /*!< Clear Overrun flag 1                 */
+#define DMAMUX_RGCFR_COF2_Pos                  (2U)
+#define DMAMUX_RGCFR_COF2_Msk                  (0x1UL << DMAMUX_RGCFR_COF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGCFR_COF2                      DMAMUX_RGCFR_COF2_Msk           /*!< Clear Overrun flag 2                 */
+#define DMAMUX_RGCFR_COF3_Pos                  (3U)
+#define DMAMUX_RGCFR_COF3_Msk                  (0x1UL << DMAMUX_RGCFR_COF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGCFR_COF3                      DMAMUX_RGCFR_COF3_Msk           /*!< Clear Overrun flag 3                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+
+/******************  Bit definition for EXTI_RTSR1 register  ******************/
+#define EXTI_RTSR1_RT_Pos        (0U)
+#define EXTI_RTSR1_RT_Msk        (0x803FFFFFUL << EXTI_RTSR1_RT_Pos)           /*!< 0x803FFFFF */
+#define EXTI_RTSR1_RT            EXTI_RTSR1_RT_Msk                             /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR1_RT0_Pos       (0U)
+#define EXTI_RTSR1_RT0_Msk       (0x1UL << EXTI_RTSR1_RT0_Pos)                 /*!< 0x00000001 */
+#define EXTI_RTSR1_RT0           EXTI_RTSR1_RT0_Msk                            /*!< Rising trigger event configuration bit of line 0 */
+#define EXTI_RTSR1_RT1_Pos       (1U)
+#define EXTI_RTSR1_RT1_Msk       (0x1UL << EXTI_RTSR1_RT1_Pos)                 /*!< 0x00000002 */
+#define EXTI_RTSR1_RT1           EXTI_RTSR1_RT1_Msk                            /*!< Rising trigger event configuration bit of line 1 */
+#define EXTI_RTSR1_RT2_Pos       (2U)
+#define EXTI_RTSR1_RT2_Msk       (0x1UL << EXTI_RTSR1_RT2_Pos)                 /*!< 0x00000004 */
+#define EXTI_RTSR1_RT2           EXTI_RTSR1_RT2_Msk                            /*!< Rising trigger event configuration bit of line 2 */
+#define EXTI_RTSR1_RT3_Pos       (3U)
+#define EXTI_RTSR1_RT3_Msk       (0x1UL << EXTI_RTSR1_RT3_Pos)                 /*!< 0x00000008 */
+#define EXTI_RTSR1_RT3           EXTI_RTSR1_RT3_Msk                            /*!< Rising trigger event configuration bit of line 3 */
+#define EXTI_RTSR1_RT4_Pos       (4U)
+#define EXTI_RTSR1_RT4_Msk       (0x1UL << EXTI_RTSR1_RT4_Pos)                 /*!< 0x00000010 */
+#define EXTI_RTSR1_RT4           EXTI_RTSR1_RT4_Msk                            /*!< Rising trigger event configuration bit of line 4 */
+#define EXTI_RTSR1_RT5_Pos       (5U)
+#define EXTI_RTSR1_RT5_Msk       (0x1UL << EXTI_RTSR1_RT5_Pos)                 /*!< 0x00000020 */
+#define EXTI_RTSR1_RT5           EXTI_RTSR1_RT5_Msk                            /*!< Rising trigger event configuration bit of line 5 */
+#define EXTI_RTSR1_RT6_Pos       (6U)
+#define EXTI_RTSR1_RT6_Msk       (0x1UL << EXTI_RTSR1_RT6_Pos)                 /*!< 0x00000040 */
+#define EXTI_RTSR1_RT6           EXTI_RTSR1_RT6_Msk                            /*!< Rising trigger event configuration bit of line 6 */
+#define EXTI_RTSR1_RT7_Pos       (7U)
+#define EXTI_RTSR1_RT7_Msk       (0x1UL << EXTI_RTSR1_RT7_Pos)                 /*!< 0x00000080 */
+#define EXTI_RTSR1_RT7           EXTI_RTSR1_RT7_Msk                            /*!< Rising trigger event configuration bit of line 7 */
+#define EXTI_RTSR1_RT8_Pos       (8U)
+#define EXTI_RTSR1_RT8_Msk       (0x1UL << EXTI_RTSR1_RT8_Pos)                 /*!< 0x00000100 */
+#define EXTI_RTSR1_RT8           EXTI_RTSR1_RT8_Msk                            /*!< Rising trigger event configuration bit of line 8 */
+#define EXTI_RTSR1_RT9_Pos       (9U)
+#define EXTI_RTSR1_RT9_Msk       (0x1UL << EXTI_RTSR1_RT9_Pos)                 /*!< 0x00000200 */
+#define EXTI_RTSR1_RT9           EXTI_RTSR1_RT9_Msk                            /*!< Rising trigger event configuration bit of line 9 */
+#define EXTI_RTSR1_RT10_Pos      (10U)
+#define EXTI_RTSR1_RT10_Msk      (0x1UL << EXTI_RTSR1_RT10_Pos)                /*!< 0x00000400 */
+#define EXTI_RTSR1_RT10          EXTI_RTSR1_RT10_Msk                           /*!< Rising trigger event configuration bit of line 10 */
+#define EXTI_RTSR1_RT11_Pos      (11U)
+#define EXTI_RTSR1_RT11_Msk      (0x1UL << EXTI_RTSR1_RT11_Pos)                /*!< 0x00000800 */
+#define EXTI_RTSR1_RT11          EXTI_RTSR1_RT11_Msk                           /*!< Rising trigger event configuration bit of line 11 */
+#define EXTI_RTSR1_RT12_Pos      (12U)
+#define EXTI_RTSR1_RT12_Msk      (0x1UL << EXTI_RTSR1_RT12_Pos)                /*!< 0x00001000 */
+#define EXTI_RTSR1_RT12          EXTI_RTSR1_RT12_Msk                           /*!< Rising trigger event configuration bit of line 12 */
+#define EXTI_RTSR1_RT13_Pos      (13U)
+#define EXTI_RTSR1_RT13_Msk      (0x1UL << EXTI_RTSR1_RT13_Pos)                /*!< 0x00002000 */
+#define EXTI_RTSR1_RT13          EXTI_RTSR1_RT13_Msk                           /*!< Rising trigger event configuration bit of line 13 */
+#define EXTI_RTSR1_RT14_Pos      (14U)
+#define EXTI_RTSR1_RT14_Msk      (0x1UL << EXTI_RTSR1_RT14_Pos)                /*!< 0x00004000 */
+#define EXTI_RTSR1_RT14          EXTI_RTSR1_RT14_Msk                           /*!< Rising trigger event configuration bit of line 14 */
+#define EXTI_RTSR1_RT15_Pos      (15U)
+#define EXTI_RTSR1_RT15_Msk      (0x1UL << EXTI_RTSR1_RT15_Pos)                /*!< 0x00008000 */
+#define EXTI_RTSR1_RT15          EXTI_RTSR1_RT15_Msk                           /*!< Rising trigger event configuration bit of line 15 */
+#define EXTI_RTSR1_RT16_Pos      (16U)
+#define EXTI_RTSR1_RT16_Msk      (0x1UL << EXTI_RTSR1_RT16_Pos)                /*!< 0x00010000 */
+#define EXTI_RTSR1_RT16          EXTI_RTSR1_RT16_Msk                           /*!< Rising trigger event configuration bit of line 16 */
+#define EXTI_RTSR1_RT17_Pos      (17U)
+#define EXTI_RTSR1_RT17_Msk      (0x1UL << EXTI_RTSR1_RT17_Pos)                /*!< 0x00020000 */
+#define EXTI_RTSR1_RT17          EXTI_RTSR1_RT17_Msk                           /*!< Rising trigger event configuration bit of line 17 */
+#define EXTI_RTSR1_RT18_Pos      (18U)
+#define EXTI_RTSR1_RT18_Msk      (0x1UL << EXTI_RTSR1_RT18_Pos)                /*!< 0x00040000 */
+#define EXTI_RTSR1_RT18          EXTI_RTSR1_RT18_Msk                           /*!< Rising trigger event configuration bit of line 18 */
+#define EXTI_RTSR1_RT19_Pos      (19U)
+#define EXTI_RTSR1_RT19_Msk      (0x1UL << EXTI_RTSR1_RT19_Pos)                /*!< 0x00080000 */
+#define EXTI_RTSR1_RT19          EXTI_RTSR1_RT19_Msk                           /*!< Rising trigger event configuration bit of line 19 */
+#define EXTI_RTSR1_RT31_Pos      (31U)
+#define EXTI_RTSR1_RT31_Msk      (0x1UL << EXTI_RTSR1_RT31_Pos)                /*!< 0x80000000 */
+#define EXTI_RTSR1_RT31          EXTI_RTSR1_RT31_Msk                           /*!< Rising trigger event configuration bit of line 31 */
+
+/******************  Bit definition for EXTI_FTSR1 register  ******************/
+#define EXTI_FTSR1_FT_Pos        (0U)
+#define EXTI_FTSR1_FT_Msk        (0x803FFFFFUL << EXTI_FTSR1_FT_Pos)           /*!< 0x803FFFFF */
+#define EXTI_FTSR1_FT            EXTI_FTSR1_FT_Msk                             /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR1_FT0_Pos       (0U)
+#define EXTI_FTSR1_FT0_Msk       (0x1UL << EXTI_FTSR1_FT0_Pos)                 /*!< 0x00000001 */
+#define EXTI_FTSR1_FT0           EXTI_FTSR1_FT0_Msk                            /*!< Falling trigger event configuration bit of line 0 */
+#define EXTI_FTSR1_FT1_Pos       (1U)
+#define EXTI_FTSR1_FT1_Msk       (0x1UL << EXTI_FTSR1_FT1_Pos)                 /*!< 0x00000002 */
+#define EXTI_FTSR1_FT1           EXTI_FTSR1_FT1_Msk                            /*!< Falling trigger event configuration bit of line 1 */
+#define EXTI_FTSR1_FT2_Pos       (2U)
+#define EXTI_FTSR1_FT2_Msk       (0x1UL << EXTI_FTSR1_FT2_Pos)                 /*!< 0x00000004 */
+#define EXTI_FTSR1_FT2           EXTI_FTSR1_FT2_Msk                            /*!< Falling trigger event configuration bit of line 2 */
+#define EXTI_FTSR1_FT3_Pos       (3U)
+#define EXTI_FTSR1_FT3_Msk       (0x1UL << EXTI_FTSR1_FT3_Pos)                 /*!< 0x00000008 */
+#define EXTI_FTSR1_FT3           EXTI_FTSR1_FT3_Msk                            /*!< Falling trigger event configuration bit of line 3 */
+#define EXTI_FTSR1_FT4_Pos       (4U)
+#define EXTI_FTSR1_FT4_Msk       (0x1UL << EXTI_FTSR1_FT4_Pos)                 /*!< 0x00000010 */
+#define EXTI_FTSR1_FT4           EXTI_FTSR1_FT4_Msk                            /*!< Falling trigger event configuration bit of line 4 */
+#define EXTI_FTSR1_FT5_Pos       (5U)
+#define EXTI_FTSR1_FT5_Msk       (0x1UL << EXTI_FTSR1_FT5_Pos)                 /*!< 0x00000020 */
+#define EXTI_FTSR1_FT5           EXTI_FTSR1_FT5_Msk                            /*!< Falling trigger event configuration bit of line 5 */
+#define EXTI_FTSR1_FT6_Pos       (6U)
+#define EXTI_FTSR1_FT6_Msk       (0x1UL << EXTI_FTSR1_FT6_Pos)                 /*!< 0x00000040 */
+#define EXTI_FTSR1_FT6           EXTI_FTSR1_FT6_Msk                            /*!< Falling trigger event configuration bit of line 6 */
+#define EXTI_FTSR1_FT7_Pos       (7U)
+#define EXTI_FTSR1_FT7_Msk       (0x1UL << EXTI_FTSR1_FT7_Pos)                 /*!< 0x00000080 */
+#define EXTI_FTSR1_FT7           EXTI_FTSR1_FT7_Msk                            /*!< Falling trigger event configuration bit of line 7 */
+#define EXTI_FTSR1_FT8_Pos       (8U)
+#define EXTI_FTSR1_FT8_Msk       (0x1UL << EXTI_FTSR1_FT8_Pos)                 /*!< 0x00000100 */
+#define EXTI_FTSR1_FT8           EXTI_FTSR1_FT8_Msk                            /*!< Falling trigger event configuration bit of line 8 */
+#define EXTI_FTSR1_FT9_Pos       (9U)
+#define EXTI_FTSR1_FT9_Msk       (0x1UL << EXTI_FTSR1_FT9_Pos)                 /*!< 0x00000200 */
+#define EXTI_FTSR1_FT9           EXTI_FTSR1_FT9_Msk                            /*!< Falling trigger event configuration bit of line 9 */
+#define EXTI_FTSR1_FT10_Pos      (10U)
+#define EXTI_FTSR1_FT10_Msk      (0x1UL << EXTI_FTSR1_FT10_Pos)                /*!< 0x00000400 */
+#define EXTI_FTSR1_FT10          EXTI_FTSR1_FT10_Msk                           /*!< Falling trigger event configuration bit of line 10 */
+#define EXTI_FTSR1_FT11_Pos      (11U)
+#define EXTI_FTSR1_FT11_Msk      (0x1UL << EXTI_FTSR1_FT11_Pos)                /*!< 0x00000800 */
+#define EXTI_FTSR1_FT11          EXTI_FTSR1_FT11_Msk                           /*!< Falling trigger event configuration bit of line 11 */
+#define EXTI_FTSR1_FT12_Pos      (12U)
+#define EXTI_FTSR1_FT12_Msk      (0x1UL << EXTI_FTSR1_FT12_Pos)                /*!< 0x00001000 */
+#define EXTI_FTSR1_FT12          EXTI_FTSR1_FT12_Msk                           /*!< Falling trigger event configuration bit of line 12 */
+#define EXTI_FTSR1_FT13_Pos      (13U)
+#define EXTI_FTSR1_FT13_Msk      (0x1UL << EXTI_FTSR1_FT13_Pos)                /*!< 0x00002000 */
+#define EXTI_FTSR1_FT13          EXTI_FTSR1_FT13_Msk                           /*!< Falling trigger event configuration bit of line 13 */
+#define EXTI_FTSR1_FT14_Pos      (14U)
+#define EXTI_FTSR1_FT14_Msk      (0x1UL << EXTI_FTSR1_FT14_Pos)                /*!< 0x00004000 */
+#define EXTI_FTSR1_FT14          EXTI_FTSR1_FT14_Msk                           /*!< Falling trigger event configuration bit of line 14 */
+#define EXTI_FTSR1_FT15_Pos      (15U)
+#define EXTI_FTSR1_FT15_Msk      (0x1UL << EXTI_FTSR1_FT15_Pos)                /*!< 0x00008000 */
+#define EXTI_FTSR1_FT15          EXTI_FTSR1_FT15_Msk                           /*!< Falling trigger event configuration bit of line 15 */
+#define EXTI_FTSR1_FT16_Pos      (16U)
+#define EXTI_FTSR1_FT16_Msk      (0x1UL << EXTI_FTSR1_FT16_Pos)                /*!< 0x00010000 */
+#define EXTI_FTSR1_FT16          EXTI_FTSR1_FT16_Msk                           /*!< Falling trigger event configuration bit of line 16 */
+#define EXTI_FTSR1_FT17_Pos      (17U)
+#define EXTI_FTSR1_FT17_Msk      (0x1UL << EXTI_FTSR1_FT17_Pos)                /*!< 0x00020000 */
+#define EXTI_FTSR1_FT17          EXTI_FTSR1_FT17_Msk                           /*!< Falling trigger event configuration bit of line 17 */
+#define EXTI_FTSR1_FT18_Pos      (18U)
+#define EXTI_FTSR1_FT18_Msk      (0x1UL << EXTI_FTSR1_FT18_Pos)                /*!< 0x00040000 */
+#define EXTI_FTSR1_FT18          EXTI_FTSR1_FT18_Msk                           /*!< Falling trigger event configuration bit of line 18 */
+#define EXTI_FTSR1_FT19_Pos      (19U)
+#define EXTI_FTSR1_FT19_Msk      (0x1UL << EXTI_FTSR1_FT19_Pos)                /*!< 0x00080000 */
+#define EXTI_FTSR1_FT19          EXTI_FTSR1_FT19_Msk                           /*!< Falling trigger event configuration bit of line 19 */
+#define EXTI_FTSR1_FT31_Pos      (31U)
+#define EXTI_FTSR1_FT31_Msk      (0x1UL << EXTI_FTSR1_FT31_Pos)                /*!< 0x80000000 */
+#define EXTI_FTSR1_FT31          EXTI_FTSR1_FT31_Msk                           /*!< Falling trigger event configuration bit of line 31 */
+
+/******************  Bit definition for EXTI_SWIER1 register  *****************/
+#define EXTI_SWIER1_SWI_Pos      (0U)
+#define EXTI_SWIER1_SWI_Msk      (0x803FFFFFUL << EXTI_SWIER1_SWI_Pos)         /*!< 0x803FFFFF */
+#define EXTI_SWIER1_SWI          EXTI_SWIER1_SWI_Msk                           /*!< Software interrupt */
+#define EXTI_SWIER1_SWI0_Pos     (0U)
+#define EXTI_SWIER1_SWI0_Msk     (0x1UL << EXTI_SWIER1_SWI0_Pos)               /*!< 0x00000001 */
+#define EXTI_SWIER1_SWI0         EXTI_SWIER1_SWI0_Msk                          /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER1_SWI1_Pos     (1U)
+#define EXTI_SWIER1_SWI1_Msk     (0x1UL << EXTI_SWIER1_SWI1_Pos)               /*!< 0x00000002 */
+#define EXTI_SWIER1_SWI1         EXTI_SWIER1_SWI1_Msk                          /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER1_SWI2_Pos     (2U)
+#define EXTI_SWIER1_SWI2_Msk     (0x1UL << EXTI_SWIER1_SWI2_Pos)               /*!< 0x00000004 */
+#define EXTI_SWIER1_SWI2         EXTI_SWIER1_SWI2_Msk                          /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER1_SWI3_Pos     (3U)
+#define EXTI_SWIER1_SWI3_Msk     (0x1UL << EXTI_SWIER1_SWI3_Pos)               /*!< 0x00000008 */
+#define EXTI_SWIER1_SWI3         EXTI_SWIER1_SWI3_Msk                          /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER1_SWI4_Pos     (4U)
+#define EXTI_SWIER1_SWI4_Msk     (0x1UL << EXTI_SWIER1_SWI4_Pos)               /*!< 0x00000010 */
+#define EXTI_SWIER1_SWI4         EXTI_SWIER1_SWI4_Msk                          /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER1_SWI5_Pos     (5U)
+#define EXTI_SWIER1_SWI5_Msk     (0x1UL << EXTI_SWIER1_SWI5_Pos)               /*!< 0x00000020 */
+#define EXTI_SWIER1_SWI5         EXTI_SWIER1_SWI5_Msk                          /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER1_SWI6_Pos     (6U)
+#define EXTI_SWIER1_SWI6_Msk     (0x1UL << EXTI_SWIER1_SWI6_Pos)               /*!< 0x00000040 */
+#define EXTI_SWIER1_SWI6         EXTI_SWIER1_SWI6_Msk                          /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER1_SWI7_Pos     (7U)
+#define EXTI_SWIER1_SWI7_Msk     (0x1UL << EXTI_SWIER1_SWI7_Pos)               /*!< 0x00000080 */
+#define EXTI_SWIER1_SWI7         EXTI_SWIER1_SWI7_Msk                          /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER1_SWI8_Pos     (8U)
+#define EXTI_SWIER1_SWI8_Msk     (0x1UL << EXTI_SWIER1_SWI8_Pos)               /*!< 0x00000100 */
+#define EXTI_SWIER1_SWI8         EXTI_SWIER1_SWI8_Msk                          /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER1_SWI9_Pos     (9U)
+#define EXTI_SWIER1_SWI9_Msk     (0x1UL << EXTI_SWIER1_SWI9_Pos)               /*!< 0x00000200 */
+#define EXTI_SWIER1_SWI9         EXTI_SWIER1_SWI9_Msk                          /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER1_SWI10_Pos    (10U)
+#define EXTI_SWIER1_SWI10_Msk    (0x1UL << EXTI_SWIER1_SWI10_Pos)              /*!< 0x00000400 */
+#define EXTI_SWIER1_SWI10        EXTI_SWIER1_SWI10_Msk                         /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER1_SWI11_Pos    (11U)
+#define EXTI_SWIER1_SWI11_Msk    (0x1UL << EXTI_SWIER1_SWI11_Pos)              /*!< 0x00000800 */
+#define EXTI_SWIER1_SWI11        EXTI_SWIER1_SWI11_Msk                         /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER1_SWI12_Pos    (12U)
+#define EXTI_SWIER1_SWI12_Msk    (0x1UL << EXTI_SWIER1_SWI12_Pos)              /*!< 0x00001000 */
+#define EXTI_SWIER1_SWI12        EXTI_SWIER1_SWI12_Msk                         /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER1_SWI13_Pos    (13U)
+#define EXTI_SWIER1_SWI13_Msk    (0x1UL << EXTI_SWIER1_SWI13_Pos)              /*!< 0x00002000 */
+#define EXTI_SWIER1_SWI13        EXTI_SWIER1_SWI13_Msk                         /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER1_SWI14_Pos    (14U)
+#define EXTI_SWIER1_SWI14_Msk    (0x1UL << EXTI_SWIER1_SWI14_Pos)              /*!< 0x00004000 */
+#define EXTI_SWIER1_SWI14        EXTI_SWIER1_SWI14_Msk                         /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER1_SWI15_Pos    (15U)
+#define EXTI_SWIER1_SWI15_Msk    (0x1UL << EXTI_SWIER1_SWI15_Pos)              /*!< 0x00008000 */
+#define EXTI_SWIER1_SWI15        EXTI_SWIER1_SWI15_Msk                         /*!< Software Interrupt on line 15 */
+#define EXTI_SWIER1_SWI16_Pos    (16U)
+#define EXTI_SWIER1_SWI16_Msk    (0x1UL << EXTI_SWIER1_SWI16_Pos)              /*!< 0x00010000 */
+#define EXTI_SWIER1_SWI16        EXTI_SWIER1_SWI16_Msk                         /*!< Software Interrupt on line 16 */
+#define EXTI_SWIER1_SWI17_Pos    (17U)
+#define EXTI_SWIER1_SWI17_Msk    (0x1UL << EXTI_SWIER1_SWI17_Pos)              /*!< 0x00020000 */
+#define EXTI_SWIER1_SWI17        EXTI_SWIER1_SWI17_Msk                         /*!< Software Interrupt on line 17 */
+#define EXTI_SWIER1_SWI18_Pos    (18U)
+#define EXTI_SWIER1_SWI18_Msk    (0x1UL << EXTI_SWIER1_SWI18_Pos)              /*!< 0x00040000 */
+#define EXTI_SWIER1_SWI18        EXTI_SWIER1_SWI18_Msk                         /*!< Software Interrupt on line 18 */
+#define EXTI_SWIER1_SWI19_Pos    (19U)
+#define EXTI_SWIER1_SWI19_Msk    (0x1UL << EXTI_SWIER1_SWI19_Pos)              /*!< 0x00080000 */
+#define EXTI_SWIER1_SWI19        EXTI_SWIER1_SWI19_Msk                         /*!< Software Interrupt on line 19 */
+#define EXTI_SWIER1_SWI31_Pos    (31U)
+#define EXTI_SWIER1_SWI31_Msk    (0x1UL << EXTI_SWIER1_SWI31_Pos)              /*!< 0x80000000 */
+#define EXTI_SWIER1_SWI31         EXTI_SWIER1_SWI31_Msk                        /*!< Software Interrupt on line 31 */
+
+/*******************  Bit definition for EXTI_PR1 register  *******************/
+#define EXTI_PR1_PIF_Pos         (0U)
+#define EXTI_PR1_PIF_Msk         (0x803FFFFFUL << EXTI_PR1_PIF_Pos)            /*!< 0x803FFFFF */
+#define EXTI_PR1_PIF             EXTI_PR1_PIF_Msk                              /*!< Pending bit */
+#define EXTI_PR1_PIF0_Pos        (0U)
+#define EXTI_PR1_PIF0_Msk        (0x1UL << EXTI_PR1_PIF0_Pos)                  /*!< 0x00000001 */
+#define EXTI_PR1_PIF0            EXTI_PR1_PIF0_Msk                             /*!< Pending bit for line 0 */
+#define EXTI_PR1_PIF1_Pos        (1U)
+#define EXTI_PR1_PIF1_Msk        (0x1UL << EXTI_PR1_PIF1_Pos)                  /*!< 0x00000002 */
+#define EXTI_PR1_PIF1            EXTI_PR1_PIF1_Msk                             /*!< Pending bit for line 1 */
+#define EXTI_PR1_PIF2_Pos        (2U)
+#define EXTI_PR1_PIF2_Msk        (0x1UL << EXTI_PR1_PIF2_Pos)                  /*!< 0x00000004 */
+#define EXTI_PR1_PIF2            EXTI_PR1_PIF2_Msk                             /*!< Pending bit for line 2 */
+#define EXTI_PR1_PIF3_Pos        (3U)
+#define EXTI_PR1_PIF3_Msk        (0x1UL << EXTI_PR1_PIF3_Pos)                  /*!< 0x00000008 */
+#define EXTI_PR1_PIF3            EXTI_PR1_PIF3_Msk                             /*!< Pending bit for line 3 */
+#define EXTI_PR1_PIF4_Pos        (4U)
+#define EXTI_PR1_PIF4_Msk        (0x1UL << EXTI_PR1_PIF4_Pos)                  /*!< 0x00000010 */
+#define EXTI_PR1_PIF4            EXTI_PR1_PIF4_Msk                             /*!< Pending bit for line 4 */
+#define EXTI_PR1_PIF5_Pos        (5U)
+#define EXTI_PR1_PIF5_Msk        (0x1UL << EXTI_PR1_PIF5_Pos)                  /*!< 0x00000020 */
+#define EXTI_PR1_PIF5            EXTI_PR1_PIF5_Msk                             /*!< Pending bit for line 5 */
+#define EXTI_PR1_PIF6_Pos        (6U)
+#define EXTI_PR1_PIF6_Msk        (0x1UL << EXTI_PR1_PIF6_Pos)                  /*!< 0x00000040 */
+#define EXTI_PR1_PIF6            EXTI_PR1_PIF6_Msk                             /*!< Pending bit for line 6 */
+#define EXTI_PR1_PIF7_Pos        (7U)
+#define EXTI_PR1_PIF7_Msk        (0x1UL << EXTI_PR1_PIF7_Pos)                  /*!< 0x00000080 */
+#define EXTI_PR1_PIF7            EXTI_PR1_PIF7_Msk                             /*!< Pending bit for line 7 */
+#define EXTI_PR1_PIF8_Pos        (8U)
+#define EXTI_PR1_PIF8_Msk        (0x1UL << EXTI_PR1_PIF8_Pos)                  /*!< 0x00000100 */
+#define EXTI_PR1_PIF8            EXTI_PR1_PIF8_Msk                             /*!< Pending bit for line 8 */
+#define EXTI_PR1_PIF9_Pos        (9U)
+#define EXTI_PR1_PIF9_Msk        (0x1UL << EXTI_PR1_PIF9_Pos)                  /*!< 0x00000200 */
+#define EXTI_PR1_PIF9            EXTI_PR1_PIF9_Msk                             /*!< Pending bit for line 9 */
+#define EXTI_PR1_PIF10_Pos       (10U)
+#define EXTI_PR1_PIF10_Msk       (0x1UL << EXTI_PR1_PIF10_Pos)                 /*!< 0x00000400 */
+#define EXTI_PR1_PIF10           EXTI_PR1_PIF10_Msk                            /*!< Pending bit for line 10 */
+#define EXTI_PR1_PIF11_Pos       (11U)
+#define EXTI_PR1_PIF11_Msk       (0x1UL << EXTI_PR1_PIF11_Pos)                 /*!< 0x00000800 */
+#define EXTI_PR1_PIF11           EXTI_PR1_PIF11_Msk                            /*!< Pending bit for line 11 */
+#define EXTI_PR1_PIF12_Pos       (12U)
+#define EXTI_PR1_PIF12_Msk       (0x1UL << EXTI_PR1_PIF12_Pos)                 /*!< 0x00001000 */
+#define EXTI_PR1_PIF12           EXTI_PR1_PIF12_Msk                            /*!< Pending bit for line 12 */
+#define EXTI_PR1_PIF13_Pos       (13U)
+#define EXTI_PR1_PIF13_Msk       (0x1UL << EXTI_PR1_PIF13_Pos)                 /*!< 0x00002000 */
+#define EXTI_PR1_PIF13           EXTI_PR1_PIF13_Msk                            /*!< Pending bit for line 13 */
+#define EXTI_PR1_PIF14_Pos       (14U)
+#define EXTI_PR1_PIF14_Msk       (0x1UL << EXTI_PR1_PIF14_Pos)                 /*!< 0x00004000 */
+#define EXTI_PR1_PIF14           EXTI_PR1_PIF14_Msk                            /*!< Pending bit for line 14 */
+#define EXTI_PR1_PIF15_Pos       (15U)
+#define EXTI_PR1_PIF15_Msk       (0x1UL << EXTI_PR1_PIF15_Pos)                 /*!< 0x00008000 */
+#define EXTI_PR1_PIF15           EXTI_PR1_PIF15_Msk                            /*!< Pending bit for line 15 */
+#define EXTI_PR1_PIF16_Pos       (16U)
+#define EXTI_PR1_PIF16_Msk       (0x1UL << EXTI_PR1_PIF16_Pos)                 /*!< 0x00010000 */
+#define EXTI_PR1_PIF16           EXTI_PR1_PIF16_Msk                            /*!< Pending bit for line 16 */
+#define EXTI_PR1_PIF17_Pos       (17U)
+#define EXTI_PR1_PIF17_Msk       (0x1UL << EXTI_PR1_PIF17_Pos)                 /*!< 0x00020000 */
+#define EXTI_PR1_PIF17           EXTI_PR1_PIF17_Msk                            /*!< Pending bit for line 17 */
+#define EXTI_PR1_PIF18_Pos       (18U)
+#define EXTI_PR1_PIF18_Msk       (0x1UL << EXTI_PR1_PIF18_Pos)                 /*!< 0x00040000 */
+#define EXTI_PR1_PIF18           EXTI_PR1_PIF18_Msk                            /*!< Pending bit for line 18 */
+#define EXTI_PR1_PIF19_Pos       (19U)
+#define EXTI_PR1_PIF19_Msk       (0x1UL << EXTI_PR1_PIF19_Pos)                 /*!< 0x00080000 */
+#define EXTI_PR1_PIF19           EXTI_PR1_PIF19_Msk                            /*!< Pending bit for line 19 */
+#define EXTI_PR1_PIF31_Pos       (31U)
+#define EXTI_PR1_PIF31_Msk       (0x1UL << EXTI_PR1_PIF31_Pos)                 /*!< 0x80000000 */
+#define EXTI_PR1_PIF31           EXTI_PR1_PIF31_Msk                            /*!< Pending bit for line 31 */
+
+/******************  Bit definition for EXTI_RTSR2 register  ******************/
+#define EXTI_RTSR2_RT_Pos        (0U)
+#define EXTI_RTSR2_RT_Msk        (0x302UL << EXTI_RTSR2_RT_Pos)                /*!< 0x00000302 */
+#define EXTI_RTSR2_RT            EXTI_RTSR2_RT_Msk                             /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR2_RT33_Pos      (1U)
+#define EXTI_RTSR2_RT33_Msk      (0x1UL << EXTI_RTSR2_RT33_Pos)                /*!< 0x00000002 */
+#define EXTI_RTSR2_RT33          EXTI_RTSR2_RT33_Msk                           /*!< Rising trigger event configuration bit of line 33 */
+#define EXTI_RTSR2_RT40_Pos      (8U)
+#define EXTI_RTSR2_RT40_Msk      (0x1UL << EXTI_RTSR2_RT40_Pos)                /*!< 0x00000100 */
+#define EXTI_RTSR2_RT40          EXTI_RTSR2_RT40_Msk                           /*!< Rising trigger event configuration bit of line 40 */
+#define EXTI_RTSR2_RT41_Pos      (9U)
+#define EXTI_RTSR2_RT41_Msk      (0x1UL << EXTI_RTSR2_RT41_Pos)                /*!< 0x00000200 */
+#define EXTI_RTSR2_RT41          EXTI_RTSR2_RT41_Msk                           /*!< Rising trigger event configuration bit of line 41 */
+
+/******************  Bit definition for EXTI_FTSR2 register  ******************/
+#define EXTI_FTSR2_FT_Pos        (0U)
+#define EXTI_FTSR2_FT_Msk        (0x302UL << EXTI_FTSR2_FT_Pos)                /*!< 0x00000302 */
+#define EXTI_FTSR2_FT            EXTI_FTSR2_FT_Msk                             /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR2_FT33_Pos      (1U)
+#define EXTI_FTSR2_FT33_Msk      (0x1UL << EXTI_FTSR2_FT33_Pos)                /*!< 0x00000002 */
+#define EXTI_FTSR2_FT33          EXTI_FTSR2_FT33_Msk                           /*!< Falling trigger event configuration bit of line 33 */
+#define EXTI_FTSR2_FT40_Pos      (8U)
+#define EXTI_FTSR2_FT40_Msk      (0x1UL << EXTI_FTSR2_FT40_Pos)                /*!< 0x00000100 */
+#define EXTI_FTSR2_FT40          EXTI_FTSR2_FT40_Msk                           /*!< Falling trigger event configuration bit of line 40 */
+#define EXTI_FTSR2_FT41_Pos      (9U)
+#define EXTI_FTSR2_FT41_Msk      (0x1UL << EXTI_FTSR2_FT41_Pos)                /*!< 0x00000200 */
+#define EXTI_FTSR2_FT41          EXTI_FTSR2_FT41_Msk                           /*!< Falling trigger event configuration bit of line 41 */
+
+/******************  Bit definition for EXTI_SWIER2 register  *****************/
+#define EXTI_SWIER2_SWI_Pos      (0U)
+#define EXTI_SWIER2_SWI_Msk      (0x302UL << EXTI_SWIER2_SWI_Pos)              /*!< 0x00000302 */
+#define EXTI_SWIER2_SWI          EXTI_SWIER2_SWI_Msk                           /*!< Falling trigger event configuration bit */
+#define EXTI_SWIER2_SWI33_Pos    (1U)
+#define EXTI_SWIER2_SWI33_Msk    (0x1UL << EXTI_SWIER2_SWI33_Pos)                /*!< 0x00000002 */
+#define EXTI_SWIER2_SWI33        EXTI_SWIER2_SWI33_Msk                           /*!< Software Interrupt on line 33 */
+#define EXTI_SWIER2_SWI40_Pos    (8U)
+#define EXTI_SWIER2_SWI40_Msk    (0x1UL << EXTI_SWIER2_SWI40_Pos)                /*!< 0x00000100 */
+#define EXTI_SWIER2_SWI40        EXTI_SWIER2_SWI40_Msk                           /*!< Software Interrupt on line 40 */
+#define EXTI_SWIER2_SWI41_Pos    (9U)
+#define EXTI_SWIER2_SWI41_Msk    (0x1UL << EXTI_SWIER2_SWI41_Pos)                /*!< 0x00000200 */
+#define EXTI_SWIER2_SWI41        EXTI_SWIER2_SWI41_Msk                           /*!< Software Interrupt on line 41 */
+
+/*******************  Bit definition for EXTI_PR2 register  *******************/
+#define EXTI_PR2_PIF_Pos         (0U)
+#define EXTI_PR2_PIF_Msk         (0x302UL << EXTI_PR2_PIF_Pos)                 /*!< 0x00000302 */
+#define EXTI_PR2_PIF             EXTI_PR2_PIF_Msk                              /*!< Pending bit */
+#define EXTI_PR2_PIF33_Pos       (1U)
+#define EXTI_PR2_PIF33_Msk       (0x1UL << EXTI_PR2_PIF33_Pos)                 /*!< 0x00000002 */
+#define EXTI_PR2_PIF33           EXTI_PR2_PIF33_Msk                            /*!< Pending bit for line 33 */
+#define EXTI_PR2_PIF40_Pos       (8U)
+#define EXTI_PR2_PIF40_Msk       (0x1UL << EXTI_PR2_PIF40_Pos)                 /*!< 0x00000100 */
+#define EXTI_PR2_PIF40           EXTI_PR2_PIF40_Msk                            /*!< Pending bit for line 40 */
+#define EXTI_PR2_PIF41_Pos       (9U)
+#define EXTI_PR2_PIF41_Msk       (0x1UL << EXTI_PR2_PIF41_Pos)                 /*!< 0x00000200 */
+#define EXTI_PR2_PIF41           EXTI_PR2_PIF41_Msk                            /*!< Pending bit for line 41 */
+
+/********************  Bits definition for EXTI_IMR1 register  ****************/
+#define EXTI_IMR1_Pos            (0U)
+#define EXTI_IMR1_Msk            (0xFFFFFFFFUL << EXTI_IMR1_Pos)               /*!< 0xFFFFFFFF */
+#define EXTI_IMR1_IM             EXTI_IMR1_Msk                                 /*!< CPU1 wakeup with interrupt Mask on Event */
+#define EXTI_IMR1_IM0_Pos        (0U)
+#define EXTI_IMR1_IM0_Msk        (0x1UL << EXTI_IMR1_IM0_Pos)                  /*!< 0x00000001 */
+#define EXTI_IMR1_IM0            EXTI_IMR1_IM0_Msk                             /*!< CPU1 Interrupt Mask on line 0 */
+#define EXTI_IMR1_IM1_Pos        (1U)
+#define EXTI_IMR1_IM1_Msk        (0x1UL << EXTI_IMR1_IM1_Pos)                  /*!< 0x00000002 */
+#define EXTI_IMR1_IM1            EXTI_IMR1_IM1_Msk                             /*!< CPU1 Interrupt Mask on line 1 */
+#define EXTI_IMR1_IM2_Pos        (2U)
+#define EXTI_IMR1_IM2_Msk        (0x1UL << EXTI_IMR1_IM2_Pos)                  /*!< 0x00000004 */
+#define EXTI_IMR1_IM2            EXTI_IMR1_IM2_Msk                             /*!< CPU1 Interrupt Mask on line 2 */
+#define EXTI_IMR1_IM3_Pos        (3U)
+#define EXTI_IMR1_IM3_Msk        (0x1UL << EXTI_IMR1_IM3_Pos)                  /*!< 0x00000008 */
+#define EXTI_IMR1_IM3            EXTI_IMR1_IM3_Msk                             /*!< CPU1 Interrupt Mask on line 3 */
+#define EXTI_IMR1_IM4_Pos        (4U)
+#define EXTI_IMR1_IM4_Msk        (0x1UL << EXTI_IMR1_IM4_Pos)                  /*!< 0x00000010 */
+#define EXTI_IMR1_IM4            EXTI_IMR1_IM4_Msk                             /*!< CPU1 Interrupt Mask on line 4 */
+#define EXTI_IMR1_IM5_Pos        (5U)
+#define EXTI_IMR1_IM5_Msk        (0x1UL << EXTI_IMR1_IM5_Pos)                  /*!< 0x00000020 */
+#define EXTI_IMR1_IM5            EXTI_IMR1_IM5_Msk                             /*!< CPU1 Interrupt Mask on line 5 */
+#define EXTI_IMR1_IM6_Pos        (6U)
+#define EXTI_IMR1_IM6_Msk        (0x1UL << EXTI_IMR1_IM6_Pos)                  /*!< 0x00000040 */
+#define EXTI_IMR1_IM6            EXTI_IMR1_IM6_Msk                             /*!< CPU1 Interrupt Mask on line 6 */
+#define EXTI_IMR1_IM7_Pos        (7U)
+#define EXTI_IMR1_IM7_Msk        (0x1UL << EXTI_IMR1_IM7_Pos)                  /*!< 0x00000080 */
+#define EXTI_IMR1_IM7            EXTI_IMR1_IM7_Msk                             /*!< CPU1 Interrupt Mask on line 7 */
+#define EXTI_IMR1_IM8_Pos        (8U)
+#define EXTI_IMR1_IM8_Msk        (0x1UL << EXTI_IMR1_IM8_Pos)                  /*!< 0x00000100 */
+#define EXTI_IMR1_IM8            EXTI_IMR1_IM8_Msk                             /*!< CPU1 Interrupt Mask on line 8 */
+#define EXTI_IMR1_IM9_Pos        (9U)
+#define EXTI_IMR1_IM9_Msk        (0x1UL << EXTI_IMR1_IM9_Pos)                  /*!< 0x00000200 */
+#define EXTI_IMR1_IM9            EXTI_IMR1_IM9_Msk                             /*!< CPU1 Interrupt Mask on line 9 */
+#define EXTI_IMR1_IM10_Pos       (10U)
+#define EXTI_IMR1_IM10_Msk       (0x1UL << EXTI_IMR1_IM10_Pos)                 /*!< 0x00000400 */
+#define EXTI_IMR1_IM10           EXTI_IMR1_IM10_Msk                            /*!< CPU1 Interrupt Mask on line 10 */
+#define EXTI_IMR1_IM11_Pos       (11U)
+#define EXTI_IMR1_IM11_Msk       (0x1UL << EXTI_IMR1_IM11_Pos)                 /*!< 0x00000800 */
+#define EXTI_IMR1_IM11           EXTI_IMR1_IM11_Msk                            /*!< CPU1 Interrupt Mask on line 11 */
+#define EXTI_IMR1_IM12_Pos       (12U)
+#define EXTI_IMR1_IM12_Msk       (0x1UL << EXTI_IMR1_IM12_Pos)                 /*!< 0x00001000 */
+#define EXTI_IMR1_IM12           EXTI_IMR1_IM12_Msk                            /*!< CPU1 Interrupt Mask on line 12 */
+#define EXTI_IMR1_IM13_Pos       (13U)
+#define EXTI_IMR1_IM13_Msk       (0x1UL << EXTI_IMR1_IM13_Pos)                 /*!< 0x00002000 */
+#define EXTI_IMR1_IM13           EXTI_IMR1_IM13_Msk                            /*!< CPU1 Interrupt Mask on line 13 */
+#define EXTI_IMR1_IM14_Pos       (14U)
+#define EXTI_IMR1_IM14_Msk       (0x1UL << EXTI_IMR1_IM14_Pos)                 /*!< 0x00004000 */
+#define EXTI_IMR1_IM14           EXTI_IMR1_IM14_Msk                            /*!< CPU1 Interrupt Mask on line 14 */
+#define EXTI_IMR1_IM15_Pos       (15U)
+#define EXTI_IMR1_IM15_Msk       (0x1UL << EXTI_IMR1_IM15_Pos)                 /*!< 0x00008000 */
+#define EXTI_IMR1_IM15           EXTI_IMR1_IM15_Msk                            /*!< CPU1 Interrupt Mask on line 15 */
+#define EXTI_IMR1_IM16_Pos       (16U)
+#define EXTI_IMR1_IM16_Msk       (0x1UL << EXTI_IMR1_IM16_Pos)                 /*!< 0x00010000 */
+#define EXTI_IMR1_IM16           EXTI_IMR1_IM16_Msk                            /*!< CPU1 Interrupt Mask on line 16 */
+#define EXTI_IMR1_IM17_Pos       (17U)
+#define EXTI_IMR1_IM17_Msk       (0x1UL << EXTI_IMR1_IM17_Pos)                 /*!< 0x00020000 */
+#define EXTI_IMR1_IM17           EXTI_IMR1_IM17_Msk                            /*!< CPU1 Interrupt Mask on line 17 */
+#define EXTI_IMR1_IM18_Pos       (18U)
+#define EXTI_IMR1_IM18_Msk       (0x1UL << EXTI_IMR1_IM18_Pos)                 /*!< 0x00040000 */
+#define EXTI_IMR1_IM18           EXTI_IMR1_IM18_Msk                            /*!< CPU1 Interrupt Mask on line 18 */
+#define EXTI_IMR1_IM19_Pos       (19U)
+#define EXTI_IMR1_IM19_Msk       (0x1UL << EXTI_IMR1_IM19_Pos)                 /*!< 0x00080000 */
+#define EXTI_IMR1_IM19           EXTI_IMR1_IM19_Msk                            /*!< CPU1 Interrupt Mask on line 19 */
+#define EXTI_IMR1_IM22_Pos       (22U)
+#define EXTI_IMR1_IM22_Msk       (0x1UL << EXTI_IMR1_IM22_Pos)                 /*!< 0x00400000 */
+#define EXTI_IMR1_IM22           EXTI_IMR1_IM22_Msk                            /*!< CPU1 Interrupt Mask on line 22 */
+#define EXTI_IMR1_IM24_Pos       (24U)
+#define EXTI_IMR1_IM24_Msk       (0x1UL << EXTI_IMR1_IM24_Pos)                 /*!< 0x01000000 */
+#define EXTI_IMR1_IM24           EXTI_IMR1_IM24_Msk                            /*!< CPU1 Interrupt Mask on line 24 */
+#define EXTI_IMR1_IM25_Pos       (25U)
+#define EXTI_IMR1_IM25_Msk       (0x1UL << EXTI_IMR1_IM25_Pos)                 /*!< 0x02000000 */
+#define EXTI_IMR1_IM25           EXTI_IMR1_IM25_Msk                            /*!< CPU1 Interrupt Mask on line 25 */
+#define EXTI_IMR1_IM29_Pos       (29U)
+#define EXTI_IMR1_IM29_Msk       (0x1UL << EXTI_IMR1_IM29_Pos)                 /*!< 0x20000000 */
+#define EXTI_IMR1_IM29           EXTI_IMR1_IM29_Msk                            /*!< CPU1 Interrupt Mask on line 29 */
+#define EXTI_IMR1_IM30_Pos       (30U)
+#define EXTI_IMR1_IM30_Msk       (0x1UL << EXTI_IMR1_IM30_Pos)                 /*!< 0x40000000 */
+#define EXTI_IMR1_IM30           EXTI_IMR1_IM30_Msk                            /*!< CPU1 Interrupt Mask on line 30 */
+#define EXTI_IMR1_IM31_Pos       (31U)
+#define EXTI_IMR1_IM31_Msk       (0x1UL << EXTI_IMR1_IM31_Pos)                 /*!< 0x80000000 */
+#define EXTI_IMR1_IM31           EXTI_IMR1_IM31_Msk                            /*!< CPU1 Interrupt Mask on line 31 */
+
+/********************  Bits definition for EXTI_EMR1 register  ****************/
+#define EXTI_EMR1_Pos            (0U)
+#define EXTI_EMR1_Msk            (0x003EFFFFUL << EXTI_EMR1_Pos)               /*!< 0xFFFFFFFF */
+#define EXTI_EMR1_EM             EXTI_EMR1_Msk                                 /*!< CPU1 Event Mask */
+#define EXTI_EMR1_EM0_Pos        (0U)
+#define EXTI_EMR1_EM0_Msk        (0x1UL << EXTI_EMR1_EM0_Pos)                  /*!< 0x00000001 */
+#define EXTI_EMR1_EM0            EXTI_EMR1_EM0_Msk                             /*!< CPU1 Event Mask on line 0 */
+#define EXTI_EMR1_EM1_Pos        (1U)
+#define EXTI_EMR1_EM1_Msk        (0x1UL << EXTI_EMR1_EM1_Pos)                  /*!< 0x00000002 */
+#define EXTI_EMR1_EM1            EXTI_EMR1_EM1_Msk                             /*!< CPU1 Event Mask on line 1 */
+#define EXTI_EMR1_EM2_Pos        (2U)
+#define EXTI_EMR1_EM2_Msk        (0x1UL << EXTI_EMR1_EM2_Pos)                  /*!< 0x00000004 */
+#define EXTI_EMR1_EM2            EXTI_EMR1_EM2_Msk                             /*!< CPU1 Event Mask on line 2 */
+#define EXTI_EMR1_EM3_Pos        (3U)
+#define EXTI_EMR1_EM3_Msk        (0x1UL << EXTI_EMR1_EM3_Pos)                  /*!< 0x00000008 */
+#define EXTI_EMR1_EM3            EXTI_EMR1_EM3_Msk                             /*!< CPU1 Event Mask on line 3 */
+#define EXTI_EMR1_EM4_Pos        (4U)
+#define EXTI_EMR1_EM4_Msk        (0x1UL << EXTI_EMR1_EM4_Pos)                  /*!< 0x00000010 */
+#define EXTI_EMR1_EM4            EXTI_EMR1_EM4_Msk                             /*!< CPU1 Event Mask on line 4 */
+#define EXTI_EMR1_EM5_Pos        (5U)
+#define EXTI_EMR1_EM5_Msk        (0x1UL << EXTI_EMR1_EM5_Pos)                  /*!< 0x00000020 */
+#define EXTI_EMR1_EM5            EXTI_EMR1_EM5_Msk                             /*!< CPU1 Event Mask on line 5 */
+#define EXTI_EMR1_EM6_Pos        (6U)
+#define EXTI_EMR1_EM6_Msk        (0x1UL << EXTI_EMR1_EM6_Pos)                  /*!< 0x00000040 */
+#define EXTI_EMR1_EM6            EXTI_EMR1_EM6_Msk                             /*!< CPU1 Event Mask on line 6 */
+#define EXTI_EMR1_EM7_Pos        (7U)
+#define EXTI_EMR1_EM7_Msk        (0x1UL << EXTI_EMR1_EM7_Pos)                  /*!< 0x00000080 */
+#define EXTI_EMR1_EM7            EXTI_EMR1_EM7_Msk                             /*!< CPU1 Event Mask on line 7 */
+#define EXTI_EMR1_EM8_Pos        (8U)
+#define EXTI_EMR1_EM8_Msk        (0x1UL << EXTI_EMR1_EM8_Pos)                  /*!< 0x00000100 */
+#define EXTI_EMR1_EM8            EXTI_EMR1_EM8_Msk                             /*!< CPU1 Event Mask on line 8 */
+#define EXTI_EMR1_EM9_Pos        (9U)
+#define EXTI_EMR1_EM9_Msk        (0x1UL << EXTI_EMR1_EM9_Pos)                  /*!< 0x00000200 */
+#define EXTI_EMR1_EM9            EXTI_EMR1_EM9_Msk                             /*!< CPU1 Event Mask on line 9 */
+#define EXTI_EMR1_EM10_Pos       (10U)
+#define EXTI_EMR1_EM10_Msk       (0x1UL << EXTI_EMR1_EM10_Pos)                 /*!< 0x00000400 */
+#define EXTI_EMR1_EM10           EXTI_EMR1_EM10_Msk                            /*!< CPU1 Event Mask on line 10 */
+#define EXTI_EMR1_EM11_Pos       (11U)
+#define EXTI_EMR1_EM11_Msk       (0x1UL << EXTI_EMR1_EM11_Pos)                 /*!< 0x00000800 */
+#define EXTI_EMR1_EM11           EXTI_EMR1_EM11_Msk                            /*!< CPU1 Event Mask on line 11 */
+#define EXTI_EMR1_EM12_Pos       (12U)
+#define EXTI_EMR1_EM12_Msk       (0x1UL << EXTI_EMR1_EM12_Pos)                 /*!< 0x00001000 */
+#define EXTI_EMR1_EM12           EXTI_EMR1_EM12_Msk                            /*!< CPU1 Event Mask on line 12 */
+#define EXTI_EMR1_EM13_Pos       (13U)
+#define EXTI_EMR1_EM13_Msk       (0x1UL << EXTI_EMR1_EM13_Pos)                 /*!< 0x00002000 */
+#define EXTI_EMR1_EM13           EXTI_EMR1_EM13_Msk                            /*!< CPU1 Event Mask on line 13 */
+#define EXTI_EMR1_EM14_Pos       (14U)
+#define EXTI_EMR1_EM14_Msk       (0x1UL << EXTI_EMR1_EM14_Pos)                 /*!< 0x00004000 */
+#define EXTI_EMR1_EM14           EXTI_EMR1_EM14_Msk                            /*!< CPU1 Event Mask on line 14 */
+#define EXTI_EMR1_EM15_Pos       (15U)
+#define EXTI_EMR1_EM15_Msk       (0x1UL << EXTI_EMR1_EM15_Pos)                 /*!< 0x00008000 */
+#define EXTI_EMR1_EM15           EXTI_EMR1_EM15_Msk                            /*!< CPU1 Event Mask on line 15 */
+#define EXTI_EMR1_EM17_Pos       (17U)
+#define EXTI_EMR1_EM17_Msk       (0x1UL << EXTI_EMR1_EM17_Pos)                 /*!< 0x00020000 */
+#define EXTI_EMR1_EM17           EXTI_EMR1_EM17_Msk                            /*!< CPU1 Event Mask on line 17 */
+#define EXTI_EMR1_EM18_Pos       (18U)
+#define EXTI_EMR1_EM18_Msk       (0x1UL << EXTI_EMR1_EM18_Pos)                 /*!< 0x00040000 */
+#define EXTI_EMR1_EM18           EXTI_EMR1_EM18_Msk                            /*!< CPU1 Event Mask on line 18 */
+#define EXTI_EMR1_EM19_Pos       (19U)
+#define EXTI_EMR1_EM19_Msk       (0x1UL << EXTI_EMR1_EM19_Pos)                 /*!< 0x00080000 */
+#define EXTI_EMR1_EM19           EXTI_EMR1_EM19_Msk                            /*!< CPU1 Event Mask on line 19 */
+
+/********************  Bits definition for EXTI_IMR2 register  ****************/
+#define EXTI_IMR2_Pos            (0U)
+#define EXTI_IMR2_Msk            (0x0001FFFFUL << EXTI_IMR2_Pos)               /*!< 0x0001FFFF */
+#define EXTI_IMR2_IM             EXTI_IMR2_Msk                                 /*!< CPU1 Interrupt Mask  */
+#define EXTI_IMR2_IM33_Pos       (1U)
+#define EXTI_IMR2_IM33_Msk       (0x1UL << EXTI_IMR2_IM33_Pos)                 /*!< 0x00000002 */
+#define EXTI_IMR2_IM33           EXTI_IMR2_IM33_Msk                            /*!< CPU1 Interrupt Mask on line 33 */
+#define EXTI_IMR2_IM36_Pos       (4U)
+#define EXTI_IMR2_IM36_Msk       (0x1UL << EXTI_IMR2_IM36_Pos)                 /*!< 0x00000010 */
+#define EXTI_IMR2_IM36           EXTI_IMR2_IM36_Msk                            /*!< CPU1 Interrupt Mask on line 36 */
+#define EXTI_IMR2_IM37_Pos       (5U)
+#define EXTI_IMR2_IM37_Msk       (0x1UL << EXTI_IMR2_IM37_Pos)                 /*!< 0x00000020 */
+#define EXTI_IMR2_IM37           EXTI_IMR2_IM37_Msk                            /*!< CPU1 Interrupt Mask on line 37 */
+#define EXTI_IMR2_IM38_Pos       (6U)
+#define EXTI_IMR2_IM38_Msk       (0x1UL << EXTI_IMR2_IM38_Pos)                 /*!< 0x00000040 */
+#define EXTI_IMR2_IM38           EXTI_IMR2_IM38_Msk                            /*!< CPU1 Interrupt Mask on line 38 */
+#define EXTI_IMR2_IM39_Pos       (7U)
+#define EXTI_IMR2_IM39_Msk       (0x1UL << EXTI_IMR2_IM39_Pos)                 /*!< 0x00000080 */
+#define EXTI_IMR2_IM39           EXTI_IMR2_IM39_Msk                            /*!< CPU1 Interrupt Mask on line 39 */
+#define EXTI_IMR2_IM40_Pos       (8U)
+#define EXTI_IMR2_IM40_Msk       (0x1UL << EXTI_IMR2_IM40_Pos)                 /*!< 0x00000100 */
+#define EXTI_IMR2_IM40           EXTI_IMR2_IM40_Msk                            /*!< CPU1 Interrupt Mask on line 40 */
+#define EXTI_IMR2_IM41_Pos       (9U)
+#define EXTI_IMR2_IM41_Msk       (0x1UL << EXTI_IMR2_IM41_Pos)                 /*!< 0x00000200 */
+#define EXTI_IMR2_IM41           EXTI_IMR2_IM41_Msk                            /*!< CPU1 Interrupt Mask on line 41 */
+#define EXTI_IMR2_IM42_Pos       (10U)
+#define EXTI_IMR2_IM42_Msk       (0x1UL << EXTI_IMR2_IM42_Pos)                 /*!< 0x00000400 */
+#define EXTI_IMR2_IM42           EXTI_IMR2_IM42_Msk                            /*!< CPU1 Interrupt Mask on line 42 */
+#define EXTI_IMR2_IM44_Pos       (12U)
+#define EXTI_IMR2_IM44_Msk       (0x1UL << EXTI_IMR2_IM44_Pos)                 /*!< 0x00001000 */
+#define EXTI_IMR2_IM44           EXTI_IMR2_IM44_Msk                            /*!< CPU1 Interrupt Mask on line 44 */
+#define EXTI_IMR2_IM45_Pos       (13U)
+#define EXTI_IMR2_IM45_Msk       (0x1UL << EXTI_IMR2_IM45_Pos)                 /*!< 0x00002000 */
+#define EXTI_IMR2_IM45           EXTI_IMR2_IM45_Msk                            /*!< CPU1 Interrupt Mask on line 45 */
+#define EXTI_IMR2_IM48_Pos       (16U)
+#define EXTI_IMR2_IM48_Msk       (0x1UL << EXTI_IMR2_IM48_Pos)                 /*!< 0x00010000 */
+#define EXTI_IMR2_IM48           EXTI_IMR2_IM48_Msk                            /*!< CPU1 Interrupt Mask on line 48 */
+
+/********************  Bits definition for EXTI_EMR2 register  ****************/
+#define EXTI_EMR2_Pos            (0U)
+#define EXTI_EMR2_Msk            (0x00000300UL << EXTI_EMR2_Pos)               /*!< 0x000003000 */
+#define EXTI_EMR2_EM             EXTI_EMR2_Msk                                 /*!< CPU1 Interrupt Mask  */
+#define EXTI_EMR2_EM40_Pos       (8U)
+#define EXTI_EMR2_EM40_Msk       (0x1UL << EXTI_EMR2_EM40_Pos)                 /*!< 0x00000100 */
+#define EXTI_EMR2_EM40           EXTI_EMR2_EM40_Msk                            /*!< CPU1 Event Mask on line 40 */
+#define EXTI_EMR2_EM41_Pos       (9U)
+#define EXTI_EMR2_EM41_Msk       (0x1UL << EXTI_EMR2_EM41_Pos)                 /*!< 0x00000200 */
+#define EXTI_EMR2_EM41           EXTI_EMR2_EM41_Msk                            /*!< CPU1 Event Mask on line 41 */
+
+/********************  Bits definition for EXTI_C2IMR1 register  **************/
+#define EXTI_C2IMR1_Pos          (0U)
+#define EXTI_C2IMR1_Msk          (0xFFFFFFFFUL << EXTI_C2IMR1_Pos)             /*!< 0xFFFFFFFF */
+#define EXTI_C2IMR1_IM           EXTI_C2IMR1_Msk                               /*!< CPU2 wakeup with interrupt Mask on Event */
+#define EXTI_C2IMR1_IM0_Pos      (0U)
+#define EXTI_C2IMR1_IM0_Msk      (0x1UL << EXTI_C2IMR1_IM0_Pos)                /*!< 0x00000001 */
+#define EXTI_C2IMR1_IM0          EXTI_C2IMR1_IM0_Msk                           /*!< CPU2 Interrupt Mask on line 0 */
+#define EXTI_C2IMR1_IM1_Pos      (1U)
+#define EXTI_C2IMR1_IM1_Msk      (0x1UL << EXTI_C2IMR1_IM1_Pos)                /*!< 0x00000002 */
+#define EXTI_C2IMR1_IM1          EXTI_C2IMR1_IM1_Msk                           /*!< CPU2 Interrupt Mask on line 1 */
+#define EXTI_C2IMR1_IM2_Pos      (2U)
+#define EXTI_C2IMR1_IM2_Msk      (0x1UL << EXTI_C2IMR1_IM2_Pos)                /*!< 0x00000004 */
+#define EXTI_C2IMR1_IM2          EXTI_C2IMR1_IM2_Msk                           /*!< CPU2 Interrupt Mask on line 2 */
+#define EXTI_C2IMR1_IM3_Pos      (3U)
+#define EXTI_C2IMR1_IM3_Msk      (0x1UL << EXTI_C2IMR1_IM3_Pos)                /*!< 0x00000008 */
+#define EXTI_C2IMR1_IM3          EXTI_C2IMR1_IM3_Msk                           /*!< CPU2 Interrupt Mask on line 3 */
+#define EXTI_C2IMR1_IM4_Pos      (4U)
+#define EXTI_C2IMR1_IM4_Msk      (0x1UL << EXTI_C2IMR1_IM4_Pos)                /*!< 0x00000010 */
+#define EXTI_C2IMR1_IM4          EXTI_C2IMR1_IM4_Msk                           /*!< CPU2 Interrupt Mask on line 4 */
+#define EXTI_C2IMR1_IM5_Pos      (5U)
+#define EXTI_C2IMR1_IM5_Msk      (0x1UL << EXTI_C2IMR1_IM5_Pos)                /*!< 0x00000020 */
+#define EXTI_C2IMR1_IM5          EXTI_C2IMR1_IM5_Msk                           /*!< CPU2 Interrupt Mask on line 5 */
+#define EXTI_C2IMR1_IM6_Pos      (6U)
+#define EXTI_C2IMR1_IM6_Msk      (0x1UL << EXTI_C2IMR1_IM6_Pos)                /*!< 0x00000040 */
+#define EXTI_C2IMR1_IM6          EXTI_C2IMR1_IM6_Msk                           /*!< CPU2 Interrupt Mask on line 6 */
+#define EXTI_C2IMR1_IM7_Pos      (7U)
+#define EXTI_C2IMR1_IM7_Msk      (0x1UL << EXTI_C2IMR1_IM7_Pos)                /*!< 0x00000080 */
+#define EXTI_C2IMR1_IM7          EXTI_C2IMR1_IM7_Msk                           /*!< CPU2 Interrupt Mask on line 7 */
+#define EXTI_C2IMR1_IM8_Pos      (8U)
+#define EXTI_C2IMR1_IM8_Msk      (0x1UL << EXTI_C2IMR1_IM8_Pos)                /*!< 0x00000100 */
+#define EXTI_C2IMR1_IM8          EXTI_C2IMR1_IM8_Msk                           /*!< CPU2 Interrupt Mask on line 8 */
+#define EXTI_C2IMR1_IM9_Pos      (9U)
+#define EXTI_C2IMR1_IM9_Msk      (0x1UL << EXTI_C2IMR1_IM9_Pos)                /*!< 0x00000200 */
+#define EXTI_C2IMR1_IM9          EXTI_C2IMR1_IM9_Msk                           /*!< CPU2 Interrupt Mask on line 9 */
+#define EXTI_C2IMR1_IM10_Pos     (10U)
+#define EXTI_C2IMR1_IM10_Msk     (0x1UL << EXTI_C2IMR1_IM10_Pos)               /*!< 0x00000400 */
+#define EXTI_C2IMR1_IM10         EXTI_C2IMR1_IM10_Msk                          /*!< CPU2 Interrupt Mask on line 10 */
+#define EXTI_C2IMR1_IM11_Pos     (11U)
+#define EXTI_C2IMR1_IM11_Msk     (0x1UL << EXTI_C2IMR1_IM11_Pos)               /*!< 0x00000800 */
+#define EXTI_C2IMR1_IM11         EXTI_C2IMR1_IM11_Msk                          /*!< CPU2 Interrupt Mask on line 11 */
+#define EXTI_C2IMR1_IM12_Pos     (12U)
+#define EXTI_C2IMR1_IM12_Msk     (0x1UL << EXTI_C2IMR1_IM12_Pos)               /*!< 0x00001000 */
+#define EXTI_C2IMR1_IM12         EXTI_C2IMR1_IM12_Msk                          /*!< CPU2 Interrupt Mask on line 12 */
+#define EXTI_C2IMR1_IM13_Pos     (13U)
+#define EXTI_C2IMR1_IM13_Msk     (0x1UL << EXTI_C2IMR1_IM13_Pos)               /*!< 0x00002000 */
+#define EXTI_C2IMR1_IM13         EXTI_C2IMR1_IM13_Msk                          /*!< CPU2 Interrupt Mask on line 13 */
+#define EXTI_C2IMR1_IM14_Pos     (14U)
+#define EXTI_C2IMR1_IM14_Msk     (0x1UL << EXTI_C2IMR1_IM14_Pos)               /*!< 0x00004000 */
+#define EXTI_C2IMR1_IM14         EXTI_C2IMR1_IM14_Msk                          /*!< CPU2 Interrupt Mask on line 14 */
+#define EXTI_C2IMR1_IM15_Pos     (15U)
+#define EXTI_C2IMR1_IM15_Msk     (0x1UL << EXTI_C2IMR1_IM15_Pos)               /*!< 0x00008000 */
+#define EXTI_C2IMR1_IM15         EXTI_C2IMR1_IM15_Msk                          /*!< CPU2 Interrupt Mask on line 15 */
+#define EXTI_C2IMR1_IM16_Pos     (16U)
+#define EXTI_C2IMR1_IM16_Msk     (0x1UL << EXTI_C2IMR1_IM16_Pos)               /*!< 0x00010000 */
+#define EXTI_C2IMR1_IM16         EXTI_C2IMR1_IM16_Msk                          /*!< CPU2 Interrupt Mask on line 16 */
+#define EXTI_C2IMR1_IM17_Pos     (17U)
+#define EXTI_C2IMR1_IM17_Msk     (0x1UL << EXTI_C2IMR1_IM17_Pos)               /*!< 0x00020000 */
+#define EXTI_C2IMR1_IM17         EXTI_C2IMR1_IM17_Msk                          /*!< CPU2 Interrupt Mask on line 17 */
+#define EXTI_C2IMR1_IM18_Pos     (18U)
+#define EXTI_C2IMR1_IM18_Msk     (0x1UL << EXTI_C2IMR1_IM18_Pos)               /*!< 0x00040000 */
+#define EXTI_C2IMR1_IM18         EXTI_C2IMR1_IM18_Msk                          /*!< CPU2 Interrupt Mask on line 18 */
+#define EXTI_C2IMR1_IM19_Pos     (19U)
+#define EXTI_C2IMR1_IM19_Msk     (0x1UL << EXTI_C2IMR1_IM19_Pos)               /*!< 0x00080000 */
+#define EXTI_C2IMR1_IM19         EXTI_C2IMR1_IM19_Msk                          /*!< CPU2 Interrupt Mask on line 19 */
+#define EXTI_C2IMR1_IM22_Pos     (22U)
+#define EXTI_C2IMR1_IM22_Msk     (0x1UL << EXTI_C2IMR1_IM22_Pos)               /*!< 0x00400000 */
+#define EXTI_C2IMR1_IM22         EXTI_C2IMR1_IM22_Msk                          /*!< CPU2 Interrupt Mask on line 22 */
+#define EXTI_C2IMR1_IM24_Pos     (24U)
+#define EXTI_C2IMR1_IM24_Msk     (0x1UL << EXTI_C2IMR1_IM24_Pos)               /*!< 0x01000000 */
+#define EXTI_C2IMR1_IM24         EXTI_C2IMR1_IM24_Msk                          /*!< CPU2 Interrupt Mask on line 24 */
+#define EXTI_C2IMR1_IM25_Pos     (25U)
+#define EXTI_C2IMR1_IM25_Msk     (0x1UL << EXTI_C2IMR1_IM25_Pos)               /*!< 0x02000000 */
+#define EXTI_C2IMR1_IM25         EXTI_C2IMR1_IM25_Msk                          /*!< CPU2 Interrupt Mask on line 25 */
+#define EXTI_C2IMR1_IM29_Pos     (29U)
+#define EXTI_C2IMR1_IM29_Msk     (0x1UL << EXTI_C2IMR1_IM29_Pos)               /*!< 0x20000000 */
+#define EXTI_C2IMR1_IM29         EXTI_C2IMR1_IM29_Msk                          /*!< CPU2 Interrupt Mask on line 29 */
+#define EXTI_C2IMR1_IM30_Pos     (30U)
+#define EXTI_C2IMR1_IM30_Msk     (0x1UL << EXTI_C2IMR1_IM30_Pos)               /*!< 0x40000000 */
+#define EXTI_C2IMR1_IM30         EXTI_C2IMR1_IM30_Msk                          /*!< CPU2 Interrupt Mask on line 30 */
+#define EXTI_C2IMR1_IM31_Pos     (31U)
+#define EXTI_C2IMR1_IM31_Msk     (0x1UL << EXTI_C2IMR1_IM31_Pos)               /*!< 0x80000000 */
+#define EXTI_C2IMR1_IM31         EXTI_C2IMR1_IM31_Msk                          /*!< CPU2 Interrupt Mask on line 31 */
+
+/********************  Bits definition for EXTI_C2EMR1 register  **************/
+#define EXTI_C2EMR1_Pos          (0U)
+#define EXTI_C2EMR1_Msk          (0x003EFFFFUL << EXTI_C2EMR1_Pos)             /*!< 0xFFFFFFFF */
+#define EXTI_C2EMR1_EM           EXTI_C2EMR1_Msk                               /*!< CPU2 Event Mask */
+#define EXTI_C2EMR1_EM0_Pos      (0U)
+#define EXTI_C2EMR1_EM0_Msk      (0x1UL << EXTI_C2EMR1_EM0_Pos)                /*!< 0x00000001 */
+#define EXTI_C2EMR1_EM0          EXTI_C2EMR1_EM0_Msk                           /*!< CPU2 Event Mask on line 0 */
+#define EXTI_C2EMR1_EM1_Pos      (1U)
+#define EXTI_C2EMR1_EM1_Msk      (0x1UL << EXTI_C2EMR1_EM1_Pos)                /*!< 0x00000002 */
+#define EXTI_C2EMR1_EM1          EXTI_C2EMR1_EM1_Msk                           /*!< CPU2 Event Mask on line 1 */
+#define EXTI_C2EMR1_EM2_Pos      (2U)
+#define EXTI_C2EMR1_EM2_Msk      (0x1UL << EXTI_C2EMR1_EM2_Pos)                /*!< 0x00000004 */
+#define EXTI_C2EMR1_EM2          EXTI_C2EMR1_EM2_Msk                           /*!< CPU2 Event Mask on line 2 */
+#define EXTI_C2EMR1_EM3_Pos      (3U)
+#define EXTI_C2EMR1_EM3_Msk      (0x1UL << EXTI_C2EMR1_EM3_Pos)                /*!< 0x00000008 */
+#define EXTI_C2EMR1_EM3          EXTI_C2EMR1_EM3_Msk                           /*!< CPU2 Event Mask on line 3 */
+#define EXTI_C2EMR1_EM4_Pos      (4U)
+#define EXTI_C2EMR1_EM4_Msk      (0x1UL << EXTI_C2EMR1_EM4_Pos)                /*!< 0x00000010 */
+#define EXTI_C2EMR1_EM4          EXTI_C2EMR1_EM4_Msk                           /*!< CPU2 Event Mask on line 4 */
+#define EXTI_C2EMR1_EM5_Pos      (5U)
+#define EXTI_C2EMR1_EM5_Msk      (0x1UL << EXTI_C2EMR1_EM5_Pos)                /*!< 0x00000020 */
+#define EXTI_C2EMR1_EM5          EXTI_C2EMR1_EM5_Msk                           /*!< CPU2 Event Mask on line 5 */
+#define EXTI_C2EMR1_EM6_Pos      (6U)
+#define EXTI_C2EMR1_EM6_Msk      (0x1UL << EXTI_C2EMR1_EM6_Pos)                /*!< 0x00000040 */
+#define EXTI_C2EMR1_EM6          EXTI_C2EMR1_EM6_Msk                           /*!< CPU2 Event Mask on line 6 */
+#define EXTI_C2EMR1_EM7_Pos      (7U)
+#define EXTI_C2EMR1_EM7_Msk      (0x1UL << EXTI_C2EMR1_EM7_Pos)                /*!< 0x00000080 */
+#define EXTI_C2EMR1_EM7          EXTI_C2EMR1_EM7_Msk                           /*!< CPU2 Event Mask on line 7 */
+#define EXTI_C2EMR1_EM8_Pos      (8U)
+#define EXTI_C2EMR1_EM8_Msk      (0x1UL << EXTI_C2EMR1_EM8_Pos)                /*!< 0x00000100 */
+#define EXTI_C2EMR1_EM8          EXTI_C2EMR1_EM8_Msk                           /*!< CPU2 Event Mask on line 8 */
+#define EXTI_C2EMR1_EM9_Pos      (9U)
+#define EXTI_C2EMR1_EM9_Msk      (0x1UL << EXTI_C2EMR1_EM9_Pos)                /*!< 0x00000200 */
+#define EXTI_C2EMR1_EM9          EXTI_C2EMR1_EM9_Msk                           /*!< CPU2 Event Mask on line 9 */
+#define EXTI_C2EMR1_EM10_Pos     (10U)
+#define EXTI_C2EMR1_EM10_Msk     (0x1UL << EXTI_C2EMR1_EM10_Pos)               /*!< 0x00000400 */
+#define EXTI_C2EMR1_EM10         EXTI_C2EMR1_EM10_Msk                          /*!< CPU2 Event Mask on line 10 */
+#define EXTI_C2EMR1_EM11_Pos     (11U)
+#define EXTI_C2EMR1_EM11_Msk     (0x1UL << EXTI_C2EMR1_EM11_Pos)               /*!< 0x00000800 */
+#define EXTI_C2EMR1_EM11         EXTI_C2EMR1_EM11_Msk                          /*!< CPU2 Event Mask on line 11 */
+#define EXTI_C2EMR1_EM12_Pos     (12U)
+#define EXTI_C2EMR1_EM12_Msk     (0x1UL << EXTI_C2EMR1_EM12_Pos)               /*!< 0x00001000 */
+#define EXTI_C2EMR1_EM12         EXTI_C2EMR1_EM12_Msk                          /*!< CPU2 Event Mask on line 12 */
+#define EXTI_C2EMR1_EM13_Pos     (13U)
+#define EXTI_C2EMR1_EM13_Msk     (0x1UL << EXTI_C2EMR1_EM13_Pos)               /*!< 0x00002000 */
+#define EXTI_C2EMR1_EM13         EXTI_C2EMR1_EM13_Msk                          /*!< CPU2 Event Mask on line 13 */
+#define EXTI_C2EMR1_EM14_Pos     (14U)
+#define EXTI_C2EMR1_EM14_Msk     (0x1UL << EXTI_C2EMR1_EM14_Pos)               /*!< 0x00004000 */
+#define EXTI_C2EMR1_EM14         EXTI_C2EMR1_EM14_Msk                          /*!< CPU2 Event Mask on line 14 */
+#define EXTI_C2EMR1_EM15_Pos     (15U)
+#define EXTI_C2EMR1_EM15_Msk     (0x1UL << EXTI_C2EMR1_EM15_Pos)               /*!< 0x00008000 */
+#define EXTI_C2EMR1_EM15         EXTI_C2EMR1_EM15_Msk                          /*!< CPU2 Event Mask on line 15 */
+#define EXTI_C2EMR1_EM17_Pos     (17U)
+#define EXTI_C2EMR1_EM17_Msk     (0x1UL << EXTI_C2EMR1_EM17_Pos)               /*!< 0x00020000 */
+#define EXTI_C2EMR1_EM17         EXTI_C2EMR1_EM17_Msk                          /*!< CPU2 Event Mask on line 17 */
+#define EXTI_C2EMR1_EM18_Pos     (18U)
+#define EXTI_C2EMR1_EM18_Msk     (0x1UL << EXTI_C2EMR1_EM18_Pos)               /*!< 0x00040000 */
+#define EXTI_C2EMR1_EM18         EXTI_C2EMR1_EM18_Msk                          /*!< CPU2 Event Mask on line 18 */
+#define EXTI_C2EMR1_EM19_Pos     (19U)
+#define EXTI_C2EMR1_EM19_Msk     (0x1UL << EXTI_C2EMR1_EM19_Pos)               /*!< 0x00080000 */
+#define EXTI_C2EMR1_EM19         EXTI_C2EMR1_EM19_Msk                          /*!< CPU2 Event Mask on line 19 */
+
+/********************  Bits definition for EXTI_C2IMR2 register  **************/
+#define EXTI_C2IMR2_Pos          (0U)
+#define EXTI_C2IMR2_Msk          (0x0001FFFFUL << EXTI_C2IMR2_Pos)             /*!< 0x0001FFFF */
+#define EXTI_C2IMR2_IM           EXTI_C2IMR2_Msk                               /*!< CPU2 Interrupt Mask  */
+#define EXTI_C2IMR2_IM33_Pos     (1U)
+#define EXTI_C2IMR2_IM33_Msk     (0x1UL << EXTI_C2IMR2_IM33_Pos)               /*!< 0x00000002 */
+#define EXTI_C2IMR2_IM33         EXTI_C2IMR2_IM33_Msk                          /*!< CPU2 Interrupt Mask on line 33 */
+#define EXTI_C2IMR2_IM36_Pos     (4U)
+#define EXTI_C2IMR2_IM36_Msk     (0x1UL << EXTI_C2IMR2_IM36_Pos)               /*!< 0x00000010 */
+#define EXTI_C2IMR2_IM36         EXTI_C2IMR2_IM36_Msk                          /*!< CPU2 Interrupt Mask on line 36 */
+#define EXTI_C2IMR2_IM37_Pos     (5U)
+#define EXTI_C2IMR2_IM37_Msk     (0x1UL << EXTI_C2IMR2_IM37_Pos)               /*!< 0x00000020 */
+#define EXTI_C2IMR2_IM37         EXTI_C2IMR2_IM37_Msk                          /*!< CPU2 Interrupt Mask on line 37 */
+#define EXTI_C2IMR2_IM38_Pos     (6U)
+#define EXTI_C2IMR2_IM38_Msk     (0x1UL << EXTI_C2IMR2_IM38_Pos)               /*!< 0x00000040 */
+#define EXTI_C2IMR2_IM38         EXTI_C2IMR2_IM38_Msk                          /*!< CPU2 Interrupt Mask on line 38 */
+#define EXTI_C2IMR2_IM39_Pos     (7U)
+#define EXTI_C2IMR2_IM39_Msk     (0x1UL << EXTI_C2IMR2_IM39_Pos)               /*!< 0x00000080 */
+#define EXTI_C2IMR2_IM39         EXTI_C2IMR2_IM39_Msk                          /*!< CPU2 Interrupt Mask on line 39 */
+#define EXTI_C2IMR2_IM40_Pos     (8U)
+#define EXTI_C2IMR2_IM40_Msk     (0x1UL << EXTI_C2IMR2_IM40_Pos)               /*!< 0x00000100 */
+#define EXTI_C2IMR2_IM40         EXTI_C2IMR2_IM40_Msk                          /*!< CPU2 Interrupt Mask on line 40 */
+#define EXTI_C2IMR2_IM41_Pos     (9U)
+#define EXTI_C2IMR2_IM41_Msk     (0x1UL << EXTI_C2IMR2_IM41_Pos)               /*!< 0x00000200 */
+#define EXTI_C2IMR2_IM41         EXTI_C2IMR2_IM41_Msk                          /*!< CPU2 Interrupt Mask on line 41 */
+#define EXTI_C2IMR2_IM42_Pos     (10U)
+#define EXTI_C2IMR2_IM42_Msk     (0x1UL << EXTI_C2IMR2_IM42_Pos)               /*!< 0x00000400 */
+#define EXTI_C2IMR2_IM42         EXTI_C2IMR2_IM42_Msk                          /*!< CPU2 Interrupt Mask on line 42 */
+#define EXTI_C2IMR2_IM44_Pos     (12U)
+#define EXTI_C2IMR2_IM44_Msk     (0x1UL << EXTI_C2IMR2_IM44_Pos)               /*!< 0x00001000 */
+#define EXTI_C2IMR2_IM44         EXTI_C2IMR2_IM44_Msk                          /*!< CPU2 Interrupt Mask on line 44 */
+#define EXTI_C2IMR2_IM45_Pos     (13U)
+#define EXTI_C2IMR2_IM45_Msk     (0x1UL << EXTI_C2IMR2_IM45_Pos)               /*!< 0x00002000 */
+#define EXTI_C2IMR2_IM45         EXTI_C2IMR2_IM45_Msk                          /*!< CPU2 Interrupt Mask on line 45 */
+#define EXTI_C2IMR2_IM48_Pos     (16U)
+#define EXTI_C2IMR2_IM48_Msk     (0x1UL << EXTI_C2IMR2_IM48_Pos)               /*!< 0x00010000 */
+#define EXTI_C2IMR2_IM48         EXTI_C2IMR2_IM48_Msk                          /*!< CPU2 Interrupt Mask on line 48 */
+
+/********************  Bits definition for EXTI_C2EMR2 register  **************/
+#define EXTI_C2EMR2_Pos          (8U)
+#define EXTI_C2EMR2_Msk          (0x00000300UL << EXTI_C2EMR2_Pos)             /*!< 0x000003000 */
+#define EXTI_C2EMR2_EM           EXTI_C2EMR2_Msk                               /*!< CPU2 Interrupt Mask  */
+#define EXTI_C2EMR2_EM40_Pos     (8U)
+#define EXTI_C2EMR2_EM40_Msk     (0x1UL << EXTI_C2EMR2_EM40_Pos)               /*!< 0x00000100 */
+#define EXTI_C2EMR2_EM40         EXTI_C2EMR2_EM40_Msk                          /*!< CPU2 Event Mask on line 40 */
+#define EXTI_C2EMR2_EM41_Pos     (9U)
+#define EXTI_C2EMR2_EM41_Msk     (0x1UL << EXTI_C2EMR2_EM41_Pos)               /*!< 0x00000200 */
+#define EXTI_C2EMR2_EM41         EXTI_C2EMR2_EM41_Msk                          /*!< CPU2 Event Mask on line 41 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Public Key Accelerator (PKA)                         */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bits definition for PKA_CR register  **************/
+#define PKA_CR_EN_Pos              (0U)
+#define PKA_CR_EN_Msk              (0x1UL << PKA_CR_EN_Pos)                /*!< 0x00000001 */
+#define PKA_CR_EN                  PKA_CR_EN_Msk                           /*!< PKA enable */
+#define PKA_CR_START_Pos           (1U)
+#define PKA_CR_START_Msk           (0x1UL << PKA_CR_START_Pos)             /*!< 0x00000002 */
+#define PKA_CR_START               PKA_CR_START_Msk                        /*!< Start operation */
+#define PKA_CR_MODE_Pos            (8U)
+#define PKA_CR_MODE_Msk            (0x3FUL << PKA_CR_MODE_Pos)             /*!< 0x00003F00 */
+#define PKA_CR_MODE                PKA_CR_MODE_Msk                         /*!< MODE[5:0] PKA operation code */
+#define PKA_CR_MODE_0              (0x01U << PKA_CR_MODE_Pos)              /*!< 0x00000100 */
+#define PKA_CR_MODE_1              (0x02U << PKA_CR_MODE_Pos)              /*!< 0x00000200 */
+#define PKA_CR_MODE_2              (0x04U << PKA_CR_MODE_Pos)              /*!< 0x00000400 */
+#define PKA_CR_MODE_3              (0x08U << PKA_CR_MODE_Pos)              /*!< 0x00000800 */
+#define PKA_CR_MODE_4              (0x10U << PKA_CR_MODE_Pos)              /*!< 0x00001000 */
+#define PKA_CR_MODE_5              (0x20U << PKA_CR_MODE_Pos)              /*!< 0x00002000 */
+#define PKA_CR_PROCENDIE_Pos       (17U)
+#define PKA_CR_PROCENDIE_Msk       (0x1UL << PKA_CR_PROCENDIE_Pos)         /*!< 0x00020000 */
+#define PKA_CR_PROCENDIE           PKA_CR_PROCENDIE_Msk                    /*!< End of operation interrupt enable */
+#define PKA_CR_RAMERRIE_Pos        (19U)
+#define PKA_CR_RAMERRIE_Msk        (0x1UL << PKA_CR_RAMERRIE_Pos)          /*!< 0x00080000 */
+#define PKA_CR_RAMERRIE            PKA_CR_RAMERRIE_Msk                     /*!< RAM error interrupt enable */
+#define PKA_CR_ADDRERRIE_Pos       (20U)
+#define PKA_CR_ADDRERRIE_Msk       (0x1UL << PKA_CR_ADDRERRIE_Pos)         /*!< 0x00100000 */
+#define PKA_CR_ADDRERRIE           PKA_CR_ADDRERRIE_Msk                    /*!< RAM error interrupt enable */
+
+/*******************  Bits definition for PKA_SR register  **************/
+#define PKA_SR_BUSY_Pos            (16U)
+#define PKA_SR_BUSY_Msk            (0x1UL << PKA_SR_BUSY_Pos)              /*!< 0x00010000 */
+#define PKA_SR_BUSY                PKA_SR_BUSY_Msk                         /*!< PKA operation is in progress */
+#define PKA_SR_PROCENDF_Pos        (17U)
+#define PKA_SR_PROCENDF_Msk        (0x1UL << PKA_SR_PROCENDF_Pos)          /*!< 0x00020000 */
+#define PKA_SR_PROCENDF            PKA_SR_PROCENDF_Msk                     /*!< PKA end of operation flag */
+#define PKA_SR_RAMERRF_Pos         (19U)
+#define PKA_SR_RAMERRF_Msk         (0x1UL << PKA_SR_RAMERRF_Pos)           /*!< 0x00080000 */
+#define PKA_SR_RAMERRF             PKA_SR_RAMERRF_Msk                      /*!< PKA RAM error flag */
+#define PKA_SR_ADDRERRF_Pos        (20U)
+#define PKA_SR_ADDRERRF_Msk        (0x1UL << PKA_SR_ADDRERRF_Pos)          /*!< 0x00100000 */
+#define PKA_SR_ADDRERRF            PKA_SR_ADDRERRF_Msk                     /*!< Address error flag */
+
+/*******************  Bits definition for PKA_CLRFR register  **************/
+#define PKA_CLRFR_PROCENDFC_Pos    (17U)
+#define PKA_CLRFR_PROCENDFC_Msk    (0x1UL << PKA_CLRFR_PROCENDFC_Pos)      /*!< 0x00020000 */
+#define PKA_CLRFR_PROCENDFC        PKA_CLRFR_PROCENDFC_Msk                 /*!< Clear PKA end of operation flag */
+#define PKA_CLRFR_RAMERRFC_Pos     (19U)
+#define PKA_CLRFR_RAMERRFC_Msk     (0x1UL << PKA_CLRFR_RAMERRFC_Pos)       /*!< 0x00080000 */
+#define PKA_CLRFR_RAMERRFC         PKA_CLRFR_RAMERRFC_Msk                  /*!< Clear PKA RAM error flag */
+#define PKA_CLRFR_ADDRERRFC_Pos    (20U)
+#define PKA_CLRFR_ADDRERRFC_Msk    (0x1UL << PKA_CLRFR_ADDRERRFC_Pos)      /*!< 0x00100000 */
+#define PKA_CLRFR_ADDRERRFC        PKA_CLRFR_ADDRERRFC_Msk                 /*!< Clear address error flag */
+
+/*******************  Bits definition for PKA RAM  *************************/
+#define PKA_RAM_OFFSET                            0x400U                           /*!< PKA RAM address offset */
+
+/* Compute Montgomery parameter input data */
+#define PKA_MONTGOMERY_PARAM_IN_MOD_NB_BITS       ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_MONTGOMERY_PARAM_IN_MODULUS           ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Compute Montgomery parameter output data */
+#define PKA_MONTGOMERY_PARAM_OUT_PARAMETER        ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Output Montgomery parameter */
+
+/* Compute modular exponentiation input data */
+#define PKA_MODULAR_EXP_IN_EXP_NB_BITS            ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent number of bits */
+#define PKA_MODULAR_EXP_IN_OP_NB_BITS             ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM       ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Input storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_IN_EXPONENT_BASE          ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input base of the exponentiation */
+#define PKA_MODULAR_EXP_IN_EXPONENT               ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent to process */
+#define PKA_MODULAR_EXP_IN_MODULUS                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Compute modular exponentiation output data */
+#define PKA_MODULAR_EXP_OUT_MONTGOMERY_PARAM      ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Output storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC1          ((0x724U - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 1 */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC2          ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 2 */
+#define PKA_MODULAR_EXP_OUT_EXPONENT_BASE         ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Output base of the exponentiation */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC3          ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 3 */
+
+/* Compute ECC scalar multiplication input data */
+#define PKA_ECC_SCALAR_MUL_IN_EXP_NB_BITS         ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_OP_NB_BITS          ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF_SIGN        ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF             ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_MOD_GF              ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECC_SCALAR_MUL_IN_MONTGOMERY_PARAM    ((0x4B4U - PKA_RAM_OFFSET)>>2)   /*!< Input storage area for Montgomery parameter */
+#define PKA_ECC_SCALAR_MUL_IN_K                   ((0x508U - PKA_RAM_OFFSET)>>2)   /*!< Input 'k' of KP */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X     ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y     ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+
+/* Compute ECC scalar multiplication output data */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_X           ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Output result X coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_Y           ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Output result Y coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_X1     ((0xDE8U - PKA_RAM_OFFSET)>>2)   /*!< Output last double X1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_Y1     ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Output last double Y1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_Z1     ((0xE90U - PKA_RAM_OFFSET)>>2)   /*!< Output last double Z1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_X2     ((0xEE4U - PKA_RAM_OFFSET)>>2)   /*!< Output check point X2 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_Y2     ((0xF38U - PKA_RAM_OFFSET)>>2)   /*!< Output check point Y2 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_Z2     ((0xF8CU - PKA_RAM_OFFSET)>>2)   /*!< Output check point Z2 coordinate */
+
+/* Point check input data */
+#define PKA_POINT_CHECK_IN_MOD_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_POINT_CHECK_IN_A_COEFF_SIGN           ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_POINT_CHECK_IN_A_COEFF                ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_POINT_CHECK_IN_B_COEFF                ((0x7FCU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'b' coefficient */
+#define PKA_POINT_CHECK_IN_MOD_GF                 ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_X        ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_Y        ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+
+/* Point check output data */
+#define PKA_POINT_CHECK_OUT_ERROR                 ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Output error */
+
+/* ECDSA signature input data */
+#define PKA_ECDSA_SIGN_IN_ORDER_NB_BITS           ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input order number of bits */
+#define PKA_ECDSA_SIGN_IN_MOD_NB_BITS             ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_ECDSA_SIGN_IN_A_COEFF_SIGN            ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_A_COEFF                 ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_MOD_GF                  ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECDSA_SIGN_IN_K                       ((0x508U - PKA_RAM_OFFSET)>>2)   /*!< Input k value of the ECDSA */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_X         ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_Y         ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_SIGN_IN_HASH_E                  ((0xDE8U - PKA_RAM_OFFSET)>>2)   /*!< Input e, hash of the message */
+#define PKA_ECDSA_SIGN_IN_PRIVATE_KEY_D           ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Input d, private key */
+#define PKA_ECDSA_SIGN_IN_ORDER_N                 ((0xE94U - PKA_RAM_OFFSET)>>2)   /*!< Input n, order of the curve */
+
+/* ECDSA signature output data */
+#define PKA_ECDSA_SIGN_OUT_ERROR                  ((0xEE8U - PKA_RAM_OFFSET)>>2)   /*!< Output error */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_R            ((0x700U - PKA_RAM_OFFSET)>>2)   /*!< Output signature r */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_S            ((0x754U - PKA_RAM_OFFSET)>>2)   /*!< Output signature s */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_X          ((0x103CU - PKA_RAM_OFFSET)>>2)  /*!< Output final point kP X coordinate */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_Y          ((0x1090U - PKA_RAM_OFFSET)>>2)  /*!< Output final point kP Y coordinate */
+
+/* ECDSA verification input data */
+#define PKA_ECDSA_VERIF_IN_ORDER_NB_BITS          ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input order number of bits */
+#define PKA_ECDSA_VERIF_IN_MOD_NB_BITS            ((0x4B4U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_ECDSA_VERIF_IN_A_COEFF_SIGN           ((0x45CU - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_A_COEFF                ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_MOD_GF                 ((0x4B8U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_X        ((0x5E8U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_Y        ((0x63CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X     ((0xF40U - PKA_RAM_OFFSET)>>2)   /*!< Input public key point X coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y     ((0xF94U - PKA_RAM_OFFSET)>>2)   /*!< Input public key point Y coordinate */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_R            ((0x1098U - PKA_RAM_OFFSET)>>2)  /*!< Input r, part of the signature */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_S            ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input s, part of the signature */
+#define PKA_ECDSA_VERIF_IN_HASH_E                 ((0xFE8U - PKA_RAM_OFFSET)>>2)   /*!< Input e, hash of the message */
+#define PKA_ECDSA_VERIF_IN_ORDER_N                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input n, order of the curve */
+
+/* ECDSA verification output data */
+#define PKA_ECDSA_VERIF_OUT_RESULT                ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* RSA CRT exponentiation input data */
+#define PKA_RSA_CRT_EXP_IN_MOD_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operands number of bits */
+#define PKA_RSA_CRT_EXP_IN_DP_CRT                 ((0x65CU - PKA_RAM_OFFSET)>>2)   /*!< Input Dp CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_DQ_CRT                 ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Input Dq CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_QINV_CRT               ((0x7ECU - PKA_RAM_OFFSET)>>2)   /*!< Input qInv CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_PRIME_P                ((0x97CU - PKA_RAM_OFFSET)>>2)   /*!< Input Prime p */
+#define PKA_RSA_CRT_EXP_IN_PRIME_Q                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input Prime q */
+#define PKA_RSA_CRT_EXP_IN_EXPONENT_BASE          ((0xEECU - PKA_RAM_OFFSET)>>2)   /*!< Input base of the exponentiation */
+
+/* RSA CRT exponentiation output data */
+#define PKA_RSA_CRT_EXP_OUT_RESULT                ((0x724U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular reduction input data */
+#define PKA_MODULAR_REDUC_IN_OP_LENGTH            ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input operand length */
+#define PKA_MODULAR_REDUC_IN_OPERAND              ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand */
+#define PKA_MODULAR_REDUC_IN_MOD_LENGTH           ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus length */
+#define PKA_MODULAR_REDUC_IN_MODULUS              ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Modular reduction output data */
+#define PKA_MODULAR_REDUC_OUT_RESULT              ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic addition input data */
+#define PKA_ARITHMETIC_ADD_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ADD_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ADD_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic addition output data */
+#define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic subtraction input data */
+#define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic subtraction output data */
+#define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic multiplication input data */
+#define PKA_ARITHMETIC_MUL_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_MUL_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_MUL_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic multiplication output data */
+#define PKA_ARITHMETIC_MUL_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Comparison input data */
+#define PKA_COMPARISON_NB_BITS                    ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_COMPARISON_IN_OP1                     ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_COMPARISON_IN_OP2                     ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Comparison output data */
+#define PKA_COMPARISON_OUT_RESULT                 ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular addition input data */
+#define PKA_MODULAR_ADD_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_ADD_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_ADD_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MODULAR_ADD_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 (modulus) */
+
+/* Modular addition output data */
+#define PKA_MODULAR_ADD_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular inversion input data */
+#define PKA_MODULAR_INV_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_INV_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_INV_IN_OP2_MOD                ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 (modulus) */
+
+/* Modular inversion output data */
+#define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular subtraction input data */
+#define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
+
+/* Modular subtraction output data */
+#define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Montgomery multiplication input data */
+#define PKA_MONTGOMERY_MUL_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MONTGOMERY_MUL_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MONTGOMERY_MUL_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MONTGOMERY_MUL_IN_OP3_MOD             ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Montgomery multiplication output data */
+#define PKA_MONTGOMERY_MUL_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Generic Arithmetic input data */
+#define PKA_ARITHMETIC_ALL_OPS_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP1             ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP2             ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP3             ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Generic Arithmetic output data */
+#define PKA_ARITHMETIC_ALL_OPS_OUT_RESULT         ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos               (0U)
+#define FLASH_ACR_LATENCY_Msk               (0x7UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY                   FLASH_ACR_LATENCY_Msk              /*!< Latency                                             */
+#define FLASH_ACR_LATENCY_0                 (0x1UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000001 */
+#define FLASH_ACR_LATENCY_1                 (0x2UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000002 */
+#define FLASH_ACR_LATENCY_2                 (0x4UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000004 */
+#define FLASH_ACR_PRFTEN_Pos                (8U)
+#define FLASH_ACR_PRFTEN_Msk                (0x1UL << FLASH_ACR_PRFTEN_Pos)    /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN                    FLASH_ACR_PRFTEN_Msk               /*!< Prefetch enable                                     */
+#define FLASH_ACR_ICEN_Pos                  (9U)
+#define FLASH_ACR_ICEN_Msk                  (0x1UL << FLASH_ACR_ICEN_Pos)      /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                      FLASH_ACR_ICEN_Msk                 /*!< Instruction cache enable                            */
+#define FLASH_ACR_DCEN_Pos                  (10U)
+#define FLASH_ACR_DCEN_Msk                  (0x1UL << FLASH_ACR_DCEN_Pos)      /*!< 0x00000400 */
+#define FLASH_ACR_DCEN                      FLASH_ACR_DCEN_Msk                 /*!< Data cache enable                                   */
+#define FLASH_ACR_ICRST_Pos                 (11U)
+#define FLASH_ACR_ICRST_Msk                 (0x1UL << FLASH_ACR_ICRST_Pos)     /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                     FLASH_ACR_ICRST_Msk                /*!< Instruction cache reset                             */
+#define FLASH_ACR_DCRST_Pos                 (12U)
+#define FLASH_ACR_DCRST_Msk                 (0x1UL << FLASH_ACR_DCRST_Pos)     /*!< 0x00001000 */
+#define FLASH_ACR_DCRST                     FLASH_ACR_DCRST_Msk                /*!< Data cache reset                                    */
+#define FLASH_ACR_PES_Pos                   (15U)
+#define FLASH_ACR_PES_Msk                   (0x1UL << FLASH_ACR_PES_Pos)       /*!< 0x00008000 */
+#define FLASH_ACR_PES                       FLASH_ACR_PES_Msk                  /*!< Program/erase suspend request                       */
+#define FLASH_ACR_EMPTY_Pos                 (16U)
+#define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
+#define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
+
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos                    (0U)
+#define FLASH_SR_EOP_Msk                    (0x1UL << FLASH_SR_EOP_Pos)        /*!< 0x00000001 */
+#define FLASH_SR_EOP                        FLASH_SR_EOP_Msk                   /*!< End of Operation                                    */
+#define FLASH_SR_OPERR_Pos                  (1U)
+#define FLASH_SR_OPERR_Msk                  (0x1UL << FLASH_SR_OPERR_Pos)      /*!< 0x00000002 */
+#define FLASH_SR_OPERR                      FLASH_SR_OPERR_Msk                 /*!< Operation error                                     */
+#define FLASH_SR_PROGERR_Pos                (3U)
+#define FLASH_SR_PROGERR_Msk                (0x1UL << FLASH_SR_PROGERR_Pos)    /*!< 0x00000008 */
+#define FLASH_SR_PROGERR                    FLASH_SR_PROGERR_Msk               /*!< Programming error                                   */
+#define FLASH_SR_WRPERR_Pos                 (4U)
+#define FLASH_SR_WRPERR_Msk                 (0x1UL << FLASH_SR_WRPERR_Pos)     /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                     FLASH_SR_WRPERR_Msk                /*!< Write protection error                              */
+#define FLASH_SR_PGAERR_Pos                 (5U)
+#define FLASH_SR_PGAERR_Msk                 (0x1UL << FLASH_SR_PGAERR_Pos)     /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                     FLASH_SR_PGAERR_Msk                /*!< Programming alignment error                         */
+#define FLASH_SR_SIZERR_Pos                 (6U)
+#define FLASH_SR_SIZERR_Msk                 (0x1UL << FLASH_SR_SIZERR_Pos)     /*!< 0x00000040 */
+#define FLASH_SR_SIZERR                     FLASH_SR_SIZERR_Msk                /*!< Size error                                          */
+#define FLASH_SR_PGSERR_Pos                 (7U)
+#define FLASH_SR_PGSERR_Msk                 (0x1UL << FLASH_SR_PGSERR_Pos)     /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                     FLASH_SR_PGSERR_Msk                /*!< Programming sequence error                          */
+#define FLASH_SR_MISERR_Pos                 (8U)
+#define FLASH_SR_MISERR_Msk                 (0x1UL << FLASH_SR_MISERR_Pos)     /*!< 0x00000100 */
+#define FLASH_SR_MISERR                     FLASH_SR_MISERR_Msk                /*!< Fast programming data miss error                    */
+#define FLASH_SR_FASTERR_Pos                (9U)
+#define FLASH_SR_FASTERR_Msk                (0x1UL << FLASH_SR_FASTERR_Pos)    /*!< 0x00000200 */
+#define FLASH_SR_FASTERR                    FLASH_SR_FASTERR_Msk               /*!< Fast programming error                              */
+#define FLASH_SR_OPTNV_Pos                  (13U)
+#define FLASH_SR_OPTNV_Msk                  (0x1UL << FLASH_SR_OPTNV_Pos)     /*!< 0x00002000 */
+#define FLASH_SR_OPTNV                      FLASH_SR_OPTNV_Msk                /*!< User option OPTVAL indication                       */
+#define FLASH_SR_RDERR_Pos                  (14U)
+#define FLASH_SR_RDERR_Msk                  (0x1UL << FLASH_SR_RDERR_Pos)      /*!< 0x00004000 */
+#define FLASH_SR_RDERR                      FLASH_SR_RDERR_Msk                 /*!< PCROP read error                                    */
+#define FLASH_SR_OPTVERR_Pos                (15U)
+#define FLASH_SR_OPTVERR_Msk                (0x1UL << FLASH_SR_OPTVERR_Pos)    /*!< 0x00008000 */
+#define FLASH_SR_OPTVERR                    FLASH_SR_OPTVERR_Msk               /*!< Option validity error                               */
+#define FLASH_SR_BSY_Pos                    (16U)
+#define FLASH_SR_BSY_Msk                    (0x1UL << FLASH_SR_BSY_Pos)        /*!< 0x00010000 */
+#define FLASH_SR_BSY                        FLASH_SR_BSY_Msk                   /*!< Flash Busy                                          */
+#define FLASH_SR_CFGBSY_Pos                 (18U)
+#define FLASH_SR_CFGBSY_Msk                 (0x1UL << FLASH_SR_CFGBSY_Pos)     /*!< 0x00040000 */
+#define FLASH_SR_CFGBSY                     FLASH_SR_CFGBSY_Msk                /*!< Programming or erase configuration busy             */
+#define FLASH_SR_PESD_Pos                   (19U)
+#define FLASH_SR_PESD_Msk                   (0x1UL << FLASH_SR_PESD_Pos)       /*!< 0x00080000 */
+#define FLASH_SR_PESD                       FLASH_SR_PESD_Msk                  /*!< Programming/erase operation suspended               */
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                     (0U)
+#define FLASH_CR_PG_Msk                     (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
+#define FLASH_CR_PG                         FLASH_CR_PG_Msk                    /*!< Flash programming                                   */
+#define FLASH_CR_PER_Pos                    (1U)
+#define FLASH_CR_PER_Msk                    (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
+#define FLASH_CR_PER                        FLASH_CR_PER_Msk                   /*!< Page erase                                          */
+#define FLASH_CR_MER_Pos                    (2U)
+#define FLASH_CR_MER_Msk                    (0x1UL << FLASH_CR_MER_Pos)        /*!< 0x00000004 */
+#define FLASH_CR_MER                        FLASH_CR_MER_Msk                   /*!< Mass erase                                          */
+#define FLASH_CR_PNB_Pos                    (3U)
+#define FLASH_CR_PNB_Msk                    (0xFFUL << FLASH_CR_PNB_Pos)       /*!< 0x000007F8 */
+#define FLASH_CR_PNB                        FLASH_CR_PNB_Msk                   /*!< Page number selection mask                          */
+#define FLASH_CR_STRT_Pos                   (16U)
+#define FLASH_CR_STRT_Msk                   (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
+#define FLASH_CR_STRT                       FLASH_CR_STRT_Msk                  /*!< Start an erase operation                            */
+#define FLASH_CR_OPTSTRT_Pos                (17U)
+#define FLASH_CR_OPTSTRT_Msk                (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT                    FLASH_CR_OPTSTRT_Msk               /*!< Options modification start                          */
+#define FLASH_CR_FSTPG_Pos                  (18U)
+#define FLASH_CR_FSTPG_Msk                  (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
+#define FLASH_CR_FSTPG                      FLASH_CR_FSTPG_Msk                 /*!< Fast programming                                    */
+#define FLASH_CR_EOPIE_Pos                  (24U)
+#define FLASH_CR_EOPIE_Msk                  (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                      FLASH_CR_EOPIE_Msk                 /*!< End of operation interrupt enable                   */
+#define FLASH_CR_ERRIE_Pos                  (25U)
+#define FLASH_CR_ERRIE_Msk                  (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
+#define FLASH_CR_ERRIE                      FLASH_CR_ERRIE_Msk                 /*!< Error interrupt enable                              */
+#define FLASH_CR_RDERRIE_Pos                (26U)
+#define FLASH_CR_RDERRIE_Msk                (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE                    FLASH_CR_RDERRIE_Msk               /*!< PCROP read error interrupt enable                   */
+#define FLASH_CR_OBL_LAUNCH_Pos             (27U)
+#define FLASH_CR_OBL_LAUNCH_Msk             (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
+#define FLASH_CR_OBL_LAUNCH                 FLASH_CR_OBL_LAUNCH_Msk            /*!< Force the option byte loading                       */
+#define FLASH_CR_OPTLOCK_Pos                (30U)
+#define FLASH_CR_OPTLOCK_Msk                (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK                    FLASH_CR_OPTLOCK_Msk               /*!< Options lock                                        */
+#define FLASH_CR_LOCK_Pos                   (31U)
+#define FLASH_CR_LOCK_Msk                   (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
+#define FLASH_CR_LOCK                       FLASH_CR_LOCK_Msk                  /*!< Flash control register lock                         */
+
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos             (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk             (0x1FFFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x0001FFFF */
+#define FLASH_ECCR_ADDR_ECC                 FLASH_ECCR_ADDR_ECC_Msk            /*!< double-word address ECC fail                        */
+#define FLASH_ECCR_SYSF_ECC_Pos             (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk             (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                 FLASH_ECCR_SYSF_ECC_Msk            /*!< System flash ECC fail                               */
+#define FLASH_ECCR_ECCCIE_Pos               (24U)
+#define FLASH_ECCR_ECCCIE_Msk               (0x1UL << FLASH_ECCR_ECCCIE_Pos)   /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                   FLASH_ECCR_ECCCIE_Msk              /*!< ECC correction interrupt enable                     */
+#define FLASH_ECCR_CPUID_Pos                (26U)
+#define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
+#define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
+#define FLASH_ECCR_ECCC_Pos                 (30U)
+#define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
+#define FLASH_ECCR_ECCD_Pos                 (31U)
+#define FLASH_ECCR_ECCD_Msk                 (0x1UL << FLASH_ECCR_ECCD_Pos)     /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                     FLASH_ECCR_ECCD_Msk                /*!< ECC detection                                       */
+
+/*******************  Bits definition for FLASH_OPTR register  ****************/
+#define FLASH_OPTR_RDP_Pos                  (0U)
+#define FLASH_OPTR_RDP_Msk                  (0xFFUL << FLASH_OPTR_RDP_Pos)     /*!< 0x000000FF */
+#define FLASH_OPTR_RDP                      FLASH_OPTR_RDP_Msk                 /*!< Read protection level                               */
+#define FLASH_OPTR_ESE_Pos                  (8U)
+#define FLASH_OPTR_ESE_Msk                  (0x1UL << FLASH_OPTR_ESE_Pos)      /*!< 0x00000100 */
+#define FLASH_OPTR_ESE                      FLASH_OPTR_ESE_Msk                 /*!< Security enable                                     */
+#define FLASH_OPTR_BOR_LEV_Pos              (9U)
+#define FLASH_OPTR_BOR_LEV_Msk              (0x7UL << FLASH_OPTR_BOR_LEV_Pos)  /*!< 0x00000E00 */
+#define FLASH_OPTR_BOR_LEV                  FLASH_OPTR_BOR_LEV_Msk             /*!< BOR reset level mask                                */
+#define FLASH_OPTR_BOR_LEV_0                (0x1U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000200 */
+#define FLASH_OPTR_BOR_LEV_1                (0x2U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000400 */
+#define FLASH_OPTR_BOR_LEV_2                (0x4U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000800 */
+#define FLASH_OPTR_nRST_STOP_Pos            (12U)
+#define FLASH_OPTR_nRST_STOP_Msk            (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_nRST_STOP                FLASH_OPTR_nRST_STOP_Msk           /*!< Reset option in Stop mode                           */
+#define FLASH_OPTR_nRST_STDBY_Pos           (13U)
+#define FLASH_OPTR_nRST_STDBY_Msk           (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STDBY               FLASH_OPTR_nRST_STDBY_Msk          /*!< Reset option in Standby mode                        */
+#define FLASH_OPTR_nRST_SHDW_Pos            (14U)
+#define FLASH_OPTR_nRST_SHDW_Msk            (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_SHDW                FLASH_OPTR_nRST_SHDW_Msk           /*!< Reset option in Shutdown mode                       */
+#define FLASH_OPTR_IRHEN_Pos                (15U)
+#define FLASH_OPTR_IRHEN_Msk                (0x1UL << FLASH_OPTR_IRHEN_Pos)    /*!< 0x00008000 */
+#define FLASH_OPTR_IRHEN                    FLASH_OPTR_IRHEN_Msk               /*!< Internal reset holder enable bit                    */
+#define FLASH_OPTR_IWDG_SW_Pos              (16U)
+#define FLASH_OPTR_IWDG_SW_Msk              (0x1UL << FLASH_OPTR_IWDG_SW_Pos)  /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW                  FLASH_OPTR_IWDG_SW_Msk             /*!< Independent watchdog selection                      */
+#define FLASH_OPTR_IWDG_STOP_Pos            (17U)
+#define FLASH_OPTR_IWDG_STOP_Msk            (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP                FLASH_OPTR_IWDG_STOP_Msk           /*!< Independent watchdog counter option in Stop mode    */
+#define FLASH_OPTR_IWDG_STDBY_Pos           (18U)
+#define FLASH_OPTR_IWDG_STDBY_Msk           (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY               FLASH_OPTR_IWDG_STDBY_Msk          /*!< Independent watchdog counter option in Standby mode */
+#define FLASH_OPTR_WWDG_SW_Pos              (19U)
+#define FLASH_OPTR_WWDG_SW_Msk              (0x1UL << FLASH_OPTR_WWDG_SW_Pos)  /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW                  FLASH_OPTR_WWDG_SW_Msk             /*!< Window watchdog selection                           */
+#define FLASH_OPTR_nRST_MODE_1_Pos          (22U)
+#define FLASH_OPTR_nRST_MODE_1_Msk          (0x1UL << FLASH_OPTR_nRST_MODE_1_Pos)  /*!< 0x04000000 */
+#define FLASH_OPTR_nRST_MODE_1              FLASH_OPTR_nRST_MODE_1_Msk         /*!< PB11 GPIO normal mode                               */
+#define FLASH_OPTR_nBOOT1_Pos               (23U)
+#define FLASH_OPTR_nBOOT1_Msk               (0x1UL << FLASH_OPTR_nBOOT1_Pos)   /*!< 0x00800000 */
+#define FLASH_OPTR_nBOOT1                   FLASH_OPTR_nBOOT1_Msk              /*!< Boot Configuration                                  */
+#define FLASH_OPTR_SRAM2PE_Pos              (24U)
+#define FLASH_OPTR_SRAM2PE_Msk              (0x1UL << FLASH_OPTR_SRAM2PE_Pos)  /*!< 0x01000000 */
+#define FLASH_OPTR_SRAM2PE                  FLASH_OPTR_SRAM2PE_Msk             /*!< SRAM2 parity check enable                           */
+#define FLASH_OPTR_SRAM2RST_Pos             (25U)
+#define FLASH_OPTR_SRAM2RST_Msk             (0x1UL << FLASH_OPTR_SRAM2RST_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_SRAM2RST                 FLASH_OPTR_SRAM2RST_Msk            /*!< SRAM2 erase option when system reset                */
+#define FLASH_OPTR_nSWBOOT0_Pos             (26U)
+#define FLASH_OPTR_nSWBOOT0_Msk             (0x1UL << FLASH_OPTR_nSWBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nSWBOOT0                 FLASH_OPTR_nSWBOOT0_Msk            /*!< Software BOOT0                                      */
+#define FLASH_OPTR_nBOOT0_Pos               (27U)
+#define FLASH_OPTR_nBOOT0_Msk               (0x1UL << FLASH_OPTR_nBOOT0_Pos)   /*!< 0x08000000 */
+#define FLASH_OPTR_nBOOT0                   FLASH_OPTR_nBOOT0_Msk              /*!< BOOT0 option bit                                    */
+#define FLASH_OPTR_nRST_MODE_0_Pos          (28U)
+#define FLASH_OPTR_nRST_MODE_0_Msk          (0x1UL << FLASH_OPTR_nRST_MODE_0_Pos)  /*!< 0x10000000 */
+#define FLASH_OPTR_nRST_MODE_0              FLASH_OPTR_nRST_MODE_0_Msk         /*!< PB11 reset input mode                               */
+#define FLASH_OPTR_nRST_MODE_Pos            (22U)
+#define FLASH_OPTR_nRST_MODE_Msk            (0x41UL << FLASH_OPTR_nRST_MODE_Pos)  /*!< 0x10400000 */
+#define FLASH_OPTR_nRST_MODE                FLASH_OPTR_nRST_MODE_Msk
+#define FLASH_OPTR_AGC_TRIM_Pos             (29U)
+#define FLASH_OPTR_AGC_TRIM_Msk             (0x7UL << FLASH_OPTR_AGC_TRIM_Pos)  /*!< 0xE0000000 */
+#define FLASH_OPTR_AGC_TRIM                 FLASH_OPTR_AGC_TRIM_Msk             /*!< Automatic Gain Control trimming mask               */
+#define FLASH_OPTR_AGC_TRIM_0               (0x1U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x20000000 */
+#define FLASH_OPTR_AGC_TRIM_1               (0x2U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x40000000 */
+#define FLASH_OPTR_AGC_TRIM_2               (0x4U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x80000000 */
+
+/******************  Bits definition for FLASH_PCROP1ASR register  ************/
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Pos    (0U)
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk    (0x1FFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT        FLASH_PCROP1ASR_PCROP1A_STRT_Msk   /*!< PCROP area A start offset                           */
+
+/******************  Bits definition for FLASH_PCROP1AER register  ************/
+#define FLASH_PCROP1AER_PCROP1A_END_Pos     (0U)
+#define FLASH_PCROP1AER_PCROP1A_END_Msk     (0x1FFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1AER_PCROP1A_END         FLASH_PCROP1AER_PCROP1A_END_Msk    /*!< PCROP area A end offset                             */
+#define FLASH_PCROP1AER_PCROP_RDP_Pos       (31U)
+#define FLASH_PCROP1AER_PCROP_RDP_Msk       (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP           FLASH_PCROP1AER_PCROP_RDP_Msk      /*!< PCROP area   preserved when RDP level decreased     */
+
+/******************  Bits definition for FLASH_WRP1AR register  ***************/
+#define FLASH_WRP1AR_WRP1A_STRT_Pos         (0U)
+#define FLASH_WRP1AR_WRP1A_STRT_Msk         (0xFFUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_WRP1AR_WRP1A_STRT             FLASH_WRP1AR_WRP1A_STRT_Msk        /*!< WRP area A start offset                             */
+#define FLASH_WRP1AR_WRP1A_END_Pos          (16U)
+#define FLASH_WRP1AR_WRP1A_END_Msk          (0xFFUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x00FF0000 */
+#define FLASH_WRP1AR_WRP1A_END              FLASH_WRP1AR_WRP1A_END_Msk         /*!< WRP area A end offset                               */
+
+/******************  Bits definition for FLASH_WRP1BR register  ***************/
+#define FLASH_WRP1BR_WRP1B_STRT_Pos         (0U)
+#define FLASH_WRP1BR_WRP1B_STRT_Msk         (0xFFUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_WRP1BR_WRP1B_STRT             FLASH_WRP1BR_WRP1B_STRT_Msk        /*!< WRP area B start offset                             */
+#define FLASH_WRP1BR_WRP1B_END_Pos          (16U)
+#define FLASH_WRP1BR_WRP1B_END_Msk          (0xFFUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x00FF0000 */
+#define FLASH_WRP1BR_WRP1B_END              FLASH_WRP1BR_WRP1B_END_Msk         /*!< WRP area B end offset                               */
+
+/******************  Bits definition for FLASH_PCROP1BSR register  ************/
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Pos    (0U)
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk    (0x1FFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT        FLASH_PCROP1BSR_PCROP1B_STRT_Msk   /*!< PCROP area B start offset                           */
+
+/******************  Bits definition for FLASH_PCROP1BER register  ************/
+#define FLASH_PCROP1BER_PCROP1B_END_Pos     (0U)
+#define FLASH_PCROP1BER_PCROP1B_END_Msk     (0x1FFUL << FLASH_PCROP1BER_PCROP1B_END_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1BER_PCROP1B_END         FLASH_PCROP1BER_PCROP1B_END_Msk    /*!< PCROP area B end offset                             */
+
+/******************  Bits definition for FLASH_IPCCBR register  ************/
+#define FLASH_IPCCBR_IPCCDBA_Pos            (0U)
+#define FLASH_IPCCBR_IPCCDBA_Msk            (0x3FFFUL << FLASH_IPCCBR_IPCCDBA_Pos) /*!< 0x00003FFF */
+#define FLASH_IPCCBR_IPCCDBA                FLASH_IPCCBR_IPCCDBA_Msk           /*!< IPCC data buffer base address                       */
+
+/******************  Bits definition for FLASH_SFR register  ************/
+#define FLASH_SFR_SFSA_Pos                  (0U)
+#define FLASH_SFR_SFSA_Msk                  (0xFFUL << FLASH_SFR_SFSA_Pos)     /*!< 0x000000FF */
+#define FLASH_SFR_SFSA                      FLASH_SFR_SFSA_Msk                 /* Secure flash start address                             */
+#define FLASH_SFR_FSD_Pos                   (8U)
+#define FLASH_SFR_FSD_Msk                   (0x1UL << FLASH_SFR_FSD_Pos)       /*!< 0x00000100 */
+#define FLASH_SFR_FSD                       FLASH_SFR_FSD_Msk                  /* Flash mode secure                                      */
+#define FLASH_SFR_DDS_Pos                   (12U)
+#define FLASH_SFR_DDS_Msk                   (0x1UL << FLASH_SFR_DDS_Pos)       /*!< 0x00001000 */
+#define FLASH_SFR_DDS                       FLASH_SFR_DDS_Msk                  /* Enabling and disabling CPU2 Debug access               */
+
+/******************  Bits definition for FLASH_SRRVR register  ************/
+#define FLASH_SRRVR_SBRV_Pos                (0U)
+#define FLASH_SRRVR_SBRV_Msk                (0x1FFFFUL << FLASH_SRRVR_SBRV_Pos) /*!< 0x0001FFFF */
+#define FLASH_SRRVR_SBRV                    FLASH_SRRVR_SBRV_Msk                /* CPU2 boot reset vector memory offset                  */
+
+#define FLASH_SRRVR_SBRSA_A_Pos             (18U)
+#define FLASH_SRRVR_SBRSA_A_Msk             (0x1FUL << FLASH_SRRVR_SBRSA_A_Pos) /*!< 0x007C0000 */
+#define FLASH_SRRVR_SBRSA_A                 FLASH_SRRVR_SBRSA_A_Msk             /* Secure backup SRAM2a start address                    */
+#define FLASH_SRRVR_BRSD_A_Pos              (23U)
+#define FLASH_SRRVR_BRSD_A_Msk              (0x1UL << FLASH_SRRVR_BRSD_A_Pos)   /*!< 0x00800000 */
+#define FLASH_SRRVR_BRSD_A                  FLASH_SRRVR_BRSD_A_Msk              /* Backup SRAM2A secure mode                             */
+
+#define FLASH_SRRVR_SBRSA_B_Pos             (25U)
+#define FLASH_SRRVR_SBRSA_B_Msk             (0x3UL << FLASH_SRRVR_SBRSA_B_Pos)  /*!< 0x06000000 */
+#define FLASH_SRRVR_SBRSA_B                 FLASH_SRRVR_SBRSA_B_Msk             /* Secure backup SRAM2b start address                    */
+#define FLASH_SRRVR_BRSD_B_Pos              (30U)
+#define FLASH_SRRVR_BRSD_B_Msk              (0x1UL << FLASH_SRRVR_BRSD_B_Pos)   /*!< 0x40000000 */
+#define FLASH_SRRVR_BRSD_B                  FLASH_SRRVR_BRSD_B_Msk              /* Backup SRAM2B secure mode                             */
+#define FLASH_SRRVR_C2OPT_Pos               (31U)
+#define FLASH_SRRVR_C2OPT_Msk               (0x1UL << FLASH_SRRVR_C2OPT_Pos)    /*!< 0x80000000 */
+#define FLASH_SRRVR_C2OPT                   FLASH_SRRVR_C2OPT_Msk               /* CPU2 boot reset vector memory selection                */
+
+/******************  Bits definition for FLASH_C2ACR register  ************/
+#define FLASH_C2ACR_PRFTEN_Pos              (8U)
+#define FLASH_C2ACR_PRFTEN_Msk              (0x1UL << FLASH_C2ACR_PRFTEN_Pos) /*!< 0x00000100 */
+#define FLASH_C2ACR_PRFTEN                  FLASH_C2ACR_PRFTEN_Msk            /*!< CPU2 Prefetch enable                                */
+#define FLASH_C2ACR_ICEN_Pos                (9U)
+#define FLASH_C2ACR_ICEN_Msk                (0x1UL << FLASH_C2ACR_ICEN_Pos)   /*!< 0x00000200 */
+#define FLASH_C2ACR_ICEN                    FLASH_C2ACR_ICEN_Msk              /*!< CPU2 Instruction cache enable                       */
+#define FLASH_C2ACR_ICRST_Pos               (11U)
+#define FLASH_C2ACR_ICRST_Msk               (0x1UL << FLASH_C2ACR_ICRST_Pos)  /*!< 0x00000800 */
+#define FLASH_C2ACR_ICRST                   FLASH_C2ACR_ICRST_Msk             /*!< CPU2 Instruction cache reset                        */
+#define FLASH_C2ACR_PES_Pos                 (15U)
+#define FLASH_C2ACR_PES_Msk                 (0x1UL << FLASH_C2ACR_PES_Pos)    /*!< 0x00008000 */
+#define FLASH_C2ACR_PES                     FLASH_C2ACR_PES_Msk               /*!< CPU2 Program/erase suspend request                  */
+
+/******************  Bits definition for FLASH_C2SR register  ************/
+#define FLASH_C2SR_EOP_Pos                  (0U)
+#define FLASH_C2SR_EOP_Msk                  (0x1UL << FLASH_C2SR_EOP_Pos)     /*!< 0x00000001 */
+#define FLASH_C2SR_EOP                      FLASH_C2SR_EOP_Msk                /*!< CPU2 End of operation                            */
+#define FLASH_C2SR_OPERR_Pos                (1U)
+#define FLASH_C2SR_OPERR_Msk                (0x1UL << FLASH_C2SR_OPERR_Pos)   /*!< 0x00000002 */
+#define FLASH_C2SR_OPERR                    FLASH_C2SR_OPERR_Msk              /*!< CPU2 Operation error                             */
+#define FLASH_C2SR_PROGERR_Pos              (3U)
+#define FLASH_C2SR_PROGERR_Msk              (0x1UL << FLASH_C2SR_PROGERR_Pos) /*!< 0x00000008 */
+#define FLASH_C2SR_PROGERR                  FLASH_C2SR_PROGERR_Msk            /*!< CPU2 Programming error                           */
+#define FLASH_C2SR_WRPERR_Pos               (4U)
+#define FLASH_C2SR_WRPERR_Msk               (0x1UL << FLASH_C2SR_WRPERR_Pos)  /*!< 0x00000010 */
+#define FLASH_C2SR_WRPERR                   FLASH_C2SR_WRPERR_Msk             /*!< CPU2 Write protection error                      */
+#define FLASH_C2SR_PGAERR_Pos               (5U)
+#define FLASH_C2SR_PGAERR_Msk               (0x1UL << FLASH_C2SR_PGAERR_Pos)  /*!< 0x00000020 */
+#define FLASH_C2SR_PGAERR                   FLASH_C2SR_PGAERR_Msk             /*!< CPU2 Programming alignment error                 */
+#define FLASH_C2SR_SIZERR_Pos               (6U)
+#define FLASH_C2SR_SIZERR_Msk               (0x1UL << FLASH_C2SR_SIZERR_Pos)  /*!< 0x00000040 */
+#define FLASH_C2SR_SIZERR                   FLASH_C2SR_SIZERR_Msk             /*!< CPU2 Size error                                  */
+#define FLASH_C2SR_PGSERR_Pos               (7U)
+#define FLASH_C2SR_PGSERR_Msk               (0x1UL << FLASH_C2SR_PGSERR_Pos)  /*!< 0x00000080 */
+#define FLASH_C2SR_PGSERR                   FLASH_C2SR_PGSERR_Msk             /*!< CPU2 Programming sequence error                  */
+#define FLASH_C2SR_MISERR_Pos               (8U)
+#define FLASH_C2SR_MISERR_Msk               (0x1UL << FLASH_C2SR_MISERR_Pos)  /*!< 0x00000100 */
+#define FLASH_C2SR_MISERR                   FLASH_C2SR_MISERR_Msk             /*!< CPU2 Fast programming data miss error            */
+#define FLASH_C2SR_FASTERR_Pos              (9U)
+#define FLASH_C2SR_FASTERR_Msk              (0x1UL << FLASH_C2SR_FASTERR_Pos) /*!< 0x00000200 */
+#define FLASH_C2SR_FASTERR                  FLASH_C2SR_FASTERR_Msk            /*!< CPU2 Fast programming error                      */
+#define FLASH_C2SR_RDERR_Pos                (14U)
+#define FLASH_C2SR_RDERR_Msk                (0x1UL << FLASH_C2SR_RDERR_Pos)   /*!< 0x00004000 */
+#define FLASH_C2SR_RDERR                    FLASH_C2SR_RDERR_Msk              /*!< CPU2 PCROP read error                            */
+#define FLASH_C2SR_BSY_Pos                  (16U)
+#define FLASH_C2SR_BSY_Msk                  (0x1UL << FLASH_C2SR_BSY_Pos)     /*!< 0x00010000 */
+#define FLASH_C2SR_BSY                      FLASH_C2SR_BSY_Msk                /*!< CPU2 Flash busy                                  */
+#define FLASH_C2SR_CFGBSY_Pos               (18U)
+#define FLASH_C2SR_CFGBSY_Msk               (0x1UL << FLASH_C2SR_CFGBSY_Pos)  /*!< 0x00040000 */
+#define FLASH_C2SR_CFGBSY                   FLASH_C2SR_CFGBSY_Msk             /*!< CPU2 Programming or erase configuration busy     */
+#define FLASH_C2SR_PESD_Pos                 (19U)
+#define FLASH_C2SR_PESD_Msk                 (0x1UL << FLASH_C2SR_PESD_Pos)   /*!< 0x00080000 */
+#define FLASH_C2SR_PESD                     FLASH_C2SR_PESD_Msk              /*!< CPU2 Programming/erase operation suspended       */
+
+/******************  Bits definition for FLASH_C2CR register  ************/
+#define FLASH_C2CR_PG_Pos                   (0U)
+#define FLASH_C2CR_PG_Msk                   (0x1UL << FLASH_C2CR_PG_Pos)      /*!< 0x00000001 */
+#define FLASH_C2CR_PG                       FLASH_C2CR_PG_Msk                 /*!< CPU2 Flash programming                                   */
+#define FLASH_C2CR_PER_Pos                  (1U)
+#define FLASH_C2CR_PER_Msk                  (0x1UL << FLASH_C2CR_PER_Pos)     /*!< 0x00000002 */
+#define FLASH_C2CR_PER                      FLASH_C2CR_PER_Msk                /*!< CPU2 Page erase                                          */
+#define FLASH_C2CR_MER_Pos                  (2U)
+#define FLASH_C2CR_MER_Msk                  (0x1UL << FLASH_C2CR_MER_Pos)     /*!< 0x00000004 */
+#define FLASH_C2CR_MER                      FLASH_C2CR_MER_Msk                /*!< CPU2 Mass erase                                          */
+#define FLASH_C2CR_PNB_Pos                  (3U)
+#define FLASH_C2CR_PNB_Msk                  (0xFFUL << FLASH_C2CR_PNB_Pos)    /*!< 0x000007F8 */
+#define FLASH_C2CR_PNB                      FLASH_C2CR_PNB_Msk                /*!< CPU2 Page number selection mask                          */
+#define FLASH_C2CR_STRT_Pos                 (16U)
+#define FLASH_C2CR_STRT_Msk                 (0x1UL << FLASH_C2CR_STRT_Pos)    /*!< 0x00010000 */
+#define FLASH_C2CR_STRT                     FLASH_C2CR_STRT_Msk               /*!< CPU2 Start an erase operation                            */
+#define FLASH_C2CR_FSTPG_Pos                (18U)
+#define FLASH_C2CR_FSTPG_Msk                (0x1UL << FLASH_C2CR_FSTPG_Pos)   /*!< 0x00040000 */
+#define FLASH_C2CR_FSTPG                    FLASH_C2CR_FSTPG_Msk              /*!< CPU2 Fast programming                                    */
+#define FLASH_C2CR_EOPIE_Pos                (24U)
+#define FLASH_C2CR_EOPIE_Msk                (0x1UL << FLASH_C2CR_EOPIE_Pos)   /*!< 0x01000000 */
+#define FLASH_C2CR_EOPIE                    FLASH_C2CR_EOPIE_Msk              /*!< CPU2 End of operation interrupt enable                   */
+#define FLASH_C2CR_ERRIE_Pos                (25U)
+#define FLASH_C2CR_ERRIE_Msk                (0x1UL << FLASH_C2CR_ERRIE_Pos)   /*!< 0x02000000 */
+#define FLASH_C2CR_ERRIE                    FLASH_C2CR_ERRIE_Msk              /*!< CPU2 Error interrupt enable                              */
+#define FLASH_C2CR_RDERRIE_Pos              (26U)
+#define FLASH_C2CR_RDERRIE_Msk              (0x1UL << FLASH_C2CR_RDERRIE_Pos) /*!< 0x04000000 */
+#define FLASH_C2CR_RDERRIE                  FLASH_C2CR_RDERRIE_Msk            /*!< CPU2 PCROP read error interrupt enable                   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0_Pos           (0U)
+#define GPIO_MODER_MODE0_Msk           (0x3UL << GPIO_MODER_MODE0_Pos)         /*!< 0x00000003 */
+#define GPIO_MODER_MODE0               GPIO_MODER_MODE0_Msk
+#define GPIO_MODER_MODE0_0             (0x1U << GPIO_MODER_MODE0_Pos)          /*!< 0x00000001 */
+#define GPIO_MODER_MODE0_1             (0x2U << GPIO_MODER_MODE0_Pos)          /*!< 0x00000002 */
+#define GPIO_MODER_MODE1_Pos           (2U)
+#define GPIO_MODER_MODE1_Msk           (0x3UL << GPIO_MODER_MODE1_Pos)         /*!< 0x0000000C */
+#define GPIO_MODER_MODE1               GPIO_MODER_MODE1_Msk
+#define GPIO_MODER_MODE1_0             (0x1U << GPIO_MODER_MODE1_Pos)          /*!< 0x00000004 */
+#define GPIO_MODER_MODE1_1             (0x2U << GPIO_MODER_MODE1_Pos)          /*!< 0x00000008 */
+#define GPIO_MODER_MODE2_Pos           (4U)
+#define GPIO_MODER_MODE2_Msk           (0x3UL << GPIO_MODER_MODE2_Pos)         /*!< 0x00000030 */
+#define GPIO_MODER_MODE2               GPIO_MODER_MODE2_Msk
+#define GPIO_MODER_MODE2_0             (0x1U << GPIO_MODER_MODE2_Pos)          /*!< 0x00000010 */
+#define GPIO_MODER_MODE2_1             (0x2U << GPIO_MODER_MODE2_Pos)          /*!< 0x00000020 */
+#define GPIO_MODER_MODE3_Pos           (6U)
+#define GPIO_MODER_MODE3_Msk           (0x3UL << GPIO_MODER_MODE3_Pos)         /*!< 0x000000C0 */
+#define GPIO_MODER_MODE3               GPIO_MODER_MODE3_Msk
+#define GPIO_MODER_MODE3_0             (0x1U << GPIO_MODER_MODE3_Pos)          /*!< 0x00000040 */
+#define GPIO_MODER_MODE3_1             (0x2U << GPIO_MODER_MODE3_Pos)          /*!< 0x00000080 */
+#define GPIO_MODER_MODE4_Pos           (8U)
+#define GPIO_MODER_MODE4_Msk           (0x3UL << GPIO_MODER_MODE4_Pos)         /*!< 0x00000300 */
+#define GPIO_MODER_MODE4               GPIO_MODER_MODE4_Msk
+#define GPIO_MODER_MODE4_0             (0x1U << GPIO_MODER_MODE4_Pos)          /*!< 0x00000100 */
+#define GPIO_MODER_MODE4_1             (0x2U << GPIO_MODER_MODE4_Pos)          /*!< 0x00000200 */
+#define GPIO_MODER_MODE5_Pos           (10U)
+#define GPIO_MODER_MODE5_Msk           (0x3UL << GPIO_MODER_MODE5_Pos)         /*!< 0x00000C00 */
+#define GPIO_MODER_MODE5               GPIO_MODER_MODE5_Msk
+#define GPIO_MODER_MODE5_0             (0x1U << GPIO_MODER_MODE5_Pos)          /*!< 0x00000400 */
+#define GPIO_MODER_MODE5_1             (0x2U << GPIO_MODER_MODE5_Pos)          /*!< 0x00000800 */
+#define GPIO_MODER_MODE6_Pos           (12U)
+#define GPIO_MODER_MODE6_Msk           (0x3UL << GPIO_MODER_MODE6_Pos)         /*!< 0x00003000 */
+#define GPIO_MODER_MODE6               GPIO_MODER_MODE6_Msk
+#define GPIO_MODER_MODE6_0             (0x1U << GPIO_MODER_MODE6_Pos)          /*!< 0x00001000 */
+#define GPIO_MODER_MODE6_1             (0x2U << GPIO_MODER_MODE6_Pos)          /*!< 0x00002000 */
+#define GPIO_MODER_MODE7_Pos           (14U)
+#define GPIO_MODER_MODE7_Msk           (0x3UL << GPIO_MODER_MODE7_Pos)         /*!< 0x0000C000 */
+#define GPIO_MODER_MODE7               GPIO_MODER_MODE7_Msk
+#define GPIO_MODER_MODE7_0             (0x1U << GPIO_MODER_MODE7_Pos)          /*!< 0x00004000 */
+#define GPIO_MODER_MODE7_1             (0x2U << GPIO_MODER_MODE7_Pos)          /*!< 0x00008000 */
+#define GPIO_MODER_MODE8_Pos           (16U)
+#define GPIO_MODER_MODE8_Msk           (0x3UL << GPIO_MODER_MODE8_Pos)         /*!< 0x00030000 */
+#define GPIO_MODER_MODE8               GPIO_MODER_MODE8_Msk
+#define GPIO_MODER_MODE8_0             (0x1U << GPIO_MODER_MODE8_Pos)          /*!< 0x00010000 */
+#define GPIO_MODER_MODE8_1             (0x2U << GPIO_MODER_MODE8_Pos)          /*!< 0x00020000 */
+#define GPIO_MODER_MODE9_Pos           (18U)
+#define GPIO_MODER_MODE9_Msk           (0x3UL << GPIO_MODER_MODE9_Pos)         /*!< 0x000C0000 */
+#define GPIO_MODER_MODE9               GPIO_MODER_MODE9_Msk
+#define GPIO_MODER_MODE9_0             (0x1U << GPIO_MODER_MODE9_Pos)          /*!< 0x00040000 */
+#define GPIO_MODER_MODE9_1             (0x2U << GPIO_MODER_MODE9_Pos)          /*!< 0x00080000 */
+#define GPIO_MODER_MODE10_Pos          (20U)
+#define GPIO_MODER_MODE10_Msk          (0x3UL << GPIO_MODER_MODE10_Pos)        /*!< 0x00300000 */
+#define GPIO_MODER_MODE10              GPIO_MODER_MODE10_Msk
+#define GPIO_MODER_MODE10_0            (0x1U << GPIO_MODER_MODE10_Pos)         /*!< 0x00100000 */
+#define GPIO_MODER_MODE10_1            (0x2U << GPIO_MODER_MODE10_Pos)         /*!< 0x00200000 */
+#define GPIO_MODER_MODE11_Pos          (22U)
+#define GPIO_MODER_MODE11_Msk          (0x3UL << GPIO_MODER_MODE11_Pos)        /*!< 0x00C00000 */
+#define GPIO_MODER_MODE11              GPIO_MODER_MODE11_Msk
+#define GPIO_MODER_MODE11_0            (0x1U << GPIO_MODER_MODE11_Pos)         /*!< 0x00400000 */
+#define GPIO_MODER_MODE11_1            (0x2U << GPIO_MODER_MODE11_Pos)         /*!< 0x00800000 */
+#define GPIO_MODER_MODE12_Pos          (24U)
+#define GPIO_MODER_MODE12_Msk          (0x3UL << GPIO_MODER_MODE12_Pos)        /*!< 0x03000000 */
+#define GPIO_MODER_MODE12              GPIO_MODER_MODE12_Msk
+#define GPIO_MODER_MODE12_0            (0x1U << GPIO_MODER_MODE12_Pos)         /*!< 0x01000000 */
+#define GPIO_MODER_MODE12_1            (0x2U << GPIO_MODER_MODE12_Pos)         /*!< 0x02000000 */
+#define GPIO_MODER_MODE13_Pos          (26U)
+#define GPIO_MODER_MODE13_Msk          (0x3UL << GPIO_MODER_MODE13_Pos)        /*!< 0x0C000000 */
+#define GPIO_MODER_MODE13              GPIO_MODER_MODE13_Msk
+#define GPIO_MODER_MODE13_0            (0x1U << GPIO_MODER_MODE13_Pos)         /*!< 0x04000000 */
+#define GPIO_MODER_MODE13_1            (0x2U << GPIO_MODER_MODE13_Pos)         /*!< 0x08000000 */
+#define GPIO_MODER_MODE14_Pos          (28U)
+#define GPIO_MODER_MODE14_Msk          (0x3UL << GPIO_MODER_MODE14_Pos)        /*!< 0x30000000 */
+#define GPIO_MODER_MODE14              GPIO_MODER_MODE14_Msk
+#define GPIO_MODER_MODE14_0            (0x1U << GPIO_MODER_MODE14_Pos)         /*!< 0x10000000 */
+#define GPIO_MODER_MODE14_1            (0x2U << GPIO_MODER_MODE14_Pos)         /*!< 0x20000000 */
+#define GPIO_MODER_MODE15_Pos          (30U)
+#define GPIO_MODER_MODE15_Msk          (0x3UL << GPIO_MODER_MODE15_Pos)        /*!< 0xC0000000 */
+#define GPIO_MODER_MODE15              GPIO_MODER_MODE15_Msk
+#define GPIO_MODER_MODE15_0            (0x1U << GPIO_MODER_MODE15_Pos)         /*!< 0x40000000 */
+#define GPIO_MODER_MODE15_1            (0x2U << GPIO_MODER_MODE15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos            (0U)
+#define GPIO_OTYPER_OT0_Msk            (0x1UL << GPIO_OTYPER_OT0_Pos)          /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                GPIO_OTYPER_OT0_Msk
+#define GPIO_OTYPER_OT1_Pos            (1U)
+#define GPIO_OTYPER_OT1_Msk            (0x1UL << GPIO_OTYPER_OT1_Pos)          /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                GPIO_OTYPER_OT1_Msk
+#define GPIO_OTYPER_OT2_Pos            (2U)
+#define GPIO_OTYPER_OT2_Msk            (0x1UL << GPIO_OTYPER_OT2_Pos)          /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                GPIO_OTYPER_OT2_Msk
+#define GPIO_OTYPER_OT3_Pos            (3U)
+#define GPIO_OTYPER_OT3_Msk            (0x1UL << GPIO_OTYPER_OT3_Pos)          /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                GPIO_OTYPER_OT3_Msk
+#define GPIO_OTYPER_OT4_Pos            (4U)
+#define GPIO_OTYPER_OT4_Msk            (0x1UL << GPIO_OTYPER_OT4_Pos)          /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                GPIO_OTYPER_OT4_Msk
+#define GPIO_OTYPER_OT5_Pos            (5U)
+#define GPIO_OTYPER_OT5_Msk            (0x1UL << GPIO_OTYPER_OT5_Pos)          /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                GPIO_OTYPER_OT5_Msk
+#define GPIO_OTYPER_OT6_Pos            (6U)
+#define GPIO_OTYPER_OT6_Msk            (0x1UL << GPIO_OTYPER_OT6_Pos)          /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                GPIO_OTYPER_OT6_Msk
+#define GPIO_OTYPER_OT7_Pos            (7U)
+#define GPIO_OTYPER_OT7_Msk            (0x1UL << GPIO_OTYPER_OT7_Pos)          /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                GPIO_OTYPER_OT7_Msk
+#define GPIO_OTYPER_OT8_Pos            (8U)
+#define GPIO_OTYPER_OT8_Msk            (0x1UL << GPIO_OTYPER_OT8_Pos)          /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                GPIO_OTYPER_OT8_Msk
+#define GPIO_OTYPER_OT9_Pos            (9U)
+#define GPIO_OTYPER_OT9_Msk            (0x1UL << GPIO_OTYPER_OT9_Pos)          /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                GPIO_OTYPER_OT9_Msk
+#define GPIO_OTYPER_OT10_Pos           (10U)
+#define GPIO_OTYPER_OT10_Msk           (0x1UL << GPIO_OTYPER_OT10_Pos)         /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10               GPIO_OTYPER_OT10_Msk
+#define GPIO_OTYPER_OT11_Pos           (11U)
+#define GPIO_OTYPER_OT11_Msk           (0x1UL << GPIO_OTYPER_OT11_Pos)         /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11               GPIO_OTYPER_OT11_Msk
+#define GPIO_OTYPER_OT12_Pos           (12U)
+#define GPIO_OTYPER_OT12_Msk           (0x1UL << GPIO_OTYPER_OT12_Pos)         /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12               GPIO_OTYPER_OT12_Msk
+#define GPIO_OTYPER_OT13_Pos           (13U)
+#define GPIO_OTYPER_OT13_Msk           (0x1UL << GPIO_OTYPER_OT13_Pos)         /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13               GPIO_OTYPER_OT13_Msk
+#define GPIO_OTYPER_OT14_Pos           (14U)
+#define GPIO_OTYPER_OT14_Msk           (0x1UL << GPIO_OTYPER_OT14_Pos)         /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14               GPIO_OTYPER_OT14_Msk
+#define GPIO_OTYPER_OT15_Pos           (15U)
+#define GPIO_OTYPER_OT15_Msk           (0x1UL << GPIO_OTYPER_OT15_Pos)         /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15               GPIO_OTYPER_OT15_Msk
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos       (0U)
+#define GPIO_OSPEEDR_OSPEED0_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)     /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0           GPIO_OSPEEDR_OSPEED0_Msk
+#define GPIO_OSPEEDR_OSPEED0_0         (0x1U << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1         (0x2U << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos       (2U)
+#define GPIO_OSPEEDR_OSPEED1_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)     /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1           GPIO_OSPEEDR_OSPEED1_Msk
+#define GPIO_OSPEEDR_OSPEED1_0         (0x1U << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1         (0x2U << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos       (4U)
+#define GPIO_OSPEEDR_OSPEED2_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)     /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2           GPIO_OSPEEDR_OSPEED2_Msk
+#define GPIO_OSPEEDR_OSPEED2_0         (0x1U << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1         (0x2U << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos       (6U)
+#define GPIO_OSPEEDR_OSPEED3_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)     /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3           GPIO_OSPEEDR_OSPEED3_Msk
+#define GPIO_OSPEEDR_OSPEED3_0         (0x1U << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1         (0x2U << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos       (8U)
+#define GPIO_OSPEEDR_OSPEED4_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)     /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4           GPIO_OSPEEDR_OSPEED4_Msk
+#define GPIO_OSPEEDR_OSPEED4_0         (0x1U << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1         (0x2U << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos       (10U)
+#define GPIO_OSPEEDR_OSPEED5_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)     /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5           GPIO_OSPEEDR_OSPEED5_Msk
+#define GPIO_OSPEEDR_OSPEED5_0         (0x1U << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1         (0x2U << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos       (12U)
+#define GPIO_OSPEEDR_OSPEED6_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)     /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6           GPIO_OSPEEDR_OSPEED6_Msk
+#define GPIO_OSPEEDR_OSPEED6_0         (0x1U << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1         (0x2U << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos       (14U)
+#define GPIO_OSPEEDR_OSPEED7_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)     /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7           GPIO_OSPEEDR_OSPEED7_Msk
+#define GPIO_OSPEEDR_OSPEED7_0         (0x1U << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1         (0x2U << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos       (16U)
+#define GPIO_OSPEEDR_OSPEED8_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)     /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8           GPIO_OSPEEDR_OSPEED8_Msk
+#define GPIO_OSPEEDR_OSPEED8_0         (0x1U << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1         (0x2U << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos       (18U)
+#define GPIO_OSPEEDR_OSPEED9_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)     /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9           GPIO_OSPEEDR_OSPEED9_Msk
+#define GPIO_OSPEEDR_OSPEED9_0         (0x1U << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1         (0x2U << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos      (20U)
+#define GPIO_OSPEEDR_OSPEED10_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)    /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10          GPIO_OSPEEDR_OSPEED10_Msk
+#define GPIO_OSPEEDR_OSPEED10_0        (0x1U << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1        (0x2U << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos      (22U)
+#define GPIO_OSPEEDR_OSPEED11_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)    /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11          GPIO_OSPEEDR_OSPEED11_Msk
+#define GPIO_OSPEEDR_OSPEED11_0        (0x1U << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1        (0x2U << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos      (24U)
+#define GPIO_OSPEEDR_OSPEED12_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)    /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12          GPIO_OSPEEDR_OSPEED12_Msk
+#define GPIO_OSPEEDR_OSPEED12_0        (0x1U << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1        (0x2U << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos      (26U)
+#define GPIO_OSPEEDR_OSPEED13_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)    /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13          GPIO_OSPEEDR_OSPEED13_Msk
+#define GPIO_OSPEEDR_OSPEED13_0        (0x1U << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1        (0x2U << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos      (28U)
+#define GPIO_OSPEEDR_OSPEED14_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)    /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14          GPIO_OSPEEDR_OSPEED14_Msk
+#define GPIO_OSPEEDR_OSPEED14_0        (0x1U << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1        (0x2U << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos      (30U)
+#define GPIO_OSPEEDR_OSPEED15_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)    /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15          GPIO_OSPEEDR_OSPEED15_Msk
+#define GPIO_OSPEEDR_OSPEED15_0        (0x1U << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1        (0x2U << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos           (0U)
+#define GPIO_PUPDR_PUPD0_Msk           (0x3UL << GPIO_PUPDR_PUPD0_Pos)         /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0               GPIO_PUPDR_PUPD0_Msk
+#define GPIO_PUPDR_PUPD0_0             (0x1U << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1             (0x2U << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos           (2U)
+#define GPIO_PUPDR_PUPD1_Msk           (0x3UL << GPIO_PUPDR_PUPD1_Pos)         /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1               GPIO_PUPDR_PUPD1_Msk
+#define GPIO_PUPDR_PUPD1_0             (0x1U << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1             (0x2U << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos           (4U)
+#define GPIO_PUPDR_PUPD2_Msk           (0x3UL << GPIO_PUPDR_PUPD2_Pos)         /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2               GPIO_PUPDR_PUPD2_Msk
+#define GPIO_PUPDR_PUPD2_0             (0x1U << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1             (0x2U << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos           (6U)
+#define GPIO_PUPDR_PUPD3_Msk           (0x3UL << GPIO_PUPDR_PUPD3_Pos)         /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3               GPIO_PUPDR_PUPD3_Msk
+#define GPIO_PUPDR_PUPD3_0             (0x1U << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1             (0x2U << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos           (8U)
+#define GPIO_PUPDR_PUPD4_Msk           (0x3UL << GPIO_PUPDR_PUPD4_Pos)         /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4               GPIO_PUPDR_PUPD4_Msk
+#define GPIO_PUPDR_PUPD4_0             (0x1U << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1             (0x2U << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos           (10U)
+#define GPIO_PUPDR_PUPD5_Msk           (0x3UL << GPIO_PUPDR_PUPD5_Pos)         /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5               GPIO_PUPDR_PUPD5_Msk
+#define GPIO_PUPDR_PUPD5_0             (0x1U << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1             (0x2U << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos           (12U)
+#define GPIO_PUPDR_PUPD6_Msk           (0x3UL << GPIO_PUPDR_PUPD6_Pos)         /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6               GPIO_PUPDR_PUPD6_Msk
+#define GPIO_PUPDR_PUPD6_0             (0x1U << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1             (0x2U << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos           (14U)
+#define GPIO_PUPDR_PUPD7_Msk           (0x3UL << GPIO_PUPDR_PUPD7_Pos)         /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7               GPIO_PUPDR_PUPD7_Msk
+#define GPIO_PUPDR_PUPD7_0             (0x1U << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1             (0x2U << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos           (16U)
+#define GPIO_PUPDR_PUPD8_Msk           (0x3UL << GPIO_PUPDR_PUPD8_Pos)         /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8               GPIO_PUPDR_PUPD8_Msk
+#define GPIO_PUPDR_PUPD8_0             (0x1U << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1             (0x2U << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos           (18U)
+#define GPIO_PUPDR_PUPD9_Msk           (0x3UL << GPIO_PUPDR_PUPD9_Pos)         /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9               GPIO_PUPDR_PUPD9_Msk
+#define GPIO_PUPDR_PUPD9_0             (0x1U << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1             (0x2U << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos          (20U)
+#define GPIO_PUPDR_PUPD10_Msk          (0x3UL << GPIO_PUPDR_PUPD10_Pos)        /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10              GPIO_PUPDR_PUPD10_Msk
+#define GPIO_PUPDR_PUPD10_0            (0x1U << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1            (0x2U << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos          (22U)
+#define GPIO_PUPDR_PUPD11_Msk          (0x3UL << GPIO_PUPDR_PUPD11_Pos)        /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11              GPIO_PUPDR_PUPD11_Msk
+#define GPIO_PUPDR_PUPD11_0            (0x1U << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1            (0x2U << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos          (24U)
+#define GPIO_PUPDR_PUPD12_Msk          (0x3UL << GPIO_PUPDR_PUPD12_Pos)        /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12              GPIO_PUPDR_PUPD12_Msk
+#define GPIO_PUPDR_PUPD12_0            (0x1U << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1            (0x2U << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos          (26U)
+#define GPIO_PUPDR_PUPD13_Msk          (0x3UL << GPIO_PUPDR_PUPD13_Pos)        /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13              GPIO_PUPDR_PUPD13_Msk
+#define GPIO_PUPDR_PUPD13_0            (0x1U << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1            (0x2U << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos          (28U)
+#define GPIO_PUPDR_PUPD14_Msk          (0x3UL << GPIO_PUPDR_PUPD14_Pos)        /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14              GPIO_PUPDR_PUPD14_Msk
+#define GPIO_PUPDR_PUPD14_0            (0x1U << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1            (0x2U << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos          (30U)
+#define GPIO_PUPDR_PUPD15_Msk          (0x3UL << GPIO_PUPDR_PUPD15_Pos)        /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15              GPIO_PUPDR_PUPD15_Msk
+#define GPIO_PUPDR_PUPD15_0            (0x1U << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1            (0x2U << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos               (0U)
+#define GPIO_IDR_ID0_Msk               (0x1UL << GPIO_IDR_ID0_Pos)             /*!< 0x00000001 */
+#define GPIO_IDR_ID0                   GPIO_IDR_ID0_Msk
+#define GPIO_IDR_ID1_Pos               (1U)
+#define GPIO_IDR_ID1_Msk               (0x1UL << GPIO_IDR_ID1_Pos)             /*!< 0x00000002 */
+#define GPIO_IDR_ID1                   GPIO_IDR_ID1_Msk
+#define GPIO_IDR_ID2_Pos               (2U)
+#define GPIO_IDR_ID2_Msk               (0x1UL << GPIO_IDR_ID2_Pos)             /*!< 0x00000004 */
+#define GPIO_IDR_ID2                   GPIO_IDR_ID2_Msk
+#define GPIO_IDR_ID3_Pos               (3U)
+#define GPIO_IDR_ID3_Msk               (0x1UL << GPIO_IDR_ID3_Pos)             /*!< 0x00000008 */
+#define GPIO_IDR_ID3                   GPIO_IDR_ID3_Msk
+#define GPIO_IDR_ID4_Pos               (4U)
+#define GPIO_IDR_ID4_Msk               (0x1UL << GPIO_IDR_ID4_Pos)             /*!< 0x00000010 */
+#define GPIO_IDR_ID4                   GPIO_IDR_ID4_Msk
+#define GPIO_IDR_ID5_Pos               (5U)
+#define GPIO_IDR_ID5_Msk               (0x1UL << GPIO_IDR_ID5_Pos)             /*!< 0x00000020 */
+#define GPIO_IDR_ID5                   GPIO_IDR_ID5_Msk
+#define GPIO_IDR_ID6_Pos               (6U)
+#define GPIO_IDR_ID6_Msk               (0x1UL << GPIO_IDR_ID6_Pos)             /*!< 0x00000040 */
+#define GPIO_IDR_ID6                   GPIO_IDR_ID6_Msk
+#define GPIO_IDR_ID7_Pos               (7U)
+#define GPIO_IDR_ID7_Msk               (0x1UL << GPIO_IDR_ID7_Pos)             /*!< 0x00000080 */
+#define GPIO_IDR_ID7                   GPIO_IDR_ID7_Msk
+#define GPIO_IDR_ID8_Pos               (8U)
+#define GPIO_IDR_ID8_Msk               (0x1UL << GPIO_IDR_ID8_Pos)             /*!< 0x00000100 */
+#define GPIO_IDR_ID8                   GPIO_IDR_ID8_Msk
+#define GPIO_IDR_ID9_Pos               (9U)
+#define GPIO_IDR_ID9_Msk               (0x1UL << GPIO_IDR_ID9_Pos)             /*!< 0x00000200 */
+#define GPIO_IDR_ID9                   GPIO_IDR_ID9_Msk
+#define GPIO_IDR_ID10_Pos              (10U)
+#define GPIO_IDR_ID10_Msk              (0x1UL << GPIO_IDR_ID10_Pos)            /*!< 0x00000400 */
+#define GPIO_IDR_ID10                  GPIO_IDR_ID10_Msk
+#define GPIO_IDR_ID11_Pos              (11U)
+#define GPIO_IDR_ID11_Msk              (0x1UL << GPIO_IDR_ID11_Pos)            /*!< 0x00000800 */
+#define GPIO_IDR_ID11                  GPIO_IDR_ID11_Msk
+#define GPIO_IDR_ID12_Pos              (12U)
+#define GPIO_IDR_ID12_Msk              (0x1UL << GPIO_IDR_ID12_Pos)            /*!< 0x00001000 */
+#define GPIO_IDR_ID12                  GPIO_IDR_ID12_Msk
+#define GPIO_IDR_ID13_Pos              (13U)
+#define GPIO_IDR_ID13_Msk              (0x1UL << GPIO_IDR_ID13_Pos)            /*!< 0x00002000 */
+#define GPIO_IDR_ID13                  GPIO_IDR_ID13_Msk
+#define GPIO_IDR_ID14_Pos              (14U)
+#define GPIO_IDR_ID14_Msk              (0x1UL << GPIO_IDR_ID14_Pos)            /*!< 0x00004000 */
+#define GPIO_IDR_ID14                  GPIO_IDR_ID14_Msk
+#define GPIO_IDR_ID15_Pos              (15U)
+#define GPIO_IDR_ID15_Msk              (0x1UL << GPIO_IDR_ID15_Pos)            /*!< 0x00008000 */
+#define GPIO_IDR_ID15                  GPIO_IDR_ID15_Msk
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos               (0U)
+#define GPIO_ODR_OD0_Msk               (0x1UL << GPIO_ODR_OD0_Pos)             /*!< 0x00000001 */
+#define GPIO_ODR_OD0                   GPIO_ODR_OD0_Msk
+#define GPIO_ODR_OD1_Pos               (1U)
+#define GPIO_ODR_OD1_Msk               (0x1UL << GPIO_ODR_OD1_Pos)             /*!< 0x00000002 */
+#define GPIO_ODR_OD1                   GPIO_ODR_OD1_Msk
+#define GPIO_ODR_OD2_Pos               (2U)
+#define GPIO_ODR_OD2_Msk               (0x1UL << GPIO_ODR_OD2_Pos)             /*!< 0x00000004 */
+#define GPIO_ODR_OD2                   GPIO_ODR_OD2_Msk
+#define GPIO_ODR_OD3_Pos               (3U)
+#define GPIO_ODR_OD3_Msk               (0x1UL << GPIO_ODR_OD3_Pos)             /*!< 0x00000008 */
+#define GPIO_ODR_OD3                   GPIO_ODR_OD3_Msk
+#define GPIO_ODR_OD4_Pos               (4U)
+#define GPIO_ODR_OD4_Msk               (0x1UL << GPIO_ODR_OD4_Pos)             /*!< 0x00000010 */
+#define GPIO_ODR_OD4                   GPIO_ODR_OD4_Msk
+#define GPIO_ODR_OD5_Pos               (5U)
+#define GPIO_ODR_OD5_Msk               (0x1UL << GPIO_ODR_OD5_Pos)             /*!< 0x00000020 */
+#define GPIO_ODR_OD5                   GPIO_ODR_OD5_Msk
+#define GPIO_ODR_OD6_Pos               (6U)
+#define GPIO_ODR_OD6_Msk               (0x1UL << GPIO_ODR_OD6_Pos)             /*!< 0x00000040 */
+#define GPIO_ODR_OD6                   GPIO_ODR_OD6_Msk
+#define GPIO_ODR_OD7_Pos               (7U)
+#define GPIO_ODR_OD7_Msk               (0x1UL << GPIO_ODR_OD7_Pos)             /*!< 0x00000080 */
+#define GPIO_ODR_OD7                   GPIO_ODR_OD7_Msk
+#define GPIO_ODR_OD8_Pos               (8U)
+#define GPIO_ODR_OD8_Msk               (0x1UL << GPIO_ODR_OD8_Pos)             /*!< 0x00000100 */
+#define GPIO_ODR_OD8                   GPIO_ODR_OD8_Msk
+#define GPIO_ODR_OD9_Pos               (9U)
+#define GPIO_ODR_OD9_Msk               (0x1UL << GPIO_ODR_OD9_Pos)             /*!< 0x00000200 */
+#define GPIO_ODR_OD9                   GPIO_ODR_OD9_Msk
+#define GPIO_ODR_OD10_Pos              (10U)
+#define GPIO_ODR_OD10_Msk              (0x1UL << GPIO_ODR_OD10_Pos)            /*!< 0x00000400 */
+#define GPIO_ODR_OD10                  GPIO_ODR_OD10_Msk
+#define GPIO_ODR_OD11_Pos              (11U)
+#define GPIO_ODR_OD11_Msk              (0x1UL << GPIO_ODR_OD11_Pos)            /*!< 0x00000800 */
+#define GPIO_ODR_OD11                  GPIO_ODR_OD11_Msk
+#define GPIO_ODR_OD12_Pos              (12U)
+#define GPIO_ODR_OD12_Msk              (0x1UL << GPIO_ODR_OD12_Pos)            /*!< 0x00001000 */
+#define GPIO_ODR_OD12                  GPIO_ODR_OD12_Msk
+#define GPIO_ODR_OD13_Pos              (13U)
+#define GPIO_ODR_OD13_Msk              (0x1UL << GPIO_ODR_OD13_Pos)            /*!< 0x00002000 */
+#define GPIO_ODR_OD13                  GPIO_ODR_OD13_Msk
+#define GPIO_ODR_OD14_Pos              (14U)
+#define GPIO_ODR_OD14_Msk              (0x1UL << GPIO_ODR_OD14_Pos)            /*!< 0x00004000 */
+#define GPIO_ODR_OD14                  GPIO_ODR_OD14_Msk
+#define GPIO_ODR_OD15_Pos              (15U)
+#define GPIO_ODR_OD15_Msk              (0x1UL << GPIO_ODR_OD15_Pos)            /*!< 0x00008000 */
+#define GPIO_ODR_OD15                  GPIO_ODR_OD15_Msk
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos              (0U)
+#define GPIO_BSRR_BS0_Msk              (0x1UL << GPIO_BSRR_BS0_Pos)            /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                  GPIO_BSRR_BS0_Msk
+#define GPIO_BSRR_BS1_Pos              (1U)
+#define GPIO_BSRR_BS1_Msk              (0x1UL << GPIO_BSRR_BS1_Pos)            /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                  GPIO_BSRR_BS1_Msk
+#define GPIO_BSRR_BS2_Pos              (2U)
+#define GPIO_BSRR_BS2_Msk              (0x1UL << GPIO_BSRR_BS2_Pos)            /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                  GPIO_BSRR_BS2_Msk
+#define GPIO_BSRR_BS3_Pos              (3U)
+#define GPIO_BSRR_BS3_Msk              (0x1UL << GPIO_BSRR_BS3_Pos)            /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                  GPIO_BSRR_BS3_Msk
+#define GPIO_BSRR_BS4_Pos              (4U)
+#define GPIO_BSRR_BS4_Msk              (0x1UL << GPIO_BSRR_BS4_Pos)            /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                  GPIO_BSRR_BS4_Msk
+#define GPIO_BSRR_BS5_Pos              (5U)
+#define GPIO_BSRR_BS5_Msk              (0x1UL << GPIO_BSRR_BS5_Pos)            /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                  GPIO_BSRR_BS5_Msk
+#define GPIO_BSRR_BS6_Pos              (6U)
+#define GPIO_BSRR_BS6_Msk              (0x1UL << GPIO_BSRR_BS6_Pos)            /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                  GPIO_BSRR_BS6_Msk
+#define GPIO_BSRR_BS7_Pos              (7U)
+#define GPIO_BSRR_BS7_Msk              (0x1UL << GPIO_BSRR_BS7_Pos)            /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                  GPIO_BSRR_BS7_Msk
+#define GPIO_BSRR_BS8_Pos              (8U)
+#define GPIO_BSRR_BS8_Msk              (0x1UL << GPIO_BSRR_BS8_Pos)            /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                  GPIO_BSRR_BS8_Msk
+#define GPIO_BSRR_BS9_Pos              (9U)
+#define GPIO_BSRR_BS9_Msk              (0x1UL << GPIO_BSRR_BS9_Pos)            /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                  GPIO_BSRR_BS9_Msk
+#define GPIO_BSRR_BS10_Pos             (10U)
+#define GPIO_BSRR_BS10_Msk             (0x1UL << GPIO_BSRR_BS10_Pos)           /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                 GPIO_BSRR_BS10_Msk
+#define GPIO_BSRR_BS11_Pos             (11U)
+#define GPIO_BSRR_BS11_Msk             (0x1UL << GPIO_BSRR_BS11_Pos)           /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                 GPIO_BSRR_BS11_Msk
+#define GPIO_BSRR_BS12_Pos             (12U)
+#define GPIO_BSRR_BS12_Msk             (0x1UL << GPIO_BSRR_BS12_Pos)           /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                 GPIO_BSRR_BS12_Msk
+#define GPIO_BSRR_BS13_Pos             (13U)
+#define GPIO_BSRR_BS13_Msk             (0x1UL << GPIO_BSRR_BS13_Pos)           /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                 GPIO_BSRR_BS13_Msk
+#define GPIO_BSRR_BS14_Pos             (14U)
+#define GPIO_BSRR_BS14_Msk             (0x1UL << GPIO_BSRR_BS14_Pos)           /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                 GPIO_BSRR_BS14_Msk
+#define GPIO_BSRR_BS15_Pos             (15U)
+#define GPIO_BSRR_BS15_Msk             (0x1UL << GPIO_BSRR_BS15_Pos)           /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                 GPIO_BSRR_BS15_Msk
+#define GPIO_BSRR_BR0_Pos              (16U)
+#define GPIO_BSRR_BR0_Msk              (0x1UL << GPIO_BSRR_BR0_Pos)            /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                  GPIO_BSRR_BR0_Msk
+#define GPIO_BSRR_BR1_Pos              (17U)
+#define GPIO_BSRR_BR1_Msk              (0x1UL << GPIO_BSRR_BR1_Pos)            /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                  GPIO_BSRR_BR1_Msk
+#define GPIO_BSRR_BR2_Pos              (18U)
+#define GPIO_BSRR_BR2_Msk              (0x1UL << GPIO_BSRR_BR2_Pos)            /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                  GPIO_BSRR_BR2_Msk
+#define GPIO_BSRR_BR3_Pos              (19U)
+#define GPIO_BSRR_BR3_Msk              (0x1UL << GPIO_BSRR_BR3_Pos)            /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                  GPIO_BSRR_BR3_Msk
+#define GPIO_BSRR_BR4_Pos              (20U)
+#define GPIO_BSRR_BR4_Msk              (0x1UL << GPIO_BSRR_BR4_Pos)            /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                  GPIO_BSRR_BR4_Msk
+#define GPIO_BSRR_BR5_Pos              (21U)
+#define GPIO_BSRR_BR5_Msk              (0x1UL << GPIO_BSRR_BR5_Pos)            /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                  GPIO_BSRR_BR5_Msk
+#define GPIO_BSRR_BR6_Pos              (22U)
+#define GPIO_BSRR_BR6_Msk              (0x1UL << GPIO_BSRR_BR6_Pos)            /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                  GPIO_BSRR_BR6_Msk
+#define GPIO_BSRR_BR7_Pos              (23U)
+#define GPIO_BSRR_BR7_Msk              (0x1UL << GPIO_BSRR_BR7_Pos)            /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                  GPIO_BSRR_BR7_Msk
+#define GPIO_BSRR_BR8_Pos              (24U)
+#define GPIO_BSRR_BR8_Msk              (0x1UL << GPIO_BSRR_BR8_Pos)            /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                  GPIO_BSRR_BR8_Msk
+#define GPIO_BSRR_BR9_Pos              (25U)
+#define GPIO_BSRR_BR9_Msk              (0x1UL << GPIO_BSRR_BR9_Pos)            /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                  GPIO_BSRR_BR9_Msk
+#define GPIO_BSRR_BR10_Pos             (26U)
+#define GPIO_BSRR_BR10_Msk             (0x1UL << GPIO_BSRR_BR10_Pos)           /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                 GPIO_BSRR_BR10_Msk
+#define GPIO_BSRR_BR11_Pos             (27U)
+#define GPIO_BSRR_BR11_Msk             (0x1UL << GPIO_BSRR_BR11_Pos)           /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                 GPIO_BSRR_BR11_Msk
+#define GPIO_BSRR_BR12_Pos             (28U)
+#define GPIO_BSRR_BR12_Msk             (0x1UL << GPIO_BSRR_BR12_Pos)           /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                 GPIO_BSRR_BR12_Msk
+#define GPIO_BSRR_BR13_Pos             (29U)
+#define GPIO_BSRR_BR13_Msk             (0x1UL << GPIO_BSRR_BR13_Pos)           /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                 GPIO_BSRR_BR13_Msk
+#define GPIO_BSRR_BR14_Pos             (30U)
+#define GPIO_BSRR_BR14_Msk             (0x1UL << GPIO_BSRR_BR14_Pos)           /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                 GPIO_BSRR_BR14_Msk
+#define GPIO_BSRR_BR15_Pos             (31U)
+#define GPIO_BSRR_BR15_Msk             (0x1UL << GPIO_BSRR_BR15_Pos)           /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                 GPIO_BSRR_BR15_Msk
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos             (0U)
+#define GPIO_LCKR_LCK0_Msk             (0x1UL << GPIO_LCKR_LCK0_Pos)           /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                 GPIO_LCKR_LCK0_Msk
+#define GPIO_LCKR_LCK1_Pos             (1U)
+#define GPIO_LCKR_LCK1_Msk             (0x1UL << GPIO_LCKR_LCK1_Pos)           /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                 GPIO_LCKR_LCK1_Msk
+#define GPIO_LCKR_LCK2_Pos             (2U)
+#define GPIO_LCKR_LCK2_Msk             (0x1UL << GPIO_LCKR_LCK2_Pos)           /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                 GPIO_LCKR_LCK2_Msk
+#define GPIO_LCKR_LCK3_Pos             (3U)
+#define GPIO_LCKR_LCK3_Msk             (0x1UL << GPIO_LCKR_LCK3_Pos)           /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                 GPIO_LCKR_LCK3_Msk
+#define GPIO_LCKR_LCK4_Pos             (4U)
+#define GPIO_LCKR_LCK4_Msk             (0x1UL << GPIO_LCKR_LCK4_Pos)           /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                 GPIO_LCKR_LCK4_Msk
+#define GPIO_LCKR_LCK5_Pos             (5U)
+#define GPIO_LCKR_LCK5_Msk             (0x1UL << GPIO_LCKR_LCK5_Pos)           /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                 GPIO_LCKR_LCK5_Msk
+#define GPIO_LCKR_LCK6_Pos             (6U)
+#define GPIO_LCKR_LCK6_Msk             (0x1UL << GPIO_LCKR_LCK6_Pos)           /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                 GPIO_LCKR_LCK6_Msk
+#define GPIO_LCKR_LCK7_Pos             (7U)
+#define GPIO_LCKR_LCK7_Msk             (0x1UL << GPIO_LCKR_LCK7_Pos)           /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                 GPIO_LCKR_LCK7_Msk
+#define GPIO_LCKR_LCK8_Pos             (8U)
+#define GPIO_LCKR_LCK8_Msk             (0x1UL << GPIO_LCKR_LCK8_Pos)           /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                 GPIO_LCKR_LCK8_Msk
+#define GPIO_LCKR_LCK9_Pos             (9U)
+#define GPIO_LCKR_LCK9_Msk             (0x1UL << GPIO_LCKR_LCK9_Pos)           /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                 GPIO_LCKR_LCK9_Msk
+#define GPIO_LCKR_LCK10_Pos            (10U)
+#define GPIO_LCKR_LCK10_Msk            (0x1UL << GPIO_LCKR_LCK10_Pos)          /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                GPIO_LCKR_LCK10_Msk
+#define GPIO_LCKR_LCK11_Pos            (11U)
+#define GPIO_LCKR_LCK11_Msk            (0x1UL << GPIO_LCKR_LCK11_Pos)          /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                GPIO_LCKR_LCK11_Msk
+#define GPIO_LCKR_LCK12_Pos            (12U)
+#define GPIO_LCKR_LCK12_Msk            (0x1UL << GPIO_LCKR_LCK12_Pos)          /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                GPIO_LCKR_LCK12_Msk
+#define GPIO_LCKR_LCK13_Pos            (13U)
+#define GPIO_LCKR_LCK13_Msk            (0x1UL << GPIO_LCKR_LCK13_Pos)          /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                GPIO_LCKR_LCK13_Msk
+#define GPIO_LCKR_LCK14_Pos            (14U)
+#define GPIO_LCKR_LCK14_Msk            (0x1UL << GPIO_LCKR_LCK14_Pos)          /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                GPIO_LCKR_LCK14_Msk
+#define GPIO_LCKR_LCK15_Pos            (15U)
+#define GPIO_LCKR_LCK15_Msk            (0x1UL << GPIO_LCKR_LCK15_Pos)          /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                GPIO_LCKR_LCK15_Msk
+#define GPIO_LCKR_LCKK_Pos             (16U)
+#define GPIO_LCKR_LCKK_Msk             (0x1UL << GPIO_LCKR_LCKK_Pos)           /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                 GPIO_LCKR_LCKK_Msk
+
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos           (0U)
+#define GPIO_AFRL_AFSEL0_Msk           (0xFUL << GPIO_AFRL_AFSEL0_Pos)         /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0               GPIO_AFRL_AFSEL0_Msk
+#define GPIO_AFRL_AFSEL0_0             (0x1U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1             (0x2U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2             (0x4U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3             (0x8U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos           (4U)
+#define GPIO_AFRL_AFSEL1_Msk           (0xFUL << GPIO_AFRL_AFSEL1_Pos)         /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1               GPIO_AFRL_AFSEL1_Msk
+#define GPIO_AFRL_AFSEL1_0             (0x1U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1             (0x2U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2             (0x4U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3             (0x8U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos           (8U)
+#define GPIO_AFRL_AFSEL2_Msk           (0xFUL << GPIO_AFRL_AFSEL2_Pos)         /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2               GPIO_AFRL_AFSEL2_Msk
+#define GPIO_AFRL_AFSEL2_0             (0x1U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1             (0x2U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2             (0x4U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3             (0x8U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos           (12U)
+#define GPIO_AFRL_AFSEL3_Msk           (0xFUL << GPIO_AFRL_AFSEL3_Pos)         /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3               GPIO_AFRL_AFSEL3_Msk
+#define GPIO_AFRL_AFSEL3_0             (0x1U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1             (0x2U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2             (0x4U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3             (0x8U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos           (16U)
+#define GPIO_AFRL_AFSEL4_Msk           (0xFUL << GPIO_AFRL_AFSEL4_Pos)         /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4               GPIO_AFRL_AFSEL4_Msk
+#define GPIO_AFRL_AFSEL4_0             (0x1U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1             (0x2U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2             (0x4U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3             (0x8U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos           (20U)
+#define GPIO_AFRL_AFSEL5_Msk           (0xFUL << GPIO_AFRL_AFSEL5_Pos)         /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5               GPIO_AFRL_AFSEL5_Msk
+#define GPIO_AFRL_AFSEL5_0             (0x1U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1             (0x2U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2             (0x4U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3             (0x8U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos           (24U)
+#define GPIO_AFRL_AFSEL6_Msk           (0xFUL << GPIO_AFRL_AFSEL6_Pos)         /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6               GPIO_AFRL_AFSEL6_Msk
+#define GPIO_AFRL_AFSEL6_0             (0x1U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1             (0x2U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2             (0x4U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3             (0x8U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos           (28U)
+#define GPIO_AFRL_AFSEL7_Msk           (0xFUL << GPIO_AFRL_AFSEL7_Pos)         /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7               GPIO_AFRL_AFSEL7_Msk
+#define GPIO_AFRL_AFSEL7_0             (0x1U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1             (0x2U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2             (0x4U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3             (0x8U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x80000000 */
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos           (0U)
+#define GPIO_AFRH_AFSEL8_Msk           (0xFUL << GPIO_AFRH_AFSEL8_Pos)         /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8               GPIO_AFRH_AFSEL8_Msk
+#define GPIO_AFRH_AFSEL8_0             (0x1U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1             (0x2U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2             (0x4U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3             (0x8U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos           (4U)
+#define GPIO_AFRH_AFSEL9_Msk           (0xFUL << GPIO_AFRH_AFSEL9_Pos)         /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9               GPIO_AFRH_AFSEL9_Msk
+#define GPIO_AFRH_AFSEL9_0             (0x1U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1             (0x2U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2             (0x4U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3             (0x8U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos          (8U)
+#define GPIO_AFRH_AFSEL10_Msk          (0xFUL << GPIO_AFRH_AFSEL10_Pos)        /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10              GPIO_AFRH_AFSEL10_Msk
+#define GPIO_AFRH_AFSEL10_0            (0x1U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1            (0x2U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2            (0x4U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3            (0x8U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos          (12U)
+#define GPIO_AFRH_AFSEL11_Msk          (0xFUL << GPIO_AFRH_AFSEL11_Pos)        /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11              GPIO_AFRH_AFSEL11_Msk
+#define GPIO_AFRH_AFSEL11_0            (0x1U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1            (0x2U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2            (0x4U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3            (0x8U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos          (16U)
+#define GPIO_AFRH_AFSEL12_Msk          (0xFUL << GPIO_AFRH_AFSEL12_Pos)        /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12              GPIO_AFRH_AFSEL12_Msk
+#define GPIO_AFRH_AFSEL12_0            (0x1U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1            (0x2U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2            (0x4U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3            (0x8U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos          (20U)
+#define GPIO_AFRH_AFSEL13_Msk          (0xFUL << GPIO_AFRH_AFSEL13_Pos)        /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13              GPIO_AFRH_AFSEL13_Msk
+#define GPIO_AFRH_AFSEL13_0            (0x1U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1            (0x2U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2            (0x4U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3            (0x8U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos          (24U)
+#define GPIO_AFRH_AFSEL14_Msk          (0xFUL << GPIO_AFRH_AFSEL14_Pos)        /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14              GPIO_AFRH_AFSEL14_Msk
+#define GPIO_AFRH_AFSEL14_0            (0x1U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1            (0x2U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2            (0x4U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3            (0x8U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos          (28U)
+#define GPIO_AFRH_AFSEL15_Msk          (0xFUL << GPIO_AFRH_AFSEL15_Pos)        /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15              GPIO_AFRH_AFSEL15_Msk
+#define GPIO_AFRH_AFSEL15_0            (0x1U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1            (0x2U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2            (0x4U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3            (0x8U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_BRR register  ******************/
+#define GPIO_BRR_BR0_Pos               (0U)
+#define GPIO_BRR_BR0_Msk               (0x1UL << GPIO_BRR_BR0_Pos)             /*!< 0x00000001 */
+#define GPIO_BRR_BR0                   GPIO_BRR_BR0_Msk
+#define GPIO_BRR_BR1_Pos               (1U)
+#define GPIO_BRR_BR1_Msk               (0x1UL << GPIO_BRR_BR1_Pos)             /*!< 0x00000002 */
+#define GPIO_BRR_BR1                   GPIO_BRR_BR1_Msk
+#define GPIO_BRR_BR2_Pos               (2U)
+#define GPIO_BRR_BR2_Msk               (0x1UL << GPIO_BRR_BR2_Pos)             /*!< 0x00000004 */
+#define GPIO_BRR_BR2                   GPIO_BRR_BR2_Msk
+#define GPIO_BRR_BR3_Pos               (3U)
+#define GPIO_BRR_BR3_Msk               (0x1UL << GPIO_BRR_BR3_Pos)             /*!< 0x00000008 */
+#define GPIO_BRR_BR3                   GPIO_BRR_BR3_Msk
+#define GPIO_BRR_BR4_Pos               (4U)
+#define GPIO_BRR_BR4_Msk               (0x1UL << GPIO_BRR_BR4_Pos)             /*!< 0x00000010 */
+#define GPIO_BRR_BR4                   GPIO_BRR_BR4_Msk
+#define GPIO_BRR_BR5_Pos               (5U)
+#define GPIO_BRR_BR5_Msk               (0x1UL << GPIO_BRR_BR5_Pos)             /*!< 0x00000020 */
+#define GPIO_BRR_BR5                   GPIO_BRR_BR5_Msk
+#define GPIO_BRR_BR6_Pos               (6U)
+#define GPIO_BRR_BR6_Msk               (0x1UL << GPIO_BRR_BR6_Pos)             /*!< 0x00000040 */
+#define GPIO_BRR_BR6                   GPIO_BRR_BR6_Msk
+#define GPIO_BRR_BR7_Pos               (7U)
+#define GPIO_BRR_BR7_Msk               (0x1UL << GPIO_BRR_BR7_Pos)             /*!< 0x00000080 */
+#define GPIO_BRR_BR7                   GPIO_BRR_BR7_Msk
+#define GPIO_BRR_BR8_Pos               (8U)
+#define GPIO_BRR_BR8_Msk               (0x1UL << GPIO_BRR_BR8_Pos)             /*!< 0x00000100 */
+#define GPIO_BRR_BR8                   GPIO_BRR_BR8_Msk
+#define GPIO_BRR_BR9_Pos               (9U)
+#define GPIO_BRR_BR9_Msk               (0x1UL << GPIO_BRR_BR9_Pos)             /*!< 0x00000200 */
+#define GPIO_BRR_BR9                   GPIO_BRR_BR9_Msk
+#define GPIO_BRR_BR10_Pos              (10U)
+#define GPIO_BRR_BR10_Msk              (0x1UL << GPIO_BRR_BR10_Pos)            /*!< 0x00000400 */
+#define GPIO_BRR_BR10                  GPIO_BRR_BR10_Msk
+#define GPIO_BRR_BR11_Pos              (11U)
+#define GPIO_BRR_BR11_Msk              (0x1UL << GPIO_BRR_BR11_Pos)            /*!< 0x00000800 */
+#define GPIO_BRR_BR11                  GPIO_BRR_BR11_Msk
+#define GPIO_BRR_BR12_Pos              (12U)
+#define GPIO_BRR_BR12_Msk              (0x1UL << GPIO_BRR_BR12_Pos)            /*!< 0x00001000 */
+#define GPIO_BRR_BR12                  GPIO_BRR_BR12_Msk
+#define GPIO_BRR_BR13_Pos              (13U)
+#define GPIO_BRR_BR13_Msk              (0x1UL << GPIO_BRR_BR13_Pos)            /*!< 0x00002000 */
+#define GPIO_BRR_BR13                  GPIO_BRR_BR13_Msk
+#define GPIO_BRR_BR14_Pos              (14U)
+#define GPIO_BRR_BR14_Msk              (0x1UL << GPIO_BRR_BR14_Pos)            /*!< 0x00004000 */
+#define GPIO_BRR_BR14                  GPIO_BRR_BR14_Msk
+#define GPIO_BRR_BR15_Pos              (15U)
+#define GPIO_BRR_BR15_Msk              (0x1UL << GPIO_BRR_BR15_Pos)            /*!< 0x00008000 */
+#define GPIO_BRR_BR15                  GPIO_BRR_BR15_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                        HSEM HW Semaphore                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for HSEM_R register  ********************/
+#define HSEM_R_PROCID_Pos        (0U)
+#define HSEM_R_PROCID_Msk        (0xFFUL << HSEM_R_PROCID_Pos)                 /*!< 0x000000FF */
+#define HSEM_R_PROCID            HSEM_R_PROCID_Msk                             /*!<Semaphore ProcessID */
+#define HSEM_R_COREID_Pos        (8U)
+#define HSEM_R_COREID_Msk        (0xFUL << HSEM_R_COREID_Pos)                  /*!< 0x00000F00 */
+#define HSEM_R_COREID            HSEM_R_COREID_Msk                             /*!<Semaphore CoreID. */
+#define HSEM_R_LOCK_Pos          (31U)
+#define HSEM_R_LOCK_Msk          (0x1UL << HSEM_R_LOCK_Pos)                    /*!< 0x80000000 */
+#define HSEM_R_LOCK              HSEM_R_LOCK_Msk                               /*!<Lock indication. */
+
+/********************  Bit definition for HSEM_RLR register  ******************/
+#define HSEM_RLR_PROCID_Pos      (0U)
+#define HSEM_RLR_PROCID_Msk      (0xFFUL << HSEM_RLR_PROCID_Pos)               /*!< 0x000000FF */
+#define HSEM_RLR_PROCID          HSEM_RLR_PROCID_Msk                           /*!<Semaphore ProcessID */
+#define HSEM_RLR_COREID_Pos      (8U)
+#define HSEM_RLR_COREID_Msk      (0xFUL << HSEM_RLR_COREID_Pos)                /*!< 0x00000F00 */
+#define HSEM_RLR_COREID          HSEM_RLR_COREID_Msk                           /*!<Semaphore CoreID. */
+#define HSEM_RLR_LOCK_Pos        (31U)
+#define HSEM_RLR_LOCK_Msk        (0x1UL << HSEM_RLR_LOCK_Pos)                  /*!< 0x80000000 */
+#define HSEM_RLR_LOCK            HSEM_RLR_LOCK_Msk                             /*!<Lock indication. */
+
+/********************  Bit definition for HSEM_C1IER register  ****************/
+#define HSEM_C1IER_ISE0_Pos      (0U)
+#define HSEM_C1IER_ISE0_Msk      (0x1UL << HSEM_C1IER_ISE0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1IER_ISE0          HSEM_C1IER_ISE0_Msk                           /*!<semaphore 0 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE1_Pos      (1U)
+#define HSEM_C1IER_ISE1_Msk      (0x1UL << HSEM_C1IER_ISE1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1IER_ISE1          HSEM_C1IER_ISE1_Msk                           /*!<semaphore 1 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE2_Pos      (2U)
+#define HSEM_C1IER_ISE2_Msk      (0x1UL << HSEM_C1IER_ISE2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1IER_ISE2          HSEM_C1IER_ISE2_Msk                           /*!<semaphore 2 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE3_Pos      (3U)
+#define HSEM_C1IER_ISE3_Msk      (0x1UL << HSEM_C1IER_ISE3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1IER_ISE3          HSEM_C1IER_ISE3_Msk                           /*!<semaphore 3 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE4_Pos      (4U)
+#define HSEM_C1IER_ISE4_Msk      (0x1UL << HSEM_C1IER_ISE4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1IER_ISE4          HSEM_C1IER_ISE4_Msk                           /*!<semaphore 4 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE5_Pos      (5U)
+#define HSEM_C1IER_ISE5_Msk      (0x1UL << HSEM_C1IER_ISE5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1IER_ISE5          HSEM_C1IER_ISE5_Msk                           /*!<semaphore 5 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE6_Pos      (6U)
+#define HSEM_C1IER_ISE6_Msk      (0x1UL << HSEM_C1IER_ISE6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1IER_ISE6          HSEM_C1IER_ISE6_Msk                           /*!<semaphore 6 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE7_Pos      (7U)
+#define HSEM_C1IER_ISE7_Msk      (0x1UL << HSEM_C1IER_ISE7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1IER_ISE7          HSEM_C1IER_ISE7_Msk                           /*!<semaphore 7 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE8_Pos      (8U)
+#define HSEM_C1IER_ISE8_Msk      (0x1UL << HSEM_C1IER_ISE8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1IER_ISE8          HSEM_C1IER_ISE8_Msk                           /*!<semaphore 8 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE9_Pos      (9U)
+#define HSEM_C1IER_ISE9_Msk      (0x1UL << HSEM_C1IER_ISE9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1IER_ISE9          HSEM_C1IER_ISE9_Msk                           /*!<semaphore 9 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE10_Pos     (10U)
+#define HSEM_C1IER_ISE10_Msk     (0x1UL << HSEM_C1IER_ISE10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1IER_ISE10         HSEM_C1IER_ISE10_Msk                          /*!<semaphore 10 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE11_Pos     (11U)
+#define HSEM_C1IER_ISE11_Msk     (0x1UL << HSEM_C1IER_ISE11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1IER_ISE11         HSEM_C1IER_ISE11_Msk                          /*!<semaphore 11 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE12_Pos     (12U)
+#define HSEM_C1IER_ISE12_Msk     (0x1UL << HSEM_C1IER_ISE12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1IER_ISE12         HSEM_C1IER_ISE12_Msk                          /*!<semaphore 12 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE13_Pos     (13U)
+#define HSEM_C1IER_ISE13_Msk     (0x1UL << HSEM_C1IER_ISE13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1IER_ISE13         HSEM_C1IER_ISE13_Msk                          /*!<semaphore 13 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE14_Pos     (14U)
+#define HSEM_C1IER_ISE14_Msk     (0x1UL << HSEM_C1IER_ISE14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1IER_ISE14         HSEM_C1IER_ISE14_Msk                          /*!<semaphore 14 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE15_Pos     (15U)
+#define HSEM_C1IER_ISE15_Msk     (0x1UL << HSEM_C1IER_ISE15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1IER_ISE15         HSEM_C1IER_ISE15_Msk                          /*!<semaphore 15 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE16_Pos     (16U)
+#define HSEM_C1IER_ISE16_Msk     (0x1UL << HSEM_C1IER_ISE16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1IER_ISE16         HSEM_C1IER_ISE16_Msk                          /*!<semaphore 16 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE17_Pos     (17U)
+#define HSEM_C1IER_ISE17_Msk     (0x1UL << HSEM_C1IER_ISE17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1IER_ISE17         HSEM_C1IER_ISE17_Msk                          /*!<semaphore 17 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE18_Pos     (18U)
+#define HSEM_C1IER_ISE18_Msk     (0x1UL << HSEM_C1IER_ISE18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1IER_ISE18         HSEM_C1IER_ISE18_Msk                          /*!<semaphore 18 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE19_Pos     (19U)
+#define HSEM_C1IER_ISE19_Msk     (0x1UL << HSEM_C1IER_ISE19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1IER_ISE19         HSEM_C1IER_ISE19_Msk                          /*!<semaphore 19 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE20_Pos     (20U)
+#define HSEM_C1IER_ISE20_Msk     (0x1UL << HSEM_C1IER_ISE20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1IER_ISE20         HSEM_C1IER_ISE20_Msk                          /*!<semaphore 20 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE21_Pos     (21U)
+#define HSEM_C1IER_ISE21_Msk     (0x1UL << HSEM_C1IER_ISE21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1IER_ISE21         HSEM_C1IER_ISE21_Msk                          /*!<semaphore 21 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE22_Pos     (22U)
+#define HSEM_C1IER_ISE22_Msk     (0x1UL << HSEM_C1IER_ISE22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1IER_ISE22         HSEM_C1IER_ISE22_Msk                          /*!<semaphore 22 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE23_Pos     (23U)
+#define HSEM_C1IER_ISE23_Msk     (0x1UL << HSEM_C1IER_ISE23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1IER_ISE23         HSEM_C1IER_ISE23_Msk                          /*!<semaphore 23 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE24_Pos     (24U)
+#define HSEM_C1IER_ISE24_Msk     (0x1UL << HSEM_C1IER_ISE24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1IER_ISE24         HSEM_C1IER_ISE24_Msk                          /*!<semaphore 24 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE25_Pos     (25U)
+#define HSEM_C1IER_ISE25_Msk     (0x1UL << HSEM_C1IER_ISE25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1IER_ISE25         HSEM_C1IER_ISE25_Msk                          /*!<semaphore 25 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE26_Pos     (26U)
+#define HSEM_C1IER_ISE26_Msk     (0x1UL << HSEM_C1IER_ISE26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1IER_ISE26         HSEM_C1IER_ISE26_Msk                          /*!<semaphore 26 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE27_Pos     (27U)
+#define HSEM_C1IER_ISE27_Msk     (0x1UL << HSEM_C1IER_ISE27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1IER_ISE27         HSEM_C1IER_ISE27_Msk                          /*!<semaphore 27 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE28_Pos     (28U)
+#define HSEM_C1IER_ISE28_Msk     (0x1UL << HSEM_C1IER_ISE28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1IER_ISE28         HSEM_C1IER_ISE28_Msk                          /*!<semaphore 28 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE29_Pos     (29U)
+#define HSEM_C1IER_ISE29_Msk     (0x1UL << HSEM_C1IER_ISE29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1IER_ISE29         HSEM_C1IER_ISE29_Msk                          /*!<semaphore 29 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE30_Pos     (30U)
+#define HSEM_C1IER_ISE30_Msk     (0x1UL << HSEM_C1IER_ISE30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1IER_ISE30         HSEM_C1IER_ISE30_Msk                          /*!<semaphore 30 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE31_Pos     (31U)
+#define HSEM_C1IER_ISE31_Msk     (0x1UL << HSEM_C1IER_ISE31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1IER_ISE31         HSEM_C1IER_ISE31_Msk                          /*!<semaphore 31 CPU1 interrupt enable bit. */
+
+/********************  Bit definition for HSEM_C1ICR register  *****************/
+#define HSEM_C1ICR_ISC0_Pos      (0U)
+#define HSEM_C1ICR_ISC0_Msk      (0x1UL << HSEM_C1ICR_ISC0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1ICR_ISC0          HSEM_C1ICR_ISC0_Msk                           /*!<semaphore 0 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC1_Pos      (1U)
+#define HSEM_C1ICR_ISC1_Msk      (0x1UL << HSEM_C1ICR_ISC1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1ICR_ISC1          HSEM_C1ICR_ISC1_Msk                           /*!<semaphore 1 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC2_Pos      (2U)
+#define HSEM_C1ICR_ISC2_Msk      (0x1UL << HSEM_C1ICR_ISC2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1ICR_ISC2          HSEM_C1ICR_ISC2_Msk                           /*!<semaphore 2 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC3_Pos      (3U)
+#define HSEM_C1ICR_ISC3_Msk      (0x1UL << HSEM_C1ICR_ISC3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1ICR_ISC3          HSEM_C1ICR_ISC3_Msk                           /*!<semaphore 3 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC4_Pos      (4U)
+#define HSEM_C1ICR_ISC4_Msk      (0x1UL << HSEM_C1ICR_ISC4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1ICR_ISC4          HSEM_C1ICR_ISC4_Msk                           /*!<semaphore 4 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC5_Pos      (5U)
+#define HSEM_C1ICR_ISC5_Msk      (0x1UL << HSEM_C1ICR_ISC5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1ICR_ISC5          HSEM_C1ICR_ISC5_Msk                           /*!<semaphore 5 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC6_Pos      (6U)
+#define HSEM_C1ICR_ISC6_Msk      (0x1UL << HSEM_C1ICR_ISC6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1ICR_ISC6          HSEM_C1ICR_ISC6_Msk                           /*!<semaphore 6 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC7_Pos      (7U)
+#define HSEM_C1ICR_ISC7_Msk      (0x1UL << HSEM_C1ICR_ISC7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1ICR_ISC7          HSEM_C1ICR_ISC7_Msk                           /*!<semaphore 7 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC8_Pos      (8U)
+#define HSEM_C1ICR_ISC8_Msk      (0x1UL << HSEM_C1ICR_ISC8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1ICR_ISC8          HSEM_C1ICR_ISC8_Msk                           /*!<semaphore 8 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC9_Pos      (9U)
+#define HSEM_C1ICR_ISC9_Msk      (0x1UL << HSEM_C1ICR_ISC9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1ICR_ISC9          HSEM_C1ICR_ISC9_Msk                           /*!<semaphore 9 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC10_Pos     (10U)
+#define HSEM_C1ICR_ISC10_Msk     (0x1UL << HSEM_C1ICR_ISC10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1ICR_ISC10         HSEM_C1ICR_ISC10_Msk                          /*!<semaphore 10 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC11_Pos     (11U)
+#define HSEM_C1ICR_ISC11_Msk     (0x1UL << HSEM_C1ICR_ISC11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1ICR_ISC11         HSEM_C1ICR_ISC11_Msk                          /*!<semaphore 11 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC12_Pos     (12U)
+#define HSEM_C1ICR_ISC12_Msk     (0x1UL << HSEM_C1ICR_ISC12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1ICR_ISC12         HSEM_C1ICR_ISC12_Msk                          /*!<semaphore 12 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC13_Pos     (13U)
+#define HSEM_C1ICR_ISC13_Msk     (0x1UL << HSEM_C1ICR_ISC13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1ICR_ISC13         HSEM_C1ICR_ISC13_Msk                          /*!<semaphore 13 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC14_Pos     (14U)
+#define HSEM_C1ICR_ISC14_Msk     (0x1UL << HSEM_C1ICR_ISC14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1ICR_ISC14         HSEM_C1ICR_ISC14_Msk                          /*!<semaphore 14 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC15_Pos     (15U)
+#define HSEM_C1ICR_ISC15_Msk     (0x1UL << HSEM_C1ICR_ISC15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1ICR_ISC15         HSEM_C1ICR_ISC15_Msk                          /*!<semaphore 15 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC16_Pos     (16U)
+#define HSEM_C1ICR_ISC16_Msk     (0x1UL << HSEM_C1ICR_ISC16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1ICR_ISC16         HSEM_C1ICR_ISC16_Msk                          /*!<semaphore 16 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC17_Pos     (17U)
+#define HSEM_C1ICR_ISC17_Msk     (0x1UL << HSEM_C1ICR_ISC17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1ICR_ISC17         HSEM_C1ICR_ISC17_Msk                          /*!<semaphore 17 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC18_Pos     (18U)
+#define HSEM_C1ICR_ISC18_Msk     (0x1UL << HSEM_C1ICR_ISC18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1ICR_ISC18         HSEM_C1ICR_ISC18_Msk                          /*!<semaphore 18 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC19_Pos     (19U)
+#define HSEM_C1ICR_ISC19_Msk     (0x1UL << HSEM_C1ICR_ISC19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1ICR_ISC19         HSEM_C1ICR_ISC19_Msk                          /*!<semaphore 19 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC20_Pos     (20U)
+#define HSEM_C1ICR_ISC20_Msk     (0x1UL << HSEM_C1ICR_ISC20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1ICR_ISC20         HSEM_C1ICR_ISC20_Msk                          /*!<semaphore 20 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC21_Pos     (21U)
+#define HSEM_C1ICR_ISC21_Msk     (0x1UL << HSEM_C1ICR_ISC21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1ICR_ISC21         HSEM_C1ICR_ISC21_Msk                          /*!<semaphore 21 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC22_Pos     (22U)
+#define HSEM_C1ICR_ISC22_Msk     (0x1UL << HSEM_C1ICR_ISC22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1ICR_ISC22         HSEM_C1ICR_ISC22_Msk                          /*!<semaphore 22 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC23_Pos     (23U)
+#define HSEM_C1ICR_ISC23_Msk     (0x1UL << HSEM_C1ICR_ISC23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1ICR_ISC23         HSEM_C1ICR_ISC23_Msk                          /*!<semaphore 23 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC24_Pos     (24U)
+#define HSEM_C1ICR_ISC24_Msk     (0x1UL << HSEM_C1ICR_ISC24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1ICR_ISC24         HSEM_C1ICR_ISC24_Msk                          /*!<semaphore 24 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC25_Pos     (25U)
+#define HSEM_C1ICR_ISC25_Msk     (0x1UL << HSEM_C1ICR_ISC25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1ICR_ISC25         HSEM_C1ICR_ISC25_Msk                          /*!<semaphore 25 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC26_Pos     (26U)
+#define HSEM_C1ICR_ISC26_Msk     (0x1UL << HSEM_C1ICR_ISC26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1ICR_ISC26         HSEM_C1ICR_ISC26_Msk                          /*!<semaphore 26 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC27_Pos     (27U)
+#define HSEM_C1ICR_ISC27_Msk     (0x1UL << HSEM_C1ICR_ISC27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1ICR_ISC27         HSEM_C1ICR_ISC27_Msk                          /*!<semaphore 27 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC28_Pos     (28U)
+#define HSEM_C1ICR_ISC28_Msk     (0x1UL << HSEM_C1ICR_ISC28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1ICR_ISC28         HSEM_C1ICR_ISC28_Msk                          /*!<semaphore 28 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC29_Pos     (29U)
+#define HSEM_C1ICR_ISC29_Msk     (0x1UL << HSEM_C1ICR_ISC29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1ICR_ISC29         HSEM_C1ICR_ISC29_Msk                          /*!<semaphore 29 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC30_Pos     (30U)
+#define HSEM_C1ICR_ISC30_Msk     (0x1UL << HSEM_C1ICR_ISC30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1ICR_ISC30         HSEM_C1ICR_ISC30_Msk                          /*!<semaphore 30 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC31_Pos     (31U)
+#define HSEM_C1ICR_ISC31_Msk     (0x1UL << HSEM_C1ICR_ISC31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1ICR_ISC31         HSEM_C1ICR_ISC31_Msk                          /*!<semaphore 31 CPU1 interrupt clear bit. */
+
+/********************  Bit definition for HSEM_C1ISR register  *****************/
+#define HSEM_C1ISR_ISF0_Pos      (0U)
+#define HSEM_C1ISR_ISF0_Msk      (0x1UL << HSEM_C1ISR_ISF0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1ISR_ISF0          HSEM_C1ISR_ISF0_Msk                           /*!<semaphore 0 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF1_Pos      (1U)
+#define HSEM_C1ISR_ISF1_Msk      (0x1UL << HSEM_C1ISR_ISF1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1ISR_ISF1          HSEM_C1ISR_ISF1_Msk                           /*!<semaphore 1 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF2_Pos      (2U)
+#define HSEM_C1ISR_ISF2_Msk      (0x1UL << HSEM_C1ISR_ISF2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1ISR_ISF2          HSEM_C1ISR_ISF2_Msk                           /*!<semaphore 2 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF3_Pos      (3U)
+#define HSEM_C1ISR_ISF3_Msk      (0x1UL << HSEM_C1ISR_ISF3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1ISR_ISF3          HSEM_C1ISR_ISF3_Msk                           /*!<semaphore 3 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF4_Pos      (4U)
+#define HSEM_C1ISR_ISF4_Msk      (0x1UL << HSEM_C1ISR_ISF4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1ISR_ISF4          HSEM_C1ISR_ISF4_Msk                           /*!<semaphore 4 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF5_Pos      (5U)
+#define HSEM_C1ISR_ISF5_Msk      (0x1UL << HSEM_C1ISR_ISF5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1ISR_ISF5          HSEM_C1ISR_ISF5_Msk                           /*!<semaphore 5 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF6_Pos      (6U)
+#define HSEM_C1ISR_ISF6_Msk      (0x1UL << HSEM_C1ISR_ISF6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1ISR_ISF6          HSEM_C1ISR_ISF6_Msk                           /*!<semaphore 6 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF7_Pos      (7U)
+#define HSEM_C1ISR_ISF7_Msk      (0x1UL << HSEM_C1ISR_ISF7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1ISR_ISF7          HSEM_C1ISR_ISF7_Msk                           /*!<semaphore 7 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF8_Pos      (8U)
+#define HSEM_C1ISR_ISF8_Msk      (0x1UL << HSEM_C1ISR_ISF8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1ISR_ISF8          HSEM_C1ISR_ISF8_Msk                           /*!<semaphore 8 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF9_Pos      (9U)
+#define HSEM_C1ISR_ISF9_Msk      (0x1UL << HSEM_C1ISR_ISF9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1ISR_ISF9          HSEM_C1ISR_ISF9_Msk                           /*!<semaphore 9 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF10_Pos     (10U)
+#define HSEM_C1ISR_ISF10_Msk     (0x1UL << HSEM_C1ISR_ISF10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1ISR_ISF10         HSEM_C1ISR_ISF10_Msk                          /*!<semaphore 10 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF11_Pos     (11U)
+#define HSEM_C1ISR_ISF11_Msk     (0x1UL << HSEM_C1ISR_ISF11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1ISR_ISF11         HSEM_C1ISR_ISF11_Msk                          /*!<semaphore 11 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF12_Pos     (12U)
+#define HSEM_C1ISR_ISF12_Msk     (0x1UL << HSEM_C1ISR_ISF12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1ISR_ISF12         HSEM_C1ISR_ISF12_Msk                          /*!<semaphore 12 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF13_Pos     (13U)
+#define HSEM_C1ISR_ISF13_Msk     (0x1UL << HSEM_C1ISR_ISF13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1ISR_ISF13         HSEM_C1ISR_ISF13_Msk                          /*!<semaphore 13 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF14_Pos     (14U)
+#define HSEM_C1ISR_ISF14_Msk     (0x1UL << HSEM_C1ISR_ISF14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1ISR_ISF14         HSEM_C1ISR_ISF14_Msk                          /*!<semaphore 14 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF15_Pos     (15U)
+#define HSEM_C1ISR_ISF15_Msk     (0x1UL << HSEM_C1ISR_ISF15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1ISR_ISF15         HSEM_C1ISR_ISF15_Msk                          /*!<semaphore 15 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF16_Pos     (16U)
+#define HSEM_C1ISR_ISF16_Msk     (0x1UL << HSEM_C1ISR_ISF16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1ISR_ISF16         HSEM_C1ISR_ISF16_Msk                          /*!<semaphore 16 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF17_Pos     (17U)
+#define HSEM_C1ISR_ISF17_Msk     (0x1UL << HSEM_C1ISR_ISF17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1ISR_ISF17         HSEM_C1ISR_ISF17_Msk                          /*!<semaphore 17 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF18_Pos     (18U)
+#define HSEM_C1ISR_ISF18_Msk     (0x1UL << HSEM_C1ISR_ISF18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1ISR_ISF18         HSEM_C1ISR_ISF18_Msk                          /*!<semaphore 18 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF19_Pos     (19U)
+#define HSEM_C1ISR_ISF19_Msk     (0x1UL << HSEM_C1ISR_ISF19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1ISR_ISF19         HSEM_C1ISR_ISF19_Msk                          /*!<semaphore 19 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF20_Pos     (20U)
+#define HSEM_C1ISR_ISF20_Msk     (0x1UL << HSEM_C1ISR_ISF20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1ISR_ISF20         HSEM_C1ISR_ISF20_Msk                          /*!<semaphore 20 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF21_Pos     (21U)
+#define HSEM_C1ISR_ISF21_Msk     (0x1UL << HSEM_C1ISR_ISF21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1ISR_ISF21         HSEM_C1ISR_ISF21_Msk                          /*!<semaphore 21 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF22_Pos     (22U)
+#define HSEM_C1ISR_ISF22_Msk     (0x1UL << HSEM_C1ISR_ISF22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1ISR_ISF22         HSEM_C1ISR_ISF22_Msk                          /*!<semaphore 22 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF23_Pos     (23U)
+#define HSEM_C1ISR_ISF23_Msk     (0x1UL << HSEM_C1ISR_ISF23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1ISR_ISF23         HSEM_C1ISR_ISF23_Msk                          /*!<semaphore 23 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF24_Pos     (24U)
+#define HSEM_C1ISR_ISF24_Msk     (0x1UL << HSEM_C1ISR_ISF24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1ISR_ISF24         HSEM_C1ISR_ISF24_Msk                          /*!<semaphore 24 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF25_Pos     (25U)
+#define HSEM_C1ISR_ISF25_Msk     (0x1UL << HSEM_C1ISR_ISF25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1ISR_ISF25         HSEM_C1ISR_ISF25_Msk                          /*!<semaphore 25 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF26_Pos     (26U)
+#define HSEM_C1ISR_ISF26_Msk     (0x1UL << HSEM_C1ISR_ISF26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1ISR_ISF26         HSEM_C1ISR_ISF26_Msk                          /*!<semaphore 26 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF27_Pos     (27U)
+#define HSEM_C1ISR_ISF27_Msk     (0x1UL << HSEM_C1ISR_ISF27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1ISR_ISF27         HSEM_C1ISR_ISF27_Msk                          /*!<semaphore 27 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF28_Pos     (28U)
+#define HSEM_C1ISR_ISF28_Msk     (0x1UL << HSEM_C1ISR_ISF28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1ISR_ISF28         HSEM_C1ISR_ISF28_Msk                          /*!<semaphore 28 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF29_Pos     (29U)
+#define HSEM_C1ISR_ISF29_Msk     (0x1UL << HSEM_C1ISR_ISF29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1ISR_ISF29         HSEM_C1ISR_ISF29_Msk                          /*!<semaphore 29 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF30_Pos     (30U)
+#define HSEM_C1ISR_ISF30_Msk     (0x1UL << HSEM_C1ISR_ISF30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1ISR_ISF30         HSEM_C1ISR_ISF30_Msk                          /*!<semaphore 30 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF31_Pos     (31U)
+#define HSEM_C1ISR_ISF31_Msk     (0x1UL << HSEM_C1ISR_ISF31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1ISR_ISF31         HSEM_C1ISR_ISF31_Msk                          /*!<semaphore 31 CPU1 interrupt status bit. */
+
+/********************  Bit definition for HSEM_C1MISR register  *****************/
+#define HSEM_C1MISR_MISF0_Pos     (0U)
+#define HSEM_C1MISR_MISF0_Msk     (0x1UL << HSEM_C1MISR_MISF0_Pos)               /*!< 0x00000001 */
+#define HSEM_C1MISR_MISF0         HSEM_C1MISR_MISF0_Msk                          /*!<semaphore 0 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF1_Pos     (1U)
+#define HSEM_C1MISR_MISF1_Msk     (0x1UL << HSEM_C1MISR_MISF1_Pos)               /*!< 0x00000002 */
+#define HSEM_C1MISR_MISF1         HSEM_C1MISR_MISF1_Msk                          /*!<semaphore 1 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF2_Pos     (2U)
+#define HSEM_C1MISR_MISF2_Msk     (0x1UL << HSEM_C1MISR_MISF2_Pos)               /*!< 0x00000004 */
+#define HSEM_C1MISR_MISF2         HSEM_C1MISR_MISF2_Msk                          /*!<semaphore 2 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF3_Pos     (3U)
+#define HSEM_C1MISR_MISF3_Msk     (0x1UL << HSEM_C1MISR_MISF3_Pos)               /*!< 0x00000008 */
+#define HSEM_C1MISR_MISF3         HSEM_C1MISR_MISF3_Msk                          /*!<semaphore 3 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF4_Pos     (4U)
+#define HSEM_C1MISR_MISF4_Msk     (0x1UL << HSEM_C1MISR_MISF4_Pos)               /*!< 0x00000010 */
+#define HSEM_C1MISR_MISF4         HSEM_C1MISR_MISF4_Msk                          /*!<semaphore 4 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF5_Pos     (5U)
+#define HSEM_C1MISR_MISF5_Msk     (0x1UL << HSEM_C1MISR_MISF5_Pos)               /*!< 0x00000020 */
+#define HSEM_C1MISR_MISF5         HSEM_C1MISR_MISF5_Msk                          /*!<semaphore 5 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF6_Pos     (6U)
+#define HSEM_C1MISR_MISF6_Msk     (0x1UL << HSEM_C1MISR_MISF6_Pos)               /*!< 0x00000040 */
+#define HSEM_C1MISR_MISF6         HSEM_C1MISR_MISF6_Msk                          /*!<semaphore 6 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF7_Pos     (7U)
+#define HSEM_C1MISR_MISF7_Msk     (0x1UL << HSEM_C1MISR_MISF7_Pos)               /*!< 0x00000080 */
+#define HSEM_C1MISR_MISF7         HSEM_C1MISR_MISF7_Msk                          /*!<semaphore 7 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF8_Pos     (8U)
+#define HSEM_C1MISR_MISF8_Msk     (0x1UL << HSEM_C1MISR_MISF8_Pos)               /*!< 0x00000100 */
+#define HSEM_C1MISR_MISF8         HSEM_C1MISR_MISF8_Msk                          /*!<semaphore 8 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF9_Pos     (9U)
+#define HSEM_C1MISR_MISF9_Msk     (0x1UL << HSEM_C1MISR_MISF9_Pos)               /*!< 0x00000200 */
+#define HSEM_C1MISR_MISF9         HSEM_C1MISR_MISF9_Msk                          /*!<semaphore 9 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF10_Pos    (10U)
+#define HSEM_C1MISR_MISF10_Msk    (0x1UL << HSEM_C1MISR_MISF10_Pos)              /*!< 0x00000400 */
+#define HSEM_C1MISR_MISF10        HSEM_C1MISR_MISF10_Msk                         /*!<semaphore 10 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF11_Pos    (11U)
+#define HSEM_C1MISR_MISF11_Msk    (0x1UL << HSEM_C1MISR_MISF11_Pos)              /*!< 0x00000800 */
+#define HSEM_C1MISR_MISF11        HSEM_C1MISR_MISF11_Msk                         /*!<semaphore 11 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF12_Pos    (12U)
+#define HSEM_C1MISR_MISF12_Msk    (0x1UL << HSEM_C1MISR_MISF12_Pos)              /*!< 0x00001000 */
+#define HSEM_C1MISR_MISF12        HSEM_C1MISR_MISF12_Msk                         /*!<semaphore 12 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF13_Pos    (13U)
+#define HSEM_C1MISR_MISF13_Msk    (0x1UL << HSEM_C1MISR_MISF13_Pos)              /*!< 0x00002000 */
+#define HSEM_C1MISR_MISF13        HSEM_C1MISR_MISF13_Msk                         /*!<semaphore 13 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF14_Pos    (14U)
+#define HSEM_C1MISR_MISF14_Msk    (0x1UL << HSEM_C1MISR_MISF14_Pos)              /*!< 0x00004000 */
+#define HSEM_C1MISR_MISF14        HSEM_C1MISR_MISF14_Msk                         /*!<semaphore 14 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF15_Pos    (15U)
+#define HSEM_C1MISR_MISF15_Msk    (0x1UL << HSEM_C1MISR_MISF15_Pos)              /*!< 0x00008000 */
+#define HSEM_C1MISR_MISF15        HSEM_C1MISR_MISF15_Msk                         /*!<semaphore 15 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF16_Pos    (16U)
+#define HSEM_C1MISR_MISF16_Msk    (0x1UL << HSEM_C1MISR_MISF16_Pos)              /*!< 0x00010000 */
+#define HSEM_C1MISR_MISF16        HSEM_C1MISR_MISF16_Msk                         /*!<semaphore 16 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF17_Pos    (17U)
+#define HSEM_C1MISR_MISF17_Msk    (0x1UL << HSEM_C1MISR_MISF17_Pos)              /*!< 0x00020000 */
+#define HSEM_C1MISR_MISF17        HSEM_C1MISR_MISF17_Msk                         /*!<semaphore 17 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF18_Pos    (18U)
+#define HSEM_C1MISR_MISF18_Msk    (0x1UL << HSEM_C1MISR_MISF18_Pos)              /*!< 0x00040000 */
+#define HSEM_C1MISR_MISF18        HSEM_C1MISR_MISF18_Msk                         /*!<semaphore 18 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF19_Pos    (19U)
+#define HSEM_C1MISR_MISF19_Msk    (0x1UL << HSEM_C1MISR_MISF19_Pos)              /*!< 0x00080000 */
+#define HSEM_C1MISR_MISF19        HSEM_C1MISR_MISF19_Msk                         /*!<semaphore 19 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF20_Pos    (20U)
+#define HSEM_C1MISR_MISF20_Msk    (0x1UL << HSEM_C1MISR_MISF20_Pos)              /*!< 0x00100000 */
+#define HSEM_C1MISR_MISF20        HSEM_C1MISR_MISF20_Msk                         /*!<semaphore 20 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF21_Pos    (21U)
+#define HSEM_C1MISR_MISF21_Msk    (0x1UL << HSEM_C1MISR_MISF21_Pos)              /*!< 0x00200000 */
+#define HSEM_C1MISR_MISF21        HSEM_C1MISR_MISF21_Msk                         /*!<semaphore 21 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF22_Pos    (22U)
+#define HSEM_C1MISR_MISF22_Msk    (0x1UL << HSEM_C1MISR_MISF22_Pos)              /*!< 0x00400000 */
+#define HSEM_C1MISR_MISF22        HSEM_C1MISR_MISF22_Msk                         /*!<semaphore 22 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF23_Pos    (23U)
+#define HSEM_C1MISR_MISF23_Msk    (0x1UL << HSEM_C1MISR_MISF23_Pos)              /*!< 0x00800000 */
+#define HSEM_C1MISR_MISF23        HSEM_C1MISR_MISF23_Msk                         /*!<semaphore 23 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF24_Pos    (24U)
+#define HSEM_C1MISR_MISF24_Msk    (0x1UL << HSEM_C1MISR_MISF24_Pos)              /*!< 0x01000000 */
+#define HSEM_C1MISR_MISF24        HSEM_C1MISR_MISF24_Msk                         /*!<semaphore 24 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF25_Pos    (25U)
+#define HSEM_C1MISR_MISF25_Msk    (0x1UL << HSEM_C1MISR_MISF25_Pos)              /*!< 0x02000000 */
+#define HSEM_C1MISR_MISF25        HSEM_C1MISR_MISF25_Msk                         /*!<semaphore 25 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF26_Pos    (26U)
+#define HSEM_C1MISR_MISF26_Msk    (0x1UL << HSEM_C1MISR_MISF26_Pos)              /*!< 0x04000000 */
+#define HSEM_C1MISR_MISF26        HSEM_C1MISR_MISF26_Msk                         /*!<semaphore 26 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF27_Pos    (27U)
+#define HSEM_C1MISR_MISF27_Msk    (0x1UL << HSEM_C1MISR_MISF27_Pos)              /*!< 0x08000000 */
+#define HSEM_C1MISR_MISF27        HSEM_C1MISR_MISF27_Msk                         /*!<semaphore 27 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF28_Pos    (28U)
+#define HSEM_C1MISR_MISF28_Msk    (0x1UL << HSEM_C1MISR_MISF28_Pos)              /*!< 0x10000000 */
+#define HSEM_C1MISR_MISF28        HSEM_C1MISR_MISF28_Msk                         /*!<semaphore 28 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF29_Pos    (29U)
+#define HSEM_C1MISR_MISF29_Msk    (0x1UL << HSEM_C1MISR_MISF29_Pos)              /*!< 0x20000000 */
+#define HSEM_C1MISR_MISF29        HSEM_C1MISR_MISF29_Msk                         /*!<semaphore 29 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF30_Pos    (30U)
+#define HSEM_C1MISR_MISF30_Msk    (0x1UL << HSEM_C1MISR_MISF30_Pos)              /*!< 0x40000000 */
+#define HSEM_C1MISR_MISF30        HSEM_C1MISR_MISF30_Msk                         /*!<semaphore 30 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF31_Pos    (31U)
+#define HSEM_C1MISR_MISF31_Msk    (0x1UL << HSEM_C1MISR_MISF31_Pos)              /*!< 0x80000000 */
+#define HSEM_C1MISR_MISF31        HSEM_C1MISR_MISF31_Msk                         /*!<semaphore 31 CPU1 interrupt masked status bit. */
+
+/********************  Bit definition for HSEM_C2IER register  *****************/
+#define HSEM_C2IER_ISE0_Pos      (0U)
+#define HSEM_C2IER_ISE0_Msk      (0x1UL << HSEM_C2IER_ISE0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2IER_ISE0          HSEM_C2IER_ISE0_Msk                           /*!<semaphore 0 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE1_Pos      (1U)
+#define HSEM_C2IER_ISE1_Msk      (0x1UL << HSEM_C2IER_ISE1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2IER_ISE1          HSEM_C2IER_ISE1_Msk                           /*!<semaphore 1 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE2_Pos      (2U)
+#define HSEM_C2IER_ISE2_Msk      (0x1UL << HSEM_C2IER_ISE2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2IER_ISE2          HSEM_C2IER_ISE2_Msk                           /*!<semaphore 2 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE3_Pos      (3U)
+#define HSEM_C2IER_ISE3_Msk      (0x1UL << HSEM_C2IER_ISE3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2IER_ISE3          HSEM_C2IER_ISE3_Msk                           /*!<semaphore 3 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE4_Pos      (4U)
+#define HSEM_C2IER_ISE4_Msk      (0x1UL << HSEM_C2IER_ISE4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2IER_ISE4          HSEM_C2IER_ISE4_Msk                           /*!<semaphore 4 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE5_Pos      (5U)
+#define HSEM_C2IER_ISE5_Msk      (0x1UL << HSEM_C2IER_ISE5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2IER_ISE5          HSEM_C2IER_ISE5_Msk                           /*!<semaphore 5 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE6_Pos      (6U)
+#define HSEM_C2IER_ISE6_Msk      (0x1UL << HSEM_C2IER_ISE6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2IER_ISE6          HSEM_C2IER_ISE6_Msk                           /*!<semaphore 6 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE7_Pos      (7U)
+#define HSEM_C2IER_ISE7_Msk      (0x1UL << HSEM_C2IER_ISE7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2IER_ISE7          HSEM_C2IER_ISE7_Msk                           /*!<semaphore 7 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE8_Pos      (8U)
+#define HSEM_C2IER_ISE8_Msk      (0x1UL << HSEM_C2IER_ISE8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2IER_ISE8          HSEM_C2IER_ISE8_Msk                           /*!<semaphore 8 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE9_Pos      (9U)
+#define HSEM_C2IER_ISE9_Msk      (0x1UL << HSEM_C2IER_ISE9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2IER_ISE9          HSEM_C2IER_ISE9_Msk                           /*!<semaphore 9 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE10_Pos     (10U)
+#define HSEM_C2IER_ISE10_Msk     (0x1UL << HSEM_C2IER_ISE10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2IER_ISE10         HSEM_C2IER_ISE10_Msk                          /*!<semaphore 10 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE11_Pos     (11U)
+#define HSEM_C2IER_ISE11_Msk     (0x1UL << HSEM_C2IER_ISE11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2IER_ISE11         HSEM_C2IER_ISE11_Msk                          /*!<semaphore 11 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE12_Pos     (12U)
+#define HSEM_C2IER_ISE12_Msk     (0x1UL << HSEM_C2IER_ISE12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2IER_ISE12         HSEM_C2IER_ISE12_Msk                          /*!<semaphore 12 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE13_Pos     (13U)
+#define HSEM_C2IER_ISE13_Msk     (0x1UL << HSEM_C2IER_ISE13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2IER_ISE13         HSEM_C2IER_ISE13_Msk                          /*!<semaphore 13 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE14_Pos     (14U)
+#define HSEM_C2IER_ISE14_Msk     (0x1UL << HSEM_C2IER_ISE14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2IER_ISE14         HSEM_C2IER_ISE14_Msk                          /*!<semaphore 14 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE15_Pos     (15U)
+#define HSEM_C2IER_ISE15_Msk     (0x1UL << HSEM_C2IER_ISE15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2IER_ISE15         HSEM_C2IER_ISE15_Msk                          /*!<semaphore 15 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE16_Pos     (16U)
+#define HSEM_C2IER_ISE16_Msk     (0x1UL << HSEM_C2IER_ISE16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2IER_ISE16         HSEM_C2IER_ISE16_Msk                          /*!<semaphore 16 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE17_Pos     (17U)
+#define HSEM_C2IER_ISE17_Msk     (0x1UL << HSEM_C2IER_ISE17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2IER_ISE17         HSEM_C2IER_ISE17_Msk                          /*!<semaphore 17 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE18_Pos     (18U)
+#define HSEM_C2IER_ISE18_Msk     (0x1UL << HSEM_C2IER_ISE18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2IER_ISE18         HSEM_C2IER_ISE18_Msk                          /*!<semaphore 18 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE19_Pos     (19U)
+#define HSEM_C2IER_ISE19_Msk     (0x1UL << HSEM_C2IER_ISE19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2IER_ISE19         HSEM_C2IER_ISE19_Msk                          /*!<semaphore 19 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE20_Pos     (20U)
+#define HSEM_C2IER_ISE20_Msk     (0x1UL << HSEM_C2IER_ISE20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2IER_ISE20         HSEM_C2IER_ISE20_Msk                          /*!<semaphore 20 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE21_Pos     (21U)
+#define HSEM_C2IER_ISE21_Msk     (0x1UL << HSEM_C2IER_ISE21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2IER_ISE21         HSEM_C2IER_ISE21_Msk                          /*!<semaphore 21 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE22_Pos     (22U)
+#define HSEM_C2IER_ISE22_Msk     (0x1UL << HSEM_C2IER_ISE22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2IER_ISE22         HSEM_C2IER_ISE22_Msk                          /*!<semaphore 22 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE23_Pos     (23U)
+#define HSEM_C2IER_ISE23_Msk     (0x1UL << HSEM_C2IER_ISE23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2IER_ISE23         HSEM_C2IER_ISE23_Msk                          /*!<semaphore 23 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE24_Pos     (24U)
+#define HSEM_C2IER_ISE24_Msk     (0x1UL << HSEM_C2IER_ISE24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2IER_ISE24         HSEM_C2IER_ISE24_Msk                          /*!<semaphore 24 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE25_Pos     (25U)
+#define HSEM_C2IER_ISE25_Msk     (0x1UL << HSEM_C2IER_ISE25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2IER_ISE25         HSEM_C2IER_ISE25_Msk                          /*!<semaphore 25 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE26_Pos     (26U)
+#define HSEM_C2IER_ISE26_Msk     (0x1UL << HSEM_C2IER_ISE26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2IER_ISE26         HSEM_C2IER_ISE26_Msk                          /*!<semaphore 26 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE27_Pos     (27U)
+#define HSEM_C2IER_ISE27_Msk     (0x1UL << HSEM_C2IER_ISE27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2IER_ISE27         HSEM_C2IER_ISE27_Msk                          /*!<semaphore 27 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE28_Pos     (28U)
+#define HSEM_C2IER_ISE28_Msk     (0x1UL << HSEM_C2IER_ISE28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2IER_ISE28         HSEM_C2IER_ISE28_Msk                          /*!<semaphore 28 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE29_Pos     (29U)
+#define HSEM_C2IER_ISE29_Msk     (0x1UL << HSEM_C2IER_ISE29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2IER_ISE29         HSEM_C2IER_ISE29_Msk                          /*!<semaphore 29 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE30_Pos     (30U)
+#define HSEM_C2IER_ISE30_Msk     (0x1UL << HSEM_C2IER_ISE30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2IER_ISE30         HSEM_C2IER_ISE30_Msk                          /*!<semaphore 30 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE31_Pos     (31U)
+#define HSEM_C2IER_ISE31_Msk     (0x1UL << HSEM_C2IER_ISE31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2IER_ISE31         HSEM_C2IER_ISE31_Msk                          /*!<semaphore 31 CPU2 interrupt enable bit. */
+
+/********************  Bit definition for HSEM_C2ICR register  *****************/
+#define HSEM_C2ICR_ISC0_Pos      (0U)
+#define HSEM_C2ICR_ISC0_Msk      (0x1UL << HSEM_C2ICR_ISC0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2ICR_ISC0          HSEM_C2ICR_ISC0_Msk                           /*!<semaphore 0 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC1_Pos      (1U)
+#define HSEM_C2ICR_ISC1_Msk      (0x1UL << HSEM_C2ICR_ISC1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2ICR_ISC1          HSEM_C2ICR_ISC1_Msk                           /*!<semaphore 1 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC2_Pos      (2U)
+#define HSEM_C2ICR_ISC2_Msk      (0x1UL << HSEM_C2ICR_ISC2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2ICR_ISC2          HSEM_C2ICR_ISC2_Msk                           /*!<semaphore 2 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC3_Pos      (3U)
+#define HSEM_C2ICR_ISC3_Msk      (0x1UL << HSEM_C2ICR_ISC3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2ICR_ISC3          HSEM_C2ICR_ISC3_Msk                           /*!<semaphore 3 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC4_Pos      (4U)
+#define HSEM_C2ICR_ISC4_Msk      (0x1UL << HSEM_C2ICR_ISC4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2ICR_ISC4          HSEM_C2ICR_ISC4_Msk                           /*!<semaphore 4 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC5_Pos      (5U)
+#define HSEM_C2ICR_ISC5_Msk      (0x1UL << HSEM_C2ICR_ISC5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2ICR_ISC5          HSEM_C2ICR_ISC5_Msk                           /*!<semaphore 5 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC6_Pos      (6U)
+#define HSEM_C2ICR_ISC6_Msk      (0x1UL << HSEM_C2ICR_ISC6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2ICR_ISC6          HSEM_C2ICR_ISC6_Msk                           /*!<semaphore 6 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC7_Pos      (7U)
+#define HSEM_C2ICR_ISC7_Msk      (0x1UL << HSEM_C2ICR_ISC7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2ICR_ISC7          HSEM_C2ICR_ISC7_Msk                           /*!<semaphore 7 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC8_Pos      (8U)
+#define HSEM_C2ICR_ISC8_Msk      (0x1UL << HSEM_C2ICR_ISC8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2ICR_ISC8          HSEM_C2ICR_ISC8_Msk                           /*!<semaphore 8 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC9_Pos      (9U)
+#define HSEM_C2ICR_ISC9_Msk      (0x1UL << HSEM_C2ICR_ISC9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2ICR_ISC9          HSEM_C2ICR_ISC9_Msk                           /*!<semaphore 9 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC10_Pos     (10U)
+#define HSEM_C2ICR_ISC10_Msk     (0x1UL << HSEM_C2ICR_ISC10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2ICR_ISC10         HSEM_C2ICR_ISC10_Msk                          /*!<semaphore 10 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC11_Pos     (11U)
+#define HSEM_C2ICR_ISC11_Msk     (0x1UL << HSEM_C2ICR_ISC11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2ICR_ISC11         HSEM_C2ICR_ISC11_Msk                          /*!<semaphore 11 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC12_Pos     (12U)
+#define HSEM_C2ICR_ISC12_Msk     (0x1UL << HSEM_C2ICR_ISC12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2ICR_ISC12         HSEM_C2ICR_ISC12_Msk                          /*!<semaphore 12 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC13_Pos     (13U)
+#define HSEM_C2ICR_ISC13_Msk     (0x1UL << HSEM_C2ICR_ISC13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2ICR_ISC13         HSEM_C2ICR_ISC13_Msk                          /*!<semaphore 13 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC14_Pos     (14U)
+#define HSEM_C2ICR_ISC14_Msk     (0x1UL << HSEM_C2ICR_ISC14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2ICR_ISC14         HSEM_C2ICR_ISC14_Msk                          /*!<semaphore 14 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC15_Pos     (15U)
+#define HSEM_C2ICR_ISC15_Msk     (0x1UL << HSEM_C2ICR_ISC15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2ICR_ISC15         HSEM_C2ICR_ISC15_Msk                          /*!<semaphore 15 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC16_Pos     (16U)
+#define HSEM_C2ICR_ISC16_Msk     (0x1UL << HSEM_C2ICR_ISC16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2ICR_ISC16         HSEM_C2ICR_ISC16_Msk                          /*!<semaphore 16 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC17_Pos     (17U)
+#define HSEM_C2ICR_ISC17_Msk     (0x1UL << HSEM_C2ICR_ISC17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2ICR_ISC17         HSEM_C2ICR_ISC17_Msk                          /*!<semaphore 17 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC18_Pos     (18U)
+#define HSEM_C2ICR_ISC18_Msk     (0x1UL << HSEM_C2ICR_ISC18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2ICR_ISC18         HSEM_C2ICR_ISC18_Msk                          /*!<semaphore 18 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC19_Pos     (19U)
+#define HSEM_C2ICR_ISC19_Msk     (0x1UL << HSEM_C2ICR_ISC19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2ICR_ISC19         HSEM_C2ICR_ISC19_Msk                          /*!<semaphore 19 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC20_Pos     (20U)
+#define HSEM_C2ICR_ISC20_Msk     (0x1UL << HSEM_C2ICR_ISC20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2ICR_ISC20         HSEM_C2ICR_ISC20_Msk                          /*!<semaphore 20 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC21_Pos     (21U)
+#define HSEM_C2ICR_ISC21_Msk     (0x1UL << HSEM_C2ICR_ISC21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2ICR_ISC21         HSEM_C2ICR_ISC21_Msk                          /*!<semaphore 21 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC22_Pos     (22U)
+#define HSEM_C2ICR_ISC22_Msk     (0x1UL << HSEM_C2ICR_ISC22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2ICR_ISC22         HSEM_C2ICR_ISC22_Msk                          /*!<semaphore 22 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC23_Pos     (23U)
+#define HSEM_C2ICR_ISC23_Msk     (0x1UL << HSEM_C2ICR_ISC23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2ICR_ISC23         HSEM_C2ICR_ISC23_Msk                          /*!<semaphore 23 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC24_Pos     (24U)
+#define HSEM_C2ICR_ISC24_Msk     (0x1UL << HSEM_C2ICR_ISC24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2ICR_ISC24         HSEM_C2ICR_ISC24_Msk                          /*!<semaphore 24 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC25_Pos     (25U)
+#define HSEM_C2ICR_ISC25_Msk     (0x1UL << HSEM_C2ICR_ISC25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2ICR_ISC25         HSEM_C2ICR_ISC25_Msk                          /*!<semaphore 25 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC26_Pos     (26U)
+#define HSEM_C2ICR_ISC26_Msk     (0x1UL << HSEM_C2ICR_ISC26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2ICR_ISC26         HSEM_C2ICR_ISC26_Msk                          /*!<semaphore 26 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC27_Pos     (27U)
+#define HSEM_C2ICR_ISC27_Msk     (0x1UL << HSEM_C2ICR_ISC27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2ICR_ISC27         HSEM_C2ICR_ISC27_Msk                          /*!<semaphore 27 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC28_Pos     (28U)
+#define HSEM_C2ICR_ISC28_Msk     (0x1UL << HSEM_C2ICR_ISC28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2ICR_ISC28         HSEM_C2ICR_ISC28_Msk                          /*!<semaphore 28 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC29_Pos     (29U)
+#define HSEM_C2ICR_ISC29_Msk     (0x1UL << HSEM_C2ICR_ISC29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2ICR_ISC29         HSEM_C2ICR_ISC29_Msk                          /*!<semaphore 29 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC30_Pos     (30U)
+#define HSEM_C2ICR_ISC30_Msk     (0x1UL << HSEM_C2ICR_ISC30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2ICR_ISC30         HSEM_C2ICR_ISC30_Msk                          /*!<semaphore 30 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC31_Pos     (31U)
+#define HSEM_C2ICR_ISC31_Msk     (0x1UL << HSEM_C2ICR_ISC31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2ICR_ISC31         HSEM_C2ICR_ISC31_Msk                          /*!<semaphore 31 CPU2 interrupt clear bit. */
+
+/********************  Bit definition for HSEM_C2ISR register  *****************/
+#define HSEM_C2ISR_ISF0_Pos      (0U)
+#define HSEM_C2ISR_ISF0_Msk      (0x1UL << HSEM_C2ISR_ISF0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2ISR_ISF0          HSEM_C2ISR_ISF0_Msk                           /*!<semaphore 0 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF1_Pos      (1U)
+#define HSEM_C2ISR_ISF1_Msk      (0x1UL << HSEM_C2ISR_ISF1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2ISR_ISF1          HSEM_C2ISR_ISF1_Msk                           /*!<semaphore 1 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF2_Pos      (2U)
+#define HSEM_C2ISR_ISF2_Msk      (0x1UL << HSEM_C2ISR_ISF2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2ISR_ISF2          HSEM_C2ISR_ISF2_Msk                           /*!<semaphore 2 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF3_Pos      (3U)
+#define HSEM_C2ISR_ISF3_Msk      (0x1UL << HSEM_C2ISR_ISF3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2ISR_ISF3          HSEM_C2ISR_ISF3_Msk                           /*!<semaphore 3 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF4_Pos      (4U)
+#define HSEM_C2ISR_ISF4_Msk      (0x1UL << HSEM_C2ISR_ISF4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2ISR_ISF4          HSEM_C2ISR_ISF4_Msk                           /*!<semaphore 4 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF5_Pos      (5U)
+#define HSEM_C2ISR_ISF5_Msk      (0x1UL << HSEM_C2ISR_ISF5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2ISR_ISF5          HSEM_C2ISR_ISF5_Msk                           /*!<semaphore 5 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF6_Pos      (6U)
+#define HSEM_C2ISR_ISF6_Msk      (0x1UL << HSEM_C2ISR_ISF6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2ISR_ISF6          HSEM_C2ISR_ISF6_Msk                           /*!<semaphore 6 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF7_Pos      (7U)
+#define HSEM_C2ISR_ISF7_Msk      (0x1UL << HSEM_C2ISR_ISF7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2ISR_ISF7          HSEM_C2ISR_ISF7_Msk                           /*!<semaphore 7 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF8_Pos      (8U)
+#define HSEM_C2ISR_ISF8_Msk      (0x1UL << HSEM_C2ISR_ISF8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2ISR_ISF8          HSEM_C2ISR_ISF8_Msk                           /*!<semaphore 8 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF9_Pos      (9U)
+#define HSEM_C2ISR_ISF9_Msk      (0x1UL << HSEM_C2ISR_ISF9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2ISR_ISF9          HSEM_C2ISR_ISF9_Msk                           /*!<semaphore 9 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF10_Pos     (10U)
+#define HSEM_C2ISR_ISF10_Msk     (0x1UL << HSEM_C2ISR_ISF10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2ISR_ISF10         HSEM_C2ISR_ISF10_Msk                          /*!<semaphore 10 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF11_Pos     (11U)
+#define HSEM_C2ISR_ISF11_Msk     (0x1UL << HSEM_C2ISR_ISF11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2ISR_ISF11         HSEM_C2ISR_ISF11_Msk                          /*!<semaphore 11 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF12_Pos     (12U)
+#define HSEM_C2ISR_ISF12_Msk     (0x1UL << HSEM_C2ISR_ISF12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2ISR_ISF12         HSEM_C2ISR_ISF12_Msk                          /*!<semaphore 12 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF13_Pos     (13U)
+#define HSEM_C2ISR_ISF13_Msk     (0x1UL << HSEM_C2ISR_ISF13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2ISR_ISF13         HSEM_C2ISR_ISF13_Msk                          /*!<semaphore 13 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF14_Pos     (14U)
+#define HSEM_C2ISR_ISF14_Msk     (0x1UL << HSEM_C2ISR_ISF14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2ISR_ISF14         HSEM_C2ISR_ISF14_Msk                          /*!<semaphore 14 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF15_Pos     (15U)
+#define HSEM_C2ISR_ISF15_Msk     (0x1UL << HSEM_C2ISR_ISF15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2ISR_ISF15         HSEM_C2ISR_ISF15_Msk                          /*!<semaphore 15 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF16_Pos     (16U)
+#define HSEM_C2ISR_ISF16_Msk     (0x1UL << HSEM_C2ISR_ISF16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2ISR_ISF16         HSEM_C2ISR_ISF16_Msk                          /*!<semaphore 16 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF17_Pos     (17U)
+#define HSEM_C2ISR_ISF17_Msk     (0x1UL << HSEM_C2ISR_ISF17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2ISR_ISF17         HSEM_C2ISR_ISF17_Msk                          /*!<semaphore 17 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF18_Pos     (18U)
+#define HSEM_C2ISR_ISF18_Msk     (0x1UL << HSEM_C2ISR_ISF18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2ISR_ISF18         HSEM_C2ISR_ISF18_Msk                          /*!<semaphore 18 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF19_Pos     (19U)
+#define HSEM_C2ISR_ISF19_Msk     (0x1UL << HSEM_C2ISR_ISF19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2ISR_ISF19         HSEM_C2ISR_ISF19_Msk                          /*!<semaphore 19 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF20_Pos     (20U)
+#define HSEM_C2ISR_ISF20_Msk     (0x1UL << HSEM_C2ISR_ISF20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2ISR_ISF20         HSEM_C2ISR_ISF20_Msk                          /*!<semaphore 20 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF21_Pos     (21U)
+#define HSEM_C2ISR_ISF21_Msk     (0x1UL << HSEM_C2ISR_ISF21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2ISR_ISF21         HSEM_C2ISR_ISF21_Msk                          /*!<semaphore 21 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF22_Pos     (22U)
+#define HSEM_C2ISR_ISF22_Msk     (0x1UL << HSEM_C2ISR_ISF22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2ISR_ISF22         HSEM_C2ISR_ISF22_Msk                          /*!<semaphore 22 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF23_Pos     (23U)
+#define HSEM_C2ISR_ISF23_Msk     (0x1UL << HSEM_C2ISR_ISF23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2ISR_ISF23         HSEM_C2ISR_ISF23_Msk                          /*!<semaphore 23 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF24_Pos     (24U)
+#define HSEM_C2ISR_ISF24_Msk     (0x1UL << HSEM_C2ISR_ISF24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2ISR_ISF24         HSEM_C2ISR_ISF24_Msk                          /*!<semaphore 24 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF25_Pos     (25U)
+#define HSEM_C2ISR_ISF25_Msk     (0x1UL << HSEM_C2ISR_ISF25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2ISR_ISF25         HSEM_C2ISR_ISF25_Msk                          /*!<semaphore 25 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF26_Pos     (26U)
+#define HSEM_C2ISR_ISF26_Msk     (0x1UL << HSEM_C2ISR_ISF26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2ISR_ISF26         HSEM_C2ISR_ISF26_Msk                          /*!<semaphore 26 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF27_Pos     (27U)
+#define HSEM_C2ISR_ISF27_Msk     (0x1UL << HSEM_C2ISR_ISF27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2ISR_ISF27         HSEM_C2ISR_ISF27_Msk                          /*!<semaphore 27 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF28_Pos     (28U)
+#define HSEM_C2ISR_ISF28_Msk     (0x1UL << HSEM_C2ISR_ISF28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2ISR_ISF28         HSEM_C2ISR_ISF28_Msk                          /*!<semaphore 28 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF29_Pos     (29U)
+#define HSEM_C2ISR_ISF29_Msk     (0x1UL << HSEM_C2ISR_ISF29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2ISR_ISF29         HSEM_C2ISR_ISF29_Msk                          /*!<semaphore 29 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF30_Pos     (30U)
+#define HSEM_C2ISR_ISF30_Msk     (0x1UL << HSEM_C2ISR_ISF30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2ISR_ISF30         HSEM_C2ISR_ISF30_Msk                          /*!<semaphore 30 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF31_Pos     (31U)
+#define HSEM_C2ISR_ISF31_Msk     (0x1UL << HSEM_C2ISR_ISF31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2ISR_ISF31         HSEM_C2ISR_ISF31_Msk                          /*!<semaphore 31 CPU2 interrupt status bit. */
+
+/********************  Bit definition for HSEM_C2MISR register  *****************/
+#define HSEM_C2MISR_MISF0_Pos     (0U)
+#define HSEM_C2MISR_MISF0_Msk     (0x1UL << HSEM_C2MISR_MISF0_Pos)               /*!< 0x00000001 */
+#define HSEM_C2MISR_MISF0         HSEM_C2MISR_MISF0_Msk                          /*!<semaphore 0 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF1_Pos     (1U)
+#define HSEM_C2MISR_MISF1_Msk     (0x1UL << HSEM_C2MISR_MISF1_Pos)               /*!< 0x00000002 */
+#define HSEM_C2MISR_MISF1         HSEM_C2MISR_MISF1_Msk                          /*!<semaphore 1 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF2_Pos     (2U)
+#define HSEM_C2MISR_MISF2_Msk     (0x1UL << HSEM_C2MISR_MISF2_Pos)               /*!< 0x00000004 */
+#define HSEM_C2MISR_MISF2         HSEM_C2MISR_MISF2_Msk                          /*!<semaphore 2 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF3_Pos     (3U)
+#define HSEM_C2MISR_MISF3_Msk     (0x1UL << HSEM_C2MISR_MISF3_Pos)               /*!< 0x00000008 */
+#define HSEM_C2MISR_MISF3         HSEM_C2MISR_MISF3_Msk                          /*!<semaphore 3 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF4_Pos     (4U)
+#define HSEM_C2MISR_MISF4_Msk     (0x1UL << HSEM_C2MISR_MISF4_Pos)               /*!< 0x00000010 */
+#define HSEM_C2MISR_MISF4         HSEM_C2MISR_MISF4_Msk                          /*!<semaphore 4 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF5_Pos     (5U)
+#define HSEM_C2MISR_MISF5_Msk     (0x1UL << HSEM_C2MISR_MISF5_Pos)               /*!< 0x00000020 */
+#define HSEM_C2MISR_MISF5         HSEM_C2MISR_MISF5_Msk                          /*!<semaphore 5 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF6_Pos     (6U)
+#define HSEM_C2MISR_MISF6_Msk     (0x1UL << HSEM_C2MISR_MISF6_Pos)               /*!< 0x00000040 */
+#define HSEM_C2MISR_MISF6         HSEM_C2MISR_MISF6_Msk                          /*!<semaphore 6 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF7_Pos     (7U)
+#define HSEM_C2MISR_MISF7_Msk     (0x1UL << HSEM_C2MISR_MISF7_Pos)               /*!< 0x00000080 */
+#define HSEM_C2MISR_MISF7         HSEM_C2MISR_MISF7_Msk                          /*!<semaphore 7 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF8_Pos     (8U)
+#define HSEM_C2MISR_MISF8_Msk     (0x1UL << HSEM_C2MISR_MISF8_Pos)               /*!< 0x00000100 */
+#define HSEM_C2MISR_MISF8         HSEM_C2MISR_MISF8_Msk                          /*!<semaphore 8 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF9_Pos     (9U)
+#define HSEM_C2MISR_MISF9_Msk     (0x1UL << HSEM_C2MISR_MISF9_Pos)               /*!< 0x00000200 */
+#define HSEM_C2MISR_MISF9         HSEM_C2MISR_MISF9_Msk                          /*!<semaphore 9 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF10_Pos    (10U)
+#define HSEM_C2MISR_MISF10_Msk    (0x1UL << HSEM_C2MISR_MISF10_Pos)              /*!< 0x00000400 */
+#define HSEM_C2MISR_MISF10        HSEM_C2MISR_MISF10_Msk                         /*!<semaphore 10 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF11_Pos    (11U)
+#define HSEM_C2MISR_MISF11_Msk    (0x1UL << HSEM_C2MISR_MISF11_Pos)              /*!< 0x00000800 */
+#define HSEM_C2MISR_MISF11        HSEM_C2MISR_MISF11_Msk                         /*!<semaphore 11 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF12_Pos    (12U)
+#define HSEM_C2MISR_MISF12_Msk    (0x1UL << HSEM_C2MISR_MISF12_Pos)              /*!< 0x00001000 */
+#define HSEM_C2MISR_MISF12        HSEM_C2MISR_MISF12_Msk                         /*!<semaphore 12 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF13_Pos    (13U)
+#define HSEM_C2MISR_MISF13_Msk    (0x1UL << HSEM_C2MISR_MISF13_Pos)              /*!< 0x00002000 */
+#define HSEM_C2MISR_MISF13        HSEM_C2MISR_MISF13_Msk                         /*!<semaphore 13 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF14_Pos    (14U)
+#define HSEM_C2MISR_MISF14_Msk    (0x1UL << HSEM_C2MISR_MISF14_Pos)              /*!< 0x00004000 */
+#define HSEM_C2MISR_MISF14        HSEM_C2MISR_MISF14_Msk                         /*!<semaphore 14 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF15_Pos    (15U)
+#define HSEM_C2MISR_MISF15_Msk    (0x1UL << HSEM_C2MISR_MISF15_Pos)              /*!< 0x00008000 */
+#define HSEM_C2MISR_MISF15        HSEM_C2MISR_MISF15_Msk                         /*!<semaphore 15 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF16_Pos    (16U)
+#define HSEM_C2MISR_MISF16_Msk    (0x1UL << HSEM_C2MISR_MISF16_Pos)              /*!< 0x00010000 */
+#define HSEM_C2MISR_MISF16        HSEM_C2MISR_MISF16_Msk                         /*!<semaphore 16 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF17_Pos    (17U)
+#define HSEM_C2MISR_MISF17_Msk    (0x1UL << HSEM_C2MISR_MISF17_Pos)              /*!< 0x00020000 */
+#define HSEM_C2MISR_MISF17        HSEM_C2MISR_MISF17_Msk                         /*!<semaphore 17 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF18_Pos    (18U)
+#define HSEM_C2MISR_MISF18_Msk    (0x1UL << HSEM_C2MISR_MISF18_Pos)              /*!< 0x00040000 */
+#define HSEM_C2MISR_MISF18        HSEM_C2MISR_MISF18_Msk                         /*!<semaphore 18 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF19_Pos    (19U)
+#define HSEM_C2MISR_MISF19_Msk    (0x1UL << HSEM_C2MISR_MISF19_Pos)              /*!< 0x00080000 */
+#define HSEM_C2MISR_MISF19        HSEM_C2MISR_MISF19_Msk                         /*!<semaphore 19 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF20_Pos    (20U)
+#define HSEM_C2MISR_MISF20_Msk    (0x1UL << HSEM_C2MISR_MISF20_Pos)              /*!< 0x00100000 */
+#define HSEM_C2MISR_MISF20        HSEM_C2MISR_MISF20_Msk                         /*!<semaphore 20 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF21_Pos    (21U)
+#define HSEM_C2MISR_MISF21_Msk    (0x1UL << HSEM_C2MISR_MISF21_Pos)              /*!< 0x00200000 */
+#define HSEM_C2MISR_MISF21        HSEM_C2MISR_MISF21_Msk                         /*!<semaphore 21 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF22_Pos    (22U)
+#define HSEM_C2MISR_MISF22_Msk    (0x1UL << HSEM_C2MISR_MISF22_Pos)              /*!< 0x00400000 */
+#define HSEM_C2MISR_MISF22        HSEM_C2MISR_MISF22_Msk                         /*!<semaphore 22 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF23_Pos    (23U)
+#define HSEM_C2MISR_MISF23_Msk    (0x1UL << HSEM_C2MISR_MISF23_Pos)              /*!< 0x00800000 */
+#define HSEM_C2MISR_MISF23        HSEM_C2MISR_MISF23_Msk                         /*!<semaphore 23 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF24_Pos    (24U)
+#define HSEM_C2MISR_MISF24_Msk    (0x1UL << HSEM_C2MISR_MISF24_Pos)              /*!< 0x01000000 */
+#define HSEM_C2MISR_MISF24        HSEM_C2MISR_MISF24_Msk                         /*!<semaphore 24 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF25_Pos    (25U)
+#define HSEM_C2MISR_MISF25_Msk    (0x1UL << HSEM_C2MISR_MISF25_Pos)              /*!< 0x02000000 */
+#define HSEM_C2MISR_MISF25        HSEM_C2MISR_MISF25_Msk                         /*!<semaphore 25 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF26_Pos    (26U)
+#define HSEM_C2MISR_MISF26_Msk    (0x1UL << HSEM_C2MISR_MISF26_Pos)              /*!< 0x04000000 */
+#define HSEM_C2MISR_MISF26        HSEM_C2MISR_MISF26_Msk                         /*!<semaphore 26 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF27_Pos    (27U)
+#define HSEM_C2MISR_MISF27_Msk    (0x1UL << HSEM_C2MISR_MISF27_Pos)              /*!< 0x08000000 */
+#define HSEM_C2MISR_MISF27        HSEM_C2MISR_MISF27_Msk                         /*!<semaphore 27 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF28_Pos    (28U)
+#define HSEM_C2MISR_MISF28_Msk    (0x1UL << HSEM_C2MISR_MISF28_Pos)              /*!< 0x10000000 */
+#define HSEM_C2MISR_MISF28        HSEM_C2MISR_MISF28_Msk                         /*!<semaphore 28 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF29_Pos    (29U)
+#define HSEM_C2MISR_MISF29_Msk    (0x1UL << HSEM_C2MISR_MISF29_Pos)              /*!< 0x20000000 */
+#define HSEM_C2MISR_MISF29        HSEM_C2MISR_MISF29_Msk                         /*!<semaphore 29 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF30_Pos    (30U)
+#define HSEM_C2MISR_MISF30_Msk    (0x1UL << HSEM_C2MISR_MISF30_Pos)              /*!< 0x40000000 */
+#define HSEM_C2MISR_MISF30        HSEM_C2MISR_MISF30_Msk                         /*!<semaphore 30 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF31_Pos    (31U)
+#define HSEM_C2MISR_MISF31_Msk    (0x1UL << HSEM_C2MISR_MISF31_Pos)              /*!< 0x80000000 */
+#define HSEM_C2MISR_MISF31        HSEM_C2MISR_MISF31_Msk                         /*!<semaphore 31 CPU2 interrupt masked status bit. */
+
+/********************  Bit definition for HSEM_CR register  *****************/
+#define HSEM_CR_COREID_Pos       (8U)
+#define HSEM_CR_COREID_Msk       (0xFUL << HSEM_CR_COREID_Pos)                 /*!< 0x00000F00 */
+#define HSEM_CR_COREID           HSEM_CR_COREID_Msk                            /*!<CoreID of semaphores to be cleared. */
+#define HSEM_CR_COREID_CPU1      (0x4U << HSEM_CR_COREID_Pos)
+#define HSEM_CR_COREID_CPU2      (0x8U << HSEM_CR_COREID_Pos)
+#define HSEM_CR_COREID_CURRENT   HSEM_CR_COREID_CPU1
+#define HSEM_CR_KEY_Pos          (16U)
+#define HSEM_CR_KEY_Msk          (0xFFFFUL << HSEM_CR_KEY_Pos)                 /*!< 0xFFFF0000 */
+#define HSEM_CR_KEY              HSEM_CR_KEY_Msk                               /*!<semaphores clear key. */
+
+/********************  Bit definition for HSEM_KEYR register  *****************/
+#define HSEM_KEYR_KEY_Pos        (16U)
+#define HSEM_KEYR_KEY_Msk        (0xFFFFUL << HSEM_KEYR_KEY_Pos)               /*!< 0xFFFF0000 */
+#define HSEM_KEYR_KEY            HSEM_KEYR_KEY_Msk                             /*!<semaphores clear key. */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define I2C_CR1_PE_Pos               (0U)
+#define I2C_CR1_PE_Msk               (0x1UL << I2C_CR1_PE_Pos)                 /*!< 0x00000001 */
+#define I2C_CR1_PE                   I2C_CR1_PE_Msk                            /*!< Peripheral enable */
+#define I2C_CR1_TXIE_Pos             (1U)
+#define I2C_CR1_TXIE_Msk             (0x1UL << I2C_CR1_TXIE_Pos)               /*!< 0x00000002 */
+#define I2C_CR1_TXIE                 I2C_CR1_TXIE_Msk                          /*!< TX interrupt enable */
+#define I2C_CR1_RXIE_Pos             (2U)
+#define I2C_CR1_RXIE_Msk             (0x1UL << I2C_CR1_RXIE_Pos)               /*!< 0x00000004 */
+#define I2C_CR1_RXIE                 I2C_CR1_RXIE_Msk                          /*!< RX interrupt enable */
+#define I2C_CR1_ADDRIE_Pos           (3U)
+#define I2C_CR1_ADDRIE_Msk           (0x1UL << I2C_CR1_ADDRIE_Pos)             /*!< 0x00000008 */
+#define I2C_CR1_ADDRIE               I2C_CR1_ADDRIE_Msk                        /*!< Address match interrupt enable */
+#define I2C_CR1_NACKIE_Pos           (4U)
+#define I2C_CR1_NACKIE_Msk           (0x1UL << I2C_CR1_NACKIE_Pos)             /*!< 0x00000010 */
+#define I2C_CR1_NACKIE               I2C_CR1_NACKIE_Msk                        /*!< NACK received interrupt enable */
+#define I2C_CR1_STOPIE_Pos           (5U)
+#define I2C_CR1_STOPIE_Msk           (0x1UL << I2C_CR1_STOPIE_Pos)             /*!< 0x00000020 */
+#define I2C_CR1_STOPIE               I2C_CR1_STOPIE_Msk                        /*!< STOP detection interrupt enable */
+#define I2C_CR1_TCIE_Pos             (6U)
+#define I2C_CR1_TCIE_Msk             (0x1UL << I2C_CR1_TCIE_Pos)               /*!< 0x00000040 */
+#define I2C_CR1_TCIE                 I2C_CR1_TCIE_Msk                          /*!< Transfer complete interrupt enable */
+#define I2C_CR1_ERRIE_Pos            (7U)
+#define I2C_CR1_ERRIE_Msk            (0x1UL << I2C_CR1_ERRIE_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_ERRIE                I2C_CR1_ERRIE_Msk                         /*!< Errors interrupt enable */
+#define I2C_CR1_DNF_Pos              (8U)
+#define I2C_CR1_DNF_Msk              (0xFUL << I2C_CR1_DNF_Pos)                /*!< 0x00000F00 */
+#define I2C_CR1_DNF                  I2C_CR1_DNF_Msk                           /*!< Digital noise filter */
+#define I2C_CR1_ANFOFF_Pos           (12U)
+#define I2C_CR1_ANFOFF_Msk           (0x1UL << I2C_CR1_ANFOFF_Pos)             /*!< 0x00001000 */
+#define I2C_CR1_ANFOFF               I2C_CR1_ANFOFF_Msk                        /*!< Analog noise filter OFF */
+#define I2C_CR1_SWRST_Pos            (13U)
+#define I2C_CR1_SWRST_Msk            (0x1UL << I2C_CR1_SWRST_Pos)              /*!< 0x00002000 */
+#define I2C_CR1_SWRST                I2C_CR1_SWRST_Msk                         /*!< Software reset */
+#define I2C_CR1_TXDMAEN_Pos          (14U)
+#define I2C_CR1_TXDMAEN_Msk          (0x1UL << I2C_CR1_TXDMAEN_Pos)            /*!< 0x00004000 */
+#define I2C_CR1_TXDMAEN              I2C_CR1_TXDMAEN_Msk                       /*!< DMA transmission requests enable */
+#define I2C_CR1_RXDMAEN_Pos          (15U)
+#define I2C_CR1_RXDMAEN_Msk          (0x1UL << I2C_CR1_RXDMAEN_Pos)            /*!< 0x00008000 */
+#define I2C_CR1_RXDMAEN              I2C_CR1_RXDMAEN_Msk                       /*!< DMA reception requests enable */
+#define I2C_CR1_SBC_Pos              (16U)
+#define I2C_CR1_SBC_Msk              (0x1UL << I2C_CR1_SBC_Pos)                /*!< 0x00010000 */
+#define I2C_CR1_SBC                  I2C_CR1_SBC_Msk                           /*!< Slave byte control */
+#define I2C_CR1_NOSTRETCH_Pos        (17U)
+#define I2C_CR1_NOSTRETCH_Msk        (0x1UL << I2C_CR1_NOSTRETCH_Pos)          /*!< 0x00020000 */
+#define I2C_CR1_NOSTRETCH            I2C_CR1_NOSTRETCH_Msk                     /*!< Clock stretching disable */
+#define I2C_CR1_WUPEN_Pos            (18U)
+#define I2C_CR1_WUPEN_Msk            (0x1UL << I2C_CR1_WUPEN_Pos)              /*!< 0x00040000 */
+#define I2C_CR1_WUPEN                I2C_CR1_WUPEN_Msk                         /*!< Wakeup from STOP enable */
+#define I2C_CR1_GCEN_Pos             (19U)
+#define I2C_CR1_GCEN_Msk             (0x1UL << I2C_CR1_GCEN_Pos)               /*!< 0x00080000 */
+#define I2C_CR1_GCEN                 I2C_CR1_GCEN_Msk                          /*!< General call enable */
+#define I2C_CR1_SMBHEN_Pos           (20U)
+#define I2C_CR1_SMBHEN_Msk           (0x1UL << I2C_CR1_SMBHEN_Pos)             /*!< 0x00100000 */
+#define I2C_CR1_SMBHEN               I2C_CR1_SMBHEN_Msk                        /*!< SMBus host address enable */
+#define I2C_CR1_SMBDEN_Pos           (21U)
+#define I2C_CR1_SMBDEN_Msk           (0x1UL << I2C_CR1_SMBDEN_Pos)             /*!< 0x00200000 */
+#define I2C_CR1_SMBDEN               I2C_CR1_SMBDEN_Msk                        /*!< SMBus device default address enable */
+#define I2C_CR1_ALERTEN_Pos          (22U)
+#define I2C_CR1_ALERTEN_Msk          (0x1UL << I2C_CR1_ALERTEN_Pos)            /*!< 0x00400000 */
+#define I2C_CR1_ALERTEN              I2C_CR1_ALERTEN_Msk                       /*!< SMBus alert enable */
+#define I2C_CR1_PECEN_Pos            (23U)
+#define I2C_CR1_PECEN_Msk            (0x1UL << I2C_CR1_PECEN_Pos)              /*!< 0x00800000 */
+#define I2C_CR1_PECEN                I2C_CR1_PECEN_Msk                         /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_SADD_Pos             (0U)
+#define I2C_CR2_SADD_Msk             (0x3FFUL << I2C_CR2_SADD_Pos)             /*!< 0x000003FF */
+#define I2C_CR2_SADD                 I2C_CR2_SADD_Msk                          /*!< Slave address (master mode) */
+#define I2C_CR2_RD_WRN_Pos           (10U)
+#define I2C_CR2_RD_WRN_Msk           (0x1UL << I2C_CR2_RD_WRN_Pos)             /*!< 0x00000400 */
+#define I2C_CR2_RD_WRN               I2C_CR2_RD_WRN_Msk                        /*!< Transfer direction (master mode) */
+#define I2C_CR2_ADD10_Pos            (11U)
+#define I2C_CR2_ADD10_Msk            (0x1UL << I2C_CR2_ADD10_Pos)              /*!< 0x00000800 */
+#define I2C_CR2_ADD10                I2C_CR2_ADD10_Msk                         /*!< 10-bit addressing mode (master mode) */
+#define I2C_CR2_HEAD10R_Pos          (12U)
+#define I2C_CR2_HEAD10R_Msk          (0x1UL << I2C_CR2_HEAD10R_Pos)            /*!< 0x00001000 */
+#define I2C_CR2_HEAD10R              I2C_CR2_HEAD10R_Msk                       /*!< 10-bit address header only read direction (master mode) */
+#define I2C_CR2_START_Pos            (13U)
+#define I2C_CR2_START_Msk            (0x1UL << I2C_CR2_START_Pos)              /*!< 0x00002000 */
+#define I2C_CR2_START                I2C_CR2_START_Msk                         /*!< START generation */
+#define I2C_CR2_STOP_Pos             (14U)
+#define I2C_CR2_STOP_Msk             (0x1UL << I2C_CR2_STOP_Pos)               /*!< 0x00004000 */
+#define I2C_CR2_STOP                 I2C_CR2_STOP_Msk                          /*!< STOP generation (master mode) */
+#define I2C_CR2_NACK_Pos             (15U)
+#define I2C_CR2_NACK_Msk             (0x1UL << I2C_CR2_NACK_Pos)               /*!< 0x00008000 */
+#define I2C_CR2_NACK                 I2C_CR2_NACK_Msk                          /*!< NACK generation (slave mode) */
+#define I2C_CR2_NBYTES_Pos           (16U)
+#define I2C_CR2_NBYTES_Msk           (0xFFUL << I2C_CR2_NBYTES_Pos)            /*!< 0x00FF0000 */
+#define I2C_CR2_NBYTES               I2C_CR2_NBYTES_Msk                        /*!< Number of bytes */
+#define I2C_CR2_RELOAD_Pos           (24U)
+#define I2C_CR2_RELOAD_Msk           (0x1UL << I2C_CR2_RELOAD_Pos)             /*!< 0x01000000 */
+#define I2C_CR2_RELOAD               I2C_CR2_RELOAD_Msk                        /*!< NBYTES reload mode */
+#define I2C_CR2_AUTOEND_Pos          (25U)
+#define I2C_CR2_AUTOEND_Msk          (0x1UL << I2C_CR2_AUTOEND_Pos)            /*!< 0x02000000 */
+#define I2C_CR2_AUTOEND              I2C_CR2_AUTOEND_Msk                       /*!< Automatic end mode (master mode) */
+#define I2C_CR2_PECBYTE_Pos          (26U)
+#define I2C_CR2_PECBYTE_Msk          (0x1UL << I2C_CR2_PECBYTE_Pos)            /*!< 0x04000000 */
+#define I2C_CR2_PECBYTE              I2C_CR2_PECBYTE_Msk                       /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define I2C_OAR1_OA1_Pos             (0U)
+#define I2C_OAR1_OA1_Msk             (0x3FFUL << I2C_OAR1_OA1_Pos)             /*!< 0x000003FF */
+#define I2C_OAR1_OA1                 I2C_OAR1_OA1_Msk                          /*!< Interface own address 1 */
+#define I2C_OAR1_OA1MODE_Pos         (10U)
+#define I2C_OAR1_OA1MODE_Msk         (0x1UL << I2C_OAR1_OA1MODE_Pos)           /*!< 0x00000400 */
+#define I2C_OAR1_OA1MODE             I2C_OAR1_OA1MODE_Msk                      /*!< Own address 1 10-bit mode */
+#define I2C_OAR1_OA1EN_Pos           (15U)
+#define I2C_OAR1_OA1EN_Msk           (0x1UL << I2C_OAR1_OA1EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR1_OA1EN               I2C_OAR1_OA1EN_Msk                        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define I2C_OAR2_OA2_Pos             (1U)
+#define I2C_OAR2_OA2_Msk             (0x7FUL << I2C_OAR2_OA2_Pos)              /*!< 0x000000FE */
+#define I2C_OAR2_OA2                 I2C_OAR2_OA2_Msk                          /*!< Interface own address 2 */
+#define I2C_OAR2_OA2MSK_Pos          (8U)
+#define I2C_OAR2_OA2MSK_Msk          (0x7UL << I2C_OAR2_OA2MSK_Pos)            /*!< 0x00000700 */
+#define I2C_OAR2_OA2MSK              I2C_OAR2_OA2MSK_Msk                       /*!< Own address 2 masks */
+#define I2C_OAR2_OA2NOMASK           (0x00000000UL)                            /*!< No mask                                        */
+#define I2C_OAR2_OA2MASK01_Pos       (8U)
+#define I2C_OAR2_OA2MASK01_Msk       (0x1UL << I2C_OAR2_OA2MASK01_Pos)         /*!< 0x00000100 */
+#define I2C_OAR2_OA2MASK01           I2C_OAR2_OA2MASK01_Msk                    /*!< OA2[1] is masked, Only OA2[7:2] are compared   */
+#define I2C_OAR2_OA2MASK02_Pos       (9U)
+#define I2C_OAR2_OA2MASK02_Msk       (0x1UL << I2C_OAR2_OA2MASK02_Pos)         /*!< 0x00000200 */
+#define I2C_OAR2_OA2MASK02           I2C_OAR2_OA2MASK02_Msk                    /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define I2C_OAR2_OA2MASK03_Pos       (8U)
+#define I2C_OAR2_OA2MASK03_Msk       (0x3UL << I2C_OAR2_OA2MASK03_Pos)         /*!< 0x00000300 */
+#define I2C_OAR2_OA2MASK03           I2C_OAR2_OA2MASK03_Msk                    /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define I2C_OAR2_OA2MASK04_Pos       (10U)
+#define I2C_OAR2_OA2MASK04_Msk       (0x1UL << I2C_OAR2_OA2MASK04_Pos)         /*!< 0x00000400 */
+#define I2C_OAR2_OA2MASK04           I2C_OAR2_OA2MASK04_Msk                    /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define I2C_OAR2_OA2MASK05_Pos       (8U)
+#define I2C_OAR2_OA2MASK05_Msk       (0x5UL << I2C_OAR2_OA2MASK05_Pos)         /*!< 0x00000500 */
+#define I2C_OAR2_OA2MASK05           I2C_OAR2_OA2MASK05_Msk                    /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define I2C_OAR2_OA2MASK06_Pos       (9U)
+#define I2C_OAR2_OA2MASK06_Msk       (0x3UL << I2C_OAR2_OA2MASK06_Pos)         /*!< 0x00000600 */
+#define I2C_OAR2_OA2MASK06           I2C_OAR2_OA2MASK06_Msk                    /*!< OA2[6:1] is masked, Only OA2[7] are compared   */
+#define I2C_OAR2_OA2MASK07_Pos       (8U)
+#define I2C_OAR2_OA2MASK07_Msk       (0x7UL << I2C_OAR2_OA2MASK07_Pos)         /*!< 0x00000700 */
+#define I2C_OAR2_OA2MASK07           I2C_OAR2_OA2MASK07_Msk                    /*!< OA2[7:1] is masked, No comparison is done      */
+#define I2C_OAR2_OA2EN_Pos           (15U)
+#define I2C_OAR2_OA2EN_Msk           (0x1UL << I2C_OAR2_OA2EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR2_OA2EN               I2C_OAR2_OA2EN_Msk                        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define I2C_TIMINGR_SCLL_Pos         (0U)
+#define I2C_TIMINGR_SCLL_Msk         (0xFFUL << I2C_TIMINGR_SCLL_Pos)          /*!< 0x000000FF */
+#define I2C_TIMINGR_SCLL             I2C_TIMINGR_SCLL_Msk                      /*!< SCL low period (master mode) */
+#define I2C_TIMINGR_SCLH_Pos         (8U)
+#define I2C_TIMINGR_SCLH_Msk         (0xFFUL << I2C_TIMINGR_SCLH_Pos)          /*!< 0x0000FF00 */
+#define I2C_TIMINGR_SCLH             I2C_TIMINGR_SCLH_Msk                      /*!< SCL high period (master mode) */
+#define I2C_TIMINGR_SDADEL_Pos       (16U)
+#define I2C_TIMINGR_SDADEL_Msk       (0xFUL << I2C_TIMINGR_SDADEL_Pos)         /*!< 0x000F0000 */
+#define I2C_TIMINGR_SDADEL           I2C_TIMINGR_SDADEL_Msk                    /*!< Data hold time */
+#define I2C_TIMINGR_SCLDEL_Pos       (20U)
+#define I2C_TIMINGR_SCLDEL_Msk       (0xFUL << I2C_TIMINGR_SCLDEL_Pos)         /*!< 0x00F00000 */
+#define I2C_TIMINGR_SCLDEL           I2C_TIMINGR_SCLDEL_Msk                    /*!< Data setup time */
+#define I2C_TIMINGR_PRESC_Pos        (28U)
+#define I2C_TIMINGR_PRESC_Msk        (0xFUL << I2C_TIMINGR_PRESC_Pos)          /*!< 0xF0000000 */
+#define I2C_TIMINGR_PRESC            I2C_TIMINGR_PRESC_Msk                     /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define I2C_TIMEOUTR_TIMEOUTA_Pos    (0U)
+#define I2C_TIMEOUTR_TIMEOUTA_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTA_Pos)    /*!< 0x00000FFF */
+#define I2C_TIMEOUTR_TIMEOUTA        I2C_TIMEOUTR_TIMEOUTA_Msk                 /*!< Bus timeout A */
+#define I2C_TIMEOUTR_TIDLE_Pos       (12U)
+#define I2C_TIMEOUTR_TIDLE_Msk       (0x1UL << I2C_TIMEOUTR_TIDLE_Pos)         /*!< 0x00001000 */
+#define I2C_TIMEOUTR_TIDLE           I2C_TIMEOUTR_TIDLE_Msk                    /*!< Idle clock timeout detection */
+#define I2C_TIMEOUTR_TIMOUTEN_Pos    (15U)
+#define I2C_TIMEOUTR_TIMOUTEN_Msk    (0x1UL << I2C_TIMEOUTR_TIMOUTEN_Pos)      /*!< 0x00008000 */
+#define I2C_TIMEOUTR_TIMOUTEN        I2C_TIMEOUTR_TIMOUTEN_Msk                 /*!< Clock timeout enable */
+#define I2C_TIMEOUTR_TIMEOUTB_Pos    (16U)
+#define I2C_TIMEOUTR_TIMEOUTB_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTB_Pos)    /*!< 0x0FFF0000 */
+#define I2C_TIMEOUTR_TIMEOUTB        I2C_TIMEOUTR_TIMEOUTB_Msk                 /*!< Bus timeout B*/
+#define I2C_TIMEOUTR_TEXTEN_Pos      (31U)
+#define I2C_TIMEOUTR_TEXTEN_Msk      (0x1UL << I2C_TIMEOUTR_TEXTEN_Pos)        /*!< 0x80000000 */
+#define I2C_TIMEOUTR_TEXTEN          I2C_TIMEOUTR_TEXTEN_Msk                   /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define I2C_ISR_TXE_Pos              (0U)
+#define I2C_ISR_TXE_Msk              (0x1UL << I2C_ISR_TXE_Pos)                /*!< 0x00000001 */
+#define I2C_ISR_TXE                  I2C_ISR_TXE_Msk                           /*!< Transmit data register empty */
+#define I2C_ISR_TXIS_Pos             (1U)
+#define I2C_ISR_TXIS_Msk             (0x1UL << I2C_ISR_TXIS_Pos)               /*!< 0x00000002 */
+#define I2C_ISR_TXIS                 I2C_ISR_TXIS_Msk                          /*!< Transmit interrupt status */
+#define I2C_ISR_RXNE_Pos             (2U)
+#define I2C_ISR_RXNE_Msk             (0x1UL << I2C_ISR_RXNE_Pos)               /*!< 0x00000004 */
+#define I2C_ISR_RXNE                 I2C_ISR_RXNE_Msk                          /*!< Receive data register not empty */
+#define I2C_ISR_ADDR_Pos             (3U)
+#define I2C_ISR_ADDR_Msk             (0x1UL << I2C_ISR_ADDR_Pos)               /*!< 0x00000008 */
+#define I2C_ISR_ADDR                 I2C_ISR_ADDR_Msk                          /*!< Address matched (slave mode)*/
+#define I2C_ISR_NACKF_Pos            (4U)
+#define I2C_ISR_NACKF_Msk            (0x1UL << I2C_ISR_NACKF_Pos)              /*!< 0x00000010 */
+#define I2C_ISR_NACKF                I2C_ISR_NACKF_Msk                         /*!< NACK received flag */
+#define I2C_ISR_STOPF_Pos            (5U)
+#define I2C_ISR_STOPF_Msk            (0x1UL << I2C_ISR_STOPF_Pos)              /*!< 0x00000020 */
+#define I2C_ISR_STOPF                I2C_ISR_STOPF_Msk                         /*!< STOP detection flag */
+#define I2C_ISR_TC_Pos               (6U)
+#define I2C_ISR_TC_Msk               (0x1UL << I2C_ISR_TC_Pos)                 /*!< 0x00000040 */
+#define I2C_ISR_TC                   I2C_ISR_TC_Msk                            /*!< Transfer complete (master mode) */
+#define I2C_ISR_TCR_Pos              (7U)
+#define I2C_ISR_TCR_Msk              (0x1UL << I2C_ISR_TCR_Pos)                /*!< 0x00000080 */
+#define I2C_ISR_TCR                  I2C_ISR_TCR_Msk                           /*!< Transfer complete reload */
+#define I2C_ISR_BERR_Pos             (8U)
+#define I2C_ISR_BERR_Msk             (0x1UL << I2C_ISR_BERR_Pos)               /*!< 0x00000100 */
+#define I2C_ISR_BERR                 I2C_ISR_BERR_Msk                          /*!< Bus error */
+#define I2C_ISR_ARLO_Pos             (9U)
+#define I2C_ISR_ARLO_Msk             (0x1UL << I2C_ISR_ARLO_Pos)               /*!< 0x00000200 */
+#define I2C_ISR_ARLO                 I2C_ISR_ARLO_Msk                          /*!< Arbitration lost */
+#define I2C_ISR_OVR_Pos              (10U)
+#define I2C_ISR_OVR_Msk              (0x1UL << I2C_ISR_OVR_Pos)                /*!< 0x00000400 */
+#define I2C_ISR_OVR                  I2C_ISR_OVR_Msk                           /*!< Overrun/Underrun */
+#define I2C_ISR_PECERR_Pos           (11U)
+#define I2C_ISR_PECERR_Msk           (0x1UL << I2C_ISR_PECERR_Pos)             /*!< 0x00000800 */
+#define I2C_ISR_PECERR               I2C_ISR_PECERR_Msk                        /*!< PEC error in reception */
+#define I2C_ISR_TIMEOUT_Pos          (12U)
+#define I2C_ISR_TIMEOUT_Msk          (0x1UL << I2C_ISR_TIMEOUT_Pos)            /*!< 0x00001000 */
+#define I2C_ISR_TIMEOUT              I2C_ISR_TIMEOUT_Msk                       /*!< Timeout or Tlow detection flag */
+#define I2C_ISR_ALERT_Pos            (13U)
+#define I2C_ISR_ALERT_Msk            (0x1UL << I2C_ISR_ALERT_Pos)              /*!< 0x00002000 */
+#define I2C_ISR_ALERT                I2C_ISR_ALERT_Msk                         /*!< SMBus alert */
+#define I2C_ISR_BUSY_Pos             (15U)
+#define I2C_ISR_BUSY_Msk             (0x1UL << I2C_ISR_BUSY_Pos)               /*!< 0x00008000 */
+#define I2C_ISR_BUSY                 I2C_ISR_BUSY_Msk                          /*!< Bus busy */
+#define I2C_ISR_DIR_Pos              (16U)
+#define I2C_ISR_DIR_Msk              (0x1UL << I2C_ISR_DIR_Pos)                /*!< 0x00010000 */
+#define I2C_ISR_DIR                  I2C_ISR_DIR_Msk                           /*!< Transfer direction (slave mode) */
+#define I2C_ISR_ADDCODE_Pos          (17U)
+#define I2C_ISR_ADDCODE_Msk          (0x7FUL << I2C_ISR_ADDCODE_Pos)           /*!< 0x00FE0000 */
+#define I2C_ISR_ADDCODE              I2C_ISR_ADDCODE_Msk                       /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define I2C_ICR_ADDRCF_Pos           (3U)
+#define I2C_ICR_ADDRCF_Msk           (0x1UL << I2C_ICR_ADDRCF_Pos)             /*!< 0x00000008 */
+#define I2C_ICR_ADDRCF               I2C_ICR_ADDRCF_Msk                        /*!< Address matched clear flag */
+#define I2C_ICR_NACKCF_Pos           (4U)
+#define I2C_ICR_NACKCF_Msk           (0x1UL << I2C_ICR_NACKCF_Pos)             /*!< 0x00000010 */
+#define I2C_ICR_NACKCF               I2C_ICR_NACKCF_Msk                        /*!< NACK clear flag */
+#define I2C_ICR_STOPCF_Pos           (5U)
+#define I2C_ICR_STOPCF_Msk           (0x1UL << I2C_ICR_STOPCF_Pos)             /*!< 0x00000020 */
+#define I2C_ICR_STOPCF               I2C_ICR_STOPCF_Msk                        /*!< STOP detection clear flag */
+#define I2C_ICR_BERRCF_Pos           (8U)
+#define I2C_ICR_BERRCF_Msk           (0x1UL << I2C_ICR_BERRCF_Pos)             /*!< 0x00000100 */
+#define I2C_ICR_BERRCF               I2C_ICR_BERRCF_Msk                        /*!< Bus error clear flag */
+#define I2C_ICR_ARLOCF_Pos           (9U)
+#define I2C_ICR_ARLOCF_Msk           (0x1UL << I2C_ICR_ARLOCF_Pos)             /*!< 0x00000200 */
+#define I2C_ICR_ARLOCF               I2C_ICR_ARLOCF_Msk                        /*!< Arbitration lost clear flag */
+#define I2C_ICR_OVRCF_Pos            (10U)
+#define I2C_ICR_OVRCF_Msk            (0x1UL << I2C_ICR_OVRCF_Pos)              /*!< 0x00000400 */
+#define I2C_ICR_OVRCF                I2C_ICR_OVRCF_Msk                         /*!< Overrun/Underrun clear flag */
+#define I2C_ICR_PECCF_Pos            (11U)
+#define I2C_ICR_PECCF_Msk            (0x1UL << I2C_ICR_PECCF_Pos)              /*!< 0x00000800 */
+#define I2C_ICR_PECCF                I2C_ICR_PECCF_Msk                         /*!< PAC error clear flag */
+#define I2C_ICR_TIMOUTCF_Pos         (12U)
+#define I2C_ICR_TIMOUTCF_Msk         (0x1UL << I2C_ICR_TIMOUTCF_Pos)           /*!< 0x00001000 */
+#define I2C_ICR_TIMOUTCF             I2C_ICR_TIMOUTCF_Msk                      /*!< Timeout clear flag */
+#define I2C_ICR_ALERTCF_Pos          (13U)
+#define I2C_ICR_ALERTCF_Msk          (0x1UL << I2C_ICR_ALERTCF_Pos)            /*!< 0x00002000 */
+#define I2C_ICR_ALERTCF              I2C_ICR_ALERTCF_Msk                       /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define I2C_PECR_PEC_Pos             (0U)
+#define I2C_PECR_PEC_Msk             (0xFFUL << I2C_PECR_PEC_Pos)              /*!< 0x000000FF */
+#define I2C_PECR_PEC                 I2C_PECR_PEC_Msk                          /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define I2C_RXDR_RXDATA_Pos          (0U)
+#define I2C_RXDR_RXDATA_Msk          (0xFFUL << I2C_RXDR_RXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_RXDR_RXDATA              I2C_RXDR_RXDATA_Msk                       /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define I2C_TXDR_TXDATA_Pos          (0U)
+#define I2C_TXDR_TXDATA_Msk          (0xFFUL << I2C_TXDR_TXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_TXDR_TXDATA              I2C_TXDR_TXDATA_Msk                       /*!< 8-bit transmit data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos      (0U)
+#define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
+#define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos       (0U)
+#define IWDG_PR_PR_Msk       (0x7UL << IWDG_PR_PR_Pos)                         /*!< 0x00000007 */
+#define IWDG_PR_PR           IWDG_PR_PR_Msk                                    /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0         (0x1U << IWDG_PR_PR_Pos)                          /*!< 0x00000001 */
+#define IWDG_PR_PR_1         (0x2U << IWDG_PR_PR_Pos)                          /*!< 0x00000002 */
+#define IWDG_PR_PR_2         (0x4U << IWDG_PR_PR_Pos)                          /*!< 0x00000004 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos      (0U)
+#define IWDG_RLR_RL_Msk      (0xFFFUL << IWDG_RLR_RL_Pos)                      /*!< 0x00000FFF */
+#define IWDG_RLR_RL          IWDG_RLR_RL_Msk                                   /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos      (0U)
+#define IWDG_SR_PVU_Msk      (0x1UL << IWDG_SR_PVU_Pos)                        /*!< 0x00000001 */
+#define IWDG_SR_PVU          IWDG_SR_PVU_Msk                                   /*!< Watchdog prescaler value update */
+#define IWDG_SR_RVU_Pos      (1U)
+#define IWDG_SR_RVU_Msk      (0x1UL << IWDG_SR_RVU_Pos)                        /*!< 0x00000002 */
+#define IWDG_SR_RVU          IWDG_SR_RVU_Msk                                   /*!< Watchdog counter reload value update */
+#define IWDG_SR_WVU_Pos      (2U)
+#define IWDG_SR_WVU_Msk      (0x1UL << IWDG_SR_WVU_Pos)                        /*!< 0x00000004 */
+#define IWDG_SR_WVU          IWDG_SR_WVU_Msk                                   /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_WINR_WIN_Pos    (0U)
+#define IWDG_WINR_WIN_Msk    (0xFFFUL << IWDG_WINR_WIN_Pos)                    /*!< 0x00000FFF */
+#define IWDG_WINR_WIN        IWDG_WINR_WIN_Msk                                 /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                               Power Control                                */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define PWR_CR1_LPMS_Pos               (0U)
+#define PWR_CR1_LPMS_Msk               (0x7UL << PWR_CR1_LPMS_Pos)             /*!< 0x00000007 */
+#define PWR_CR1_LPMS                   PWR_CR1_LPMS_Msk                        /*!< Low Power Mode Selection for CPU1 */
+#define PWR_CR1_LPMS_0                 (0x1U << PWR_CR1_LPMS_Pos)              /*!< 0x00000001 */
+#define PWR_CR1_LPMS_1                 (0x2U << PWR_CR1_LPMS_Pos)              /*!< 0x00000002 */
+#define PWR_CR1_LPMS_2                 (0x4U << PWR_CR1_LPMS_Pos)              /*!< 0x00000004 */
+
+#define PWR_CR1_FPDR_Pos               (4U)
+#define PWR_CR1_FPDR_Msk               (0x1UL << PWR_CR1_FPDR_Pos)             /*!< 0x00000010 */
+#define PWR_CR1_FPDR                   PWR_CR1_FPDR_Msk                        /*!< Flash power down mode during LPrun for CPU1 */
+
+#define PWR_CR1_FPDS_Pos               (5U)
+#define PWR_CR1_FPDS_Msk               (0x1UL << PWR_CR1_FPDS_Pos)             /*!< 0x00000020 */
+#define PWR_CR1_FPDS                   PWR_CR1_FPDS_Msk                        /*!< Flash power down mode during LPsleep for CPU1 */
+
+#define PWR_CR1_DBP_Pos                (8U)
+#define PWR_CR1_DBP_Msk                (0x1UL << PWR_CR1_DBP_Pos)              /*!< 0x00000100 */
+#define PWR_CR1_DBP                    PWR_CR1_DBP_Msk                         /*!< Disable Backup Domain write protection */
+
+#define PWR_CR1_LPR_Pos                (14U)
+#define PWR_CR1_LPR_Msk                (0x1UL << PWR_CR1_LPR_Pos)              /*!< 0x00004000 */
+#define PWR_CR1_LPR                    PWR_CR1_LPR_Msk                         /*!< Regulator Low-Power Run mode */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define PWR_CR2_PVDE_Pos               (0U)
+#define PWR_CR2_PVDE_Msk               (0x1UL << PWR_CR2_PVDE_Pos)             /*!< 0x00000001 */
+#define PWR_CR2_PVDE                   PWR_CR2_PVDE_Msk                        /*!< Power voltage detector enable */
+
+#define PWR_CR2_PLS_Pos                (1U)
+#define PWR_CR2_PLS_Msk                (0x7UL << PWR_CR2_PLS_Pos)              /*!< 0x0000000E */
+#define PWR_CR2_PLS                    PWR_CR2_PLS_Msk                         /*!< Power voltage detector level selection */
+#define PWR_CR2_PLS_0                  (0x1U << PWR_CR2_PLS_Pos)               /*!< 0x00000002 */
+#define PWR_CR2_PLS_1                  (0x2U << PWR_CR2_PLS_Pos)               /*!< 0x00000004 */
+#define PWR_CR2_PLS_2                  (0x4U << PWR_CR2_PLS_Pos)               /*!< 0x00000008 */
+
+#define PWR_CR2_PVME_Pos               (4U)
+#define PWR_CR2_PVME_Msk               (0x4UL << PWR_CR2_PVME_Pos)             /*!< 0x00000040 */
+#define PWR_CR2_PVME                   PWR_CR2_PVME_Msk                        /*!< Peripherical Voltage Monitor Enable for all power domains */
+#define PWR_CR2_PVME3_Pos              (6U)
+#define PWR_CR2_PVME3_Msk              (0x1UL << PWR_CR2_PVME3_Pos)            /*!< 0x00000040 */
+#define PWR_CR2_PVME3                  PWR_CR2_PVME3_Msk                       /*!< Peripherical Voltage Monitor Vdda Enable */
+
+/********************  Bit definition for PWR_CR3 register  ********************/
+#define PWR_CR3_EWUP_Pos               (0U)
+#define PWR_CR3_EWUP_Msk               (0x09UL << PWR_CR3_EWUP_Pos)            /*!< 0x00000009 */
+#define PWR_CR3_EWUP                   PWR_CR3_EWUP_Msk                        /*!< Enable all external Wake-Up lines  */
+#define PWR_CR3_EWUP1_Pos              (0U)
+#define PWR_CR3_EWUP1_Msk              (0x1UL << PWR_CR3_EWUP1_Pos)            /*!< 0x00000001 */
+#define PWR_CR3_EWUP1                  PWR_CR3_EWUP1_Msk                       /*!< Enable external WKUP Pin 1 [line 0] */
+#define PWR_CR3_EWUP4_Pos              (3U)
+#define PWR_CR3_EWUP4_Msk              (0x1UL << PWR_CR3_EWUP4_Pos)            /*!< 0x00000008 */
+#define PWR_CR3_EWUP4                  PWR_CR3_EWUP4_Msk                       /*!< Enable external WKUP Pin 4 [line 3] */
+
+#define PWR_CR3_EBORHSMPSFB_Pos        (8U)
+#define PWR_CR3_EBORHSMPSFB_Msk        (0x1UL << PWR_CR3_EBORHSMPSFB_Pos)      /*!< 0x00000100 */
+#define PWR_CR3_EBORHSMPSFB            PWR_CR3_EBORHSMPSFB_Msk                 /*!< BORH and SMPS Step Down converter forced in Bypass interrupts for CPU1 */
+
+#define PWR_CR3_RRS_Pos                (9U)
+#define PWR_CR3_RRS_Msk                (0x1UL << PWR_CR3_RRS_Pos)              /*!< 0x00000200 */
+#define PWR_CR3_RRS                    PWR_CR3_RRS_Msk                         /*!< SRAM2 retention in STANDBY mode */
+
+#define PWR_CR3_APC_Pos                (10U)
+#define PWR_CR3_APC_Msk                (0x1UL << PWR_CR3_APC_Pos)              /*!< 0x00000400 */
+#define PWR_CR3_APC                    PWR_CR3_APC_Msk                         /*!< Apply pull-up and pull-down configuration for CPU1 */
+
+#define PWR_CR3_ECRPE_Pos              (11U)
+#define PWR_CR3_ECRPE_Msk              (0x1UL << PWR_CR3_ECRPE_Pos)            /*!< 0x00000800 */
+#define PWR_CR3_ECRPE                  PWR_CR3_ECRPE_Msk                       /*!< Critical radio phase end of activity interrupt for CPU1 */
+#define PWR_CR3_EBLEA_Pos              (12U)
+#define PWR_CR3_EBLEA_Msk              (0x1UL << PWR_CR3_EBLEA_Pos)            /*!< 0x00010000 */
+#define PWR_CR3_EBLEA                  PWR_CR3_EBLEA_Msk                       /*!< BLE end of activity interrupt for CPU1 */
+#define PWR_CR3_EC2H_Pos               (14U)
+#define PWR_CR3_EC2H_Msk               (0x1UL << PWR_CR3_EC2H_Pos)             /*!< 0x00040000 */
+#define PWR_CR3_EC2H                    PWR_CR3_EC2H_Msk                       /*!< CPU2 Hold interrupt for CPU1 */
+
+#define PWR_CR3_EIWUL_Pos              (15U)
+#define PWR_CR3_EIWUL_Msk              (0x1UL << PWR_CR3_EIWUL_Pos)            /*!< 0x00080000 */
+#define PWR_CR3_EIWUL                  PWR_CR3_EIWUL_Msk                       /*!< Internal Wake-Up line interrupt for CPU1 */
+
+/********************  Bit definition for PWR_CR4 register  ********************/
+#define PWR_CR4_WP_Pos                 (0U)
+#define PWR_CR4_WP_Msk                 (0x09UL << PWR_CR4_WP_Pos)              /*!< 0x00000009 */
+#define PWR_CR4_WP                     PWR_CR4_WP_Msk                          /*!< Wake-Up polarity for all pins */
+#define PWR_CR4_WP1_Pos                (0U)
+#define PWR_CR4_WP1_Msk                (0x1UL << PWR_CR4_WP1_Pos)              /*!< 0x00000001 */
+#define PWR_CR4_WP1                    PWR_CR4_WP1_Msk                         /*!< Wake-Up Pin 1 [line 0] polarity */
+#define PWR_CR4_WP4_Pos                (3U)
+#define PWR_CR4_WP4_Msk                (0x1UL << PWR_CR4_WP4_Pos)              /*!< 0x00000008 */
+#define PWR_CR4_WP4                    PWR_CR4_WP4_Msk                         /*!< Wake-Up Pin 4 [line 3] polarity */
+
+#define PWR_CR4_VBE_Pos                (8U)
+#define PWR_CR4_VBE_Msk                (0x1UL << PWR_CR4_VBE_Pos)              /*!< 0x00000100 */
+#define PWR_CR4_VBE                    PWR_CR4_VBE_Msk                         /*!< VBAT battery charging enable  */
+#define PWR_CR4_VBRS_Pos               (9U)
+#define PWR_CR4_VBRS_Msk               (0x1UL << PWR_CR4_VBRS_Pos)             /*!< 0x00000200 */
+#define PWR_CR4_VBRS                   PWR_CR4_VBRS_Msk                        /*!< VBAT battery charging resistor selection */
+
+#define PWR_CR4_C2BOOT_Pos             (15U)
+#define PWR_CR4_C2BOOT_Msk             (0x1UL << PWR_CR4_C2BOOT_Pos)           /*!< 0x00008000 */
+#define PWR_CR4_C2BOOT                 PWR_CR4_C2BOOT_Msk                      /*!< Boot CPU2 after reset or wakeup from Stop or Standby modes */
+
+/********************  Bit definition for PWR_SR1 register  ********************/
+#define PWR_SR1_WUF_Pos                (0U)
+#define PWR_SR1_WUF_Msk                (0x09UL << PWR_SR1_WUF_Pos)             /*!< 0x00000009 */
+#define PWR_SR1_WUF                    PWR_SR1_WUF_Msk                         /*!< Wakeup Flags of all pins */
+#define PWR_SR1_WUF1_Pos               (0U)
+#define PWR_SR1_WUF1_Msk               (0x1UL << PWR_SR1_WUF1_Pos)             /*!< 0x00000001 */
+#define PWR_SR1_WUF1                   PWR_SR1_WUF1_Msk                        /*!< Wakeup Pin 1 [Flag 0] */
+#define PWR_SR1_WUF4_Pos               (3U)
+#define PWR_SR1_WUF4_Msk               (0x1UL << PWR_SR1_WUF4_Pos)             /*!< 0x00000008 */
+#define PWR_SR1_WUF4                   PWR_SR1_WUF4_Msk                        /*!< Wakeup Pin 4 [Flag 3] */
+
+#define PWR_SR1_SMPSFBF_Pos            (7U)
+#define PWR_SR1_SMPSFBF_Msk            (0x1UL << PWR_SR1_SMPSFBF_Pos)          /*!< 0x00000100 */
+#define PWR_SR1_SMPSFBF                PWR_SR1_SMPSFBF_Msk                     /*!< SMPS Step Down converter forced in bypass mode interrupt flag */
+
+#define PWR_SR1_BORHF_Pos              (8U)
+#define PWR_SR1_BORHF_Msk              (0x1UL << PWR_SR1_BORHF_Pos)            /*!< 0x00000100 */
+#define PWR_SR1_BORHF                  PWR_SR1_BORHF_Msk                       /*!< BORH interrupt flag */
+
+#define PWR_SR1_BLEWUF_Pos             (9U)
+#define PWR_SR1_BLEWUF_Msk             (0x1UL << PWR_SR1_BLEWUF_Pos)           /*!< 0x00000200 */
+#define PWR_SR1_BLEWUF                 PWR_SR1_BLEWUF_Msk                      /*!< BLE wakeup interrupt flag */
+
+#define PWR_SR1_CRPEF_Pos              (11U)
+#define PWR_SR1_CRPEF_Msk              (0x1UL << PWR_SR1_CRPEF_Pos)            /*!< 0x00000800 */
+#define PWR_SR1_CRPEF                  PWR_SR1_CRPEF_Msk                       /*!< Critical radio phase end of activity interrupt flag */
+#define PWR_SR1_BLEAF_Pos              (12U)
+#define PWR_SR1_BLEAF_Msk              (0x1UL << PWR_SR1_BLEAF_Pos)            /*!< 0x00001000 */
+#define PWR_SR1_BLEAF                  PWR_SR1_BLEAF_Msk                       /*!< BLE end of activity interrupt flag */
+
+#define PWR_SR1_C2HF_Pos               (14U)
+#define PWR_SR1_C2HF_Msk               (0x1UL << PWR_SR1_C2HF_Pos)             /*!< 0x00004000 */
+#define PWR_SR1_C2HF                   PWR_SR1_C2HF_Msk                        /*!< CPU2 Hold interrupt flag */
+
+#define PWR_SR1_WUFI_Pos               (15U)
+#define PWR_SR1_WUFI_Msk               (0x1UL << PWR_SR1_WUFI_Pos)             /*!< 0x00008000 */
+#define PWR_SR1_WUFI                   PWR_SR1_WUFI_Msk                        /*!< Internal wakeup interrupt flag */
+
+/********************  Bit definition for PWR_SR2 register  ********************/
+#define PWR_SR2_REGLPS_Pos             (8U)
+#define PWR_SR2_REGLPS_Msk             (0x1UL << PWR_SR2_REGLPS_Pos)           /*!< 0x00000100 */
+#define PWR_SR2_REGLPS                 PWR_SR2_REGLPS_Msk                      /*!< Low-power regulator started */
+#define PWR_SR2_REGLPF_Pos             (9U)
+#define PWR_SR2_REGLPF_Msk             (0x1UL << PWR_SR2_REGLPF_Pos)           /*!< 0x00000200 */
+#define PWR_SR2_REGLPF                 PWR_SR2_REGLPF_Msk                      /*!< Low-power regulator flag */
+
+#define PWR_SR2_PVDO_Pos               (11U)
+#define PWR_SR2_PVDO_Msk               (0x1UL << PWR_SR2_PVDO_Pos)             /*!< 0x00000800 */
+#define PWR_SR2_PVDO                   PWR_SR2_PVDO_Msk                        /*!< Power voltage detector output */
+
+#define PWR_SR2_PVMO3_Pos              (14U)
+#define PWR_SR2_PVMO3_Msk              (0x1UL << PWR_SR2_PVMO3_Pos)            /*!< 0x00004000 */
+#define PWR_SR2_PVMO3                  PWR_SR2_PVMO3_Msk                       /*!< Peripheral voltage monitor output 3: VDDA vs. 1.62V */
+
+/********************  Bit definition for PWR_SCR register  ********************/
+#define PWR_SCR_CWUF_Pos               (0U)
+#define PWR_SCR_CWUF_Msk               (0x09UL << PWR_SCR_CWUF_Pos)            /*!< 0x00000009 */
+#define PWR_SCR_CWUF                   PWR_SCR_CWUF_Msk                        /*!< Clear Wake-up Flags for all pins */
+#define PWR_SCR_CWUF1_Pos              (0U)
+#define PWR_SCR_CWUF1_Msk              (0x1UL << PWR_SCR_CWUF1_Pos)            /*!< 0x00000001 */
+#define PWR_SCR_CWUF1                  PWR_SCR_CWUF1_Msk                       /*!< Clear Wake-up Pin 1 [Flag 0] */
+#define PWR_SCR_CWUF4_Pos              (3U)
+#define PWR_SCR_CWUF4_Msk              (0x1UL << PWR_SCR_CWUF4_Pos)            /*!< 0x00000008 */
+#define PWR_SCR_CWUF4                  PWR_SCR_CWUF4_Msk                       /*!< Clear Wake-up Pin 4 [Flag 3] */
+
+#define PWR_SCR_CBORHF_Pos             (8U)
+#define PWR_SCR_CBORHF_Msk             (0x1UL << PWR_SCR_CBORHF_Pos)           /*!< 0x00000100 */
+#define PWR_SCR_CBORHF                 PWR_SCR_CBORHF_Msk                      /*!< Clear BORH interrupt flag  */
+
+#define PWR_SCR_CBLEWUF_Pos            (9U)
+#define PWR_SCR_CBLEWUF_Msk            (0x1UL << PWR_SCR_CBLEWUF_Pos)          /*!< 0x00000200 */
+#define PWR_SCR_CBLEWUF                PWR_SCR_CBLEWUF_Msk                     /*!< Clear BLE wakeup interrupt flag */
+
+#define PWR_SCR_CCRPEF_Pos             (11U)
+#define PWR_SCR_CCRPEF_Msk             (0x1UL << PWR_SCR_CCRPEF_Pos)           /*!< 0x00000800 */
+#define PWR_SCR_CCRPEF                 PWR_SCR_CCRPEF_Msk                      /*!< Clear Critical radio phase end of activity interrupt flag */
+#define PWR_SCR_CBLEAF_Pos             (12U)
+#define PWR_SCR_CBLEAF_Msk             (0x1UL << PWR_SCR_CBLEAF_Pos)           /*!< 0x00001000 */
+#define PWR_SCR_CBLEAF                 PWR_SCR_CBLEAF_Msk                      /*!< Clear BLE end of activity interrupt flag */
+
+#define PWR_SCR_CC2HF_Pos              (14U)
+#define PWR_SCR_CC2HF_Msk              (0x1UL << PWR_SCR_CC2HF_Pos)            /*!< 0x00004000 */
+#define PWR_SCR_CC2HF                  PWR_SCR_CC2HF_Msk                       /*!< Clear CPU2 Hold interrupt flag */
+
+/********************  Bit definition for PWR_PUCRA register  *****************/
+#define PWR_PUCRA_PA0_Pos              (0U)
+#define PWR_PUCRA_PA0_Msk              (0x1UL << PWR_PUCRA_PA0_Pos)            /*!< 0x00000001 */
+#define PWR_PUCRA_PA0                  PWR_PUCRA_PA0_Msk                       /*!< Pin PA0 Pull-Up set */
+#define PWR_PUCRA_PA1_Pos              (1U)
+#define PWR_PUCRA_PA1_Msk              (0x1UL << PWR_PUCRA_PA1_Pos)            /*!< 0x00000002 */
+#define PWR_PUCRA_PA1                  PWR_PUCRA_PA1_Msk                       /*!< Pin PA1 Pull-Up set */
+#define PWR_PUCRA_PA2_Pos              (2U)
+#define PWR_PUCRA_PA2_Msk              (0x1UL << PWR_PUCRA_PA2_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRA_PA2                  PWR_PUCRA_PA2_Msk                       /*!< Pin PA2 Pull-Up set */
+#define PWR_PUCRA_PA3_Pos              (3U)
+#define PWR_PUCRA_PA3_Msk              (0x1UL << PWR_PUCRA_PA3_Pos)            /*!< 0x00000008 */
+#define PWR_PUCRA_PA3                  PWR_PUCRA_PA3_Msk                       /*!< Pin PA3 Pull-Up set */
+#define PWR_PUCRA_PA4_Pos              (4U)
+#define PWR_PUCRA_PA4_Msk              (0x1UL << PWR_PUCRA_PA4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRA_PA4                  PWR_PUCRA_PA4_Msk                       /*!< Pin PA4 Pull-Up set */
+#define PWR_PUCRA_PA5_Pos              (5U)
+#define PWR_PUCRA_PA5_Msk              (0x1UL << PWR_PUCRA_PA5_Pos)            /*!< 0x00000020 */
+#define PWR_PUCRA_PA5                  PWR_PUCRA_PA5_Msk                       /*!< Pin PA5 Pull-Up set */
+#define PWR_PUCRA_PA6_Pos              (6U)
+#define PWR_PUCRA_PA6_Msk              (0x1UL << PWR_PUCRA_PA6_Pos)            /*!< 0x00000040 */
+#define PWR_PUCRA_PA6                  PWR_PUCRA_PA6_Msk                       /*!< Pin PA6 Pull-Up set */
+#define PWR_PUCRA_PA7_Pos              (7U)
+#define PWR_PUCRA_PA7_Msk              (0x1UL << PWR_PUCRA_PA7_Pos)            /*!< 0x00000080 */
+#define PWR_PUCRA_PA7                  PWR_PUCRA_PA7_Msk                       /*!< Pin PA7 Pull-Up set */
+#define PWR_PUCRA_PA8_Pos              (8U)
+#define PWR_PUCRA_PA8_Msk              (0x1UL << PWR_PUCRA_PA8_Pos)            /*!< 0x00000100 */
+#define PWR_PUCRA_PA8                  PWR_PUCRA_PA8_Msk                       /*!< Pin PA8 Pull-Up set */
+#define PWR_PUCRA_PA9_Pos              (9U)
+#define PWR_PUCRA_PA9_Msk              (0x1UL << PWR_PUCRA_PA9_Pos)            /*!< 0x00000200 */
+#define PWR_PUCRA_PA9                  PWR_PUCRA_PA9_Msk                       /*!< Pin PA9 Pull-Up set */
+#define PWR_PUCRA_PA10_Pos             (10U)
+#define PWR_PUCRA_PA10_Msk             (0x1UL << PWR_PUCRA_PA10_Pos)           /*!< 0x00000400 */
+#define PWR_PUCRA_PA10                 PWR_PUCRA_PA10_Msk                      /*!< Pin PA10 Pull-Up set */
+#define PWR_PUCRA_PA11_Pos             (11U)
+#define PWR_PUCRA_PA11_Msk             (0x1UL << PWR_PUCRA_PA11_Pos)           /*!< 0x00000800 */
+#define PWR_PUCRA_PA11                 PWR_PUCRA_PA11_Msk                      /*!< Pin PA11 Pull-Up set */
+#define PWR_PUCRA_PA12_Pos             (12U)
+#define PWR_PUCRA_PA12_Msk             (0x1UL << PWR_PUCRA_PA12_Pos)           /*!< 0x00001000 */
+#define PWR_PUCRA_PA12                 PWR_PUCRA_PA12_Msk                      /*!< Pin PA12 Pull-Up set */
+#define PWR_PUCRA_PA13_Pos             (13U)
+#define PWR_PUCRA_PA13_Msk             (0x1UL << PWR_PUCRA_PA13_Pos)           /*!< 0x00002000 */
+#define PWR_PUCRA_PA13                 PWR_PUCRA_PA13_Msk                      /*!< Pin PA13 Pull-Up set */
+#define PWR_PUCRA_PA15_Pos             (15U)
+#define PWR_PUCRA_PA15_Msk             (0x1UL << PWR_PUCRA_PA15_Pos)           /*!< 0x00008000 */
+#define PWR_PUCRA_PA15                 PWR_PUCRA_PA15_Msk                      /*!< Pin PA15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRA register  *****************/
+#define PWR_PDCRA_PA0_Pos              (0U)
+#define PWR_PDCRA_PA0_Msk              (0x1UL << PWR_PDCRA_PA0_Pos)            /*!< 0x00000001 */
+#define PWR_PDCRA_PA0                  PWR_PDCRA_PA0_Msk                       /*!< Pin PA0 Pull-Down set */
+#define PWR_PDCRA_PA1_Pos              (1U)
+#define PWR_PDCRA_PA1_Msk              (0x1UL << PWR_PDCRA_PA1_Pos)            /*!< 0x00000002 */
+#define PWR_PDCRA_PA1                  PWR_PDCRA_PA1_Msk                       /*!< Pin PA1 Pull-Down set */
+#define PWR_PDCRA_PA2_Pos              (2U)
+#define PWR_PDCRA_PA2_Msk              (0x1UL << PWR_PDCRA_PA2_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRA_PA2                  PWR_PDCRA_PA2_Msk                       /*!< Pin PA2 Pull-Down set */
+#define PWR_PDCRA_PA3_Pos              (3U)
+#define PWR_PDCRA_PA3_Msk              (0x1UL << PWR_PDCRA_PA3_Pos)            /*!< 0x00000008 */
+#define PWR_PDCRA_PA3                  PWR_PDCRA_PA3_Msk                       /*!< Pin PA3 Pull-Down set */
+#define PWR_PDCRA_PA4_Pos              (4U)
+#define PWR_PDCRA_PA4_Msk              (0x1UL << PWR_PDCRA_PA4_Pos)            /*!< 0x00000010 */
+#define PWR_PDCRA_PA4                  PWR_PDCRA_PA4_Msk                       /*!< Pin PA4 Pull-Down set */
+#define PWR_PDCRA_PA5_Pos              (5U)
+#define PWR_PDCRA_PA5_Msk              (0x1UL << PWR_PDCRA_PA5_Pos)            /*!< 0x00000020 */
+#define PWR_PDCRA_PA5                  PWR_PDCRA_PA5_Msk                       /*!< Pin PA5 Pull-Down set */
+#define PWR_PDCRA_PA6_Pos              (6U)
+#define PWR_PDCRA_PA6_Msk              (0x1UL << PWR_PDCRA_PA6_Pos)            /*!< 0x00000040 */
+#define PWR_PDCRA_PA6                  PWR_PDCRA_PA6_Msk                       /*!< Pin PA6 Pull-Down set */
+#define PWR_PDCRA_PA7_Pos              (7U)
+#define PWR_PDCRA_PA7_Msk              (0x1UL << PWR_PDCRA_PA7_Pos)            /*!< 0x00000080 */
+#define PWR_PDCRA_PA7                  PWR_PDCRA_PA7_Msk                       /*!< Pin PA7 Pull-Down set */
+#define PWR_PDCRA_PA8_Pos              (8U)
+#define PWR_PDCRA_PA8_Msk              (0x1UL << PWR_PDCRA_PA8_Pos)            /*!< 0x00000100 */
+#define PWR_PDCRA_PA8                  PWR_PDCRA_PA8_Msk                       /*!< Pin PA8 Pull-Down set */
+#define PWR_PDCRA_PA9_Pos              (9U)
+#define PWR_PDCRA_PA9_Msk              (0x1UL << PWR_PDCRA_PA9_Pos)            /*!< 0x00000200 */
+#define PWR_PDCRA_PA9                  PWR_PDCRA_PA9_Msk                       /*!< Pin PA9 Pull-Down set */
+#define PWR_PDCRA_PA10_Pos             (10U)
+#define PWR_PDCRA_PA10_Msk             (0x1UL << PWR_PDCRA_PA10_Pos)           /*!< 0x00000400 */
+#define PWR_PDCRA_PA10                 PWR_PDCRA_PA10_Msk                      /*!< Pin PA10 Pull-Down set */
+#define PWR_PDCRA_PA11_Pos             (11U)
+#define PWR_PDCRA_PA11_Msk             (0x1UL << PWR_PDCRA_PA11_Pos)           /*!< 0x00000800 */
+#define PWR_PDCRA_PA11                 PWR_PDCRA_PA11_Msk                      /*!< Pin PA11 Pull-Down set */
+#define PWR_PDCRA_PA12_Pos             (12U)
+#define PWR_PDCRA_PA12_Msk             (0x1UL << PWR_PDCRA_PA12_Pos)           /*!< 0x00001000 */
+#define PWR_PDCRA_PA12                 PWR_PDCRA_PA12_Msk                      /*!< Pin PA12 Pull-Down set */
+#define PWR_PDCRA_PA14_Pos             (14U)
+#define PWR_PDCRA_PA14_Msk             (0x1UL << PWR_PDCRA_PA14_Pos)           /*!< 0x00004000 */
+#define PWR_PDCRA_PA14                 PWR_PDCRA_PA14_Msk                      /*!< Pin PA14 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRB register  *****************/
+#define PWR_PUCRB_PB0_Pos              (0U)
+#define PWR_PUCRB_PB0_Msk              (0x1UL << PWR_PUCRB_PB0_Pos)            /*!< 0x00000001 */
+#define PWR_PUCRB_PB0                  PWR_PUCRB_PB0_Msk                       /*!< Pin PB0 Pull-Up set */
+#define PWR_PUCRB_PB1_Pos              (1U)
+#define PWR_PUCRB_PB1_Msk              (0x1UL << PWR_PUCRB_PB1_Pos)            /*!< 0x00000002 */
+#define PWR_PUCRB_PB1                  PWR_PUCRB_PB1_Msk                       /*!< Pin PB1 Pull-Up set */
+#define PWR_PUCRB_PB2_Pos              (2U)
+#define PWR_PUCRB_PB2_Msk              (0x1UL << PWR_PUCRB_PB2_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRB_PB2                  PWR_PUCRB_PB2_Msk                       /*!< Pin PB2 Pull-Up set */
+#define PWR_PUCRB_PB3_Pos              (3U)
+#define PWR_PUCRB_PB3_Msk              (0x1UL << PWR_PUCRB_PB3_Pos)            /*!< 0x00000008 */
+#define PWR_PUCRB_PB3                  PWR_PUCRB_PB3_Msk                       /*!< Pin PB3 Pull-Up set */
+#define PWR_PUCRB_PB4_Pos              (4U)
+#define PWR_PUCRB_PB4_Msk              (0x1UL << PWR_PUCRB_PB4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRB_PB4                  PWR_PUCRB_PB4_Msk                       /*!< Pin PB4 Pull-Up set */
+#define PWR_PUCRB_PB5_Pos              (5U)
+#define PWR_PUCRB_PB5_Msk              (0x1UL << PWR_PUCRB_PB5_Pos)            /*!< 0x00000020 */
+#define PWR_PUCRB_PB5                  PWR_PUCRB_PB5_Msk                       /*!< Pin PB5 Pull-Up set */
+#define PWR_PUCRB_PB6_Pos              (6U)
+#define PWR_PUCRB_PB6_Msk              (0x1UL << PWR_PUCRB_PB6_Pos)            /*!< 0x00000040 */
+#define PWR_PUCRB_PB6                  PWR_PUCRB_PB6_Msk                       /*!< Pin PB6 Pull-Up set */
+#define PWR_PUCRB_PB7_Pos              (7U)
+#define PWR_PUCRB_PB7_Msk              (0x1UL << PWR_PUCRB_PB7_Pos)            /*!< 0x00000080 */
+#define PWR_PUCRB_PB7                  PWR_PUCRB_PB7_Msk                       /*!< Pin PB7 Pull-Up set */
+#define PWR_PUCRB_PB8_Pos              (8U)
+#define PWR_PUCRB_PB8_Msk              (0x1UL << PWR_PUCRB_PB8_Pos)            /*!< 0x00000100 */
+#define PWR_PUCRB_PB8                  PWR_PUCRB_PB8_Msk                       /*!< Pin PB8 Pull-Up set */
+#define PWR_PUCRB_PB9_Pos              (9U)
+#define PWR_PUCRB_PB9_Msk              (0x1UL << PWR_PUCRB_PB9_Pos)            /*!< 0x00000200 */
+#define PWR_PUCRB_PB9                  PWR_PUCRB_PB9_Msk                       /*!< Pin PB9 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRB register  *****************/
+#define PWR_PDCRB_PB0_Pos              (0U)
+#define PWR_PDCRB_PB0_Msk              (0x1UL << PWR_PDCRB_PB0_Pos)            /*!< 0x00000001 */
+#define PWR_PDCRB_PB0                  PWR_PDCRB_PB0_Msk                       /*!< Pin PB0 Pull-Down set */
+#define PWR_PDCRB_PB1_Pos              (1U)
+#define PWR_PDCRB_PB1_Msk              (0x1UL << PWR_PDCRB_PB1_Pos)            /*!< 0x00000002 */
+#define PWR_PDCRB_PB1                  PWR_PDCRB_PB1_Msk                       /*!< Pin PB1 Pull-Down set */
+#define PWR_PDCRB_PB2_Pos              (2U)
+#define PWR_PDCRB_PB2_Msk              (0x1UL << PWR_PDCRB_PB2_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRB_PB2                  PWR_PDCRB_PB2_Msk                       /*!< Pin PB2 Pull-Down set */
+#define PWR_PDCRB_PB3_Pos              (3U)
+#define PWR_PDCRB_PB3_Msk              (0x1UL << PWR_PDCRB_PB3_Pos)            /*!< 0x00000008 */
+#define PWR_PDCRB_PB3                  PWR_PDCRB_PB3_Msk                       /*!< Pin PB3 Pull-Down set */
+#define PWR_PDCRB_PB5_Pos              (5U)
+#define PWR_PDCRB_PB5_Msk              (0x1UL << PWR_PDCRB_PB5_Pos)            /*!< 0x00000020 */
+#define PWR_PDCRB_PB5                  PWR_PDCRB_PB5_Msk                       /*!< Pin PB5 Pull-Down set */
+#define PWR_PDCRB_PB6_Pos              (6U)
+#define PWR_PDCRB_PB6_Msk              (0x1UL << PWR_PDCRB_PB6_Pos)            /*!< 0x00000040 */
+#define PWR_PDCRB_PB6                  PWR_PDCRB_PB6_Msk                       /*!< Pin PB6 Pull-Down set */
+#define PWR_PDCRB_PB7_Pos              (7U)
+#define PWR_PDCRB_PB7_Msk              (0x1UL << PWR_PDCRB_PB7_Pos)            /*!< 0x00000080 */
+#define PWR_PDCRB_PB7                  PWR_PDCRB_PB7_Msk                       /*!< Pin PB7 Pull-Down set */
+#define PWR_PDCRB_PB8_Pos              (8U)
+#define PWR_PDCRB_PB8_Msk              (0x1UL << PWR_PDCRB_PB8_Pos)            /*!< 0x00000100 */
+#define PWR_PDCRB_PB8                  PWR_PDCRB_PB8_Msk                       /*!< Pin PB8 Pull-Down set */
+#define PWR_PDCRB_PB9_Pos              (9U)
+#define PWR_PDCRB_PB9_Msk              (0x1UL << PWR_PDCRB_PB9_Pos)            /*!< 0x00000200 */
+#define PWR_PDCRB_PB9                  PWR_PDCRB_PB9_Msk                       /*!< Pin PB9 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRC register  *****************/
+#define PWR_PUCRC_PC14_Pos             (14U)
+#define PWR_PUCRC_PC14_Msk             (0x1UL << PWR_PUCRC_PC14_Pos)           /*!< 0x00004000 */
+#define PWR_PUCRC_PC14                 PWR_PUCRC_PC14_Msk                      /*!< Pin PC14 Pull-Up set */
+#define PWR_PUCRC_PC15_Pos             (15U)
+#define PWR_PUCRC_PC15_Msk             (0x1UL << PWR_PUCRC_PC15_Pos)           /*!< 0x00008000 */
+#define PWR_PUCRC_PC15                 PWR_PUCRC_PC15_Msk                      /*!< Pin PC15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRC register  *****************/
+#define PWR_PDCRC_PC14_Pos             (14U)
+#define PWR_PDCRC_PC14_Msk             (0x1UL << PWR_PDCRC_PC14_Pos)           /*!< 0x00004000 */
+#define PWR_PDCRC_PC14                 PWR_PDCRC_PC14_Msk                      /*!< Pin PC14 Pull-Down set */
+#define PWR_PDCRC_PC15_Pos             (15U)
+#define PWR_PDCRC_PC15_Msk             (0x1UL << PWR_PDCRC_PC15_Pos)           /*!< 0x00008000 */
+#define PWR_PDCRC_PC15                 PWR_PDCRC_PC15_Msk                      /*!< Pin PC15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRE register  *****************/
+#define PWR_PUCRE_PE4_Pos              (4U)
+#define PWR_PUCRE_PE4_Msk              (0x1UL << PWR_PUCRE_PE4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRE_PE4                  PWR_PUCRE_PE4_Msk                       /*!< Pin PE4 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRE register  *****************/
+#define PWR_PDCRE_PE4_Pos              (4U)
+#define PWR_PDCRE_PE4_Msk              (0x1UL << PWR_PDCRE_PE4_Pos)            /*!< 0x00000010 */
+#define PWR_PDCRE_PE4                  PWR_PDCRE_PE4_Msk                       /*!< Pin PE4 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRH register  *****************/
+#define PWR_PUCRH_PH3_Pos              (3U)
+#define PWR_PUCRH_PH3_Msk              (0x1UL << PWR_PUCRH_PH3_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRH_PH3                  PWR_PUCRH_PH3_Msk                       /*!< Pin PH3 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRH register  *****************/
+#define PWR_PDCRH_PH3_Pos              (3U)
+#define PWR_PDCRH_PH3_Msk              (0x1UL << PWR_PDCRH_PH3_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRH_PH3                  PWR_PDCRH_PH3_Msk                       /*!< Pin PH3 Pull-Down set */
+
+/********************  Bit definition for PWR_C2CR1 register  ********************/
+#define PWR_C2CR1_LPMS_Pos             (0U)
+#define PWR_C2CR1_LPMS_Msk             (0x7UL << PWR_C2CR1_LPMS_Pos)           /*!< 0x00000007 */
+#define PWR_C2CR1_LPMS                 PWR_C2CR1_LPMS_Msk                      /*!< Low Power Mode Selection for CPU2 */
+#define PWR_C2CR1_LPMS_0               (0x1U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000001 */
+#define PWR_C2CR1_LPMS_1               (0x2U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000002 */
+#define PWR_C2CR1_LPMS_2               (0x4U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000004 */
+
+#define PWR_C2CR1_FPDR_Pos             (4U)
+#define PWR_C2CR1_FPDR_Msk             (0x1UL << PWR_C2CR1_FPDR_Pos)           /*!< 0x00000010 */
+#define PWR_C2CR1_FPDR                 PWR_C2CR1_FPDR_Msk                      /*!< Flash power down mode during LPrun for CPU2 */
+
+#define PWR_C2CR1_FPDS_Pos             (5U)
+#define PWR_C2CR1_FPDS_Msk             (0x1UL << PWR_C2CR1_FPDS_Pos)           /*!< 0x00000020 */
+#define PWR_C2CR1_FPDS                 PWR_C2CR1_FPDS_Msk                      /*!< Flash power down mode during LPsleep for CPU2 */
+
+#define PWR_C2CR1_BLEEWKUP_Pos         (14U)
+#define PWR_C2CR1_BLEEWKUP_Msk         (0x1UL << PWR_C2CR1_BLEEWKUP_Pos)       /*!< 0x00008000 */
+#define PWR_C2CR1_BLEEWKUP             PWR_C2CR1_BLEEWKUP_Msk                  /*!< Radio BLE external wakeup signal */
+
+/********************  Bit definition for PWR_C2CR3 register  ********************/
+#define PWR_C2CR3_EWUP_Pos             (0U)
+#define PWR_C2CR3_EWUP_Msk             (0x09UL << PWR_C2CR3_EWUP_Pos)           /*!< 0x00000009 */
+#define PWR_C2CR3_EWUP                 PWR_C2CR3_EWUP_Msk                       /*!< Enable all external Wake-Up lines for CPU2 */
+#define PWR_C2CR3_EWUP1_Pos            (0U)
+#define PWR_C2CR3_EWUP1_Msk            (0x1UL << PWR_C2CR3_EWUP1_Pos)           /*!< 0x00000001 */
+#define PWR_C2CR3_EWUP1                PWR_C2CR3_EWUP1_Msk                      /*!< Enable external WKUP Pin 1 [line 0] for CPU2 */
+#define PWR_C2CR3_EWUP4_Pos            (3U)
+#define PWR_C2CR3_EWUP4_Msk            (0x1UL << PWR_C2CR3_EWUP4_Pos)           /*!< 0x00000008 */
+#define PWR_C2CR3_EWUP4                PWR_C2CR3_EWUP4_Msk                      /*!< Enable external WKUP Pin 4 [line 3] for CPU2 */
+
+#define PWR_C2CR3_EBLEWUP_Pos          (9U)
+#define PWR_C2CR3_EBLEWUP_Msk          (0x1UL << PWR_C2CR3_EBLEWUP_Pos)       /*!< 0x00000200 */
+#define PWR_C2CR3_EBLEWUP              PWR_C2CR3_EBLEWUP_Msk                 /*!< Enable BLE host wakeup interrupt for CPU2 */
+
+#define PWR_C2CR3_APC_Pos              (12U)
+#define PWR_C2CR3_APC_Msk              (0x1UL << PWR_C2CR3_APC_Pos)            /*!< 0x00001000 */
+#define PWR_C2CR3_APC                  PWR_C2CR3_APC_Msk                       /*!< Apply pull-up and pull-down configuration for CPU2 */
+
+#define PWR_C2CR3_EIWUL_Pos            (15U)
+#define PWR_C2CR3_EIWUL_Msk            (0x1UL << PWR_C2CR3_EIWUL_Pos)          /*!< 0x00008000 */
+#define PWR_C2CR3_EIWUL                PWR_C2CR3_EIWUL_Msk                     /*!< Internal Wake-Up line interrupt for CPU2 */
+
+/********************  Bit definition for PWR_EXTSCR register  ********************/
+#define PWR_EXTSCR_C1CSSF_Pos          (0U)
+#define PWR_EXTSCR_C1CSSF_Msk          (0x1UL << PWR_EXTSCR_C1CSSF_Pos)        /*!< 0x00000001 */
+#define PWR_EXTSCR_C1CSSF              PWR_EXTSCR_C1CSSF_Msk                   /*!< Clear standby and stop flags for CPU1 */
+#define PWR_EXTSCR_C2CSSF_Pos          (1U)
+#define PWR_EXTSCR_C2CSSF_Msk          (0x1UL << PWR_EXTSCR_C2CSSF_Pos)        /*!< 0x00000002 */
+#define PWR_EXTSCR_C2CSSF              PWR_EXTSCR_C2CSSF_Msk                   /*!< Clear standby and stop flags for CPU2 */
+#define PWR_EXTSCR_CCRPF_Pos           (2U)
+#define PWR_EXTSCR_CCRPF_Msk           (0x1UL << PWR_EXTSCR_CCRPF_Pos)         /*!< 0x00000004 */
+#define PWR_EXTSCR_CCRPF               PWR_EXTSCR_CCRPF_Msk                    /*!< Clear critical radio system phase flag */
+
+#define PWR_EXTSCR_C1SBF_Pos           (8U)
+#define PWR_EXTSCR_C1SBF_Msk           (0x1UL << PWR_EXTSCR_C1SBF_Pos)         /*!< 0x00000100 */
+#define PWR_EXTSCR_C1SBF               PWR_EXTSCR_C1SBF_Msk                    /*!< System standby flag for CPU1 */
+#define PWR_EXTSCR_C1STOPF_Pos         (9U)
+#define PWR_EXTSCR_C1STOPF_Msk         (0x1UL << PWR_EXTSCR_C1STOPF_Pos)       /*!< 0x00000200 */
+#define PWR_EXTSCR_C1STOPF             PWR_EXTSCR_C1STOPF_Msk                  /*!< System stop flag for CPU1 */
+#define PWR_EXTSCR_C2SBF_Pos           (10U)
+#define PWR_EXTSCR_C2SBF_Msk           (0x1UL << PWR_EXTSCR_C2SBF_Pos)         /*!< 0x00000400 */
+#define PWR_EXTSCR_C2SBF               PWR_EXTSCR_C2SBF_Msk                    /*!< System standby flag for CPU2 */
+#define PWR_EXTSCR_C2STOPF_Pos         (11U)
+#define PWR_EXTSCR_C2STOPF_Msk         (0x1UL << PWR_EXTSCR_C2STOPF_Pos)       /*!< 0x00000800 */
+#define PWR_EXTSCR_C2STOPF             PWR_EXTSCR_C2STOPF_Msk                  /*!< System stop flag for CPU2 */
+
+#define PWR_EXTSCR_CRPF_Pos            (13U)
+#define PWR_EXTSCR_CRPF_Msk            (0x1UL << PWR_EXTSCR_CRPF_Pos)          /*!< 0x00002000 */
+#define PWR_EXTSCR_CRPF                PWR_EXTSCR_CRPF_Msk                     /*!< Critical radio system phase flag */
+
+#define PWR_EXTSCR_C1DS_Pos            (14U)
+#define PWR_EXTSCR_C1DS_Msk            (0x1UL << PWR_EXTSCR_C1DS_Pos)          /*!< 0x00004000 */
+#define PWR_EXTSCR_C1DS                PWR_EXTSCR_C1DS_Msk                     /*!< CPU1 deepsleep mode flag */
+#define PWR_EXTSCR_C2DS_Pos            (15U)
+#define PWR_EXTSCR_C2DS_Msk            (0x1UL << PWR_EXTSCR_C2DS_Pos)          /*!< 0x00008000 */
+#define PWR_EXTSCR_C2DS                PWR_EXTSCR_C2DS_Msk                     /*!< CPU2 deepsleep mode flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+  * @brief Specific device feature definitions
+  */
+
+/********************  Bit definition for RCC_CR register  *****************/
+#define RCC_CR_MSION_Pos                     (0U)
+#define RCC_CR_MSION_Msk                     (0x1UL << RCC_CR_MSION_Pos)       /*!< 0x00000001 */
+#define RCC_CR_MSION                         RCC_CR_MSION_Msk                  /*!< Internal Multi Speed oscillator (MSI) clock enable */
+#define RCC_CR_MSIRDY_Pos                    (1U)
+#define RCC_CR_MSIRDY_Msk                    (0x1UL << RCC_CR_MSIRDY_Pos)      /*!< 0x00000002 */
+#define RCC_CR_MSIRDY                        RCC_CR_MSIRDY_Msk                 /*!< Internal Multi Speed oscillator (MSI) clock ready flag */
+#define RCC_CR_MSIPLLEN_Pos                  (2U)
+#define RCC_CR_MSIPLLEN_Msk                  (0x1UL << RCC_CR_MSIPLLEN_Pos)    /*!< 0x00000004 */
+#define RCC_CR_MSIPLLEN                      RCC_CR_MSIPLLEN_Msk               /*!< Internal Multi Speed oscillator (MSI) PLL enable */
+
+/*!< MSIRANGE configuration : 12 frequency ranges available */
+#define RCC_CR_MSIRANGE_Pos                  (4U)
+#define RCC_CR_MSIRANGE_Msk                  (0xFUL << RCC_CR_MSIRANGE_Pos)    /*!< 0x000000F0 */
+#define RCC_CR_MSIRANGE                      RCC_CR_MSIRANGE_Msk               /*!< Internal Multi Speed oscillator (MSI) clock Range */
+#define RCC_CR_MSIRANGE_0                    (0x0U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000000 */
+#define RCC_CR_MSIRANGE_1                    (0x1U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000010 */
+#define RCC_CR_MSIRANGE_2                    (0x2U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000020 */
+#define RCC_CR_MSIRANGE_3                    (0x3U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000030 */
+#define RCC_CR_MSIRANGE_4                    (0x4U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000040 */
+#define RCC_CR_MSIRANGE_5                    (0x5U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000050 */
+#define RCC_CR_MSIRANGE_6                    (0x6U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000060 */
+#define RCC_CR_MSIRANGE_7                    (0x7U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000070 */
+#define RCC_CR_MSIRANGE_8                    (0x8U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000080 */
+#define RCC_CR_MSIRANGE_9                    (0x9U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000090 */
+#define RCC_CR_MSIRANGE_10                   (0xAU << RCC_CR_MSIRANGE_Pos)     /*!< 0x000000A0 */
+#define RCC_CR_MSIRANGE_11                   (0xBU << RCC_CR_MSIRANGE_Pos)     /*!< 0x000000B0 */
+
+#define RCC_CR_HSION_Pos                     (8U)
+#define RCC_CR_HSION_Msk                     (0x1UL << RCC_CR_HSION_Pos)       /*!< 0x00000100 */
+#define RCC_CR_HSION                         RCC_CR_HSION_Msk                  /*!< Internal High Speed oscillator (HSI16) clock enable */
+#define RCC_CR_HSIKERON_Pos                  (9U)
+#define RCC_CR_HSIKERON_Msk                  (0x1UL << RCC_CR_HSIKERON_Pos)    /*!< 0x00000200 */
+#define RCC_CR_HSIKERON                      RCC_CR_HSIKERON_Msk               /*!< Internal High Speed oscillator (HSI16) clock enable for some IPs Kernel */
+#define RCC_CR_HSIRDY_Pos                    (10U)
+#define RCC_CR_HSIRDY_Msk                    (0x1UL << RCC_CR_HSIRDY_Pos)      /*!< 0x00000400 */
+#define RCC_CR_HSIRDY                        RCC_CR_HSIRDY_Msk                 /*!< Internal High Speed oscillator (HSI16) clock ready flag */
+#define RCC_CR_HSIASFS_Pos                   (11U)
+#define RCC_CR_HSIASFS_Msk                   (0x1UL << RCC_CR_HSIASFS_Pos)     /*!< 0x00000800 */
+#define RCC_CR_HSIASFS                       RCC_CR_HSIASFS_Msk                /*!< HSI16 Automatic Start from Stop */
+#define RCC_CR_HSIKERDY_Pos                  (12U)
+#define RCC_CR_HSIKERDY_Msk                  (0x1UL << RCC_CR_HSIKERDY_Pos)     /*!< 0x00001000 */
+#define RCC_CR_HSIKERDY                       RCC_CR_HSIKERDY_Msk               /*!< Internal High Speed oscillator (HSI16) clock enable for some IPs Kernel ready flag*/
+
+#define RCC_CR_HSEON_Pos                     (16U)
+#define RCC_CR_HSEON_Msk                     (0x1UL << RCC_CR_HSEON_Pos)       /*!< 0x00010000 */
+#define RCC_CR_HSEON                         RCC_CR_HSEON_Msk                  /*!< External High Speed oscillator (HSE) clock enable */
+#define RCC_CR_HSERDY_Pos                    (17U)
+#define RCC_CR_HSERDY_Msk                    (0x1UL << RCC_CR_HSERDY_Pos)      /*!< 0x00020000 */
+#define RCC_CR_HSERDY                        RCC_CR_HSERDY_Msk                 /*!< External High Speed oscillator (HSE) clock ready */
+#define RCC_CR_CSSON_Pos                     (19U)
+#define RCC_CR_CSSON_Msk                     (0x1UL << RCC_CR_CSSON_Pos)       /*!< 0x00080000 */
+#define RCC_CR_CSSON                         RCC_CR_CSSON_Msk                  /*!< HSE Clock Security System enable */
+#define RCC_CR_HSEPRE_Pos                    (20U)
+#define RCC_CR_HSEPRE_Msk                    (0x1UL << RCC_CR_HSEPRE_Pos)       /*!< 0x00100000 */
+#define RCC_CR_HSEPRE                        RCC_CR_HSEPRE_Msk                  /*!< HSE sysclk prescaler */
+
+#define RCC_CR_PLLON_Pos                     (24U)
+#define RCC_CR_PLLON_Msk                     (0x1UL << RCC_CR_PLLON_Pos)       /*!< 0x01000000 */
+#define RCC_CR_PLLON                         RCC_CR_PLLON_Msk                  /*!< System PLL clock enable */
+#define RCC_CR_PLLRDY_Pos                    (25U)
+#define RCC_CR_PLLRDY_Msk                    (0x1UL << RCC_CR_PLLRDY_Pos)      /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                        RCC_CR_PLLRDY_Msk                 /*!< System PLL clock ready */
+
+/********************  Bit definition for RCC_ICSCR register  ***************/
+/*!< MSICAL configuration */
+#define RCC_ICSCR_MSICAL_Pos                 (0U)
+#define RCC_ICSCR_MSICAL_Msk                 (0xFFUL << RCC_ICSCR_MSICAL_Pos)  /*!< 0x000000FF */
+#define RCC_ICSCR_MSICAL                     RCC_ICSCR_MSICAL_Msk              /*!< MSICAL[7:0] bits */
+#define RCC_ICSCR_MSICAL_0                   (0x01U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000001 */
+#define RCC_ICSCR_MSICAL_1                   (0x02U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000002 */
+#define RCC_ICSCR_MSICAL_2                   (0x04U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000004 */
+#define RCC_ICSCR_MSICAL_3                   (0x08U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000008 */
+#define RCC_ICSCR_MSICAL_4                   (0x10U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000010 */
+#define RCC_ICSCR_MSICAL_5                   (0x20U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000020 */
+#define RCC_ICSCR_MSICAL_6                   (0x40U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000040 */
+#define RCC_ICSCR_MSICAL_7                   (0x80U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000080 */
+
+/*!< MSITRIM configuration */
+#define RCC_ICSCR_MSITRIM_Pos                (8U)
+#define RCC_ICSCR_MSITRIM_Msk                (0xFFUL << RCC_ICSCR_MSITRIM_Pos) /*!< 0x0000FF00 */
+#define RCC_ICSCR_MSITRIM                    RCC_ICSCR_MSITRIM_Msk             /*!< MSITRIM[7:0] bits */
+#define RCC_ICSCR_MSITRIM_0                  (0x01U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000100 */
+#define RCC_ICSCR_MSITRIM_1                  (0x02U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000200 */
+#define RCC_ICSCR_MSITRIM_2                  (0x04U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000400 */
+#define RCC_ICSCR_MSITRIM_3                  (0x08U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000800 */
+#define RCC_ICSCR_MSITRIM_4                  (0x10U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00001000 */
+#define RCC_ICSCR_MSITRIM_5                  (0x20U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00002000 */
+#define RCC_ICSCR_MSITRIM_6                  (0x40U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00004000 */
+#define RCC_ICSCR_MSITRIM_7                  (0x80U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00008000 */
+
+/*!< HSICAL configuration */
+#define RCC_ICSCR_HSICAL_Pos                 (16U)
+#define RCC_ICSCR_HSICAL_Msk                 (0xFFUL << RCC_ICSCR_HSICAL_Pos)  /*!< 0x00FF0000 */
+#define RCC_ICSCR_HSICAL                     RCC_ICSCR_HSICAL_Msk              /*!< HSICAL[7:0] bits */
+#define RCC_ICSCR_HSICAL_0                   (0x01U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00010000 */
+#define RCC_ICSCR_HSICAL_1                   (0x02U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00020000 */
+#define RCC_ICSCR_HSICAL_2                   (0x04U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00040000 */
+#define RCC_ICSCR_HSICAL_3                   (0x08U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00080000 */
+#define RCC_ICSCR_HSICAL_4                   (0x10U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00100000 */
+#define RCC_ICSCR_HSICAL_5                   (0x20U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00200000 */
+#define RCC_ICSCR_HSICAL_6                   (0x40U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00400000 */
+#define RCC_ICSCR_HSICAL_7                   (0x80U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00800000 */
+
+/*!< HSITRIM configuration */
+#define RCC_ICSCR_HSITRIM_Pos                (24U)
+#define RCC_ICSCR_HSITRIM_Msk                (0x7FUL << RCC_ICSCR_HSITRIM_Pos) /*!< 0x7F000000 */
+#define RCC_ICSCR_HSITRIM                    RCC_ICSCR_HSITRIM_Msk             /*!< HSITRIM[6:0] bits */
+#define RCC_ICSCR_HSITRIM_0                  (0x01U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x01000000 */
+#define RCC_ICSCR_HSITRIM_1                  (0x02U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x02000000 */
+#define RCC_ICSCR_HSITRIM_2                  (0x04U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x04000000 */
+#define RCC_ICSCR_HSITRIM_3                  (0x08U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x08000000 */
+#define RCC_ICSCR_HSITRIM_4                  (0x10U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x10000000 */
+#define RCC_ICSCR_HSITRIM_5                  (0x20U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x20000000 */
+#define RCC_ICSCR_HSITRIM_6                  (0x40U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                      (0U)
+#define RCC_CFGR_SW_Msk                      (0x3UL << RCC_CFGR_SW_Pos)        /*!< 0x00000003 */
+#define RCC_CFGR_SW                          RCC_CFGR_SW_Msk                   /*!< SW[1:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                        (0x1U << RCC_CFGR_SW_Pos)         /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                        (0x2U << RCC_CFGR_SW_Pos)         /*!< 0x00000002 */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos                     (2U)
+#define RCC_CFGR_SWS_Msk                     (0x3UL << RCC_CFGR_SWS_Pos)       /*!< 0x0000000C */
+#define RCC_CFGR_SWS                         RCC_CFGR_SWS_Msk                  /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                       (0x1U << RCC_CFGR_SWS_Pos)        /*!< 0x00000004 */
+#define RCC_CFGR_SWS_1                       (0x2U << RCC_CFGR_SWS_Pos)        /*!< 0x00000008 */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos                    (4U)
+#define RCC_CFGR_HPRE_Msk                    (0xFUL << RCC_CFGR_HPRE_Pos)      /*!< 0x000000F0 */
+#define RCC_CFGR_HPRE                        RCC_CFGR_HPRE_Msk                 /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                      (0x1U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000010 */
+#define RCC_CFGR_HPRE_1                      (0x2U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000020 */
+#define RCC_CFGR_HPRE_2                      (0x4U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000040 */
+#define RCC_CFGR_HPRE_3                      (0x8U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000080 */
+
+/*!< PPRE1 configuration */
+#define RCC_CFGR_PPRE1_Pos                   (8U)
+#define RCC_CFGR_PPRE1_Msk                   (0x7UL << RCC_CFGR_PPRE1_Pos)     /*!< 0x00000700 */
+#define RCC_CFGR_PPRE1                       RCC_CFGR_PPRE1_Msk                /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define RCC_CFGR_PPRE1_0                     (0x1U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000100 */
+#define RCC_CFGR_PPRE1_1                     (0x2U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000200 */
+#define RCC_CFGR_PPRE1_2                     (0x4U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000400 */
+
+/*!< PPRE2 configuration */
+#define RCC_CFGR_PPRE2_Pos                   (11U)
+#define RCC_CFGR_PPRE2_Msk                   (0x7UL << RCC_CFGR_PPRE2_Pos)     /*!< 0x00003800 */
+#define RCC_CFGR_PPRE2                       RCC_CFGR_PPRE2_Msk                /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define RCC_CFGR_PPRE2_0                     (0x1U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00000800 */
+#define RCC_CFGR_PPRE2_1                     (0x2U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00001000 */
+#define RCC_CFGR_PPRE2_2                     (0x4U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00002000 */
+
+/*!< STOPWUCK configuration */
+#define RCC_CFGR_STOPWUCK_Pos                (15U)
+#define RCC_CFGR_STOPWUCK_Msk                (0x1UL << RCC_CFGR_STOPWUCK_Pos)  /*!< 0x00008000 */
+#define RCC_CFGR_STOPWUCK                    RCC_CFGR_STOPWUCK_Msk             /*!< Wake Up from stop and CSS backup clock selection */
+
+/*!< HPREF configuration */
+#define RCC_CFGR_HPREF_Pos                   (16U)
+#define RCC_CFGR_HPREF_Msk                   (0x1UL << RCC_CFGR_HPREF_Pos)     /*!< 0x00010000 */
+#define RCC_CFGR_HPREF                       RCC_CFGR_HPREF_Msk                /*!< AHB prescaler flag */
+
+/*!< PPRE1F configuration */
+#define RCC_CFGR_PPRE1F_Pos                  (17U)
+#define RCC_CFGR_PPRE1F_Msk                  (0x1UL << RCC_CFGR_PPRE1F_Pos)    /*!< 0x00020000 */
+#define RCC_CFGR_PPRE1F                      RCC_CFGR_PPRE1F_Msk               /*!< CPU1 APB1 prescaler flag */
+
+/*!< PPRE2F configuration */
+#define RCC_CFGR_PPRE2F_Pos                  (18U)
+#define RCC_CFGR_PPRE2F_Msk                  (0x1UL << RCC_CFGR_PPRE2F_Pos)    /*!< 0x00040000 */
+#define RCC_CFGR_PPRE2F                      RCC_CFGR_PPRE2F_Msk               /*!< APB2 prescaler flag */
+
+/*!< MCOSEL configuration */
+#define RCC_CFGR_MCOSEL_Pos                  (24U)
+#define RCC_CFGR_MCOSEL_Msk                  (0xFUL << RCC_CFGR_MCOSEL_Pos)    /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL                      RCC_CFGR_MCOSEL_Msk               /*!< MCOSEL [3:0] bits (Clock output selection) */
+#define RCC_CFGR_MCOSEL_0                    (0x1U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x01000000 */
+#define RCC_CFGR_MCOSEL_1                    (0x2U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x02000000 */
+#define RCC_CFGR_MCOSEL_2                    (0x4U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x04000000 */
+#define RCC_CFGR_MCOSEL_3                    (0x8U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x08000000 */
+
+/*!< MCOPRE configuration */
+#define RCC_CFGR_MCOPRE_Pos                  (28U)
+#define RCC_CFGR_MCOPRE_Msk                  (0x7UL << RCC_CFGR_MCOPRE_Pos)    /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE                      RCC_CFGR_MCOPRE_Msk               /*!< MCO prescaler */
+#define RCC_CFGR_MCOPRE_0                    (0x1U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x10000000 */
+#define RCC_CFGR_MCOPRE_1                    (0x2U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x20000000 */
+#define RCC_CFGR_MCOPRE_2                    (0x4U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLSRC_Pos               (0U)
+#define RCC_PLLCFGR_PLLSRC_Msk               (0x3UL << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC                   RCC_PLLCFGR_PLLSRC_Msk
+#define RCC_PLLCFGR_PLLSRC_0                 (0x1U << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLSRC_1                 (0x2U << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000002 */
+
+#define RCC_PLLCFGR_PLLM_Pos                 (4U)
+#define RCC_PLLCFGR_PLLM_Msk                 (0x7UL << RCC_PLLCFGR_PLLM_Pos) /*!< 0x00000070 */
+#define RCC_PLLCFGR_PLLM                     RCC_PLLCFGR_PLLM_Msk
+#define RCC_PLLCFGR_PLLM_0                   (0x1U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_1                   (0x2U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000020 */
+#define RCC_PLLCFGR_PLLM_2                   (0x4U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000040 */
+
+#define RCC_PLLCFGR_PLLN_Pos                 (8U)
+#define RCC_PLLCFGR_PLLN_Msk                 (0x7FUL << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00007F00 */
+#define RCC_PLLCFGR_PLLN                     RCC_PLLCFGR_PLLN_Msk
+#define RCC_PLLCFGR_PLLN_0                   (0x01U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_1                   (0x02U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_2                   (0x04U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_3                   (0x08U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_4                   (0x10U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_5                   (0x20U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_6                   (0x40U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLPEN_Pos               (16U)
+#define RCC_PLLCFGR_PLLPEN_Msk               (0x1UL << RCC_PLLCFGR_PLLPEN_Pos) /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLPEN                   RCC_PLLCFGR_PLLPEN_Msk
+#define RCC_PLLCFGR_PLLP_Pos                 (17U)
+#define RCC_PLLCFGR_PLLP_Msk                 (0x1FUL << RCC_PLLCFGR_PLLP_Pos) /*!< 0x003E0000 */
+#define RCC_PLLCFGR_PLLP                     RCC_PLLCFGR_PLLP_Msk
+#define RCC_PLLCFGR_PLLP_0                   (0x01U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00020000 */
+#define RCC_PLLCFGR_PLLP_1                   (0x02U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00040000 */
+#define RCC_PLLCFGR_PLLP_2                   (0x04U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00080000 */
+#define RCC_PLLCFGR_PLLP_3                   (0x08U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00100000 */
+#define RCC_PLLCFGR_PLLP_4                   (0x10U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00200000 */
+
+#define RCC_PLLCFGR_PLLQEN_Pos               (24U)
+#define RCC_PLLCFGR_PLLQEN_Msk               (0x1UL << RCC_PLLCFGR_PLLQEN_Pos) /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQEN                   RCC_PLLCFGR_PLLQEN_Msk
+#define RCC_PLLCFGR_PLLQ_Pos                 (25U)
+#define RCC_PLLCFGR_PLLQ_Msk                 (0x7UL << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x0E000000 */
+#define RCC_PLLCFGR_PLLQ                     RCC_PLLCFGR_PLLQ_Msk
+#define RCC_PLLCFGR_PLLQ_0                   (0x1U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_1                   (0x2U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_2                   (0x4U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x08000000 */
+
+#define RCC_PLLCFGR_PLLREN_Pos               (28U)
+#define RCC_PLLCFGR_PLLREN_Msk               (0x1UL << RCC_PLLCFGR_PLLREN_Pos) /*!< 0x10000000 */
+#define RCC_PLLCFGR_PLLREN                   RCC_PLLCFGR_PLLREN_Msk
+#define RCC_PLLCFGR_PLLR_Pos                 (29U)
+#define RCC_PLLCFGR_PLLR_Msk                 (0x7UL << RCC_PLLCFGR_PLLR_Pos) /*!< 0xE0000000 */
+#define RCC_PLLCFGR_PLLR                     RCC_PLLCFGR_PLLR_Msk
+#define RCC_PLLCFGR_PLLR_0                   (0x1U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x20000000 */
+#define RCC_PLLCFGR_PLLR_1                   (0x2U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x40000000 */
+#define RCC_PLLCFGR_PLLR_2                   (0x4U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIER register  ******************/
+#define RCC_CIER_LSI1RDYIE_Pos               (0U)
+#define RCC_CIER_LSI1RDYIE_Msk               (0x1UL << RCC_CIER_LSI1RDYIE_Pos)  /*!< 0x00000001 */
+#define RCC_CIER_LSI1RDYIE                   RCC_CIER_LSI1RDYIE_Msk
+#define RCC_CIER_LSERDYIE_Pos                (1U)
+#define RCC_CIER_LSERDYIE_Msk                (0x1UL << RCC_CIER_LSERDYIE_Pos)   /*!< 0x00000002 */
+#define RCC_CIER_LSERDYIE                    RCC_CIER_LSERDYIE_Msk
+#define RCC_CIER_MSIRDYIE_Pos                (2U)
+#define RCC_CIER_MSIRDYIE_Msk                (0x1UL << RCC_CIER_MSIRDYIE_Pos)   /*!< 0x00000004 */
+#define RCC_CIER_MSIRDYIE                    RCC_CIER_MSIRDYIE_Msk
+#define RCC_CIER_HSIRDYIE_Pos                (3U)
+#define RCC_CIER_HSIRDYIE_Msk                (0x1UL << RCC_CIER_HSIRDYIE_Pos)   /*!< 0x00000008 */
+#define RCC_CIER_HSIRDYIE                    RCC_CIER_HSIRDYIE_Msk
+#define RCC_CIER_HSERDYIE_Pos                (4U)
+#define RCC_CIER_HSERDYIE_Msk                (0x1UL << RCC_CIER_HSERDYIE_Pos)   /*!< 0x00000010 */
+#define RCC_CIER_HSERDYIE                    RCC_CIER_HSERDYIE_Msk
+#define RCC_CIER_PLLRDYIE_Pos                (5U)
+#define RCC_CIER_PLLRDYIE_Msk                (0x1UL << RCC_CIER_PLLRDYIE_Pos) /*!< 0x00000020 */
+#define RCC_CIER_PLLRDYIE                    RCC_CIER_PLLRDYIE_Msk
+#define RCC_CIER_LSECSSIE_Pos                (9U)
+#define RCC_CIER_LSECSSIE_Msk                (0x1UL << RCC_CIER_LSECSSIE_Pos)   /*!< 0x00000200 */
+#define RCC_CIER_LSECSSIE                    RCC_CIER_LSECSSIE_Msk
+#define RCC_CIER_LSI2RDYIE_Pos               (11U)
+#define RCC_CIER_LSI2RDYIE_Msk               (0x1UL << RCC_CIER_LSI2RDYIE_Pos)  /*!< 0x00000800 */
+#define RCC_CIER_LSI2RDYIE                   RCC_CIER_LSI2RDYIE_Msk
+
+
+/********************  Bit definition for RCC_CIFR register  ******************/
+#define RCC_CIFR_LSI1RDYF_Pos                (0U)
+#define RCC_CIFR_LSI1RDYF_Msk                (0x1UL << RCC_CIFR_LSI1RDYF_Pos)  /*!< 0x00000001 */
+#define RCC_CIFR_LSI1RDYF                    RCC_CIFR_LSI1RDYF_Msk
+#define RCC_CIFR_LSERDYF_Pos                 (1U)
+#define RCC_CIFR_LSERDYF_Msk                 (0x1UL << RCC_CIFR_LSERDYF_Pos)   /*!< 0x00000002 */
+#define RCC_CIFR_LSERDYF                     RCC_CIFR_LSERDYF_Msk
+#define RCC_CIFR_MSIRDYF_Pos                 (2U)
+#define RCC_CIFR_MSIRDYF_Msk                 (0x1UL << RCC_CIFR_MSIRDYF_Pos)   /*!< 0x00000004 */
+#define RCC_CIFR_MSIRDYF                     RCC_CIFR_MSIRDYF_Msk
+#define RCC_CIFR_HSIRDYF_Pos                 (3U)
+#define RCC_CIFR_HSIRDYF_Msk                 (0x1UL << RCC_CIFR_HSIRDYF_Pos)   /*!< 0x00000008 */
+#define RCC_CIFR_HSIRDYF                     RCC_CIFR_HSIRDYF_Msk
+#define RCC_CIFR_HSERDYF_Pos                 (4U)
+#define RCC_CIFR_HSERDYF_Msk                 (0x1UL << RCC_CIFR_HSERDYF_Pos)   /*!< 0x00000010 */
+#define RCC_CIFR_HSERDYF                     RCC_CIFR_HSERDYF_Msk
+#define RCC_CIFR_PLLRDYF_Pos                 (5U)
+#define RCC_CIFR_PLLRDYF_Msk                 (0x1UL << RCC_CIFR_PLLRDYF_Pos) /*!< 0x00000020 */
+#define RCC_CIFR_PLLRDYF                     RCC_CIFR_PLLRDYF_Msk
+#define RCC_CIFR_CSSF_Pos                    (8U)
+#define RCC_CIFR_CSSF_Msk                    (0x1UL << RCC_CIFR_CSSF_Pos)   /*!< 0x00000100 */
+#define RCC_CIFR_CSSF                        RCC_CIFR_CSSF_Msk
+#define RCC_CIFR_LSECSSF_Pos                 (9U)
+#define RCC_CIFR_LSECSSF_Msk                 (0x1UL << RCC_CIFR_LSECSSF_Pos)   /*!< 0x00000200 */
+#define RCC_CIFR_LSECSSF                     RCC_CIFR_LSECSSF_Msk
+#define RCC_CIFR_LSI2RDYF_Pos                (11U)
+#define RCC_CIFR_LSI2RDYF_Msk                (0x1UL << RCC_CIFR_LSI2RDYF_Pos)  /*!< 0x00000800 */
+#define RCC_CIFR_LSI2RDYF                    RCC_CIFR_LSI2RDYF_Msk
+
+/********************  Bit definition for RCC_CICR register  ******************/
+#define RCC_CICR_LSI1RDYC_Pos               (0U)
+#define RCC_CICR_LSI1RDYC_Msk               (0x1UL << RCC_CICR_LSI1RDYC_Pos)  /*!< 0x00000001 */
+#define RCC_CICR_LSI1RDYC                   RCC_CICR_LSI1RDYC_Msk
+#define RCC_CICR_LSERDYC_Pos                (1U)
+#define RCC_CICR_LSERDYC_Msk                (0x1UL << RCC_CICR_LSERDYC_Pos)   /*!< 0x00000002 */
+#define RCC_CICR_LSERDYC                    RCC_CICR_LSERDYC_Msk
+#define RCC_CICR_MSIRDYC_Pos                (2U)
+#define RCC_CICR_MSIRDYC_Msk                (0x1UL << RCC_CICR_MSIRDYC_Pos)   /*!< 0x00000004 */
+#define RCC_CICR_MSIRDYC                    RCC_CICR_MSIRDYC_Msk
+#define RCC_CICR_HSIRDYC_Pos                (3U)
+#define RCC_CICR_HSIRDYC_Msk                (0x1UL << RCC_CICR_HSIRDYC_Pos)   /*!< 0x00000008 */
+#define RCC_CICR_HSIRDYC                    RCC_CICR_HSIRDYC_Msk
+#define RCC_CICR_HSERDYC_Pos                (4U)
+#define RCC_CICR_HSERDYC_Msk                (0x1UL << RCC_CICR_HSERDYC_Pos)   /*!< 0x00000010 */
+#define RCC_CICR_HSERDYC                    RCC_CICR_HSERDYC_Msk
+#define RCC_CICR_PLLRDYC_Pos                (5U)
+#define RCC_CICR_PLLRDYC_Msk                (0x1UL << RCC_CICR_PLLRDYC_Pos) /*!< 0x00000020 */
+#define RCC_CICR_PLLRDYC                    RCC_CICR_PLLRDYC_Msk
+#define RCC_CICR_CSSC_Pos                   (8U)
+#define RCC_CICR_CSSC_Msk                   (0x1UL << RCC_CICR_CSSC_Pos)   /*!< 0x00000100 */
+#define RCC_CICR_CSSC                       RCC_CICR_CSSC_Msk
+#define RCC_CICR_LSECSSC_Pos                (9U)
+#define RCC_CICR_LSECSSC_Msk                (0x1UL << RCC_CICR_LSECSSC_Pos)   /*!< 0x00000200 */
+#define RCC_CICR_LSECSSC                    RCC_CICR_LSECSSC_Msk
+#define RCC_CICR_LSI2RDYC_Pos               (11U)
+#define RCC_CICR_LSI2RDYC_Msk               (0x1UL << RCC_CICR_LSI2RDYC_Pos)  /*!< 0x00000800 */
+#define RCC_CICR_LSI2RDYC                   RCC_CICR_LSI2RDYC_Msk
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define RCC_AHB1RSTR_DMA1RST_Pos             (0U)
+#define RCC_AHB1RSTR_DMA1RST_Msk             (0x1UL << RCC_AHB1RSTR_DMA1RST_Pos) /*!< 0x00000001 */
+#define RCC_AHB1RSTR_DMA1RST                 RCC_AHB1RSTR_DMA1RST_Msk
+#define RCC_AHB1RSTR_DMAMUX1RST_Pos          (2U)
+#define RCC_AHB1RSTR_DMAMUX1RST_Msk          (0x1UL << RCC_AHB1RSTR_DMAMUX1RST_Pos) /*!< 0x00000004 */
+#define RCC_AHB1RSTR_DMAMUX1RST              RCC_AHB1RSTR_DMAMUX1RST_Msk
+#define RCC_AHB1RSTR_CRCRST_Pos              (12U)
+#define RCC_AHB1RSTR_CRCRST_Msk              (0x1UL << RCC_AHB1RSTR_CRCRST_Pos) /*!< 0x00001000 */
+#define RCC_AHB1RSTR_CRCRST                  RCC_AHB1RSTR_CRCRST_Msk
+#define RCC_AHB1RSTR_TSCRST_Pos              (16U)
+#define RCC_AHB1RSTR_TSCRST_Msk              (0x1UL << RCC_AHB1RSTR_TSCRST_Pos) /*!< 0x00010000 */
+#define RCC_AHB1RSTR_TSCRST                  RCC_AHB1RSTR_TSCRST_Msk
+
+/********************  Bit definition for RCC_AHB2RSTR register  ***************/
+#define RCC_AHB2RSTR_GPIOARST_Pos           (0U)
+#define RCC_AHB2RSTR_GPIOARST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOARST_Pos) /*!< 0x00000001 */
+#define RCC_AHB2RSTR_GPIOARST               RCC_AHB2RSTR_GPIOARST_Msk
+#define RCC_AHB2RSTR_GPIOBRST_Pos           (1U)
+#define RCC_AHB2RSTR_GPIOBRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOBRST_Pos) /*!< 0x00000002 */
+#define RCC_AHB2RSTR_GPIOBRST               RCC_AHB2RSTR_GPIOBRST_Msk
+#define RCC_AHB2RSTR_GPIOCRST_Pos           (2U)
+#define RCC_AHB2RSTR_GPIOCRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOCRST_Pos) /*!< 0x00000004 */
+#define RCC_AHB2RSTR_GPIOCRST               RCC_AHB2RSTR_GPIOCRST_Msk
+#define RCC_AHB2RSTR_GPIOERST_Pos           (4U)
+#define RCC_AHB2RSTR_GPIOERST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOERST_Pos) /*!< 0x00000010 */
+#define RCC_AHB2RSTR_GPIOERST               RCC_AHB2RSTR_GPIOERST_Msk
+#define RCC_AHB2RSTR_GPIOHRST_Pos           (7U)
+#define RCC_AHB2RSTR_GPIOHRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOHRST_Pos) /*!< 0x00000080 */
+#define RCC_AHB2RSTR_GPIOHRST               RCC_AHB2RSTR_GPIOHRST_Msk
+
+/********************  Bit definition for RCC_AHB3RSTR register  ***************/
+#define RCC_AHB3RSTR_PKARST_Pos             (16U)
+#define RCC_AHB3RSTR_PKARST_Msk             (0x1UL << RCC_AHB3RSTR_PKARST_Pos) /*!< 0x00010000 */
+#define RCC_AHB3RSTR_PKARST                 RCC_AHB3RSTR_PKARST_Msk
+#define RCC_AHB3RSTR_AES2RST_Pos            (17U)
+#define RCC_AHB3RSTR_AES2RST_Msk            (0x1UL << RCC_AHB3RSTR_AES2RST_Pos) /*!< 0x00020000 */
+#define RCC_AHB3RSTR_AES2RST                RCC_AHB3RSTR_AES2RST_Msk
+#define RCC_AHB3RSTR_RNGRST_Pos             (18U)
+#define RCC_AHB3RSTR_RNGRST_Msk             (0x1UL << RCC_AHB3RSTR_RNGRST_Pos) /*!< 0x00040000 */
+#define RCC_AHB3RSTR_RNGRST                 RCC_AHB3RSTR_RNGRST_Msk
+#define RCC_AHB3RSTR_HSEMRST_Pos            (19U)
+#define RCC_AHB3RSTR_HSEMRST_Msk            (0x1UL << RCC_AHB3RSTR_HSEMRST_Pos) /*!< 0x00080000 */
+#define RCC_AHB3RSTR_HSEMRST                RCC_AHB3RSTR_HSEMRST_Msk
+#define RCC_AHB3RSTR_IPCCRST_Pos            (20U)
+#define RCC_AHB3RSTR_IPCCRST_Msk            (0x1UL << RCC_AHB3RSTR_IPCCRST_Pos) /*!< 0x00100000 */
+#define RCC_AHB3RSTR_IPCCRST                RCC_AHB3RSTR_IPCCRST_Msk
+#define RCC_AHB3RSTR_FLASHRST_Pos           (25U)
+#define RCC_AHB3RSTR_FLASHRST_Msk           (0x1UL << RCC_AHB3RSTR_FLASHRST_Pos) /*!< 0x02000000 */
+#define RCC_AHB3RSTR_FLASHRST               RCC_AHB3RSTR_FLASHRST_Msk
+
+/********************  Bit definition for RCC_APB1RSTR1 register  **************/
+#define RCC_APB1RSTR1_TIM2RST_Pos           (0U)
+#define RCC_APB1RSTR1_TIM2RST_Msk           (0x1UL << RCC_APB1RSTR1_TIM2RST_Pos) /*!< 0x00000001 */
+#define RCC_APB1RSTR1_TIM2RST               RCC_APB1RSTR1_TIM2RST_Msk
+#define RCC_APB1RSTR1_I2C1RST_Pos           (21U)
+#define RCC_APB1RSTR1_I2C1RST_Msk           (0x1UL << RCC_APB1RSTR1_I2C1RST_Pos) /*!< 0x00200000 */
+#define RCC_APB1RSTR1_I2C1RST               RCC_APB1RSTR1_I2C1RST_Msk
+#define RCC_APB1RSTR1_LPTIM1RST_Pos         (31U)
+#define RCC_APB1RSTR1_LPTIM1RST_Msk         (0x1UL << RCC_APB1RSTR1_LPTIM1RST_Pos) /*!< 0x80000000 */
+#define RCC_APB1RSTR1_LPTIM1RST             RCC_APB1RSTR1_LPTIM1RST_Msk
+
+/********************  Bit definition for RCC_APB1RSTR2 register  **************/
+#define RCC_APB1RSTR2_LPTIM2RST_Pos         (5U)
+#define RCC_APB1RSTR2_LPTIM2RST_Msk         (0x1UL << RCC_APB1RSTR2_LPTIM2RST_Pos) /*!< 0x00000020 */
+#define RCC_APB1RSTR2_LPTIM2RST             RCC_APB1RSTR2_LPTIM2RST_Msk
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define RCC_APB2RSTR_ADCRST_Pos             (9U)
+#define RCC_APB2RSTR_ADCRST_Msk             (0x1UL << RCC_APB2RSTR_ADCRST_Pos)    /*!< 0x00000200 */
+#define RCC_APB2RSTR_ADCRST                 RCC_APB2RSTR_ADCRST_Msk
+#define RCC_APB2RSTR_TIM1RST_Pos            (11U)
+#define RCC_APB2RSTR_TIM1RST_Msk            (0x1UL << RCC_APB2RSTR_TIM1RST_Pos)   /*!< 0x00000800 */
+#define RCC_APB2RSTR_TIM1RST                RCC_APB2RSTR_TIM1RST_Msk
+#define RCC_APB2RSTR_SPI1RST_Pos            (12U)
+#define RCC_APB2RSTR_SPI1RST_Msk            (0x1UL << RCC_APB2RSTR_SPI1RST_Pos)   /*!< 0x00001000 */
+#define RCC_APB2RSTR_SPI1RST                RCC_APB2RSTR_SPI1RST_Msk
+#define RCC_APB2RSTR_USART1RST_Pos          (14U)
+#define RCC_APB2RSTR_USART1RST_Msk          (0x1UL << RCC_APB2RSTR_USART1RST_Pos) /*!< 0x00004000 */
+#define RCC_APB2RSTR_USART1RST              RCC_APB2RSTR_USART1RST_Msk
+
+/********************  Bit definition for RCC_APB3RSTR register  **************/
+#define RCC_APB3RSTR_RFRST_Pos             (0U)
+#define RCC_APB3RSTR_RFRST_Msk             (0x1UL << RCC_APB3RSTR_RFRST_Pos) /*!< 0x00000001 */
+#define RCC_APB3RSTR_RFRST                 RCC_APB3RSTR_RFRST_Msk
+
+/********************  Bit definition for RCC_AHB1ENR register  ****************/
+#define RCC_AHB1ENR_DMA1EN_Pos              (0U)
+#define RCC_AHB1ENR_DMA1EN_Msk              (0x1UL << RCC_AHB1ENR_DMA1EN_Pos)  /*!< 0x00000001 */
+#define RCC_AHB1ENR_DMA1EN                  RCC_AHB1ENR_DMA1EN_Msk
+#define RCC_AHB1ENR_DMAMUX1EN_Pos           (2U)
+#define RCC_AHB1ENR_DMAMUX1EN_Msk           (0x1UL << RCC_AHB1ENR_DMAMUX1EN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1ENR_DMAMUX1EN               RCC_AHB1ENR_DMAMUX1EN_Msk
+#define RCC_AHB1ENR_CRCEN_Pos               (12U)
+#define RCC_AHB1ENR_CRCEN_Msk               (0x1UL << RCC_AHB1ENR_CRCEN_Pos)   /*!< 0x00001000 */
+#define RCC_AHB1ENR_CRCEN                   RCC_AHB1ENR_CRCEN_Msk
+#define RCC_AHB1ENR_TSCEN_Pos               (16U)
+#define RCC_AHB1ENR_TSCEN_Msk               (0x1UL << RCC_AHB1ENR_TSCEN_Pos)   /*!< 0x00010000 */
+#define RCC_AHB1ENR_TSCEN                   RCC_AHB1ENR_TSCEN_Msk
+
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+#define RCC_AHB2ENR_GPIOAEN_Pos             (0U)
+#define RCC_AHB2ENR_GPIOAEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOAEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB2ENR_GPIOAEN                 RCC_AHB2ENR_GPIOAEN_Msk
+#define RCC_AHB2ENR_GPIOBEN_Pos             (1U)
+#define RCC_AHB2ENR_GPIOBEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOBEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB2ENR_GPIOBEN                 RCC_AHB2ENR_GPIOBEN_Msk
+#define RCC_AHB2ENR_GPIOCEN_Pos             (2U)
+#define RCC_AHB2ENR_GPIOCEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOCEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB2ENR_GPIOCEN                 RCC_AHB2ENR_GPIOCEN_Msk
+#define RCC_AHB2ENR_GPIOEEN_Pos             (4U)
+#define RCC_AHB2ENR_GPIOEEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOEEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB2ENR_GPIOEEN                 RCC_AHB2ENR_GPIOEEN_Msk
+#define RCC_AHB2ENR_GPIOHEN_Pos             (7U)
+#define RCC_AHB2ENR_GPIOHEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOHEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2ENR_GPIOHEN                 RCC_AHB2ENR_GPIOHEN_Msk
+
+/********************  Bit definition for RCC_AHB3ENR register  ***************/
+#define RCC_AHB3ENR_PKAEN_Pos               (16U)
+#define RCC_AHB3ENR_PKAEN_Msk               (0x1UL << RCC_AHB3ENR_PKAEN_Pos)   /*!< 0x00010000 */
+#define RCC_AHB3ENR_PKAEN                   RCC_AHB3ENR_PKAEN_Msk
+#define RCC_AHB3ENR_AES2EN_Pos              (17U)
+#define RCC_AHB3ENR_AES2EN_Msk              (0x1UL << RCC_AHB3ENR_AES2EN_Pos) /*!< 0x00020000 */
+#define RCC_AHB3ENR_AES2EN                  RCC_AHB3ENR_AES2EN_Msk
+#define RCC_AHB3ENR_RNGEN_Pos               (18U)
+#define RCC_AHB3ENR_RNGEN_Msk               (0x1UL << RCC_AHB3ENR_RNGEN_Pos)  /*!< 0x00040000 */
+#define RCC_AHB3ENR_RNGEN                   RCC_AHB3ENR_RNGEN_Msk
+#define RCC_AHB3ENR_HSEMEN_Pos              (19U)
+#define RCC_AHB3ENR_HSEMEN_Msk              (0x1UL << RCC_AHB3ENR_HSEMEN_Pos)  /*!< 0x00080000 */
+#define RCC_AHB3ENR_HSEMEN                  RCC_AHB3ENR_HSEMEN_Msk
+#define RCC_AHB3ENR_IPCCEN_Pos              (20U)
+#define RCC_AHB3ENR_IPCCEN_Msk              (0x1UL << RCC_AHB3ENR_IPCCEN_Pos)  /*!< 0x00100000 */
+#define RCC_AHB3ENR_IPCCEN                  RCC_AHB3ENR_IPCCEN_Msk
+#define RCC_AHB3ENR_FLASHEN_Pos             (25U)
+#define RCC_AHB3ENR_FLASHEN_Msk             (0x1UL << RCC_AHB3ENR_FLASHEN_Pos)   /*!< 0x02000000 */
+#define RCC_AHB3ENR_FLASHEN                 RCC_AHB3ENR_FLASHEN_Msk
+
+/********************  Bit definition for RCC_APB1ENR1 register  **************/
+#define RCC_APB1ENR1_TIM2EN_Pos             (0U)
+#define RCC_APB1ENR1_TIM2EN_Msk             (0x1UL << RCC_APB1ENR1_TIM2EN_Pos) /*!< 0x00000001 */
+#define RCC_APB1ENR1_TIM2EN                 RCC_APB1ENR1_TIM2EN_Msk
+#define RCC_APB1ENR1_RTCAPBEN_Pos           (10U)
+#define RCC_APB1ENR1_RTCAPBEN_Msk           (0x1UL << RCC_APB1ENR1_RTCAPBEN_Pos) /*!< 0x00000400 */
+#define RCC_APB1ENR1_RTCAPBEN               RCC_APB1ENR1_RTCAPBEN_Msk
+#define RCC_APB1ENR1_WWDGEN_Pos             (11U)
+#define RCC_APB1ENR1_WWDGEN_Msk             (0x1UL << RCC_APB1ENR1_WWDGEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1ENR1_WWDGEN                 RCC_APB1ENR1_WWDGEN_Msk
+#define RCC_APB1ENR1_I2C1EN_Pos             (21U)
+#define RCC_APB1ENR1_I2C1EN_Msk             (0x1UL << RCC_APB1ENR1_I2C1EN_Pos) /*!< 0x00200000 */
+#define RCC_APB1ENR1_I2C1EN                 RCC_APB1ENR1_I2C1EN_Msk
+#define RCC_APB1ENR1_LPTIM1EN_Pos           (31U)
+#define RCC_APB1ENR1_LPTIM1EN_Msk           (0x1UL << RCC_APB1ENR1_LPTIM1EN_Pos) /*!< 0x80000000 */
+#define RCC_APB1ENR1_LPTIM1EN               RCC_APB1ENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_APB1ENR2 register  **************/
+#define RCC_APB1ENR2_LPTIM2EN_Pos           (5U)
+#define RCC_APB1ENR2_LPTIM2EN_Msk           (0x1UL << RCC_APB1ENR2_LPTIM2EN_Pos) /*!< 0x00000020 */
+#define RCC_APB1ENR2_LPTIM2EN               RCC_APB1ENR2_LPTIM2EN_Msk
+
+/********************  Bit definition for RCC_APB2ENR register  **************/
+#define RCC_APB2ENR_ADCEN_Pos               (9U)
+#define RCC_APB2ENR_ADCEN_Msk               (0x1UL << RCC_APB2ENR_ADCEN_Pos)    /*!< 0x00000200 */
+#define RCC_APB2ENR_ADCEN                   RCC_APB2ENR_ADCEN_Msk
+#define RCC_APB2ENR_TIM1EN_Pos              (11U)
+#define RCC_APB2ENR_TIM1EN_Msk              (0x1UL << RCC_APB2ENR_TIM1EN_Pos)   /*!< 0x00000800 */
+#define RCC_APB2ENR_TIM1EN                  RCC_APB2ENR_TIM1EN_Msk
+#define RCC_APB2ENR_SPI1EN_Pos              (12U)
+#define RCC_APB2ENR_SPI1EN_Msk              (0x1UL << RCC_APB2ENR_SPI1EN_Pos)   /*!< 0x00001000 */
+#define RCC_APB2ENR_SPI1EN                  RCC_APB2ENR_SPI1EN_Msk
+#define RCC_APB2ENR_USART1EN_Pos            (14U)
+#define RCC_APB2ENR_USART1EN_Msk            (0x1UL << RCC_APB2ENR_USART1EN_Pos) /*!< 0x00004000 */
+#define RCC_APB2ENR_USART1EN                RCC_APB2ENR_USART1EN_Msk
+
+/********************  Bit definition for RCC_AHB1SMENR register  ****************/
+#define RCC_AHB1SMENR_DMA1SMEN_Pos          (0U)
+#define RCC_AHB1SMENR_DMA1SMEN_Msk          (0x1UL << RCC_AHB1SMENR_DMA1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB1SMENR_DMA1SMEN              RCC_AHB1SMENR_DMA1SMEN_Msk
+#define RCC_AHB1SMENR_DMAMUX1SMEN_Pos       (2U)
+#define RCC_AHB1SMENR_DMAMUX1SMEN_Msk       (0x1UL << RCC_AHB1SMENR_DMAMUX1SMEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1SMENR_DMAMUX1SMEN           RCC_AHB1SMENR_DMAMUX1SMEN_Msk
+#define RCC_AHB1SMENR_SRAM1SMEN_Pos         (9U)
+#define RCC_AHB1SMENR_SRAM1SMEN_Msk         (0x1UL << RCC_AHB1SMENR_SRAM1SMEN_Pos) /*!< 0x00000200 */
+#define RCC_AHB1SMENR_SRAM1SMEN             RCC_AHB1SMENR_SRAM1SMEN_Msk
+#define RCC_AHB1SMENR_CRCSMEN_Pos           (12U)
+#define RCC_AHB1SMENR_CRCSMEN_Msk           (0x1UL << RCC_AHB1SMENR_CRCSMEN_Pos) /*!< 0x00001000 */
+#define RCC_AHB1SMENR_CRCSMEN               RCC_AHB1SMENR_CRCSMEN_Msk
+#define RCC_AHB1SMENR_TSCSMEN_Pos           (16U)
+#define RCC_AHB1SMENR_TSCSMEN_Msk           (0x1UL << RCC_AHB1SMENR_TSCSMEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB1SMENR_TSCSMEN               RCC_AHB1SMENR_TSCSMEN_Msk
+
+/********************  Bit definition for RCC_AHB2SMENR register  ***************/
+#define RCC_AHB2SMENR_GPIOASMEN_Pos         (0U)
+#define RCC_AHB2SMENR_GPIOASMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOASMEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB2SMENR_GPIOASMEN             RCC_AHB2SMENR_GPIOASMEN_Msk
+#define RCC_AHB2SMENR_GPIOBSMEN_Pos         (1U)
+#define RCC_AHB2SMENR_GPIOBSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOBSMEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB2SMENR_GPIOBSMEN             RCC_AHB2SMENR_GPIOBSMEN_Msk
+#define RCC_AHB2SMENR_GPIOCSMEN_Pos         (2U)
+#define RCC_AHB2SMENR_GPIOCSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOCSMEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB2SMENR_GPIOCSMEN             RCC_AHB2SMENR_GPIOCSMEN_Msk
+#define RCC_AHB2SMENR_GPIOESMEN_Pos         (4U)
+#define RCC_AHB2SMENR_GPIOESMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOESMEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB2SMENR_GPIOESMEN             RCC_AHB2SMENR_GPIOESMEN_Msk
+#define RCC_AHB2SMENR_GPIOHSMEN_Pos         (7U)
+#define RCC_AHB2SMENR_GPIOHSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOHSMEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2SMENR_GPIOHSMEN             RCC_AHB2SMENR_GPIOHSMEN_Msk
+
+/********************  Bit definition for RCC_AHB3SMENR register  ***************/
+#define RCC_AHB3SMENR_PKASMEN_Pos           (16U)
+#define RCC_AHB3SMENR_PKASMEN_Msk           (0x1UL << RCC_AHB3SMENR_PKASMEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB3SMENR_PKASMEN               RCC_AHB3SMENR_PKASMEN_Msk
+#define RCC_AHB3SMENR_AES2SMEN_Pos          (17U)
+#define RCC_AHB3SMENR_AES2SMEN_Msk          (0x1UL << RCC_AHB3SMENR_AES2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_AHB3SMENR_AES2SMEN              RCC_AHB3SMENR_AES2SMEN_Msk
+#define RCC_AHB3SMENR_RNGSMEN_Pos           (18U)
+#define RCC_AHB3SMENR_RNGSMEN_Msk           (0x1UL << RCC_AHB3SMENR_RNGSMEN_Pos) /*!< 0x00040000 */
+#define RCC_AHB3SMENR_RNGSMEN                RCC_AHB3SMENR_RNGSMEN_Msk
+#define RCC_AHB3SMENR_SRAM2SMEN_Pos         (24U)
+#define RCC_AHB3SMENR_SRAM2SMEN_Msk         (0x1UL << RCC_AHB3SMENR_SRAM2SMEN_Pos) /*!< 0x01000000 */
+#define RCC_AHB3SMENR_SRAM2SMEN             RCC_AHB3SMENR_SRAM2SMEN_Msk
+#define RCC_AHB3SMENR_FLASHSMEN_Pos         (25U)
+#define RCC_AHB3SMENR_FLASHSMEN_Msk         (0x1UL << RCC_AHB3SMENR_FLASHSMEN_Pos) /*!< 0x02000000 */
+#define RCC_AHB3SMENR_FLASHSMEN             RCC_AHB3SMENR_FLASHSMEN_Msk
+
+/********************  Bit definition for RCC_APB1SMENR1 register  **************/
+#define RCC_APB1SMENR1_TIM2SMEN_Pos         (0U)
+#define RCC_APB1SMENR1_TIM2SMEN_Msk         (0x1UL << RCC_APB1SMENR1_TIM2SMEN_Pos) /*!< 0x00000001 */
+#define RCC_APB1SMENR1_TIM2SMEN             RCC_APB1SMENR1_TIM2SMEN_Msk
+#define RCC_APB1SMENR1_RTCAPBSMEN_Pos       (10U)
+#define RCC_APB1SMENR1_RTCAPBSMEN_Msk       (0x1UL << RCC_APB1SMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_APB1SMENR1_RTCAPBSMEN           RCC_APB1SMENR1_RTCAPBSMEN_Msk
+#define RCC_APB1SMENR1_WWDGSMEN_Pos         (11U)
+#define RCC_APB1SMENR1_WWDGSMEN_Msk         (0x1UL << RCC_APB1SMENR1_WWDGSMEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1SMENR1_WWDGSMEN             RCC_APB1SMENR1_WWDGSMEN_Msk
+#define RCC_APB1SMENR1_I2C1SMEN_Pos         (21U)
+#define RCC_APB1SMENR1_I2C1SMEN_Msk         (0x1UL << RCC_APB1SMENR1_I2C1SMEN_Pos) /*!< 0x00200000 */
+#define RCC_APB1SMENR1_I2C1SMEN             RCC_APB1SMENR1_I2C1SMEN_Msk
+#define RCC_APB1SMENR1_LPTIM1SMEN_Pos       (31U)
+#define RCC_APB1SMENR1_LPTIM1SMEN_Msk       (0x1UL << RCC_APB1SMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_APB1SMENR1_LPTIM1SMEN           RCC_APB1SMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_APB1SMENR2 register  **************/
+#define RCC_APB1SMENR2_LPTIM2SMEN_Pos       (5U)
+#define RCC_APB1SMENR2_LPTIM2SMEN_Msk       (0x1UL << RCC_APB1SMENR2_LPTIM2SMEN_Pos) /*!< 0x00000020 */
+#define RCC_APB1SMENR2_LPTIM2SMEN           RCC_APB1SMENR2_LPTIM2SMEN_Msk
+
+/********************  Bit definition for RCC_APB2SMENR register  **************/
+#define RCC_APB2SMENR_ADCSMEN_Pos           (9U)
+#define RCC_APB2SMENR_ADCSMEN_Msk           (0x1UL << RCC_APB2SMENR_ADCSMEN_Pos)    /*!< 0x00000200 */
+#define RCC_APB2SMENR_ADCSMEN               RCC_APB2SMENR_ADCSMEN_Msk
+#define RCC_APB2SMENR_TIM1SMEN_Pos          (11U)
+#define RCC_APB2SMENR_TIM1SMEN_Msk          (0x1UL << RCC_APB2SMENR_TIM1SMEN_Pos)   /*!< 0x00000800 */
+#define RCC_APB2SMENR_TIM1SMEN              RCC_APB2SMENR_TIM1SMEN_Msk
+#define RCC_APB2SMENR_SPI1SMEN_Pos          (12U)
+#define RCC_APB2SMENR_SPI1SMEN_Msk          (0x1UL << RCC_APB2SMENR_SPI1SMEN_Pos)   /*!< 0x00001000 */
+#define RCC_APB2SMENR_SPI1SMEN              RCC_APB2SMENR_SPI1SMEN_Msk
+#define RCC_APB2SMENR_USART1SMEN_Pos        (14U)
+#define RCC_APB2SMENR_USART1SMEN_Msk        (0x1UL << RCC_APB2SMENR_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_APB2SMENR_USART1SMEN            RCC_APB2SMENR_USART1SMEN_Msk
+
+/********************  Bit definition for RCC_CCIPR register  ******************/
+#define RCC_CCIPR_USART1SEL_Pos             (0U)
+#define RCC_CCIPR_USART1SEL_Msk             (0x3UL << RCC_CCIPR_USART1SEL_Pos) /*!< 0x00000003 */
+#define RCC_CCIPR_USART1SEL                 RCC_CCIPR_USART1SEL_Msk
+#define RCC_CCIPR_USART1SEL_0               (0x1U << RCC_CCIPR_USART1SEL_Pos)  /*!< 0x00000001 */
+#define RCC_CCIPR_USART1SEL_1               (0x2U << RCC_CCIPR_USART1SEL_Pos)  /*!< 0x00000002 */
+
+#define RCC_CCIPR_I2C1SEL_Pos               (12U)
+#define RCC_CCIPR_I2C1SEL_Msk               (0x3UL << RCC_CCIPR_I2C1SEL_Pos)   /*!< 0x00003000 */
+#define RCC_CCIPR_I2C1SEL                   RCC_CCIPR_I2C1SEL_Msk
+#define RCC_CCIPR_I2C1SEL_0                 (0x1U << RCC_CCIPR_I2C1SEL_Pos)    /*!< 0x00001000 */
+#define RCC_CCIPR_I2C1SEL_1                 (0x2U << RCC_CCIPR_I2C1SEL_Pos)    /*!< 0x00002000 */
+
+#define RCC_CCIPR_LPTIM1SEL_Pos             (18U)
+#define RCC_CCIPR_LPTIM1SEL_Msk             (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos) /*!< 0x000C0000 */
+#define RCC_CCIPR_LPTIM1SEL                 RCC_CCIPR_LPTIM1SEL_Msk
+#define RCC_CCIPR_LPTIM1SEL_0               (0x1U << RCC_CCIPR_LPTIM1SEL_Pos)  /*!< 0x00040000 */
+#define RCC_CCIPR_LPTIM1SEL_1               (0x2U << RCC_CCIPR_LPTIM1SEL_Pos)  /*!< 0x00080000 */
+
+#define RCC_CCIPR_LPTIM2SEL_Pos             (20U)
+#define RCC_CCIPR_LPTIM2SEL_Msk             (0x3UL << RCC_CCIPR_LPTIM2SEL_Pos) /*!< 0x00300000 */
+#define RCC_CCIPR_LPTIM2SEL                 RCC_CCIPR_LPTIM2SEL_Msk
+#define RCC_CCIPR_LPTIM2SEL_0               (0x1U << RCC_CCIPR_LPTIM2SEL_Pos)  /*!< 0x00100000 */
+#define RCC_CCIPR_LPTIM2SEL_1               (0x2U << RCC_CCIPR_LPTIM2SEL_Pos)  /*!< 0x00200000 */
+
+#define RCC_CCIPR_CLK48SEL_Pos              (26U)
+#define RCC_CCIPR_CLK48SEL_Msk              (0x3UL << RCC_CCIPR_CLK48SEL_Pos)  /*!< 0x0C000000 */
+#define RCC_CCIPR_CLK48SEL                  RCC_CCIPR_CLK48SEL_Msk
+#define RCC_CCIPR_CLK48SEL_0                (0x1U << RCC_CCIPR_CLK48SEL_Pos)   /*!< 0x04000000 */
+#define RCC_CCIPR_CLK48SEL_1                (0x2U << RCC_CCIPR_CLK48SEL_Pos)   /*!< 0x08000000 */
+
+#define RCC_CCIPR_ADCSEL_Pos                (28U)
+#define RCC_CCIPR_ADCSEL_Msk                (0x3UL << RCC_CCIPR_ADCSEL_Pos)    /*!< 0x30000000 */
+#define RCC_CCIPR_ADCSEL                    RCC_CCIPR_ADCSEL_Msk
+#define RCC_CCIPR_ADCSEL_0                  (0x1U << RCC_CCIPR_ADCSEL_Pos)     /*!< 0x10000000 */
+#define RCC_CCIPR_ADCSEL_1                  (0x2U << RCC_CCIPR_ADCSEL_Pos)     /*!< 0x20000000 */
+
+#define RCC_CCIPR_RNGSEL_Pos                (30U)
+#define RCC_CCIPR_RNGSEL_Msk                (0x3UL << RCC_CCIPR_RNGSEL_Pos)    /*!< 0xC0000000 */
+#define RCC_CCIPR_RNGSEL                    RCC_CCIPR_RNGSEL_Msk
+#define RCC_CCIPR_RNGSEL_0                  (0x1U << RCC_CCIPR_RNGSEL_Pos)     /*!< 0x40000000 */
+#define RCC_CCIPR_RNGSEL_1                  (0x2U << RCC_CCIPR_RNGSEL_Pos)     /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos                  (0U)
+#define RCC_BDCR_LSEON_Msk                  (0x1UL << RCC_BDCR_LSEON_Pos)      /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                      RCC_BDCR_LSEON_Msk
+#define RCC_BDCR_LSERDY_Pos                 (1U)
+#define RCC_BDCR_LSERDY_Msk                 (0x1UL << RCC_BDCR_LSERDY_Pos)     /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                     RCC_BDCR_LSERDY_Msk
+#define RCC_BDCR_LSEBYP_Pos                 (2U)
+#define RCC_BDCR_LSEBYP_Msk                 (0x1UL << RCC_BDCR_LSEBYP_Pos)     /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                     RCC_BDCR_LSEBYP_Msk
+
+#define RCC_BDCR_LSEDRV_Pos                 (3U)
+#define RCC_BDCR_LSEDRV_Msk                 (0x3UL << RCC_BDCR_LSEDRV_Pos)     /*!< 0x00000018 */
+#define RCC_BDCR_LSEDRV                     RCC_BDCR_LSEDRV_Msk
+#define RCC_BDCR_LSEDRV_0                   (0x1U << RCC_BDCR_LSEDRV_Pos)      /*!< 0x00000008 */
+#define RCC_BDCR_LSEDRV_1                   (0x2U << RCC_BDCR_LSEDRV_Pos)      /*!< 0x00000010 */
+
+#define RCC_BDCR_LSECSSON_Pos               (5U)
+#define RCC_BDCR_LSECSSON_Msk               (0x1UL << RCC_BDCR_LSECSSON_Pos)   /*!< 0x00000020 */
+#define RCC_BDCR_LSECSSON                   RCC_BDCR_LSECSSON_Msk
+#define RCC_BDCR_LSECSSD_Pos                (6U)
+#define RCC_BDCR_LSECSSD_Msk                (0x1UL << RCC_BDCR_LSECSSD_Pos)    /*!< 0x00000040 */
+#define RCC_BDCR_LSECSSD                    RCC_BDCR_LSECSSD_Msk
+
+#define RCC_BDCR_RTCSEL_Pos                 (8U)
+#define RCC_BDCR_RTCSEL_Msk                 (0x3UL << RCC_BDCR_RTCSEL_Pos)     /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                     RCC_BDCR_RTCSEL_Msk
+#define RCC_BDCR_RTCSEL_0                   (0x1U << RCC_BDCR_RTCSEL_Pos)      /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                   (0x2U << RCC_BDCR_RTCSEL_Pos)      /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos                  (15U)
+#define RCC_BDCR_RTCEN_Msk                  (0x1UL << RCC_BDCR_RTCEN_Pos)      /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                      RCC_BDCR_RTCEN_Msk
+
+#define RCC_BDCR_BDRST_Pos                  (16U)
+#define RCC_BDCR_BDRST_Msk                  (0x1UL << RCC_BDCR_BDRST_Pos)      /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                      RCC_BDCR_BDRST_Msk
+
+#define RCC_BDCR_LSCOEN_Pos                 (24U)
+#define RCC_BDCR_LSCOEN_Msk                 (0x1UL << RCC_BDCR_LSCOEN_Pos)     /*!< 0x01000000 */
+#define RCC_BDCR_LSCOEN                     RCC_BDCR_LSCOEN_Msk
+#define RCC_BDCR_LSCOSEL_Pos                (25U)
+#define RCC_BDCR_LSCOSEL_Msk                (0x1UL << RCC_BDCR_LSCOSEL_Pos)    /*!< 0x02000000 */
+#define RCC_BDCR_LSCOSEL                    RCC_BDCR_LSCOSEL_Msk
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSI1ON_Pos                  (0U)
+#define RCC_CSR_LSI1ON_Msk                  (0x1UL << RCC_CSR_LSI1ON_Pos)      /*!< 0x00000001 */
+#define RCC_CSR_LSI1ON                      RCC_CSR_LSI1ON_Msk
+#define RCC_CSR_LSI1RDY_Pos                 (1U)
+#define RCC_CSR_LSI1RDY_Msk                 (0x1UL << RCC_CSR_LSI1RDY_Pos)     /*!< 0x00000002 */
+#define RCC_CSR_LSI1RDY                     RCC_CSR_LSI1RDY_Msk
+#define RCC_CSR_LSI2ON_Pos                  (2U)
+#define RCC_CSR_LSI2ON_Msk                  (0x1UL << RCC_CSR_LSI2ON_Pos)      /*!< 0x00000004 */
+#define RCC_CSR_LSI2ON                      RCC_CSR_LSI2ON_Msk
+#define RCC_CSR_LSI2RDY_Pos                 (3U)
+#define RCC_CSR_LSI2RDY_Msk                 (0x1UL << RCC_CSR_LSI2RDY_Pos)     /*!< 0x00000008 */
+#define RCC_CSR_LSI2RDY                     RCC_CSR_LSI2RDY_Msk
+#define RCC_CSR_LSI2TRIM_Pos                (8U)
+#define RCC_CSR_LSI2TRIM_Msk                (0xFUL << RCC_CSR_LSI2TRIM_Pos)      /*!< 0x00000F00 */
+#define RCC_CSR_LSI2TRIM                    RCC_CSR_LSI2TRIM_Msk
+#define RCC_CSR_LSI2TRIM_0                  (0x1U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000100 */
+#define RCC_CSR_LSI2TRIM_1                  (0x2U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000200 */
+#define RCC_CSR_LSI2TRIM_2                  (0x4U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000400 */
+#define RCC_CSR_LSI2TRIM_3                  (0x8U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000800 */
+#define RCC_CSR_RFWKPSEL_Pos                (14U)
+#define RCC_CSR_RFWKPSEL_Msk                (0x3UL << RCC_CSR_RFWKPSEL_Pos)    /*!< 0x0000C000 */
+#define RCC_CSR_RFWKPSEL                    RCC_CSR_RFWKPSEL_Msk
+#define RCC_CSR_RFWKPSEL_0                  (0x1U << RCC_CSR_RFWKPSEL_Pos)     /*!< 0x00004000 */
+#define RCC_CSR_RFWKPSEL_1                  (0x2U << RCC_CSR_RFWKPSEL_Pos)     /*!< 0x00008000 */
+#define RCC_CSR_RFRSTS_Pos                  (16U)
+#define RCC_CSR_RFRSTS_Msk                  (0x1UL << RCC_CSR_RFRSTS_Pos)      /*!< 0x00010000 */
+#define RCC_CSR_RFRSTS                      RCC_CSR_RFRSTS_Msk
+#define RCC_CSR_RMVF_Pos                    (23U)
+#define RCC_CSR_RMVF_Msk                    (0x1UL << RCC_CSR_RMVF_Pos)        /*!< 0x00800000 */
+#define RCC_CSR_RMVF                        RCC_CSR_RMVF_Msk
+#define RCC_CSR_OBLRSTF_Pos                 (25U)
+#define RCC_CSR_OBLRSTF_Msk                 (0x1UL << RCC_CSR_OBLRSTF_Pos)     /*!< 0x02000000 */
+#define RCC_CSR_OBLRSTF                     RCC_CSR_OBLRSTF_Msk
+#define RCC_CSR_PINRSTF_Pos                 (26U)
+#define RCC_CSR_PINRSTF_Msk                 (0x1UL << RCC_CSR_PINRSTF_Pos)     /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                     RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_BORRSTF_Pos                 (27U)
+#define RCC_CSR_BORRSTF_Msk                 (0x1UL << RCC_CSR_BORRSTF_Pos)     /*!< 0x08000000 */
+#define RCC_CSR_BORRSTF                     RCC_CSR_BORRSTF_Msk
+#define RCC_CSR_SFTRSTF_Pos                 (28U)
+#define RCC_CSR_SFTRSTF_Msk                 (0x1UL << RCC_CSR_SFTRSTF_Pos)     /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                     RCC_CSR_SFTRSTF_Msk
+#define RCC_CSR_IWDGRSTF_Pos                (29U)
+#define RCC_CSR_IWDGRSTF_Msk                (0x1UL << RCC_CSR_IWDGRSTF_Pos)     /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                    RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos                (30U)
+#define RCC_CSR_WWDGRSTF_Msk                (0x1UL << RCC_CSR_WWDGRSTF_Pos)    /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                    RCC_CSR_WWDGRSTF_Msk
+#define RCC_CSR_LPWRRSTF_Pos                (31U)
+#define RCC_CSR_LPWRRSTF_Msk                (0x1UL << RCC_CSR_LPWRRSTF_Pos)    /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                    RCC_CSR_LPWRRSTF_Msk
+
+/********************  Bit definition for RCC_HSECR register  *******************/
+#define RCC_HSECR_UNLOCKED_Pos              (0U)
+#define RCC_HSECR_UNLOCKED_Msk              (0x1UL << RCC_HSECR_UNLOCKED_Pos)  /*!< 0x00000001 */
+#define RCC_HSECR_UNLOCKED                  RCC_HSECR_UNLOCKED_Msk
+
+#define RCC_HSECR_HSES_Pos                  (3U)
+#define RCC_HSECR_HSES_Msk                  (0x1UL << RCC_HSECR_HSES_Pos)      /*!< 0x00000008 */
+#define RCC_HSECR_HSES                      RCC_HSECR_HSES_Msk
+
+#define RCC_HSECR_HSEGMC_Pos                (4U)
+#define RCC_HSECR_HSEGMC_Msk                (0x7UL << RCC_HSECR_HSEGMC_Pos)       /*!< 0x00000070 */
+#define RCC_HSECR_HSEGMC                    RCC_HSECR_HSEGMC_Msk
+#define RCC_HSECR_HSEGMC0_Pos               (4U)
+#define RCC_HSECR_HSEGMC0_Msk               (0x1UL << RCC_HSECR_HSEGMC0_Pos)      /*!< 0x00000010 */
+#define RCC_HSECR_HSEGMC0                   RCC_HSECR_HSEGMC0_Msk
+#define RCC_HSECR_HSEGMC1_Pos               (5U)
+#define RCC_HSECR_HSEGMC1_Msk               (0x1UL << RCC_HSECR_HSEGMC1_Pos)      /*!< 0x00000020 */
+#define RCC_HSECR_HSEGMC1                   RCC_HSECR_HSEGMC1_Msk
+#define RCC_HSECR_HSEGMC2_Pos               (6U)
+#define RCC_HSECR_HSEGMC2_Msk               (0x1UL << RCC_HSECR_HSEGMC2_Pos)      /*!< 0x00000040 */
+#define RCC_HSECR_HSEGMC2                   RCC_HSECR_HSEGMC2_Msk
+
+#define RCC_HSECR_HSETUNE_Pos              (8U)
+#define RCC_HSECR_HSETUNE_Msk              (0x3FUL << RCC_HSECR_HSETUNE_Pos)   /*!< 0x00003F00 */
+#define RCC_HSECR_HSETUNE                  RCC_HSECR_HSETUNE_Msk
+#define RCC_HSECR_HSETUNE0_Pos             (8U)
+#define RCC_HSECR_HSETUNE0_Msk             (0x1UL << RCC_HSECR_HSETUNE0_Pos)   /*!< 0x00000100 */
+#define RCC_HSECR_HSETUNE0                 RCC_HSECR_HSETUNE0_Msk
+#define RCC_HSECR_HSETUNE1_Pos             (9U)
+#define RCC_HSECR_HSETUNE1_Msk             (0x1UL << RCC_HSECR_HSETUNE1_Pos)   /*!< 0x00000200 */
+#define RCC_HSECR_HSETUNE1                 RCC_HSECR_HSETUNE1_Msk
+#define RCC_HSECR_HSETUNE2_Pos             (10U)
+#define RCC_HSECR_HSETUNE2_Msk             (0x1UL << RCC_HSECR_HSETUNE2_Pos)   /*!< 0x00000400 */
+#define RCC_HSECR_HSETUNE2                 RCC_HSECR_HSETUNE2_Msk
+#define RCC_HSECR_HSETUNE3_Pos             (11U)
+#define RCC_HSECR_HSETUNE3_Msk             (0x1UL << RCC_HSECR_HSETUNE3_Pos)   /*!< 0x00000800 */
+#define RCC_HSECR_HSETUNE3                 RCC_HSECR_HSETUNE3_Msk
+#define RCC_HSECR_HSETUNE4_Pos             (12U)
+#define RCC_HSECR_HSETUNE4_Msk             (0x1UL << RCC_HSECR_HSETUNE4_Pos)   /*!< 0x00001000 */
+#define RCC_HSECR_HSETUNE4                 RCC_HSECR_HSETUNE4_Msk
+#define RCC_HSECR_HSETUNE5_Pos             (13U)
+#define RCC_HSECR_HSETUNE5_Msk             (0x1UL << RCC_HSECR_HSETUNE5_Pos)   /*!< 0x00002000 */
+#define RCC_HSECR_HSETUNE5                 RCC_HSECR_HSETUNE5_Msk
+
+/********************  Bit definition for RCC_EXTCFGR register  *******************/
+#define RCC_EXTCFGR_SHDHPRE_Pos             (0U)
+#define RCC_EXTCFGR_SHDHPRE_Msk             (0xFUL << RCC_EXTCFGR_SHDHPRE_Pos) /*!< 0x0000000F */
+#define RCC_EXTCFGR_SHDHPRE                 RCC_EXTCFGR_SHDHPRE_Msk
+#define RCC_EXTCFGR_SHDHPRE_0               (0x1U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000001 */
+#define RCC_EXTCFGR_SHDHPRE_1               (0x2U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000002 */
+#define RCC_EXTCFGR_SHDHPRE_2               (0x4U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000004 */
+#define RCC_EXTCFGR_SHDHPRE_3               (0x8U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000008 */
+
+#define RCC_EXTCFGR_C2HPRE_Pos              (4U)
+#define RCC_EXTCFGR_C2HPRE_Msk              (0xFUL << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x000000F0 */
+#define RCC_EXTCFGR_C2HPRE                  RCC_EXTCFGR_C2HPRE_Msk
+#define RCC_EXTCFGR_C2HPRE_0                (0x1U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000010 */
+#define RCC_EXTCFGR_C2HPRE_1                (0x2U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000020 */
+#define RCC_EXTCFGR_C2HPRE_2                (0x4U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000040 */
+#define RCC_EXTCFGR_C2HPRE_3                (0x8U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000080 */
+
+#define RCC_EXTCFGR_SHDHPREF_Pos            (16U)
+#define RCC_EXTCFGR_SHDHPREF_Msk            (0x1UL << RCC_EXTCFGR_SHDHPREF_Pos) /*!< 0x00010000 */
+#define RCC_EXTCFGR_SHDHPREF                RCC_EXTCFGR_SHDHPREF_Msk
+#define RCC_EXTCFGR_C2HPREF_Pos             (17U)
+#define RCC_EXTCFGR_C2HPREF_Msk             (0x1UL << RCC_EXTCFGR_C2HPREF_Pos) /*!< 0x00020000 */
+#define RCC_EXTCFGR_C2HPREF                 RCC_EXTCFGR_C2HPREF_Msk
+#define RCC_EXTCFGR_RFCSS_Pos               (20U)
+#define RCC_EXTCFGR_RFCSS_Msk               (0x1UL << RCC_EXTCFGR_RFCSS_Pos)   /*!< 0x00100000 */
+#define RCC_EXTCFGR_RFCSS                   RCC_EXTCFGR_RFCSS_Msk
+
+/********************  Bit definition for RCC_C2AHB1ENR register  ****************/
+#define RCC_C2AHB1ENR_DMA1EN_Pos            (0U)
+#define RCC_C2AHB1ENR_DMA1EN_Msk            (0x1UL << RCC_C2AHB1ENR_DMA1EN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB1ENR_DMA1EN                RCC_C2AHB1ENR_DMA1EN_Msk
+#define RCC_C2AHB1ENR_DMAMUX1EN_Pos         (2U)
+#define RCC_C2AHB1ENR_DMAMUX1EN_Msk         (0x1UL << RCC_C2AHB1ENR_DMAMUX1EN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB1ENR_DMAMUX1EN             RCC_C2AHB1ENR_DMAMUX1EN_Msk
+#define RCC_C2AHB1ENR_SRAM1EN_Pos           (9U)
+#define RCC_C2AHB1ENR_SRAM1EN_Msk           (0x1UL << RCC_C2AHB1ENR_SRAM1EN_Pos) /*!< 0x00000200 */
+#define RCC_C2AHB1ENR_SRAM1EN                RCC_C2AHB1ENR_SRAM1EN_Msk
+#define RCC_C2AHB1ENR_CRCEN_Pos             (12U)
+#define RCC_C2AHB1ENR_CRCEN_Msk             (0x1UL << RCC_C2AHB1ENR_CRCEN_Pos) /*!< 0x00001000 */
+#define RCC_C2AHB1ENR_CRCEN                  RCC_C2AHB1ENR_CRCEN_Msk
+#define RCC_C2AHB1ENR_TSCEN_Pos             (16U)
+#define RCC_C2AHB1ENR_TSCEN_Msk             (0x1UL << RCC_C2AHB1ENR_TSCEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB1ENR_TSCEN                 RCC_C2AHB1ENR_TSCEN_Msk
+
+/********************  Bit definition for RCC_C2AHB2ENR register  ***************/
+#define RCC_C2AHB2ENR_GPIOAEN_Pos          (0U)
+#define RCC_C2AHB2ENR_GPIOAEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOAEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB2ENR_GPIOAEN              RCC_C2AHB2ENR_GPIOAEN_Msk
+#define RCC_C2AHB2ENR_GPIOBEN_Pos          (1U)
+#define RCC_C2AHB2ENR_GPIOBEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOBEN_Pos) /*!< 0x00000002 */
+#define RCC_C2AHB2ENR_GPIOBEN              RCC_C2AHB2ENR_GPIOBEN_Msk
+#define RCC_C2AHB2ENR_GPIOCEN_Pos          (2U)
+#define RCC_C2AHB2ENR_GPIOCEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOCEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB2ENR_GPIOCEN              RCC_C2AHB2ENR_GPIOCEN_Msk
+#define RCC_C2AHB2ENR_GPIOEEN_Pos          (4U)
+#define RCC_C2AHB2ENR_GPIOEEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOEEN_Pos) /*!< 0x00000010 */
+#define RCC_C2AHB2ENR_GPIOEEN              RCC_C2AHB2ENR_GPIOEEN_Msk
+#define RCC_C2AHB2ENR_GPIOHEN_Pos          (7U)
+#define RCC_C2AHB2ENR_GPIOHEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOHEN_Pos) /*!< 0x00000080 */
+#define RCC_C2AHB2ENR_GPIOHEN              RCC_C2AHB2ENR_GPIOHEN_Msk
+
+/********************  Bit definition for RCC_C2AHB3ENR register  ***************/
+#define RCC_C2AHB3ENR_PKAEN_Pos            (16U)
+#define RCC_C2AHB3ENR_PKAEN_Msk            (0x1UL << RCC_C2AHB3ENR_PKAEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB3ENR_PKAEN                RCC_C2AHB3ENR_PKAEN_Msk
+#define RCC_C2AHB3ENR_AES2EN_Pos           (17U)
+#define RCC_C2AHB3ENR_AES2EN_Msk           (0x1UL << RCC_C2AHB3ENR_AES2EN_Pos) /*!< 0x00020000 */
+#define RCC_C2AHB3ENR_AES2EN               RCC_C2AHB3ENR_AES2EN_Msk
+#define RCC_C2AHB3ENR_RNGEN_Pos            (18U)
+#define RCC_C2AHB3ENR_RNGEN_Msk            (0x1UL << RCC_C2AHB3ENR_RNGEN_Pos) /*!< 0x00040000 */
+#define RCC_C2AHB3ENR_RNGEN                RCC_C2AHB3ENR_RNGEN_Msk
+#define RCC_C2AHB3ENR_HSEMEN_Pos           (19U)
+#define RCC_C2AHB3ENR_HSEMEN_Msk           (0x1UL << RCC_C2AHB3ENR_HSEMEN_Pos) /*!< 0x00080000 */
+#define RCC_C2AHB3ENR_HSEMEN               RCC_C2AHB3ENR_HSEMEN_Msk
+#define RCC_C2AHB3ENR_IPCCEN_Pos           (20U)
+#define RCC_C2AHB3ENR_IPCCEN_Msk           (0x1UL << RCC_C2AHB3ENR_IPCCEN_Pos) /*!< 0x00100000 */
+#define RCC_C2AHB3ENR_IPCCEN               RCC_C2AHB3ENR_IPCCEN_Msk
+#define RCC_C2AHB3ENR_FLASHEN_Pos          (25U)
+#define RCC_C2AHB3ENR_FLASHEN_Msk          (0x1UL << RCC_C2AHB3ENR_FLASHEN_Pos) /*!< 0x02000000 */
+#define RCC_C2AHB3ENR_FLASHEN              RCC_C2AHB3ENR_FLASHEN_Msk
+
+/********************  Bit definition for RCC_C2APB1ENR1 register  **************/
+#define RCC_C2APB1ENR1_TIM2EN_Pos          (0U)
+#define RCC_C2APB1ENR1_TIM2EN_Msk          (0x1UL << RCC_C2APB1ENR1_TIM2EN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1ENR1_TIM2EN              RCC_C2APB1ENR1_TIM2EN_Msk
+#define RCC_C2APB1ENR1_RTCAPBEN_Pos        (10U)
+#define RCC_C2APB1ENR1_RTCAPBEN_Msk        (0x1UL << RCC_C2APB1ENR1_RTCAPBEN_Pos) /*!< 0x00000400 */
+#define RCC_C2APB1ENR1_RTCAPBEN            RCC_C2APB1ENR1_RTCAPBEN_Msk
+#define RCC_C2APB1ENR1_I2C1EN_Pos          (21U)
+#define RCC_C2APB1ENR1_I2C1EN_Msk          (0x1UL << RCC_C2APB1ENR1_I2C1EN_Pos) /*!< 0x00200000 */
+#define RCC_C2APB1ENR1_I2C1EN              RCC_C2APB1ENR1_I2C1EN_Msk
+#define RCC_C2APB1ENR1_LPTIM1EN_Pos        (31U)
+#define RCC_C2APB1ENR1_LPTIM1EN_Msk        (0x1UL << RCC_C2APB1ENR1_LPTIM1EN_Pos) /*!< 0x80000000 */
+#define RCC_C2APB1ENR1_LPTIM1EN            RCC_C2APB1ENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_C2APB1ENR2 register  **************/
+#define RCC_C2APB1ENR2_LPTIM2EN_Pos        (5U)
+#define RCC_C2APB1ENR2_LPTIM2EN_Msk        (0x1UL << RCC_C2APB1ENR2_LPTIM2EN_Pos) /*!< 0x00000020 */
+#define RCC_C2APB1ENR2_LPTIM2EN            RCC_C2APB1ENR2_LPTIM2EN_Msk
+
+/********************  Bit definition for RCC_C2APB2ENR register  **************/
+#define RCC_C2APB2ENR_ADCEN_Pos            (9U)
+#define RCC_C2APB2ENR_ADCEN_Msk            (0x1UL << RCC_C2APB2ENR_ADCEN_Pos)    /*!< 0x00000200 */
+#define RCC_C2APB2ENR_ADCEN                RCC_C2APB2ENR_ADCEN_Msk
+#define RCC_C2APB2ENR_TIM1EN_Pos           (11U)
+#define RCC_C2APB2ENR_TIM1EN_Msk           (0x1UL << RCC_C2APB2ENR_TIM1EN_Pos)   /*!< 0x00000800 */
+#define RCC_C2APB2ENR_TIM1EN               RCC_C2APB2ENR_TIM1EN_Msk
+#define RCC_C2APB2ENR_SPI1EN_Pos           (12U)
+#define RCC_C2APB2ENR_SPI1EN_Msk           (0x1UL << RCC_C2APB2ENR_SPI1EN_Pos)   /*!< 0x00001000 */
+#define RCC_C2APB2ENR_SPI1EN               RCC_C2APB2ENR_SPI1EN_Msk
+#define RCC_C2APB2ENR_USART1EN_Pos         (14U)
+#define RCC_C2APB2ENR_USART1EN_Msk         (0x1UL << RCC_C2APB2ENR_USART1EN_Pos) /*!< 0x00004000 */
+#define RCC_C2APB2ENR_USART1EN             RCC_C2APB2ENR_USART1EN_Msk
+
+/********************  Bit definition for RCC_C2APB3ENR register  **************/
+#define RCC_C2APB3ENR_BLEEN_Pos            (0U)
+#define RCC_C2APB3ENR_BLEEN_Msk            (0x1UL << RCC_C2APB3ENR_BLEEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB3ENR_BLEEN                RCC_C2APB3ENR_BLEEN_Msk
+
+/********************  Bit definition for RCC_C2AHB1SMENR register  ****************/
+#define RCC_C2AHB1SMENR_DMA1SMEN_Pos       (0U)
+#define RCC_C2AHB1SMENR_DMA1SMEN_Msk       (0x1UL << RCC_C2AHB1SMENR_DMA1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB1SMENR_DMA1SMEN           RCC_C2AHB1SMENR_DMA1SMEN_Msk
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN_Pos    (2U)
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN_Msk    (0x1UL << RCC_C2AHB1SMENR_DMAMUX1SMEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN        RCC_C2AHB1SMENR_DMAMUX1SMEN_Msk
+#define RCC_C2AHB1SMENR_SRAM1SMEN_Pos      (9U)
+#define RCC_C2AHB1SMENR_SRAM1SMEN_Msk      (0x1UL << RCC_C2AHB1SMENR_SRAM1SMEN_Pos) /*!< 0x00000200 */
+#define RCC_C2AHB1SMENR_SRAM1SMEN          RCC_C2AHB1SMENR_SRAM1SMEN_Msk
+#define RCC_C2AHB1SMENR_CRCSMEN_Pos        (12U)
+#define RCC_C2AHB1SMENR_CRCSMEN_Msk        (0x1UL << RCC_C2AHB1SMENR_CRCSMEN_Pos) /*!< 0x00001000 */
+#define RCC_C2AHB1SMENR_CRCSMEN            RCC_C2AHB1SMENR_CRCSMEN_Msk
+#define RCC_C2AHB1SMENR_TSCSMEN_Pos        (16U)
+#define RCC_C2AHB1SMENR_TSCSMEN_Msk        (0x1UL << RCC_C2AHB1SMENR_TSCSMEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB1SMENR_TSCSMEN            RCC_C2AHB1SMENR_TSCSMEN_Msk
+
+/********************  Bit definition for RCC_C2AHB2SMENR register  ***************/
+#define RCC_C2AHB2SMENR_GPIOASMEN_Pos      (0U)
+#define RCC_C2AHB2SMENR_GPIOASMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOASMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB2SMENR_GPIOASMEN          RCC_C2AHB2SMENR_GPIOASMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOBSMEN_Pos      (1U)
+#define RCC_C2AHB2SMENR_GPIOBSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOBSMEN_Pos) /*!< 0x00000002 */
+#define RCC_C2AHB2SMENR_GPIOBSMEN          RCC_C2AHB2SMENR_GPIOBSMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOCSMEN_Pos      (2U)
+#define RCC_C2AHB2SMENR_GPIOCSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOCSMEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB2SMENR_GPIOCSMEN          RCC_C2AHB2SMENR_GPIOCSMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOESMEN_Pos      (4U)
+#define RCC_C2AHB2SMENR_GPIOESMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOESMEN_Pos) /*!< 0x00000010 */
+#define RCC_C2AHB2SMENR_GPIOESMEN          RCC_C2AHB2SMENR_GPIOESMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOHSMEN_Pos      (7U)
+#define RCC_C2AHB2SMENR_GPIOHSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOHSMEN_Pos) /*!< 0x00000080 */
+#define RCC_C2AHB2SMENR_GPIOHSMEN          RCC_C2AHB2SMENR_GPIOHSMEN_Msk
+
+/********************  Bit definition for RCC_C2AHB3SMENR register  ***************/
+#define RCC_C2AHB3SMENR_PKASMEN_Pos        (16U)
+#define RCC_C2AHB3SMENR_PKASMEN_Msk        (0x1UL << RCC_C2AHB3SMENR_PKASMEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB3SMENR_PKASMEN            RCC_C2AHB3SMENR_PKASMEN_Msk
+#define RCC_C2AHB3SMENR_AES2SMEN_Pos       (17U)
+#define RCC_C2AHB3SMENR_AES2SMEN_Msk       (0x1UL << RCC_C2AHB3SMENR_AES2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_C2AHB3SMENR_AES2SMEN           RCC_C2AHB3SMENR_AES2SMEN_Msk
+#define RCC_C2AHB3SMENR_RNGSMEN_Pos        (18U)
+#define RCC_C2AHB3SMENR_RNGSMEN_Msk        (0x1UL << RCC_C2AHB3SMENR_RNGSMEN_Pos) /*!< 0x00040000 */
+#define RCC_C2AHB3SMENR_RNGSMEN            RCC_C2AHB3SMENR_RNGSMEN_Msk
+#define RCC_C2AHB3SMENR_SRAM2SMEN_Pos      (24U)
+#define RCC_C2AHB3SMENR_SRAM2SMEN_Msk      (0x1UL << RCC_C2AHB3SMENR_SRAM2SMEN_Pos) /*!< 0x01000000 */
+#define RCC_C2AHB3SMENR_SRAM2SMEN           RCC_C2AHB3SMENR_SRAM2SMEN_Msk
+#define RCC_C2AHB3SMENR_FLASHSMEN_Pos      (25U)
+#define RCC_C2AHB3SMENR_FLASHSMEN_Msk      (0x1UL << RCC_C2AHB3SMENR_FLASHSMEN_Pos) /*!< 0x02000000 */
+#define RCC_C2AHB3SMENR_FLASHSMEN          RCC_C2AHB3SMENR_FLASHSMEN_Msk
+
+/********************  Bit definition for RCC_C2APB1SMENR1 register  **************/
+#define RCC_C2APB1SMENR1_TIM2SMEN_Pos      (0U)
+#define RCC_C2APB1SMENR1_TIM2SMEN_Msk      (0x1UL << RCC_C2APB1SMENR1_TIM2SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1SMENR1_TIM2SMEN          RCC_C2APB1SMENR1_TIM2SMEN_Msk
+#define RCC_C2APB1SMENR1_RTCAPBSMEN_Pos    (10U)
+#define RCC_C2APB1SMENR1_RTCAPBSMEN_Msk    (0x1UL << RCC_C2APB1SMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_C2APB1SMENR1_RTCAPBSMEN        RCC_C2APB1SMENR1_RTCAPBSMEN_Msk
+#define RCC_C2APB1SMENR1_I2C1SMEN_Pos      (21U)
+#define RCC_C2APB1SMENR1_I2C1SMEN_Msk      (0x1UL << RCC_C2APB1SMENR1_I2C1SMEN_Pos) /*!< 0x00200000 */
+#define RCC_C2APB1SMENR1_I2C1SMEN          RCC_C2APB1SMENR1_I2C1SMEN_Msk
+#define RCC_C2APB1SMENR1_LPTIM1SMEN_Pos    (31U)
+#define RCC_C2APB1SMENR1_LPTIM1SMEN_Msk    (0x1UL << RCC_C2APB1SMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_C2APB1SMENR1_LPTIM1SMEN        RCC_C2APB1SMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB1SMENR2 register  **************/
+#define RCC_C2APB1SMENR2_LPTIM2SMEN_Pos     (5U)
+#define RCC_C2APB1SMENR2_LPTIM2SMEN_Msk     (0x1UL << RCC_C2APB1SMENR2_LPTIM2SMEN_Pos) /*!< 0x00000020 */
+#define RCC_C2APB1SMENR2_LPTIM2SMEN         RCC_C2APB1SMENR2_LPTIM2SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB2SMENR register  **************/
+#define RCC_C2APB2SMENR_ADCSMEN_Pos        (9U)
+#define RCC_C2APB2SMENR_ADCSMEN_Msk        (0x1UL << RCC_C2APB2SMENR_ADCSMEN_Pos)    /*!< 0x00000200 */
+#define RCC_C2APB2SMENR_ADCSMEN            RCC_C2APB2SMENR_ADCSMEN_Msk
+#define RCC_C2APB2SMENR_TIM1SMEN_Pos       (11U)
+#define RCC_C2APB2SMENR_TIM1SMEN_Msk       (0x1UL << RCC_C2APB2SMENR_TIM1SMEN_Pos)   /*!< 0x00000800 */
+#define RCC_C2APB2SMENR_TIM1SMEN           RCC_C2APB2SMENR_TIM1SMEN_Msk
+#define RCC_C2APB2SMENR_SPI1SMEN_Pos       (12U)
+#define RCC_C2APB2SMENR_SPI1SMEN_Msk       (0x1UL << RCC_C2APB2SMENR_SPI1SMEN_Pos)   /*!< 0x00001000 */
+#define RCC_C2APB2SMENR_SPI1SMEN           RCC_C2APB2SMENR_SPI1SMEN_Msk
+#define RCC_C2APB2SMENR_USART1SMEN_Pos     (14U)
+#define RCC_C2APB2SMENR_USART1SMEN_Msk     (0x1UL << RCC_C2APB2SMENR_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_C2APB2SMENR_USART1SMEN         RCC_C2APB2SMENR_USART1SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB3SMENR register  **************/
+#define RCC_C2APB3SMENR_BLESMEN_Pos        (0U)
+#define RCC_C2APB3SMENR_BLESMEN_Msk        (0x1UL << RCC_C2APB3SMENR_BLESMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB3SMENR_BLESMEN            RCC_C2APB3SMENR_BLESMEN_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for  register  *******************/
+#define RNG_CR_RNGEN_Pos    (2U)
+#define RNG_CR_RNGEN_Msk    (0x1UL << RNG_CR_RNGEN_Pos)                        /*!< 0x00000004 */
+#define RNG_CR_RNGEN        RNG_CR_RNGEN_Msk
+#define RNG_CR_IE_Pos       (3U)
+#define RNG_CR_IE_Msk       (0x1UL << RNG_CR_IE_Pos)                           /*!< 0x00000008 */
+#define RNG_CR_IE           RNG_CR_IE_Msk
+#define RNG_CR_CED_Pos      (5U)
+#define RNG_CR_CED_Msk      (0x1UL << RNG_CR_CED_Pos)                          /*!< 0x00000020 */
+#define RNG_CR_CED          RNG_CR_CED_Msk
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY_Pos     (0U)
+#define RNG_SR_DRDY_Msk     (0x1UL << RNG_SR_DRDY_Pos)                         /*!< 0x00000001 */
+#define RNG_SR_DRDY         RNG_SR_DRDY_Msk
+#define RNG_SR_CECS_Pos     (1U)
+#define RNG_SR_CECS_Msk     (0x1UL << RNG_SR_CECS_Pos)                         /*!< 0x00000002 */
+#define RNG_SR_CECS         RNG_SR_CECS_Msk
+#define RNG_SR_SECS_Pos     (2U)
+#define RNG_SR_SECS_Msk     (0x1UL << RNG_SR_SECS_Pos)                         /*!< 0x00000004 */
+#define RNG_SR_SECS         RNG_SR_SECS_Msk
+#define RNG_SR_CEIS_Pos     (5U)
+#define RNG_SR_CEIS_Msk     (0x1UL << RNG_SR_CEIS_Pos)                         /*!< 0x00000020 */
+#define RNG_SR_CEIS         RNG_SR_CEIS_Msk
+#define RNG_SR_SEIS_Pos     (6U)
+#define RNG_SR_SEIS_Msk     (0x1UL << RNG_SR_SEIS_Pos)                         /*!< 0x00000040 */
+#define RNG_SR_SEIS         RNG_SR_SEIS_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+  * @brief Specific device feature definitions
+  */
+#define RTC_TAMPER2_SUPPORT
+#define RTC_WAKEUP_SUPPORT
+#define RTC_BACKUP_SUPPORT
+#define RTC_CPU2_SUPPORT_D
+#define RTC_INTERNALTS_SUPPORT
+
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                  (22U)
+#define RTC_TR_PM_Msk                  (0x1UL << RTC_TR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TR_PM                      RTC_TR_PM_Msk                           /*!< AM/PM notation */
+#define RTC_TR_HT_Pos                  (20U)
+#define RTC_TR_HT_Msk                  (0x3UL << RTC_TR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TR_HT                      RTC_TR_HT_Msk                           /*!< Hour tens in BCD format */
+#define RTC_TR_HT_0                    (0x1U << RTC_TR_HT_Pos)                 /*!< 0x00100000 */
+#define RTC_TR_HT_1                    (0x2U << RTC_TR_HT_Pos)                 /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                  (16U)
+#define RTC_TR_HU_Msk                  (0xFUL << RTC_TR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TR_HU                      RTC_TR_HU_Msk                           /*!< Hour units in BCD format */
+#define RTC_TR_HU_0                    (0x1U << RTC_TR_HU_Pos)                 /*!< 0x00010000 */
+#define RTC_TR_HU_1                    (0x2U << RTC_TR_HU_Pos)                 /*!< 0x00020000 */
+#define RTC_TR_HU_2                    (0x4U << RTC_TR_HU_Pos)                 /*!< 0x00040000 */
+#define RTC_TR_HU_3                    (0x8U << RTC_TR_HU_Pos)                 /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos                 (12U)
+#define RTC_TR_MNT_Msk                 (0x7UL << RTC_TR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TR_MNT                     RTC_TR_MNT_Msk                          /*!< Minute tens in BCD format */
+#define RTC_TR_MNT_0                   (0x1U << RTC_TR_MNT_Pos)                /*!< 0x00001000 */
+#define RTC_TR_MNT_1                   (0x2U << RTC_TR_MNT_Pos)                /*!< 0x00002000 */
+#define RTC_TR_MNT_2                   (0x4U << RTC_TR_MNT_Pos)                /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos                 (8U)
+#define RTC_TR_MNU_Msk                 (0xFUL << RTC_TR_MNU_Pos)               /*!< 0x00000F00 */
+#define RTC_TR_MNU                     RTC_TR_MNU_Msk                          /*!< Minute unit in BCD format */
+#define RTC_TR_MNU_0                   (0x1U << RTC_TR_MNU_Pos)                /*!< 0x00000100 */
+#define RTC_TR_MNU_1                   (0x2U << RTC_TR_MNU_Pos)                /*!< 0x00000200 */
+#define RTC_TR_MNU_2                   (0x4U << RTC_TR_MNU_Pos)                /*!< 0x00000400 */
+#define RTC_TR_MNU_3                   (0x8U << RTC_TR_MNU_Pos)                /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                  (4U)
+#define RTC_TR_ST_Msk                  (0x7UL << RTC_TR_ST_Pos)                /*!< 0x00000070 */
+#define RTC_TR_ST                      RTC_TR_ST_Msk                           /*!< Second tens in BCD format */
+#define RTC_TR_ST_0                    (0x1U << RTC_TR_ST_Pos)                 /*!< 0x00000010 */
+#define RTC_TR_ST_1                    (0x2U << RTC_TR_ST_Pos)                 /*!< 0x00000020 */
+#define RTC_TR_ST_2                    (0x4U << RTC_TR_ST_Pos)                 /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                  (0U)
+#define RTC_TR_SU_Msk                  (0xFUL << RTC_TR_SU_Pos)                /*!< 0x0000000F */
+#define RTC_TR_SU                      RTC_TR_SU_Msk                           /*!< Second units in BCD format */
+#define RTC_TR_SU_0                    (0x1U << RTC_TR_SU_Pos)                 /*!< 0x00000001 */
+#define RTC_TR_SU_1                    (0x2U << RTC_TR_SU_Pos)                 /*!< 0x00000002 */
+#define RTC_TR_SU_2                    (0x4U << RTC_TR_SU_Pos)                 /*!< 0x00000004 */
+#define RTC_TR_SU_3                    (0x8U << RTC_TR_SU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                  (20U)
+#define RTC_DR_YT_Msk                  (0xFUL << RTC_DR_YT_Pos)                /*!< 0x00F00000 */
+#define RTC_DR_YT                      RTC_DR_YT_Msk                           /*!< Year tens in BCD format */
+#define RTC_DR_YT_0                    (0x1U << RTC_DR_YT_Pos)                 /*!< 0x00100000 */
+#define RTC_DR_YT_1                    (0x2U << RTC_DR_YT_Pos)                 /*!< 0x00200000 */
+#define RTC_DR_YT_2                    (0x4U << RTC_DR_YT_Pos)                 /*!< 0x00400000 */
+#define RTC_DR_YT_3                    (0x8U << RTC_DR_YT_Pos)                 /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                  (16U)
+#define RTC_DR_YU_Msk                  (0xFUL << RTC_DR_YU_Pos)                /*!< 0x000F0000 */
+#define RTC_DR_YU                      RTC_DR_YU_Msk                           /*!< Years units in BCD format */
+#define RTC_DR_YU_0                    (0x1U << RTC_DR_YU_Pos)                 /*!< 0x00010000 */
+#define RTC_DR_YU_1                    (0x2U << RTC_DR_YU_Pos)                 /*!< 0x00020000 */
+#define RTC_DR_YU_2                    (0x4U << RTC_DR_YU_Pos)                 /*!< 0x00040000 */
+#define RTC_DR_YU_3                    (0x8U << RTC_DR_YU_Pos)                 /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos                 (13U)
+#define RTC_DR_WDU_Msk                 (0x7UL << RTC_DR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_DR_WDU                     RTC_DR_WDU_Msk                          /*!< Week day units */
+#define RTC_DR_WDU_0                   (0x1U << RTC_DR_WDU_Pos)                /*!< 0x00002000 */
+#define RTC_DR_WDU_1                   (0x2U << RTC_DR_WDU_Pos)                /*!< 0x00004000 */
+#define RTC_DR_WDU_2                   (0x4U << RTC_DR_WDU_Pos)                /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                  (12U)
+#define RTC_DR_MT_Msk                  (0x1UL << RTC_DR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_DR_MT                      RTC_DR_MT_Msk                           /*!< Month tens in BCD format */
+#define RTC_DR_MU_Pos                  (8U)
+#define RTC_DR_MU_Msk                  (0xFUL << RTC_DR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_DR_MU                      RTC_DR_MU_Msk                           /*!< Month units in BCD format */
+#define RTC_DR_MU_0                    (0x1U << RTC_DR_MU_Pos)                 /*!< 0x00000100 */
+#define RTC_DR_MU_1                    (0x2U << RTC_DR_MU_Pos)                 /*!< 0x00000200 */
+#define RTC_DR_MU_2                    (0x4U << RTC_DR_MU_Pos)                 /*!< 0x00000400 */
+#define RTC_DR_MU_3                    (0x8U << RTC_DR_MU_Pos)                 /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                  (4U)
+#define RTC_DR_DT_Msk                  (0x3UL << RTC_DR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_DR_DT                      RTC_DR_DT_Msk                           /*!< Date tens in BCD format */
+#define RTC_DR_DT_0                    (0x1U << RTC_DR_DT_Pos)                 /*!< 0x00000010 */
+#define RTC_DR_DT_1                    (0x2U << RTC_DR_DT_Pos)                 /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                  (0U)
+#define RTC_DR_DU_Msk                  (0xFUL << RTC_DR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_DR_DU                      RTC_DR_DU_Msk                           /*!< Date units in BCD format */
+#define RTC_DR_DU_0                    (0x1U << RTC_DR_DU_Pos)                 /*!< 0x00000001 */
+#define RTC_DR_DU_1                    (0x2U << RTC_DR_DU_Pos)                 /*!< 0x00000002 */
+#define RTC_DR_DU_2                    (0x4U << RTC_DR_DU_Pos)                 /*!< 0x00000004 */
+#define RTC_DR_DU_3                    (0x8U << RTC_DR_DU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_ITSE_Pos                (24U)
+#define RTC_CR_ITSE_Msk                (0x1UL << RTC_CR_ITSE_Pos)              /*!< 0x01000000 */
+#define RTC_CR_ITSE                    RTC_CR_ITSE_Msk                         /*!< Timestamp on internal event enable */
+#define RTC_CR_COE_Pos                 (23U)
+#define RTC_CR_COE_Msk                 (0x1UL << RTC_CR_COE_Pos)               /*!< 0x00800000 */
+#define RTC_CR_COE                     RTC_CR_COE_Msk                          /*!< Calibration output enable */
+#define RTC_CR_OSEL_Pos                (21U)
+#define RTC_CR_OSEL_Msk                (0x3UL << RTC_CR_OSEL_Pos)              /*!< 0x00600000 */
+#define RTC_CR_OSEL                    RTC_CR_OSEL_Msk                         /*!< Output selection */
+#define RTC_CR_OSEL_0                  (0x1U << RTC_CR_OSEL_Pos)               /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
+#define RTC_CR_POL_Pos                 (20U)
+#define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
+#define RTC_CR_COSEL_Pos               (19U)
+#define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
+#define RTC_CR_BKP_Pos                 (18U)
+#define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
+#define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
+#define RTC_CR_SUB1H_Pos               (17U)
+#define RTC_CR_SUB1H_Msk               (0x1UL << RTC_CR_SUB1H_Pos)             /*!< 0x00020000 */
+#define RTC_CR_SUB1H                   RTC_CR_SUB1H_Msk                        /*!< Subtract 1 hour (winter time change) */
+#define RTC_CR_ADD1H_Pos               (16U)
+#define RTC_CR_ADD1H_Msk               (0x1UL << RTC_CR_ADD1H_Pos)             /*!< 0x00010000 */
+#define RTC_CR_ADD1H                   RTC_CR_ADD1H_Msk                        /*!< Add 1 hour (summer time change) */
+#define RTC_CR_TSIE_Pos                (15U)
+#define RTC_CR_TSIE_Msk                (0x1UL << RTC_CR_TSIE_Pos)              /*!< 0x00008000 */
+#define RTC_CR_TSIE                    RTC_CR_TSIE_Msk                         /*!< Time-stamp interrupt enable */
+#define RTC_CR_WUTIE_Pos               (14U)
+#define RTC_CR_WUTIE_Msk               (0x1UL << RTC_CR_WUTIE_Pos)             /*!< 0x00004000 */
+#define RTC_CR_WUTIE                   RTC_CR_WUTIE_Msk                        /*!< Wakeup timer interrupt enable */
+#define RTC_CR_ALRBIE_Pos              (13U)
+#define RTC_CR_ALRBIE_Msk              (0x1UL << RTC_CR_ALRBIE_Pos)            /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                  RTC_CR_ALRBIE_Msk                       /*!< Alarm B interrupt enable */
+#define RTC_CR_ALRAIE_Pos              (12U)
+#define RTC_CR_ALRAIE_Msk              (0x1UL << RTC_CR_ALRAIE_Pos)            /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                  RTC_CR_ALRAIE_Msk                       /*!< Alarm A interrupt enable */
+#define RTC_CR_TSE_Pos                 (11U)
+#define RTC_CR_TSE_Msk                 (0x1UL << RTC_CR_TSE_Pos)               /*!< 0x00000800 */
+#define RTC_CR_TSE                     RTC_CR_TSE_Msk                          /*!< Timestamp on RTC TS input edge enable */
+#define RTC_CR_WUTE_Pos                (10U)
+#define RTC_CR_WUTE_Msk                (0x1UL << RTC_CR_WUTE_Pos)              /*!< 0x00000400 */
+#define RTC_CR_WUTE                    RTC_CR_WUTE_Msk                         /*!< Wakeup timer enable */
+#define RTC_CR_ALRBE_Pos               (9U)
+#define RTC_CR_ALRBE_Msk               (0x1UL << RTC_CR_ALRBE_Pos)             /*!< 0x00000200 */
+#define RTC_CR_ALRBE                   RTC_CR_ALRBE_Msk                        /*!< Alarm B enable */
+#define RTC_CR_ALRAE_Pos               (8U)
+#define RTC_CR_ALRAE_Msk               (0x1UL << RTC_CR_ALRAE_Pos)             /*!< 0x00000100 */
+#define RTC_CR_ALRAE                   RTC_CR_ALRAE_Msk                        /*!< Alarm A enable */
+#define RTC_CR_FMT_Pos                 (6U)
+#define RTC_CR_FMT_Msk                 (0x1UL << RTC_CR_FMT_Pos)               /*!< 0x00000040 */
+#define RTC_CR_FMT                     RTC_CR_FMT_Msk                          /*!< Hour AM/PM or 24H format */
+#define RTC_CR_BYPSHAD_Pos             (5U)
+#define RTC_CR_BYPSHAD_Msk             (0x1UL << RTC_CR_BYPSHAD_Pos)           /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD                 RTC_CR_BYPSHAD_Msk                      /*!< Bypass the shadow registers */
+#define RTC_CR_REFCKON_Pos             (4U)
+#define RTC_CR_REFCKON_Msk             (0x1UL << RTC_CR_REFCKON_Pos)           /*!< 0x00000010 */
+#define RTC_CR_REFCKON                 RTC_CR_REFCKON_Msk                      /*!< RTC_REFIN reference clock detection enable (50 or 60 Hz) */
+#define RTC_CR_TSEDGE_Pos              (3U)
+#define RTC_CR_TSEDGE_Msk              (0x1UL << RTC_CR_TSEDGE_Pos)            /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                  RTC_CR_TSEDGE_Msk                       /*!< Timestamp event active edge */
+#define RTC_CR_WUCKSEL_Pos             (0U)
+#define RTC_CR_WUCKSEL_Msk             (0x7UL << RTC_CR_WUCKSEL_Pos)           /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL                 RTC_CR_WUCKSEL_Msk                      /*!< Wakekup clock selection */
+#define RTC_CR_WUCKSEL_0               (0x1U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1               (0x2U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2               (0x4U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000004 */
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_ITSF_Pos               (17U)
+#define RTC_ISR_ITSF_Msk               (0x1UL << RTC_ISR_ITSF_Pos)             /*!< 0x00020000 */
+#define RTC_ISR_ITSF                   RTC_ISR_ITSF_Msk                        /*!< Internal timestamp flag */
+#define RTC_ISR_RECALPF_Pos            (16U)
+#define RTC_ISR_RECALPF_Msk            (0x1UL << RTC_ISR_RECALPF_Pos)          /*!< 0x00010000 */
+#define RTC_ISR_RECALPF                RTC_ISR_RECALPF_Msk                     /*!< Recalibration pending flag */
+#define RTC_ISR_TAMP2F_Pos             (14U)
+#define RTC_ISR_TAMP2F_Msk             (0x1UL << RTC_ISR_TAMP2F_Pos)           /*!< 0x00004000 */
+#define RTC_ISR_TAMP2F                 RTC_ISR_TAMP2F_Msk                      /*!< RTC_TAMP2 detection flag */
+#define RTC_ISR_TSOVF_Pos              (12U)
+#define RTC_ISR_TSOVF_Msk              (0x1UL << RTC_ISR_TSOVF_Pos)            /*!< 0x00001000 */
+#define RTC_ISR_TSOVF                  RTC_ISR_TSOVF_Msk                       /*!< Timestamp overflow flag */
+#define RTC_ISR_TSF_Pos                (11U)
+#define RTC_ISR_TSF_Msk                (0x1UL << RTC_ISR_TSF_Pos)              /*!< 0x00000800 */
+#define RTC_ISR_TSF                    RTC_ISR_TSF_Msk                         /*!< Timestamp flag */
+#define RTC_ISR_WUTF_Pos               (10U)
+#define RTC_ISR_WUTF_Msk               (0x1UL << RTC_ISR_WUTF_Pos)             /*!< 0x00000400 */
+#define RTC_ISR_WUTF                   RTC_ISR_WUTF_Msk                        /*!< Wakeup timer flag */
+#define RTC_ISR_ALRBF_Pos              (9U)
+#define RTC_ISR_ALRBF_Msk              (0x1UL << RTC_ISR_ALRBF_Pos)            /*!< 0x00000200 */
+#define RTC_ISR_ALRBF                  RTC_ISR_ALRBF_Msk                       /*!< Alarm B flag */
+#define RTC_ISR_ALRAF_Pos              (8U)
+#define RTC_ISR_ALRAF_Msk              (0x1UL << RTC_ISR_ALRAF_Pos)            /*!< 0x00000100 */
+#define RTC_ISR_ALRAF                  RTC_ISR_ALRAF_Msk                       /*!< Alarm A flag */
+#define RTC_ISR_INIT_Pos               (7U)
+#define RTC_ISR_INIT_Msk               (0x1UL << RTC_ISR_INIT_Pos)             /*!< 0x00000080 */
+#define RTC_ISR_INIT                   RTC_ISR_INIT_Msk                        /*!< Initialization mode */
+#define RTC_ISR_INITF_Pos              (6U)
+#define RTC_ISR_INITF_Msk              (0x1UL << RTC_ISR_INITF_Pos)            /*!< 0x00000040 */
+#define RTC_ISR_INITF                  RTC_ISR_INITF_Msk                       /*!< Initialization flag */
+#define RTC_ISR_RSF_Pos                (5U)
+#define RTC_ISR_RSF_Msk                (0x1UL << RTC_ISR_RSF_Pos)              /*!< 0x00000020 */
+#define RTC_ISR_RSF                    RTC_ISR_RSF_Msk                         /*!< Registers synchronization flag */
+#define RTC_ISR_INITS_Pos              (4U)
+#define RTC_ISR_INITS_Msk              (0x1UL << RTC_ISR_INITS_Pos)            /*!< 0x00000010 */
+#define RTC_ISR_INITS                  RTC_ISR_INITS_Msk                       /*!< Initialization status flag */
+#define RTC_ISR_SHPF_Pos               (3U)
+#define RTC_ISR_SHPF_Msk               (0x1UL << RTC_ISR_SHPF_Pos)             /*!< 0x00000008 */
+#define RTC_ISR_SHPF                   RTC_ISR_SHPF_Msk                        /*!< Shift operation pending */
+#define RTC_ISR_WUTWF_Pos              (2U)
+#define RTC_ISR_WUTWF_Msk              (0x1UL << RTC_ISR_WUTWF_Pos)            /*!< 0x00000004 */
+#define RTC_ISR_WUTWF                  RTC_ISR_WUTWF_Msk                       /*!< Wakeup timer write flag */
+#define RTC_ISR_ALRBWF_Pos             (1U)
+#define RTC_ISR_ALRBWF_Msk             (0x1UL << RTC_ISR_ALRBWF_Pos)           /*!< 0x00000002 */
+#define RTC_ISR_ALRBWF                 RTC_ISR_ALRBWF_Msk                      /*!< Alarm B write flag */
+#define RTC_ISR_ALRAWF_Pos             (0U)
+#define RTC_ISR_ALRAWF_Msk             (0x1UL << RTC_ISR_ALRAWF_Pos)           /*!< 0x00000001 */
+#define RTC_ISR_ALRAWF                 RTC_ISR_ALRAWF_Msk                      /*!< Alarm A write flag */
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos          (16U)
+#define RTC_PRER_PREDIV_A_Msk          (0x7FUL << RTC_PRER_PREDIV_A_Pos)       /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A              RTC_PRER_PREDIV_A_Msk                   /*!< Asynchronous prescaler factor */
+#define RTC_PRER_PREDIV_S_Pos          (0U)
+#define RTC_PRER_PREDIV_S_Msk          (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)     /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S              RTC_PRER_PREDIV_S_Msk                   /*!< Synchronous prescaler factor */
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos               (0U)
+#define RTC_WUTR_WUT_Msk               (0xFFFFUL << RTC_WUTR_WUT_Pos)          /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                   RTC_WUTR_WUT_Msk                        /*!< Wakeup auto-reload value bits */
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos            (31U)
+#define RTC_ALRMAR_MSK4_Msk            (0x1UL << RTC_ALRMAR_MSK4_Pos)          /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4                RTC_ALRMAR_MSK4_Msk                     /*!< Alarm A date mask */
+#define RTC_ALRMAR_WDSEL_Pos           (30U)
+#define RTC_ALRMAR_WDSEL_Msk           (0x1UL << RTC_ALRMAR_WDSEL_Pos)         /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL               RTC_ALRMAR_WDSEL_Msk                    /*!< Alarm A week day selection */
+#define RTC_ALRMAR_DT_Pos              (28U)
+#define RTC_ALRMAR_DT_Msk              (0x3UL << RTC_ALRMAR_DT_Pos)            /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                  RTC_ALRMAR_DT_Msk                       /*!< Alarm A date tens in BCD format */
+#define RTC_ALRMAR_DT_0                (0x1U << RTC_ALRMAR_DT_Pos)             /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1                (0x2U << RTC_ALRMAR_DT_Pos)             /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos              (24U)
+#define RTC_ALRMAR_DU_Msk              (0xFUL << RTC_ALRMAR_DU_Pos)            /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                  RTC_ALRMAR_DU_Msk                       /*!< Alarm A date units in BCD format */
+#define RTC_ALRMAR_DU_0                (0x1U << RTC_ALRMAR_DU_Pos)             /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1                (0x2U << RTC_ALRMAR_DU_Pos)             /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2                (0x4U << RTC_ALRMAR_DU_Pos)             /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3                (0x8U << RTC_ALRMAR_DU_Pos)             /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos            (23U)
+#define RTC_ALRMAR_MSK3_Msk            (0x1UL << RTC_ALRMAR_MSK3_Pos)          /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3                RTC_ALRMAR_MSK3_Msk                     /*!< Alarm A hours mask */
+#define RTC_ALRMAR_PM_Pos              (22U)
+#define RTC_ALRMAR_PM_Msk              (0x1UL << RTC_ALRMAR_PM_Pos)            /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                  RTC_ALRMAR_PM_Msk                       /*!< Alarm A AM/PM or 24H format */
+#define RTC_ALRMAR_HT_Pos              (20U)
+#define RTC_ALRMAR_HT_Msk              (0x3UL << RTC_ALRMAR_HT_Pos)            /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                  RTC_ALRMAR_HT_Msk                       /*!< Alarm A hour tens in BCD format */
+#define RTC_ALRMAR_HT_0                (0x1U << RTC_ALRMAR_HT_Pos)             /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1                (0x2U << RTC_ALRMAR_HT_Pos)             /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos              (16U)
+#define RTC_ALRMAR_HU_Msk              (0xFUL << RTC_ALRMAR_HU_Pos)            /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                  RTC_ALRMAR_HU_Msk                       /*!< Alarm A hour units in BCD format */
+#define RTC_ALRMAR_HU_0                (0x1U << RTC_ALRMAR_HU_Pos)             /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1                (0x2U << RTC_ALRMAR_HU_Pos)             /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2                (0x4U << RTC_ALRMAR_HU_Pos)             /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3                (0x8U << RTC_ALRMAR_HU_Pos)             /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos            (15U)
+#define RTC_ALRMAR_MSK2_Msk            (0x1UL << RTC_ALRMAR_MSK2_Pos)          /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2                RTC_ALRMAR_MSK2_Msk                     /*!< Alarm A minutes mask */
+#define RTC_ALRMAR_MNT_Pos             (12U)
+#define RTC_ALRMAR_MNT_Msk             (0x7UL << RTC_ALRMAR_MNT_Pos)           /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT                 RTC_ALRMAR_MNT_Msk                      /*!< Alarm A minute tens in BCD format */
+#define RTC_ALRMAR_MNT_0               (0x1U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1               (0x2U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2               (0x4U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos             (8U)
+#define RTC_ALRMAR_MNU_Msk             (0xFUL << RTC_ALRMAR_MNU_Pos)           /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU                 RTC_ALRMAR_MNU_Msk                      /*!< Alarm A minute units in BCD format */
+#define RTC_ALRMAR_MNU_0               (0x1U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1               (0x2U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2               (0x4U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3               (0x8U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos            (7U)
+#define RTC_ALRMAR_MSK1_Msk            (0x1UL << RTC_ALRMAR_MSK1_Pos)          /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1                RTC_ALRMAR_MSK1_Msk                     /*!< Alarm A seconds mask */
+#define RTC_ALRMAR_ST_Pos              (4U)
+#define RTC_ALRMAR_ST_Msk              (0x7UL << RTC_ALRMAR_ST_Pos)            /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                  RTC_ALRMAR_ST_Msk                       /*!< Alarm A second tens in BCD format */
+#define RTC_ALRMAR_ST_0                (0x1U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1                (0x2U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2                (0x4U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos              (0U)
+#define RTC_ALRMAR_SU_Msk              (0xFUL << RTC_ALRMAR_SU_Pos)            /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                  RTC_ALRMAR_SU_Msk                       /*!< Alarm A second units in BCD format */
+#define RTC_ALRMAR_SU_0                (0x1U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1                (0x2U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2                (0x4U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3                (0x8U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos            (31U)
+#define RTC_ALRMBR_MSK4_Msk            (0x1UL << RTC_ALRMBR_MSK4_Pos)          /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4                RTC_ALRMBR_MSK4_Msk                     /*!< Alarm B date mask */
+#define RTC_ALRMBR_WDSEL_Pos           (30U)
+#define RTC_ALRMBR_WDSEL_Msk           (0x1UL << RTC_ALRMBR_WDSEL_Pos)         /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL               RTC_ALRMBR_WDSEL_Msk                    /*!< Alarm B week day selection */
+#define RTC_ALRMBR_DT_Pos              (28U)
+#define RTC_ALRMBR_DT_Msk              (0x3UL << RTC_ALRMBR_DT_Pos)            /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                  RTC_ALRMBR_DT_Msk                       /*!< Alarm B data tens in BCD format */
+#define RTC_ALRMBR_DT_0                (0x1U << RTC_ALRMBR_DT_Pos)             /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1                (0x2U << RTC_ALRMBR_DT_Pos)             /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos              (24U)
+#define RTC_ALRMBR_DU_Msk              (0xFUL << RTC_ALRMBR_DU_Pos)            /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                  RTC_ALRMBR_DU_Msk                       /*!< Alarm B data units or day in BCD format */
+#define RTC_ALRMBR_DU_0                (0x1U << RTC_ALRMBR_DU_Pos)             /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1                (0x2U << RTC_ALRMBR_DU_Pos)             /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2                (0x4U << RTC_ALRMBR_DU_Pos)             /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3                (0x8U << RTC_ALRMBR_DU_Pos)             /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos            (23U)
+#define RTC_ALRMBR_MSK3_Msk            (0x1UL << RTC_ALRMBR_MSK3_Pos)          /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3                RTC_ALRMBR_MSK3_Msk                     /*!< Alarm B hour mask */
+#define RTC_ALRMBR_PM_Pos              (22U)
+#define RTC_ALRMBR_PM_Msk              (0x1UL << RTC_ALRMBR_PM_Pos)            /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                  RTC_ALRMBR_PM_Msk                       /*!< Alarm B AM/PM or 24H format */
+#define RTC_ALRMBR_HT_Pos              (20U)
+#define RTC_ALRMBR_HT_Msk              (0x3UL << RTC_ALRMBR_HT_Pos)            /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                  RTC_ALRMBR_HT_Msk                       /*!< Alarm B hour tens in BCD format */
+#define RTC_ALRMBR_HT_0                (0x1U << RTC_ALRMBR_HT_Pos)             /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1                (0x2U << RTC_ALRMBR_HT_Pos)             /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos              (16U)
+#define RTC_ALRMBR_HU_Msk              (0xFUL << RTC_ALRMBR_HU_Pos)            /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                  RTC_ALRMBR_HU_Msk                       /*!< Alarm B hour units in BCD format */
+#define RTC_ALRMBR_HU_0                (0x1U << RTC_ALRMBR_HU_Pos)             /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1                (0x2U << RTC_ALRMBR_HU_Pos)             /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2                (0x4U << RTC_ALRMBR_HU_Pos)             /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3                (0x8U << RTC_ALRMBR_HU_Pos)             /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos            (15U)
+#define RTC_ALRMBR_MSK2_Msk            (0x1UL << RTC_ALRMBR_MSK2_Pos)          /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2                RTC_ALRMBR_MSK2_Msk                     /*!< Alarm B minutes mask */
+#define RTC_ALRMBR_MNT_Pos             (12U)
+#define RTC_ALRMBR_MNT_Msk             (0x7UL << RTC_ALRMBR_MNT_Pos)           /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT                 RTC_ALRMBR_MNT_Msk                      /*!< Alarm B minute tens in BCD format */
+#define RTC_ALRMBR_MNT_0               (0x1U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1               (0x2U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2               (0x4U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos             (8U)
+#define RTC_ALRMBR_MNU_Msk             (0xFUL << RTC_ALRMBR_MNU_Pos)           /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU                 RTC_ALRMBR_MNU_Msk                      /*!< Alarm B minute units in BCD format */
+#define RTC_ALRMBR_MNU_0               (0x1U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1               (0x2U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2               (0x4U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3               (0x8U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos            (7U)
+#define RTC_ALRMBR_MSK1_Msk            (0x1UL << RTC_ALRMBR_MSK1_Pos)          /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1                RTC_ALRMBR_MSK1_Msk                     /*!< Alarm B seconds mask */
+#define RTC_ALRMBR_ST_Pos              (4U)
+#define RTC_ALRMBR_ST_Msk              (0x7UL << RTC_ALRMBR_ST_Pos)            /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                  RTC_ALRMBR_ST_Msk                       /*!< Alarm B second tens in BCD format */
+#define RTC_ALRMBR_ST_0                (0x1U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1                (0x2U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2                (0x4U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos              (0U)
+#define RTC_ALRMBR_SU_Msk              (0xFUL << RTC_ALRMBR_SU_Pos)            /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                  RTC_ALRMBR_SU_Msk                       /*!< Alarm B second units in BCD format */
+#define RTC_ALRMBR_SU_0                (0x1U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1                (0x2U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2                (0x4U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3                (0x8U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos                (0U)
+#define RTC_WPR_KEY_Msk                (0xFFUL << RTC_WPR_KEY_Pos)             /*!< 0x000000FF */
+#define RTC_WPR_KEY                    RTC_WPR_KEY_Msk                         /*!< Write protection key */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos                 (0U)
+#define RTC_SSR_SS_Msk                 (0xFFFFUL << RTC_SSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_SSR_SS                     RTC_SSR_SS_Msk                          /*!< Sub second value */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos           (0U)
+#define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
+#define RTC_SHIFTR_ADD1S_Pos           (31U)
+#define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos                (22U)
+#define RTC_TSTR_PM_Msk                (0x1UL << RTC_TSTR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_TSTR_PM                    RTC_TSTR_PM_Msk                         /*!< Timestamp AM/PM or 24H format */
+#define RTC_TSTR_HT_Pos                (20U)
+#define RTC_TSTR_HT_Msk                (0x3UL << RTC_TSTR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_TSTR_HT                    RTC_TSTR_HT_Msk                         /*!< Timestamp hour tens in BCD format */
+#define RTC_TSTR_HT_0                  (0x1U << RTC_TSTR_HT_Pos)               /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                  (0x2U << RTC_TSTR_HT_Pos)               /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos                (16U)
+#define RTC_TSTR_HU_Msk                (0xFUL << RTC_TSTR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_TSTR_HU                    RTC_TSTR_HU_Msk                         /*!< Timestamp hour units in BCD format */
+#define RTC_TSTR_HU_0                  (0x1U << RTC_TSTR_HU_Pos)               /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                  (0x2U << RTC_TSTR_HU_Pos)               /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                  (0x4U << RTC_TSTR_HU_Pos)               /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                  (0x8U << RTC_TSTR_HU_Pos)               /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos               (12U)
+#define RTC_TSTR_MNT_Msk               (0x7UL << RTC_TSTR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_TSTR_MNT                   RTC_TSTR_MNT_Msk                        /*!< Timestamp minute tens in BCD format */
+#define RTC_TSTR_MNT_0                 (0x1U << RTC_TSTR_MNT_Pos)              /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1                 (0x2U << RTC_TSTR_MNT_Pos)              /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2                 (0x4U << RTC_TSTR_MNT_Pos)              /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos               (8U)
+#define RTC_TSTR_MNU_Msk               (0xFUL << RTC_TSTR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                   RTC_TSTR_MNU_Msk                        /*!< Timestamp minute units in BCD format */
+#define RTC_TSTR_MNU_0                 (0x1U << RTC_TSTR_MNU_Pos)              /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1                 (0x2U << RTC_TSTR_MNU_Pos)              /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2                 (0x4U << RTC_TSTR_MNU_Pos)              /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3                 (0x8U << RTC_TSTR_MNU_Pos)              /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos                (4U)
+#define RTC_TSTR_ST_Msk                (0x7UL << RTC_TSTR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_TSTR_ST                    RTC_TSTR_ST_Msk                         /*!< Timestamp second tens in BCD format */
+#define RTC_TSTR_ST_0                  (0x1U << RTC_TSTR_ST_Pos)               /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                  (0x2U << RTC_TSTR_ST_Pos)               /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                  (0x4U << RTC_TSTR_ST_Pos)               /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos                (0U)
+#define RTC_TSTR_SU_Msk                (0xFUL << RTC_TSTR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_TSTR_SU                    RTC_TSTR_SU_Msk                         /*!< Timestamp second units in BCD format */
+#define RTC_TSTR_SU_0                  (0x1U << RTC_TSTR_SU_Pos)               /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                  (0x2U << RTC_TSTR_SU_Pos)               /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                  (0x4U << RTC_TSTR_SU_Pos)               /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                  (0x8U << RTC_TSTR_SU_Pos)               /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos               (13U)
+#define RTC_TSDR_WDU_Msk               (0x7UL << RTC_TSDR_WDU_Pos)             /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                   RTC_TSDR_WDU_Msk                        /*!< Timestamp week day units */
+#define RTC_TSDR_WDU_0                 (0x1U << RTC_TSDR_WDU_Pos)              /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1                 (0x2U << RTC_TSDR_WDU_Pos)              /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2                 (0x4U << RTC_TSDR_WDU_Pos)              /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos                (12U)
+#define RTC_TSDR_MT_Msk                (0x1UL << RTC_TSDR_MT_Pos)              /*!< 0x00001000 */
+#define RTC_TSDR_MT                    RTC_TSDR_MT_Msk                         /*!< Timestamp month tens in BCD format */
+#define RTC_TSDR_MU_Pos                (8U)
+#define RTC_TSDR_MU_Msk                (0xFUL << RTC_TSDR_MU_Pos)              /*!< 0x00000F00 */
+#define RTC_TSDR_MU                    RTC_TSDR_MU_Msk                         /*!< Timestamp month units in BCD format */
+#define RTC_TSDR_MU_0                  (0x1U << RTC_TSDR_MU_Pos)               /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                  (0x2U << RTC_TSDR_MU_Pos)               /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                  (0x4U << RTC_TSDR_MU_Pos)               /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                  (0x8U << RTC_TSDR_MU_Pos)               /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos                (4U)
+#define RTC_TSDR_DT_Msk                (0x3UL << RTC_TSDR_DT_Pos)              /*!< 0x00000030 */
+#define RTC_TSDR_DT                    RTC_TSDR_DT_Msk                         /*!< Timestamp date tens in BCD format */
+#define RTC_TSDR_DT_0                  (0x1U << RTC_TSDR_DT_Pos)               /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                  (0x2U << RTC_TSDR_DT_Pos)               /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos                (0U)
+#define RTC_TSDR_DU_Msk                (0xFUL << RTC_TSDR_DU_Pos)              /*!< 0x0000000F */
+#define RTC_TSDR_DU                    RTC_TSDR_DU_Msk                         /*!< Timestamp date units in BCD format */
+#define RTC_TSDR_DU_0                  (0x1U << RTC_TSDR_DU_Pos)               /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                  (0x2U << RTC_TSDR_DU_Pos)               /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                  (0x4U << RTC_TSDR_DU_Pos)               /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                  (0x8U << RTC_TSDR_DU_Pos)               /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos               (0U)
+#define RTC_TSSSR_SS_Msk               (0xFFFFUL << RTC_TSSSR_SS_Pos)          /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                   RTC_TSSSR_SS_Msk                        /*!< Timestamp sub second value */
+
+/********************  Bits definition for RTC_CALR register  *****************/
+#define RTC_CALR_CALP_Pos              (15U)
+#define RTC_CALR_CALP_Msk              (0x1UL << RTC_CALR_CALP_Pos)            /*!< 0x00008000 */
+#define RTC_CALR_CALP                  RTC_CALR_CALP_Msk                       /*!< Increase frequency of RTC 488.5 ppm */
+#define RTC_CALR_CALW8_Pos             (14U)
+#define RTC_CALR_CALW8_Msk             (0x1UL << RTC_CALR_CALW8_Pos)           /*!< 0x00004000 */
+#define RTC_CALR_CALW8                 RTC_CALR_CALW8_Msk                      /*!< Use a 8-second calibration cycle period */
+#define RTC_CALR_CALW16_Pos            (13U)
+#define RTC_CALR_CALW16_Msk            (0x1UL << RTC_CALR_CALW16_Pos)          /*!< 0x00002000 */
+#define RTC_CALR_CALW16                RTC_CALR_CALW16_Msk                     /*!< Use a 16-second calibration cycle period */
+#define RTC_CALR_CALM_Pos              (0U)
+#define RTC_CALR_CALM_Msk              (0x1FFUL << RTC_CALR_CALM_Pos)          /*!< 0x000001FF */
+#define RTC_CALR_CALM                  RTC_CALR_CALM_Msk                       /*!< Calibration minus */
+#define RTC_CALR_CALM_0                (0x001U << RTC_CALR_CALM_Pos)           /*!< 0x00000001 */
+#define RTC_CALR_CALM_1                (0x002U << RTC_CALR_CALM_Pos)           /*!< 0x00000002 */
+#define RTC_CALR_CALM_2                (0x004U << RTC_CALR_CALM_Pos)           /*!< 0x00000004 */
+#define RTC_CALR_CALM_3                (0x008U << RTC_CALR_CALM_Pos)           /*!< 0x00000008 */
+#define RTC_CALR_CALM_4                (0x010U << RTC_CALR_CALM_Pos)           /*!< 0x00000010 */
+#define RTC_CALR_CALM_5                (0x020U << RTC_CALR_CALM_Pos)           /*!< 0x00000020 */
+#define RTC_CALR_CALM_6                (0x040U << RTC_CALR_CALM_Pos)           /*!< 0x00000040 */
+#define RTC_CALR_CALM_7                (0x080U << RTC_CALR_CALM_Pos)           /*!< 0x00000080 */
+#define RTC_CALR_CALM_8                (0x100U << RTC_CALR_CALM_Pos)           /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP2MF_Pos         (21U)
+#define RTC_TAMPCR_TAMP2MF_Msk         (0x1UL << RTC_TAMPCR_TAMP2MF_Pos)       /*!< 0x00200000 */
+#define RTC_TAMPCR_TAMP2MF             RTC_TAMPCR_TAMP2MF_Msk                  /*!< Tamper 2 generates a trigger event */
+#define RTC_TAMPCR_TAMP2NOERASE_Pos    (20U)
+#define RTC_TAMPCR_TAMP2NOERASE_Msk    (0x1UL << RTC_TAMPCR_TAMP2NOERASE_Pos)  /*!< 0x00100000 */
+#define RTC_TAMPCR_TAMP2NOERASE        RTC_TAMPCR_TAMP2NOERASE_Msk             /*!< Tamper 2 no erase backup registers */
+#define RTC_TAMPCR_TAMP2IE_Pos         (19U)
+#define RTC_TAMPCR_TAMP2IE_Msk         (0x1UL << RTC_TAMPCR_TAMP2IE_Pos)       /*!< 0x00080000 */
+#define RTC_TAMPCR_TAMP2IE             RTC_TAMPCR_TAMP2IE_Msk                  /*!< Tamper 2 interrupt enable */
+#define RTC_TAMPCR_TAMPPUDIS_Pos       (15U)
+#define RTC_TAMPCR_TAMPPUDIS_Msk       (0x1UL << RTC_TAMPCR_TAMPPUDIS_Pos)     /*!< 0x00008000 */
+#define RTC_TAMPCR_TAMPPUDIS           RTC_TAMPCR_TAMPPUDIS_Msk                /*!< RTC_TAMPx pull-up disable */
+#define RTC_TAMPCR_TAMPPRCH_Pos        (13U)
+#define RTC_TAMPCR_TAMPPRCH_Msk        (0x3UL << RTC_TAMPCR_TAMPPRCH_Pos)      /*!< 0x00006000 */
+#define RTC_TAMPCR_TAMPPRCH            RTC_TAMPCR_TAMPPRCH_Msk                 /*!< RTC_TAMPx precharge duration */
+#define RTC_TAMPCR_TAMPPRCH_0          (0x1U << RTC_TAMPCR_TAMPPRCH_Pos)       /*!< 0x00002000 */
+#define RTC_TAMPCR_TAMPPRCH_1          (0x2U << RTC_TAMPCR_TAMPPRCH_Pos)       /*!< 0x00004000 */
+#define RTC_TAMPCR_TAMPFLT_Pos         (11U)
+#define RTC_TAMPCR_TAMPFLT_Msk         (0x3UL << RTC_TAMPCR_TAMPFLT_Pos)       /*!< 0x00001800 */
+#define RTC_TAMPCR_TAMPFLT             RTC_TAMPCR_TAMPFLT_Msk                  /*!< RTC_TAMPx filter count */
+#define RTC_TAMPCR_TAMPFLT_0           (0x1U << RTC_TAMPCR_TAMPFLT_Pos)        /*!< 0x00000800 */
+#define RTC_TAMPCR_TAMPFLT_1           (0x2U << RTC_TAMPCR_TAMPFLT_Pos)        /*!< 0x00001000 */
+#define RTC_TAMPCR_TAMPFREQ_Pos        (8U)
+#define RTC_TAMPCR_TAMPFREQ_Msk        (0x7UL << RTC_TAMPCR_TAMPFREQ_Pos)      /*!< 0x00000700 */
+#define RTC_TAMPCR_TAMPFREQ            RTC_TAMPCR_TAMPFREQ_Msk                 /*!< Tamper sampling frequency */
+#define RTC_TAMPCR_TAMPFREQ_0          (0x1U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000100 */
+#define RTC_TAMPCR_TAMPFREQ_1          (0x2U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000200 */
+#define RTC_TAMPCR_TAMPFREQ_2          (0x4U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000400 */
+#define RTC_TAMPCR_TAMPTS_Pos          (7U)
+#define RTC_TAMPCR_TAMPTS_Msk          (0x1UL << RTC_TAMPCR_TAMPTS_Pos)        /*!< 0x00000080 */
+#define RTC_TAMPCR_TAMPTS              RTC_TAMPCR_TAMPTS_Msk                   /*!< Activate timestamp on tamper detection event */
+#define RTC_TAMPCR_TAMP2TRG_Pos        (4U)
+#define RTC_TAMPCR_TAMP2TRG_Msk        (0x1UL << RTC_TAMPCR_TAMP2TRG_Pos)      /*!< 0x00000010 */
+#define RTC_TAMPCR_TAMP2TRG            RTC_TAMPCR_TAMP2TRG_Msk                 /*!< Active level for RTC_TAMP2 input */
+#define RTC_TAMPCR_TAMP2E_Pos          (3U)
+#define RTC_TAMPCR_TAMP2E_Msk          (0x1UL << RTC_TAMPCR_TAMP2E_Pos)        /*!< 0x00000008 */
+#define RTC_TAMPCR_TAMP2E              RTC_TAMPCR_TAMP2E_Msk                   /*!< RTC_TAMP2 detection enable */
+#define RTC_TAMPCR_TAMPIE_Pos          (2U)
+#define RTC_TAMPCR_TAMPIE_Msk          (0x1UL << RTC_TAMPCR_TAMPIE_Pos)        /*!< 0x00000004 */
+#define RTC_TAMPCR_TAMPIE              RTC_TAMPCR_TAMPIE_Msk                   /*!< Tampers interrupt enable */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos        (24U)
+#define RTC_ALRMASSR_MASKSS_Msk        (0xFUL << RTC_ALRMASSR_MASKSS_Pos)      /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS            RTC_ALRMASSR_MASKSS_Msk                 /*!< Alarm A mask the most-significant bits starting at this bit */
+#define RTC_ALRMASSR_MASKSS_0          (0x1U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1          (0x2U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2          (0x4U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3          (0x8U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos            (0U)                                    /*!< Alarm A sub seconds value*/
+#define RTC_ALRMASSR_SS_Msk            (0x7FFFUL << RTC_ALRMASSR_SS_Pos)       /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS                RTC_ALRMASSR_SS_Msk
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos        (24U)
+#define RTC_ALRMBSSR_MASKSS_Msk        (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)      /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS            RTC_ALRMBSSR_MASKSS_Msk                 /*!< Alarm B mask the most-significant bits starting at this bit */
+#define RTC_ALRMBSSR_MASKSS_0          (0x1U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1          (0x2U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2          (0x4U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3          (0x8U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos            (0U)                                    /*!< Alarm B sub seconds value*/
+#define RTC_ALRMBSSR_SS_Msk            (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)       /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS                RTC_ALRMBSSR_SS_Msk
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_OUT_RMP_Pos             (1U)
+#define RTC_OR_OUT_RMP_Msk             (0x1UL << RTC_OR_OUT_RMP_Pos)       /*!< 0x00000002 */
+#define RTC_OR_OUT_RMP                 RTC_OR_OUT_RMP_Msk                  /*!< RTC_OUT remap */
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R_Pos                  (0U)
+#define RTC_BKP0R_Msk                  (0xFFFFFFFFUL << RTC_BKP0R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP0R                      RTC_BKP0R_Msk                           /*!< RTC backup register 0 */
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R_Pos                  (0U)
+#define RTC_BKP1R_Msk                  (0xFFFFFFFFUL << RTC_BKP1R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP1R                      RTC_BKP1R_Msk                           /*!< RTC backup register 1 */
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R_Pos                  (0U)
+#define RTC_BKP2R_Msk                  (0xFFFFFFFFUL << RTC_BKP2R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP2R                      RTC_BKP2R_Msk                           /*!< RTC backup register 2 */
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R_Pos                  (0U)
+#define RTC_BKP3R_Msk                  (0xFFFFFFFFUL << RTC_BKP3R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP3R                      RTC_BKP3R_Msk                           /*!< RTC backup register 3 */
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R_Pos                  (0U)
+#define RTC_BKP4R_Msk                  (0xFFFFFFFFUL << RTC_BKP4R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP4R                      RTC_BKP4R_Msk                           /*!< RTC backup register 4 */
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R_Pos                  (0U)
+#define RTC_BKP5R_Msk                  (0xFFFFFFFFUL << RTC_BKP5R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP5R                      RTC_BKP5R_Msk                           /*!< RTC backup register 5 */
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R_Pos                  (0U)
+#define RTC_BKP6R_Msk                  (0xFFFFFFFFUL << RTC_BKP6R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP6R                      RTC_BKP6R_Msk                           /*!< RTC backup register 6 */
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R_Pos                  (0U)
+#define RTC_BKP7R_Msk                  (0xFFFFFFFFUL << RTC_BKP7R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP7R                      RTC_BKP7R_Msk                           /*!< RTC backup register 7 */
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R_Pos                  (0U)
+#define RTC_BKP8R_Msk                  (0xFFFFFFFFUL << RTC_BKP8R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP8R                      RTC_BKP8R_Msk                           /*!< RTC backup register 8 */
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R_Pos                  (0U)
+#define RTC_BKP9R_Msk                  (0xFFFFFFFFUL << RTC_BKP9R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP9R                      RTC_BKP9R_Msk                           /*!< RTC backup register 9 */
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R_Pos                 (0U)
+#define RTC_BKP10R_Msk                 (0xFFFFFFFFUL << RTC_BKP10R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP10R                     RTC_BKP10R_Msk                          /*!< RTC backup register 10 */
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R_Pos                 (0U)
+#define RTC_BKP11R_Msk                 (0xFFFFFFFFUL << RTC_BKP11R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP11R                     RTC_BKP11R_Msk                          /*!< RTC backup register 11 */
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R_Pos                 (0U)
+#define RTC_BKP12R_Msk                 (0xFFFFFFFFUL << RTC_BKP12R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP12R                     RTC_BKP12R_Msk                          /*!< RTC backup register 12 */
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R_Pos                 (0U)
+#define RTC_BKP13R_Msk                 (0xFFFFFFFFUL << RTC_BKP13R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP13R                     RTC_BKP13R_Msk                          /*!< RTC backup register 13 */
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R_Pos                 (0U)
+#define RTC_BKP14R_Msk                 (0xFFFFFFFFUL << RTC_BKP14R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP14R                     RTC_BKP14R_Msk                          /*!< RTC backup register 14 */
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R_Pos                 (0U)
+#define RTC_BKP15R_Msk                 (0xFFFFFFFFUL << RTC_BKP15R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP15R                     RTC_BKP15R_Msk                          /*!< RTC backup register 15 */
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R_Pos                 (0U)
+#define RTC_BKP16R_Msk                 (0xFFFFFFFFUL << RTC_BKP16R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP16R                     RTC_BKP16R_Msk                          /*!< RTC backup register 16 */
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R_Pos                 (0U)
+#define RTC_BKP17R_Msk                 (0xFFFFFFFFUL << RTC_BKP17R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP17R                     RTC_BKP17R_Msk                          /*!< RTC backup register 17 */
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R_Pos                 (0U)
+#define RTC_BKP18R_Msk                 (0xFFFFFFFFUL << RTC_BKP18R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP18R                     RTC_BKP18R_Msk                          /*!< RTC backup register 18 */
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R_Pos                 (0U)
+#define RTC_BKP19R_Msk                 (0xFFFFFFFFUL << RTC_BKP19R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP19R                     RTC_BKP19R_Msk                          /*!< RTC backup register 19 */
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                 (20U)
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                  /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                  /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                  /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                  /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                 /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)            /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                 /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                 /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)              /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_CRCL_Pos            (11U)
+#define SPI_CR1_CRCL_Msk            (0x1UL << SPI_CR1_CRCL_Pos)                /*!< 0x00000800 */
+#define SPI_CR1_CRCL                SPI_CR1_CRCL_Msk                           /*!< CRC Length */
+#define SPI_CR1_CRCNEXT_Pos         (12U)
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)             /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)               /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)              /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)            /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)             /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!< Rx Buffer DMA Enable */
+#define SPI_CR2_TXDMAEN_Pos         (1U)
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)             /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!< Tx Buffer DMA Enable */
+#define SPI_CR2_SSOE_Pos            (2U)
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!< SS Output Enable */
+#define SPI_CR2_NSSP_Pos            (3U)
+#define SPI_CR2_NSSP_Msk            (0x1UL << SPI_CR2_NSSP_Pos)                /*!< 0x00000008 */
+#define SPI_CR2_NSSP                SPI_CR2_NSSP_Msk                           /*!< NSS pulse management Enable */
+#define SPI_CR2_FRF_Pos             (4U)
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                 /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!< Frame Format Enable */
+#define SPI_CR2_ERRIE_Pos           (5U)
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)               /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!< Error Interrupt Enable */
+#define SPI_CR2_RXNEIE_Pos          (6U)
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)              /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!< RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)               /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!< Tx buffer Empty Interrupt Enable */
+#define SPI_CR2_DS_Pos              (8U)
+#define SPI_CR2_DS_Msk              (0xFUL << SPI_CR2_DS_Pos)                  /*!< 0x00000F00 */
+#define SPI_CR2_DS                  SPI_CR2_DS_Msk                             /*!< DS[3:0] Data Size */
+#define SPI_CR2_DS_0                (0x1UL << SPI_CR2_DS_Pos)                  /*!< 0x00000100 */
+#define SPI_CR2_DS_1                (0x2UL << SPI_CR2_DS_Pos)                  /*!< 0x00000200 */
+#define SPI_CR2_DS_2                (0x4UL << SPI_CR2_DS_Pos)                  /*!< 0x00000400 */
+#define SPI_CR2_DS_3                (0x8UL << SPI_CR2_DS_Pos)                  /*!< 0x00000800 */
+#define SPI_CR2_FRXTH_Pos           (12U)
+#define SPI_CR2_FRXTH_Msk           (0x1UL << SPI_CR2_FRXTH_Pos)               /*!< 0x00001000 */
+#define SPI_CR2_FRXTH               SPI_CR2_FRXTH_Msk                          /*!< FIFO reception Threshold */
+#define SPI_CR2_LDMARX_Pos          (13U)
+#define SPI_CR2_LDMARX_Msk          (0x1UL << SPI_CR2_LDMARX_Pos)              /*!< 0x00002000 */
+#define SPI_CR2_LDMARX              SPI_CR2_LDMARX_Msk                         /*!< Last DMA transfer for reception */
+#define SPI_CR2_LDMATX_Pos          (14U)
+#define SPI_CR2_LDMATX_Msk          (0x1UL << SPI_CR2_LDMATX_Pos)              /*!< 0x00004000 */
+#define SPI_CR2_LDMATX              SPI_CR2_LDMATX_Msk                         /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                 /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!< Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                  /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!< Transmit buffer Empty */
+#define SPI_SR_CRCERR_Pos           (4U)
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)               /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!< CRC Error flag */
+#define SPI_SR_MODF_Pos             (5U)
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                 /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!< Mode fault */
+#define SPI_SR_OVR_Pos              (6U)
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                  /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!< Overrun flag */
+#define SPI_SR_BSY_Pos              (7U)
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                  /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!< Busy flag */
+#define SPI_SR_FRE_Pos              (8U)
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                  /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!< TI frame format error */
+#define SPI_SR_FRLVL_Pos            (9U)
+#define SPI_SR_FRLVL_Msk            (0x3UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000600 */
+#define SPI_SR_FRLVL                SPI_SR_FRLVL_Msk                           /*!< FIFO Reception Level */
+#define SPI_SR_FRLVL_0              (0x1UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000200 */
+#define SPI_SR_FRLVL_1              (0x2UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000400 */
+#define SPI_SR_FTLVL_Pos            (11U)
+#define SPI_SR_FTLVL_Msk            (0x3UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001800 */
+#define SPI_SR_FTLVL                SPI_SR_FTLVL_Msk                           /*!< FIFO Transmission Level */
+#define SPI_SR_FTLVL_0              (0x1UL << SPI_SR_FTLVL_Pos)                /*!< 0x00000800 */
+#define SPI_SR_FTLVL_1              (0x2UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001000 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)        /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Touch Sensing Controller (TSC)                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TSC_CR register  *********************/
+#define TSC_CR_TSCE_Pos          (0U)
+#define TSC_CR_TSCE_Msk          (0x1UL << TSC_CR_TSCE_Pos)                    /*!< 0x00000001 */
+#define TSC_CR_TSCE              TSC_CR_TSCE_Msk                               /*!< Touch sensing controller enable */
+#define TSC_CR_START_Pos         (1U)
+#define TSC_CR_START_Msk         (0x1UL << TSC_CR_START_Pos)                   /*!< 0x00000002 */
+#define TSC_CR_START             TSC_CR_START_Msk                              /*!< Start a new acquisition */
+#define TSC_CR_AM_Pos            (2U)
+#define TSC_CR_AM_Msk            (0x1UL << TSC_CR_AM_Pos)                      /*!< 0x00000004 */
+#define TSC_CR_AM                TSC_CR_AM_Msk                                 /*!< Acquisition mode */
+#define TSC_CR_SYNCPOL_Pos       (3U)
+#define TSC_CR_SYNCPOL_Msk       (0x1UL << TSC_CR_SYNCPOL_Pos)                 /*!< 0x00000008 */
+#define TSC_CR_SYNCPOL           TSC_CR_SYNCPOL_Msk                            /*!< Synchronization pin polarity */
+#define TSC_CR_IODEF_Pos         (4U)
+#define TSC_CR_IODEF_Msk         (0x1UL << TSC_CR_IODEF_Pos)                   /*!< 0x00000010 */
+#define TSC_CR_IODEF             TSC_CR_IODEF_Msk                              /*!< IO default mode */
+
+#define TSC_CR_MCV_Pos           (5U)
+#define TSC_CR_MCV_Msk           (0x7UL << TSC_CR_MCV_Pos)                     /*!< 0x000000E0 */
+#define TSC_CR_MCV               TSC_CR_MCV_Msk                                /*!< MCV[2:0] bits (Max Count Value) */
+#define TSC_CR_MCV_0             (0x1U << TSC_CR_MCV_Pos)                      /*!< 0x00000020 */
+#define TSC_CR_MCV_1             (0x2U << TSC_CR_MCV_Pos)                      /*!< 0x00000040 */
+#define TSC_CR_MCV_2             (0x4U << TSC_CR_MCV_Pos)                      /*!< 0x00000080 */
+
+#define TSC_CR_PGPSC_Pos         (12U)
+#define TSC_CR_PGPSC_Msk         (0x7UL << TSC_CR_PGPSC_Pos)                   /*!< 0x00007000 */
+#define TSC_CR_PGPSC             TSC_CR_PGPSC_Msk                              /*!< PGPSC[2:0] bits (Pulse Generator Prescaler) */
+#define TSC_CR_PGPSC_0           (0x1U << TSC_CR_PGPSC_Pos)                    /*!< 0x00001000 */
+#define TSC_CR_PGPSC_1           (0x2U << TSC_CR_PGPSC_Pos)                    /*!< 0x00002000 */
+#define TSC_CR_PGPSC_2           (0x4U << TSC_CR_PGPSC_Pos)                    /*!< 0x00004000 */
+
+#define TSC_CR_SSPSC_Pos         (15U)
+#define TSC_CR_SSPSC_Msk         (0x1UL << TSC_CR_SSPSC_Pos)                   /*!< 0x00008000 */
+#define TSC_CR_SSPSC             TSC_CR_SSPSC_Msk                              /*!< Spread Spectrum Prescaler */
+#define TSC_CR_SSE_Pos           (16U)
+#define TSC_CR_SSE_Msk           (0x1UL << TSC_CR_SSE_Pos)                     /*!< 0x00010000 */
+#define TSC_CR_SSE               TSC_CR_SSE_Msk                                /*!< Spread Spectrum Enable */
+
+#define TSC_CR_SSD_Pos           (17U)
+#define TSC_CR_SSD_Msk           (0x7FUL << TSC_CR_SSD_Pos)                    /*!< 0x00FE0000 */
+#define TSC_CR_SSD               TSC_CR_SSD_Msk                                /*!< SSD[6:0] bits (Spread Spectrum Deviation) */
+#define TSC_CR_SSD_0             (0x01U << TSC_CR_SSD_Pos)                     /*!< 0x00020000 */
+#define TSC_CR_SSD_1             (0x02U << TSC_CR_SSD_Pos)                     /*!< 0x00040000 */
+#define TSC_CR_SSD_2             (0x04U << TSC_CR_SSD_Pos)                     /*!< 0x00080000 */
+#define TSC_CR_SSD_3             (0x08U << TSC_CR_SSD_Pos)                     /*!< 0x00100000 */
+#define TSC_CR_SSD_4             (0x10U << TSC_CR_SSD_Pos)                     /*!< 0x00200000 */
+#define TSC_CR_SSD_5             (0x20U << TSC_CR_SSD_Pos)                     /*!< 0x00400000 */
+#define TSC_CR_SSD_6             (0x40U << TSC_CR_SSD_Pos)                     /*!< 0x00800000 */
+
+#define TSC_CR_CTPL_Pos          (24U)
+#define TSC_CR_CTPL_Msk          (0xFUL << TSC_CR_CTPL_Pos)                    /*!< 0x0F000000 */
+#define TSC_CR_CTPL              TSC_CR_CTPL_Msk                               /*!< CTPL[3:0] bits (Charge Transfer pulse low) */
+#define TSC_CR_CTPL_0            (0x1U << TSC_CR_CTPL_Pos)                     /*!< 0x01000000 */
+#define TSC_CR_CTPL_1            (0x2U << TSC_CR_CTPL_Pos)                     /*!< 0x02000000 */
+#define TSC_CR_CTPL_2            (0x4U << TSC_CR_CTPL_Pos)                     /*!< 0x04000000 */
+#define TSC_CR_CTPL_3            (0x8U << TSC_CR_CTPL_Pos)                     /*!< 0x08000000 */
+
+#define TSC_CR_CTPH_Pos          (28U)
+#define TSC_CR_CTPH_Msk          (0xFUL << TSC_CR_CTPH_Pos)                    /*!< 0xF0000000 */
+#define TSC_CR_CTPH              TSC_CR_CTPH_Msk                               /*!< CTPH[3:0] bits (Charge Transfer pulse high) */
+#define TSC_CR_CTPH_0            (0x1U << TSC_CR_CTPH_Pos)                     /*!< 0x10000000 */
+#define TSC_CR_CTPH_1            (0x2U << TSC_CR_CTPH_Pos)                     /*!< 0x20000000 */
+#define TSC_CR_CTPH_2            (0x4U << TSC_CR_CTPH_Pos)                     /*!< 0x40000000 */
+#define TSC_CR_CTPH_3            (0x8U << TSC_CR_CTPH_Pos)                     /*!< 0x80000000 */
+
+/*******************  Bit definition for TSC_IER register  ********************/
+#define TSC_IER_EOAIE_Pos        (0U)
+#define TSC_IER_EOAIE_Msk        (0x1UL << TSC_IER_EOAIE_Pos)                  /*!< 0x00000001 */
+#define TSC_IER_EOAIE            TSC_IER_EOAIE_Msk                             /*!< End of acquisition interrupt enable */
+#define TSC_IER_MCEIE_Pos        (1U)
+#define TSC_IER_MCEIE_Msk        (0x1UL << TSC_IER_MCEIE_Pos)                  /*!< 0x00000002 */
+#define TSC_IER_MCEIE            TSC_IER_MCEIE_Msk                             /*!< Max count error interrupt enable */
+
+/*******************  Bit definition for TSC_ICR register  ********************/
+#define TSC_ICR_EOAIC_Pos        (0U)
+#define TSC_ICR_EOAIC_Msk        (0x1UL << TSC_ICR_EOAIC_Pos)                  /*!< 0x00000001 */
+#define TSC_ICR_EOAIC            TSC_ICR_EOAIC_Msk                             /*!< End of acquisition interrupt clear */
+#define TSC_ICR_MCEIC_Pos        (1U)
+#define TSC_ICR_MCEIC_Msk        (0x1UL << TSC_ICR_MCEIC_Pos)                  /*!< 0x00000002 */
+#define TSC_ICR_MCEIC            TSC_ICR_MCEIC_Msk                             /*!< Max count error interrupt clear */
+
+/*******************  Bit definition for TSC_ISR register  ********************/
+#define TSC_ISR_EOAF_Pos         (0U)
+#define TSC_ISR_EOAF_Msk         (0x1UL << TSC_ISR_EOAF_Pos)                   /*!< 0x00000001 */
+#define TSC_ISR_EOAF             TSC_ISR_EOAF_Msk                              /*!< End of acquisition flag */
+#define TSC_ISR_MCEF_Pos         (1U)
+#define TSC_ISR_MCEF_Msk         (0x1UL << TSC_ISR_MCEF_Pos)                   /*!< 0x00000002 */
+#define TSC_ISR_MCEF             TSC_ISR_MCEF_Msk                              /*!< Max count error flag */
+
+/*******************  Bit definition for TSC_IOHCR register  ******************/
+#define TSC_IOHCR_G1_IO1_Pos     (0U)
+#define TSC_IOHCR_G1_IO1_Msk     (0x1UL << TSC_IOHCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOHCR_G1_IO1         TSC_IOHCR_G1_IO1_Msk                          /*!< GROUP1_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO2_Pos     (1U)
+#define TSC_IOHCR_G1_IO2_Msk     (0x1UL << TSC_IOHCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOHCR_G1_IO2         TSC_IOHCR_G1_IO2_Msk                          /*!< GROUP1_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO3_Pos     (2U)
+#define TSC_IOHCR_G1_IO3_Msk     (0x1UL << TSC_IOHCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOHCR_G1_IO3         TSC_IOHCR_G1_IO3_Msk                          /*!< GROUP1_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO4_Pos     (3U)
+#define TSC_IOHCR_G1_IO4_Msk     (0x1UL << TSC_IOHCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOHCR_G1_IO4         TSC_IOHCR_G1_IO4_Msk                          /*!< GROUP1_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO1_Pos     (4U)
+#define TSC_IOHCR_G2_IO1_Msk     (0x1UL << TSC_IOHCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOHCR_G2_IO1         TSC_IOHCR_G2_IO1_Msk                          /*!< GROUP2_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO2_Pos     (5U)
+#define TSC_IOHCR_G2_IO2_Msk     (0x1UL << TSC_IOHCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOHCR_G2_IO2         TSC_IOHCR_G2_IO2_Msk                          /*!< GROUP2_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO3_Pos     (6U)
+#define TSC_IOHCR_G2_IO3_Msk     (0x1UL << TSC_IOHCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOHCR_G2_IO3         TSC_IOHCR_G2_IO3_Msk                          /*!< GROUP2_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO4_Pos     (7U)
+#define TSC_IOHCR_G2_IO4_Msk     (0x1UL << TSC_IOHCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOHCR_G2_IO4         TSC_IOHCR_G2_IO4_Msk                          /*!< GROUP2_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO1_Pos     (8U)
+#define TSC_IOHCR_G3_IO1_Msk     (0x1UL << TSC_IOHCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOHCR_G3_IO1         TSC_IOHCR_G3_IO1_Msk                          /*!< GROUP3_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO2_Pos     (9U)
+#define TSC_IOHCR_G3_IO2_Msk     (0x1UL << TSC_IOHCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOHCR_G3_IO2         TSC_IOHCR_G3_IO2_Msk                          /*!< GROUP3_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO3_Pos     (10U)
+#define TSC_IOHCR_G3_IO3_Msk     (0x1UL << TSC_IOHCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOHCR_G3_IO3         TSC_IOHCR_G3_IO3_Msk                          /*!< GROUP3_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO4_Pos     (11U)
+#define TSC_IOHCR_G3_IO4_Msk     (0x1UL << TSC_IOHCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOHCR_G3_IO4         TSC_IOHCR_G3_IO4_Msk                          /*!< GROUP3_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO1_Pos     (12U)
+#define TSC_IOHCR_G4_IO1_Msk     (0x1UL << TSC_IOHCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOHCR_G4_IO1         TSC_IOHCR_G4_IO1_Msk                          /*!< GROUP4_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO2_Pos     (13U)
+#define TSC_IOHCR_G4_IO2_Msk     (0x1UL << TSC_IOHCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOHCR_G4_IO2         TSC_IOHCR_G4_IO2_Msk                          /*!< GROUP4_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO3_Pos     (14U)
+#define TSC_IOHCR_G4_IO3_Msk     (0x1UL << TSC_IOHCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOHCR_G4_IO3         TSC_IOHCR_G4_IO3_Msk                          /*!< GROUP4_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO4_Pos     (15U)
+#define TSC_IOHCR_G4_IO4_Msk     (0x1UL << TSC_IOHCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOHCR_G4_IO4         TSC_IOHCR_G4_IO4_Msk                          /*!< GROUP4_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO1_Pos     (16U)
+#define TSC_IOHCR_G5_IO1_Msk     (0x1UL << TSC_IOHCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOHCR_G5_IO1         TSC_IOHCR_G5_IO1_Msk                          /*!< GROUP5_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO2_Pos     (17U)
+#define TSC_IOHCR_G5_IO2_Msk     (0x1UL << TSC_IOHCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOHCR_G5_IO2         TSC_IOHCR_G5_IO2_Msk                          /*!< GROUP5_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO3_Pos     (18U)
+#define TSC_IOHCR_G5_IO3_Msk     (0x1UL << TSC_IOHCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOHCR_G5_IO3         TSC_IOHCR_G5_IO3_Msk                          /*!< GROUP5_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO4_Pos     (19U)
+#define TSC_IOHCR_G5_IO4_Msk     (0x1UL << TSC_IOHCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOHCR_G5_IO4         TSC_IOHCR_G5_IO4_Msk                          /*!< GROUP5_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO1_Pos     (20U)
+#define TSC_IOHCR_G6_IO1_Msk     (0x1UL << TSC_IOHCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOHCR_G6_IO1         TSC_IOHCR_G6_IO1_Msk                          /*!< GROUP6_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO2_Pos     (21U)
+#define TSC_IOHCR_G6_IO2_Msk     (0x1UL << TSC_IOHCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOHCR_G6_IO2         TSC_IOHCR_G6_IO2_Msk                          /*!< GROUP6_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO3_Pos     (22U)
+#define TSC_IOHCR_G6_IO3_Msk     (0x1UL << TSC_IOHCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOHCR_G6_IO3         TSC_IOHCR_G6_IO3_Msk                          /*!< GROUP6_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO4_Pos     (23U)
+#define TSC_IOHCR_G6_IO4_Msk     (0x1UL << TSC_IOHCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOHCR_G6_IO4         TSC_IOHCR_G6_IO4_Msk                          /*!< GROUP6_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO1_Pos     (24U)
+#define TSC_IOHCR_G7_IO1_Msk     (0x1UL << TSC_IOHCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOHCR_G7_IO1         TSC_IOHCR_G7_IO1_Msk                          /*!< GROUP7_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO2_Pos     (25U)
+#define TSC_IOHCR_G7_IO2_Msk     (0x1UL << TSC_IOHCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOHCR_G7_IO2         TSC_IOHCR_G7_IO2_Msk                          /*!< GROUP7_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO3_Pos     (26U)
+#define TSC_IOHCR_G7_IO3_Msk     (0x1UL << TSC_IOHCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOHCR_G7_IO3         TSC_IOHCR_G7_IO3_Msk                          /*!< GROUP7_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO4_Pos     (27U)
+#define TSC_IOHCR_G7_IO4_Msk     (0x1UL << TSC_IOHCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOHCR_G7_IO4         TSC_IOHCR_G7_IO4_Msk                          /*!< GROUP7_IO4 schmitt trigger hysteresis mode */
+
+/*******************  Bit definition for TSC_IOASCR register  *****************/
+#define TSC_IOASCR_G1_IO1_Pos    (0U)
+#define TSC_IOASCR_G1_IO1_Msk    (0x1UL << TSC_IOASCR_G1_IO1_Pos)              /*!< 0x00000001 */
+#define TSC_IOASCR_G1_IO1        TSC_IOASCR_G1_IO1_Msk                         /*!< GROUP1_IO1 analog switch enable */
+#define TSC_IOASCR_G1_IO2_Pos    (1U)
+#define TSC_IOASCR_G1_IO2_Msk    (0x1UL << TSC_IOASCR_G1_IO2_Pos)              /*!< 0x00000002 */
+#define TSC_IOASCR_G1_IO2        TSC_IOASCR_G1_IO2_Msk                         /*!< GROUP1_IO2 analog switch enable */
+#define TSC_IOASCR_G1_IO3_Pos    (2U)
+#define TSC_IOASCR_G1_IO3_Msk    (0x1UL << TSC_IOASCR_G1_IO3_Pos)              /*!< 0x00000004 */
+#define TSC_IOASCR_G1_IO3        TSC_IOASCR_G1_IO3_Msk                         /*!< GROUP1_IO3 analog switch enable */
+#define TSC_IOASCR_G1_IO4_Pos    (3U)
+#define TSC_IOASCR_G1_IO4_Msk    (0x1UL << TSC_IOASCR_G1_IO4_Pos)              /*!< 0x00000008 */
+#define TSC_IOASCR_G1_IO4        TSC_IOASCR_G1_IO4_Msk                         /*!< GROUP1_IO4 analog switch enable */
+#define TSC_IOASCR_G2_IO1_Pos    (4U)
+#define TSC_IOASCR_G2_IO1_Msk    (0x1UL << TSC_IOASCR_G2_IO1_Pos)              /*!< 0x00000010 */
+#define TSC_IOASCR_G2_IO1        TSC_IOASCR_G2_IO1_Msk                         /*!< GROUP2_IO1 analog switch enable */
+#define TSC_IOASCR_G2_IO2_Pos    (5U)
+#define TSC_IOASCR_G2_IO2_Msk    (0x1UL << TSC_IOASCR_G2_IO2_Pos)              /*!< 0x00000020 */
+#define TSC_IOASCR_G2_IO2        TSC_IOASCR_G2_IO2_Msk                         /*!< GROUP2_IO2 analog switch enable */
+#define TSC_IOASCR_G2_IO3_Pos    (6U)
+#define TSC_IOASCR_G2_IO3_Msk    (0x1UL << TSC_IOASCR_G2_IO3_Pos)              /*!< 0x00000040 */
+#define TSC_IOASCR_G2_IO3        TSC_IOASCR_G2_IO3_Msk                         /*!< GROUP2_IO3 analog switch enable */
+#define TSC_IOASCR_G2_IO4_Pos    (7U)
+#define TSC_IOASCR_G2_IO4_Msk    (0x1UL << TSC_IOASCR_G2_IO4_Pos)              /*!< 0x00000080 */
+#define TSC_IOASCR_G2_IO4        TSC_IOASCR_G2_IO4_Msk                         /*!< GROUP2_IO4 analog switch enable */
+#define TSC_IOASCR_G3_IO1_Pos    (8U)
+#define TSC_IOASCR_G3_IO1_Msk    (0x1UL << TSC_IOASCR_G3_IO1_Pos)              /*!< 0x00000100 */
+#define TSC_IOASCR_G3_IO1        TSC_IOASCR_G3_IO1_Msk                         /*!< GROUP3_IO1 analog switch enable */
+#define TSC_IOASCR_G3_IO2_Pos    (9U)
+#define TSC_IOASCR_G3_IO2_Msk    (0x1UL << TSC_IOASCR_G3_IO2_Pos)              /*!< 0x00000200 */
+#define TSC_IOASCR_G3_IO2        TSC_IOASCR_G3_IO2_Msk                         /*!< GROUP3_IO2 analog switch enable */
+#define TSC_IOASCR_G3_IO3_Pos    (10U)
+#define TSC_IOASCR_G3_IO3_Msk    (0x1UL << TSC_IOASCR_G3_IO3_Pos)              /*!< 0x00000400 */
+#define TSC_IOASCR_G3_IO3        TSC_IOASCR_G3_IO3_Msk                         /*!< GROUP3_IO3 analog switch enable */
+#define TSC_IOASCR_G3_IO4_Pos    (11U)
+#define TSC_IOASCR_G3_IO4_Msk    (0x1UL << TSC_IOASCR_G3_IO4_Pos)              /*!< 0x00000800 */
+#define TSC_IOASCR_G3_IO4        TSC_IOASCR_G3_IO4_Msk                         /*!< GROUP3_IO4 analog switch enable */
+#define TSC_IOASCR_G4_IO1_Pos    (12U)
+#define TSC_IOASCR_G4_IO1_Msk    (0x1UL << TSC_IOASCR_G4_IO1_Pos)              /*!< 0x00001000 */
+#define TSC_IOASCR_G4_IO1        TSC_IOASCR_G4_IO1_Msk                         /*!< GROUP4_IO1 analog switch enable */
+#define TSC_IOASCR_G4_IO2_Pos    (13U)
+#define TSC_IOASCR_G4_IO2_Msk    (0x1UL << TSC_IOASCR_G4_IO2_Pos)              /*!< 0x00002000 */
+#define TSC_IOASCR_G4_IO2        TSC_IOASCR_G4_IO2_Msk                         /*!< GROUP4_IO2 analog switch enable */
+#define TSC_IOASCR_G4_IO3_Pos    (14U)
+#define TSC_IOASCR_G4_IO3_Msk    (0x1UL << TSC_IOASCR_G4_IO3_Pos)              /*!< 0x00004000 */
+#define TSC_IOASCR_G4_IO3        TSC_IOASCR_G4_IO3_Msk                         /*!< GROUP4_IO3 analog switch enable */
+#define TSC_IOASCR_G4_IO4_Pos    (15U)
+#define TSC_IOASCR_G4_IO4_Msk    (0x1UL << TSC_IOASCR_G4_IO4_Pos)              /*!< 0x00008000 */
+#define TSC_IOASCR_G4_IO4        TSC_IOASCR_G4_IO4_Msk                         /*!< GROUP4_IO4 analog switch enable */
+#define TSC_IOASCR_G5_IO1_Pos    (16U)
+#define TSC_IOASCR_G5_IO1_Msk    (0x1UL << TSC_IOASCR_G5_IO1_Pos)              /*!< 0x00010000 */
+#define TSC_IOASCR_G5_IO1        TSC_IOASCR_G5_IO1_Msk                         /*!< GROUP5_IO1 analog switch enable */
+#define TSC_IOASCR_G5_IO2_Pos    (17U)
+#define TSC_IOASCR_G5_IO2_Msk    (0x1UL << TSC_IOASCR_G5_IO2_Pos)              /*!< 0x00020000 */
+#define TSC_IOASCR_G5_IO2        TSC_IOASCR_G5_IO2_Msk                         /*!< GROUP5_IO2 analog switch enable */
+#define TSC_IOASCR_G5_IO3_Pos    (18U)
+#define TSC_IOASCR_G5_IO3_Msk    (0x1UL << TSC_IOASCR_G5_IO3_Pos)              /*!< 0x00040000 */
+#define TSC_IOASCR_G5_IO3        TSC_IOASCR_G5_IO3_Msk                         /*!< GROUP5_IO3 analog switch enable */
+#define TSC_IOASCR_G5_IO4_Pos    (19U)
+#define TSC_IOASCR_G5_IO4_Msk    (0x1UL << TSC_IOASCR_G5_IO4_Pos)              /*!< 0x00080000 */
+#define TSC_IOASCR_G5_IO4        TSC_IOASCR_G5_IO4_Msk                         /*!< GROUP5_IO4 analog switch enable */
+#define TSC_IOASCR_G6_IO1_Pos    (20U)
+#define TSC_IOASCR_G6_IO1_Msk    (0x1UL << TSC_IOASCR_G6_IO1_Pos)              /*!< 0x00100000 */
+#define TSC_IOASCR_G6_IO1        TSC_IOASCR_G6_IO1_Msk                         /*!< GROUP6_IO1 analog switch enable */
+#define TSC_IOASCR_G6_IO2_Pos    (21U)
+#define TSC_IOASCR_G6_IO2_Msk    (0x1UL << TSC_IOASCR_G6_IO2_Pos)              /*!< 0x00200000 */
+#define TSC_IOASCR_G6_IO2        TSC_IOASCR_G6_IO2_Msk                         /*!< GROUP6_IO2 analog switch enable */
+#define TSC_IOASCR_G6_IO3_Pos    (22U)
+#define TSC_IOASCR_G6_IO3_Msk    (0x1UL << TSC_IOASCR_G6_IO3_Pos)              /*!< 0x00400000 */
+#define TSC_IOASCR_G6_IO3        TSC_IOASCR_G6_IO3_Msk                         /*!< GROUP6_IO3 analog switch enable */
+#define TSC_IOASCR_G6_IO4_Pos    (23U)
+#define TSC_IOASCR_G6_IO4_Msk    (0x1UL << TSC_IOASCR_G6_IO4_Pos)              /*!< 0x00800000 */
+#define TSC_IOASCR_G6_IO4        TSC_IOASCR_G6_IO4_Msk                         /*!< GROUP6_IO4 analog switch enable */
+#define TSC_IOASCR_G7_IO1_Pos    (24U)
+#define TSC_IOASCR_G7_IO1_Msk    (0x1UL << TSC_IOASCR_G7_IO1_Pos)              /*!< 0x01000000 */
+#define TSC_IOASCR_G7_IO1        TSC_IOASCR_G7_IO1_Msk                         /*!< GROUP7_IO1 analog switch enable */
+#define TSC_IOASCR_G7_IO2_Pos    (25U)
+#define TSC_IOASCR_G7_IO2_Msk    (0x1UL << TSC_IOASCR_G7_IO2_Pos)              /*!< 0x02000000 */
+#define TSC_IOASCR_G7_IO2        TSC_IOASCR_G7_IO2_Msk                         /*!< GROUP7_IO2 analog switch enable */
+#define TSC_IOASCR_G7_IO3_Pos    (26U)
+#define TSC_IOASCR_G7_IO3_Msk    (0x1UL << TSC_IOASCR_G7_IO3_Pos)              /*!< 0x04000000 */
+#define TSC_IOASCR_G7_IO3        TSC_IOASCR_G7_IO3_Msk                         /*!< GROUP7_IO3 analog switch enable */
+#define TSC_IOASCR_G7_IO4_Pos    (27U)
+#define TSC_IOASCR_G7_IO4_Msk    (0x1UL << TSC_IOASCR_G7_IO4_Pos)              /*!< 0x08000000 */
+#define TSC_IOASCR_G7_IO4        TSC_IOASCR_G7_IO4_Msk                         /*!< GROUP7_IO4 analog switch enable */
+
+/*******************  Bit definition for TSC_IOSCR register  ******************/
+#define TSC_IOSCR_G1_IO1_Pos     (0U)
+#define TSC_IOSCR_G1_IO1_Msk     (0x1UL << TSC_IOSCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOSCR_G1_IO1         TSC_IOSCR_G1_IO1_Msk                          /*!< GROUP1_IO1 sampling mode */
+#define TSC_IOSCR_G1_IO2_Pos     (1U)
+#define TSC_IOSCR_G1_IO2_Msk     (0x1UL << TSC_IOSCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOSCR_G1_IO2         TSC_IOSCR_G1_IO2_Msk                          /*!< GROUP1_IO2 sampling mode */
+#define TSC_IOSCR_G1_IO3_Pos     (2U)
+#define TSC_IOSCR_G1_IO3_Msk     (0x1UL << TSC_IOSCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOSCR_G1_IO3         TSC_IOSCR_G1_IO3_Msk                          /*!< GROUP1_IO3 sampling mode */
+#define TSC_IOSCR_G1_IO4_Pos     (3U)
+#define TSC_IOSCR_G1_IO4_Msk     (0x1UL << TSC_IOSCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOSCR_G1_IO4         TSC_IOSCR_G1_IO4_Msk                          /*!< GROUP1_IO4 sampling mode */
+#define TSC_IOSCR_G2_IO1_Pos     (4U)
+#define TSC_IOSCR_G2_IO1_Msk     (0x1UL << TSC_IOSCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOSCR_G2_IO1         TSC_IOSCR_G2_IO1_Msk                          /*!< GROUP2_IO1 sampling mode */
+#define TSC_IOSCR_G2_IO2_Pos     (5U)
+#define TSC_IOSCR_G2_IO2_Msk     (0x1UL << TSC_IOSCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOSCR_G2_IO2         TSC_IOSCR_G2_IO2_Msk                          /*!< GROUP2_IO2 sampling mode */
+#define TSC_IOSCR_G2_IO3_Pos     (6U)
+#define TSC_IOSCR_G2_IO3_Msk     (0x1UL << TSC_IOSCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOSCR_G2_IO3         TSC_IOSCR_G2_IO3_Msk                          /*!< GROUP2_IO3 sampling mode */
+#define TSC_IOSCR_G2_IO4_Pos     (7U)
+#define TSC_IOSCR_G2_IO4_Msk     (0x1UL << TSC_IOSCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOSCR_G2_IO4         TSC_IOSCR_G2_IO4_Msk                          /*!< GROUP2_IO4 sampling mode */
+#define TSC_IOSCR_G3_IO1_Pos     (8U)
+#define TSC_IOSCR_G3_IO1_Msk     (0x1UL << TSC_IOSCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOSCR_G3_IO1         TSC_IOSCR_G3_IO1_Msk                          /*!< GROUP3_IO1 sampling mode */
+#define TSC_IOSCR_G3_IO2_Pos     (9U)
+#define TSC_IOSCR_G3_IO2_Msk     (0x1UL << TSC_IOSCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOSCR_G3_IO2         TSC_IOSCR_G3_IO2_Msk                          /*!< GROUP3_IO2 sampling mode */
+#define TSC_IOSCR_G3_IO3_Pos     (10U)
+#define TSC_IOSCR_G3_IO3_Msk     (0x1UL << TSC_IOSCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOSCR_G3_IO3         TSC_IOSCR_G3_IO3_Msk                          /*!< GROUP3_IO3 sampling mode */
+#define TSC_IOSCR_G3_IO4_Pos     (11U)
+#define TSC_IOSCR_G3_IO4_Msk     (0x1UL << TSC_IOSCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOSCR_G3_IO4         TSC_IOSCR_G3_IO4_Msk                          /*!< GROUP3_IO4 sampling mode */
+#define TSC_IOSCR_G4_IO1_Pos     (12U)
+#define TSC_IOSCR_G4_IO1_Msk     (0x1UL << TSC_IOSCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOSCR_G4_IO1         TSC_IOSCR_G4_IO1_Msk                          /*!< GROUP4_IO1 sampling mode */
+#define TSC_IOSCR_G4_IO2_Pos     (13U)
+#define TSC_IOSCR_G4_IO2_Msk     (0x1UL << TSC_IOSCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOSCR_G4_IO2         TSC_IOSCR_G4_IO2_Msk                          /*!< GROUP4_IO2 sampling mode */
+#define TSC_IOSCR_G4_IO3_Pos     (14U)
+#define TSC_IOSCR_G4_IO3_Msk     (0x1UL << TSC_IOSCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOSCR_G4_IO3         TSC_IOSCR_G4_IO3_Msk                          /*!< GROUP4_IO3 sampling mode */
+#define TSC_IOSCR_G4_IO4_Pos     (15U)
+#define TSC_IOSCR_G4_IO4_Msk     (0x1UL << TSC_IOSCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOSCR_G4_IO4         TSC_IOSCR_G4_IO4_Msk                          /*!< GROUP4_IO4 sampling mode */
+#define TSC_IOSCR_G5_IO1_Pos     (16U)
+#define TSC_IOSCR_G5_IO1_Msk     (0x1UL << TSC_IOSCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOSCR_G5_IO1         TSC_IOSCR_G5_IO1_Msk                          /*!< GROUP5_IO1 sampling mode */
+#define TSC_IOSCR_G5_IO2_Pos     (17U)
+#define TSC_IOSCR_G5_IO2_Msk     (0x1UL << TSC_IOSCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOSCR_G5_IO2         TSC_IOSCR_G5_IO2_Msk                          /*!< GROUP5_IO2 sampling mode */
+#define TSC_IOSCR_G5_IO3_Pos     (18U)
+#define TSC_IOSCR_G5_IO3_Msk     (0x1UL << TSC_IOSCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOSCR_G5_IO3         TSC_IOSCR_G5_IO3_Msk                          /*!< GROUP5_IO3 sampling mode */
+#define TSC_IOSCR_G5_IO4_Pos     (19U)
+#define TSC_IOSCR_G5_IO4_Msk     (0x1UL << TSC_IOSCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOSCR_G5_IO4         TSC_IOSCR_G5_IO4_Msk                          /*!< GROUP5_IO4 sampling mode */
+#define TSC_IOSCR_G6_IO1_Pos     (20U)
+#define TSC_IOSCR_G6_IO1_Msk     (0x1UL << TSC_IOSCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOSCR_G6_IO1         TSC_IOSCR_G6_IO1_Msk                          /*!< GROUP6_IO1 sampling mode */
+#define TSC_IOSCR_G6_IO2_Pos     (21U)
+#define TSC_IOSCR_G6_IO2_Msk     (0x1UL << TSC_IOSCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOSCR_G6_IO2         TSC_IOSCR_G6_IO2_Msk                          /*!< GROUP6_IO2 sampling mode */
+#define TSC_IOSCR_G6_IO3_Pos     (22U)
+#define TSC_IOSCR_G6_IO3_Msk     (0x1UL << TSC_IOSCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOSCR_G6_IO3         TSC_IOSCR_G6_IO3_Msk                          /*!< GROUP6_IO3 sampling mode */
+#define TSC_IOSCR_G6_IO4_Pos     (23U)
+#define TSC_IOSCR_G6_IO4_Msk     (0x1UL << TSC_IOSCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOSCR_G6_IO4         TSC_IOSCR_G6_IO4_Msk                          /*!< GROUP6_IO4 sampling mode */
+#define TSC_IOSCR_G7_IO1_Pos     (24U)
+#define TSC_IOSCR_G7_IO1_Msk     (0x1UL << TSC_IOSCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOSCR_G7_IO1         TSC_IOSCR_G7_IO1_Msk                          /*!< GROUP7_IO1 sampling mode */
+#define TSC_IOSCR_G7_IO2_Pos     (25U)
+#define TSC_IOSCR_G7_IO2_Msk     (0x1UL << TSC_IOSCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOSCR_G7_IO2         TSC_IOSCR_G7_IO2_Msk                          /*!< GROUP7_IO2 sampling mode */
+#define TSC_IOSCR_G7_IO3_Pos     (26U)
+#define TSC_IOSCR_G7_IO3_Msk     (0x1UL << TSC_IOSCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOSCR_G7_IO3         TSC_IOSCR_G7_IO3_Msk                          /*!< GROUP7_IO3 sampling mode */
+#define TSC_IOSCR_G7_IO4_Pos     (27U)
+#define TSC_IOSCR_G7_IO4_Msk     (0x1UL << TSC_IOSCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOSCR_G7_IO4         TSC_IOSCR_G7_IO4_Msk                          /*!< GROUP7_IO4 sampling mode */
+
+/*******************  Bit definition for TSC_IOCCR register  ******************/
+#define TSC_IOCCR_G1_IO1_Pos     (0U)
+#define TSC_IOCCR_G1_IO1_Msk     (0x1UL << TSC_IOCCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOCCR_G1_IO1         TSC_IOCCR_G1_IO1_Msk                          /*!< GROUP1_IO1 channel mode */
+#define TSC_IOCCR_G1_IO2_Pos     (1U)
+#define TSC_IOCCR_G1_IO2_Msk     (0x1UL << TSC_IOCCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOCCR_G1_IO2         TSC_IOCCR_G1_IO2_Msk                          /*!< GROUP1_IO2 channel mode */
+#define TSC_IOCCR_G1_IO3_Pos     (2U)
+#define TSC_IOCCR_G1_IO3_Msk     (0x1UL << TSC_IOCCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOCCR_G1_IO3         TSC_IOCCR_G1_IO3_Msk                          /*!< GROUP1_IO3 channel mode */
+#define TSC_IOCCR_G1_IO4_Pos     (3U)
+#define TSC_IOCCR_G1_IO4_Msk     (0x1UL << TSC_IOCCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOCCR_G1_IO4         TSC_IOCCR_G1_IO4_Msk                          /*!< GROUP1_IO4 channel mode */
+#define TSC_IOCCR_G2_IO1_Pos     (4U)
+#define TSC_IOCCR_G2_IO1_Msk     (0x1UL << TSC_IOCCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOCCR_G2_IO1         TSC_IOCCR_G2_IO1_Msk                          /*!< GROUP2_IO1 channel mode */
+#define TSC_IOCCR_G2_IO2_Pos     (5U)
+#define TSC_IOCCR_G2_IO2_Msk     (0x1UL << TSC_IOCCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOCCR_G2_IO2         TSC_IOCCR_G2_IO2_Msk                          /*!< GROUP2_IO2 channel mode */
+#define TSC_IOCCR_G2_IO3_Pos     (6U)
+#define TSC_IOCCR_G2_IO3_Msk     (0x1UL << TSC_IOCCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOCCR_G2_IO3         TSC_IOCCR_G2_IO3_Msk                          /*!< GROUP2_IO3 channel mode */
+#define TSC_IOCCR_G2_IO4_Pos     (7U)
+#define TSC_IOCCR_G2_IO4_Msk     (0x1UL << TSC_IOCCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOCCR_G2_IO4         TSC_IOCCR_G2_IO4_Msk                          /*!< GROUP2_IO4 channel mode */
+#define TSC_IOCCR_G3_IO1_Pos     (8U)
+#define TSC_IOCCR_G3_IO1_Msk     (0x1UL << TSC_IOCCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOCCR_G3_IO1         TSC_IOCCR_G3_IO1_Msk                          /*!< GROUP3_IO1 channel mode */
+#define TSC_IOCCR_G3_IO2_Pos     (9U)
+#define TSC_IOCCR_G3_IO2_Msk     (0x1UL << TSC_IOCCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOCCR_G3_IO2         TSC_IOCCR_G3_IO2_Msk                          /*!< GROUP3_IO2 channel mode */
+#define TSC_IOCCR_G3_IO3_Pos     (10U)
+#define TSC_IOCCR_G3_IO3_Msk     (0x1UL << TSC_IOCCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOCCR_G3_IO3         TSC_IOCCR_G3_IO3_Msk                          /*!< GROUP3_IO3 channel mode */
+#define TSC_IOCCR_G3_IO4_Pos     (11U)
+#define TSC_IOCCR_G3_IO4_Msk     (0x1UL << TSC_IOCCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOCCR_G3_IO4         TSC_IOCCR_G3_IO4_Msk                          /*!< GROUP3_IO4 channel mode */
+#define TSC_IOCCR_G4_IO1_Pos     (12U)
+#define TSC_IOCCR_G4_IO1_Msk     (0x1UL << TSC_IOCCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOCCR_G4_IO1         TSC_IOCCR_G4_IO1_Msk                          /*!< GROUP4_IO1 channel mode */
+#define TSC_IOCCR_G4_IO2_Pos     (13U)
+#define TSC_IOCCR_G4_IO2_Msk     (0x1UL << TSC_IOCCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOCCR_G4_IO2         TSC_IOCCR_G4_IO2_Msk                          /*!< GROUP4_IO2 channel mode */
+#define TSC_IOCCR_G4_IO3_Pos     (14U)
+#define TSC_IOCCR_G4_IO3_Msk     (0x1UL << TSC_IOCCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOCCR_G4_IO3         TSC_IOCCR_G4_IO3_Msk                          /*!< GROUP4_IO3 channel mode */
+#define TSC_IOCCR_G4_IO4_Pos     (15U)
+#define TSC_IOCCR_G4_IO4_Msk     (0x1UL << TSC_IOCCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOCCR_G4_IO4         TSC_IOCCR_G4_IO4_Msk                          /*!< GROUP4_IO4 channel mode */
+#define TSC_IOCCR_G5_IO1_Pos     (16U)
+#define TSC_IOCCR_G5_IO1_Msk     (0x1UL << TSC_IOCCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOCCR_G5_IO1         TSC_IOCCR_G5_IO1_Msk                          /*!< GROUP5_IO1 channel mode */
+#define TSC_IOCCR_G5_IO2_Pos     (17U)
+#define TSC_IOCCR_G5_IO2_Msk     (0x1UL << TSC_IOCCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOCCR_G5_IO2         TSC_IOCCR_G5_IO2_Msk                          /*!< GROUP5_IO2 channel mode */
+#define TSC_IOCCR_G5_IO3_Pos     (18U)
+#define TSC_IOCCR_G5_IO3_Msk     (0x1UL << TSC_IOCCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOCCR_G5_IO3         TSC_IOCCR_G5_IO3_Msk                          /*!< GROUP5_IO3 channel mode */
+#define TSC_IOCCR_G5_IO4_Pos     (19U)
+#define TSC_IOCCR_G5_IO4_Msk     (0x1UL << TSC_IOCCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOCCR_G5_IO4         TSC_IOCCR_G5_IO4_Msk                          /*!< GROUP5_IO4 channel mode */
+#define TSC_IOCCR_G6_IO1_Pos     (20U)
+#define TSC_IOCCR_G6_IO1_Msk     (0x1UL << TSC_IOCCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOCCR_G6_IO1         TSC_IOCCR_G6_IO1_Msk                          /*!< GROUP6_IO1 channel mode */
+#define TSC_IOCCR_G6_IO2_Pos     (21U)
+#define TSC_IOCCR_G6_IO2_Msk     (0x1UL << TSC_IOCCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOCCR_G6_IO2         TSC_IOCCR_G6_IO2_Msk                          /*!< GROUP6_IO2 channel mode */
+#define TSC_IOCCR_G6_IO3_Pos     (22U)
+#define TSC_IOCCR_G6_IO3_Msk     (0x1UL << TSC_IOCCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOCCR_G6_IO3         TSC_IOCCR_G6_IO3_Msk                          /*!< GROUP6_IO3 channel mode */
+#define TSC_IOCCR_G6_IO4_Pos     (23U)
+#define TSC_IOCCR_G6_IO4_Msk     (0x1UL << TSC_IOCCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOCCR_G6_IO4         TSC_IOCCR_G6_IO4_Msk                          /*!< GROUP6_IO4 channel mode */
+#define TSC_IOCCR_G7_IO1_Pos     (24U)
+#define TSC_IOCCR_G7_IO1_Msk     (0x1UL << TSC_IOCCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOCCR_G7_IO1         TSC_IOCCR_G7_IO1_Msk                          /*!< GROUP7_IO1 channel mode */
+#define TSC_IOCCR_G7_IO2_Pos     (25U)
+#define TSC_IOCCR_G7_IO2_Msk     (0x1UL << TSC_IOCCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOCCR_G7_IO2         TSC_IOCCR_G7_IO2_Msk                          /*!< GROUP7_IO2 channel mode */
+#define TSC_IOCCR_G7_IO3_Pos     (26U)
+#define TSC_IOCCR_G7_IO3_Msk     (0x1UL << TSC_IOCCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOCCR_G7_IO3         TSC_IOCCR_G7_IO3_Msk                          /*!< GROUP7_IO3 channel mode */
+#define TSC_IOCCR_G7_IO4_Pos     (27U)
+#define TSC_IOCCR_G7_IO4_Msk     (0x1UL << TSC_IOCCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOCCR_G7_IO4         TSC_IOCCR_G7_IO4_Msk                          /*!< GROUP7_IO4 channel mode */
+
+/*******************  Bit definition for TSC_IOGCSR register  *****************/
+#define TSC_IOGCSR_G1E_Pos       (0U)
+#define TSC_IOGCSR_G1E_Msk       (0x1UL << TSC_IOGCSR_G1E_Pos)                 /*!< 0x00000001 */
+#define TSC_IOGCSR_G1E           TSC_IOGCSR_G1E_Msk                            /*!< Analog IO GROUP1 enable */
+#define TSC_IOGCSR_G2E_Pos       (1U)
+#define TSC_IOGCSR_G2E_Msk       (0x1UL << TSC_IOGCSR_G2E_Pos)                 /*!< 0x00000002 */
+#define TSC_IOGCSR_G2E           TSC_IOGCSR_G2E_Msk                            /*!< Analog IO GROUP2 enable */
+#define TSC_IOGCSR_G3E_Pos       (2U)
+#define TSC_IOGCSR_G3E_Msk       (0x1UL << TSC_IOGCSR_G3E_Pos)                 /*!< 0x00000004 */
+#define TSC_IOGCSR_G3E           TSC_IOGCSR_G3E_Msk                            /*!< Analog IO GROUP3 enable */
+#define TSC_IOGCSR_G4E_Pos       (3U)
+#define TSC_IOGCSR_G4E_Msk       (0x1UL << TSC_IOGCSR_G4E_Pos)                 /*!< 0x00000008 */
+#define TSC_IOGCSR_G4E           TSC_IOGCSR_G4E_Msk                            /*!< Analog IO GROUP4 enable */
+#define TSC_IOGCSR_G5E_Pos       (4U)
+#define TSC_IOGCSR_G5E_Msk       (0x1UL << TSC_IOGCSR_G5E_Pos)                 /*!< 0x00000010 */
+#define TSC_IOGCSR_G5E           TSC_IOGCSR_G5E_Msk                            /*!< Analog IO GROUP5 enable */
+#define TSC_IOGCSR_G6E_Pos       (5U)
+#define TSC_IOGCSR_G6E_Msk       (0x1UL << TSC_IOGCSR_G6E_Pos)                 /*!< 0x00000020 */
+#define TSC_IOGCSR_G6E           TSC_IOGCSR_G6E_Msk                            /*!< Analog IO GROUP6 enable */
+#define TSC_IOGCSR_G7E_Pos       (6U)
+#define TSC_IOGCSR_G7E_Msk       (0x1UL << TSC_IOGCSR_G7E_Pos)                 /*!< 0x00000040 */
+#define TSC_IOGCSR_G7E           TSC_IOGCSR_G7E_Msk                            /*!< Analog IO GROUP7 enable */
+#define TSC_IOGCSR_G1S_Pos       (16U)
+#define TSC_IOGCSR_G1S_Msk       (0x1UL << TSC_IOGCSR_G1S_Pos)                 /*!< 0x00010000 */
+#define TSC_IOGCSR_G1S           TSC_IOGCSR_G1S_Msk                            /*!< Analog IO GROUP1 status */
+#define TSC_IOGCSR_G2S_Pos       (17U)
+#define TSC_IOGCSR_G2S_Msk       (0x1UL << TSC_IOGCSR_G2S_Pos)                 /*!< 0x00020000 */
+#define TSC_IOGCSR_G2S           TSC_IOGCSR_G2S_Msk                            /*!< Analog IO GROUP2 status */
+#define TSC_IOGCSR_G3S_Pos       (18U)
+#define TSC_IOGCSR_G3S_Msk       (0x1UL << TSC_IOGCSR_G3S_Pos)                 /*!< 0x00040000 */
+#define TSC_IOGCSR_G3S           TSC_IOGCSR_G3S_Msk                            /*!< Analog IO GROUP3 status */
+#define TSC_IOGCSR_G4S_Pos       (19U)
+#define TSC_IOGCSR_G4S_Msk       (0x1UL << TSC_IOGCSR_G4S_Pos)                 /*!< 0x00080000 */
+#define TSC_IOGCSR_G4S           TSC_IOGCSR_G4S_Msk                            /*!< Analog IO GROUP4 status */
+#define TSC_IOGCSR_G5S_Pos       (20U)
+#define TSC_IOGCSR_G5S_Msk       (0x1UL << TSC_IOGCSR_G5S_Pos)                 /*!< 0x00100000 */
+#define TSC_IOGCSR_G5S           TSC_IOGCSR_G5S_Msk                            /*!< Analog IO GROUP5 status */
+#define TSC_IOGCSR_G6S_Pos       (21U)
+#define TSC_IOGCSR_G6S_Msk       (0x1UL << TSC_IOGCSR_G6S_Pos)                 /*!< 0x00200000 */
+#define TSC_IOGCSR_G6S           TSC_IOGCSR_G6S_Msk                            /*!< Analog IO GROUP6 status */
+#define TSC_IOGCSR_G7S_Pos       (22U)
+#define TSC_IOGCSR_G7S_Msk       (0x1UL << TSC_IOGCSR_G7S_Pos)                 /*!< 0x00400000 */
+#define TSC_IOGCSR_G7S           TSC_IOGCSR_G7S_Msk                            /*!< Analog IO GROUP7 status */
+
+/*******************  Bit definition for TSC_IOGXCR register  *****************/
+#define TSC_IOGXCR_CNT_Pos       (0U)
+#define TSC_IOGXCR_CNT_Msk       (0x3FFFUL << TSC_IOGXCR_CNT_Pos)              /*!< 0x00003FFF */
+#define TSC_IOGXCR_CNT           TSC_IOGXCR_CNT_Msk                            /*!< CNT[13:0] bits (Counter value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for SYSCFG_MEMRMP register  (SYSCFG memory remap register) ***********************************/
+#define SYSCFG_MEMRMP_MEM_MODE_Pos              (0U)
+#define SYSCFG_MEMRMP_MEM_MODE_Msk              (0x7UL << SYSCFG_MEMRMP_MEM_MODE_Pos)           /*!< 0x00000007 */
+#define SYSCFG_MEMRMP_MEM_MODE                  SYSCFG_MEMRMP_MEM_MODE_Msk                      /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_MEMRMP_MEM_MODE_0                (0x1U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000001 */
+#define SYSCFG_MEMRMP_MEM_MODE_1                (0x2U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000002 */
+#define SYSCFG_MEMRMP_MEM_MODE_2                (0x4U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000004 */
+
+/*****************  Bit definition for SYSCFG_CFGR1 register  (SYSCFG configuration register 1) ****************************************************************/
+#define SYSCFG_CFGR1_BOOSTEN_Pos                (8U)
+#define SYSCFG_CFGR1_BOOSTEN_Msk                (0x1UL << SYSCFG_CFGR1_BOOSTEN_Pos)             /*!< 0x00000100 */
+#define SYSCFG_CFGR1_BOOSTEN                    SYSCFG_CFGR1_BOOSTEN_Msk                        /*!< I/O analog switch voltage booster enable                  */
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Pos            (16U)
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB6_FMP_Pos)         /*!< 0x00010000 */
+#define SYSCFG_CFGR1_I2C_PB6_FMP                SYSCFG_CFGR1_I2C_PB6_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB6 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Pos            (17U)
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB7_FMP_Pos)         /*!< 0x00020000 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP                SYSCFG_CFGR1_I2C_PB7_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB7 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Pos            (18U)
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB8_FMP_Pos)         /*!< 0x00040000 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP                SYSCFG_CFGR1_I2C_PB8_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB8 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Pos            (19U)
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB9_FMP_Pos)         /*!< 0x00080000 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP                SYSCFG_CFGR1_I2C_PB9_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB9 */
+#define SYSCFG_CFGR1_I2C1_FMP_Pos               (20U)
+#define SYSCFG_CFGR1_I2C1_FMP_Msk               (0x1UL << SYSCFG_CFGR1_I2C1_FMP_Pos)            /*!< 0x00100000 */
+#define SYSCFG_CFGR1_I2C1_FMP                   SYSCFG_CFGR1_I2C1_FMP_Msk                       /*!< I2C1 Fast-mode Plus (Fm+) driving capability activation   */
+#define SYSCFG_CFGR1_FPU_IE_Pos                 (26U)
+#define SYSCFG_CFGR1_FPU_IE_Msk                 (0x3FUL << SYSCFG_CFGR1_FPU_IE_Pos)             /*!< 0xFC000000 */
+#define SYSCFG_CFGR1_FPU_IE                     SYSCFG_CFGR1_FPU_IE_Msk                         /*!< Cortex M4 Floating Point Unit interrupts enable bits      */
+#define SYSCFG_CFGR1_FPU_IE_0                   (0x01U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x04000000 */
+#define SYSCFG_CFGR1_FPU_IE_1                   (0x02U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x08000000 */
+#define SYSCFG_CFGR1_FPU_IE_2                   (0x04U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x10000000 */
+#define SYSCFG_CFGR1_FPU_IE_3                   (0x08U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x20000000 */
+#define SYSCFG_CFGR1_FPU_IE_4                   (0x10U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x40000000 */
+#define SYSCFG_CFGR1_FPU_IE_5                   (0x20U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x80000000 */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  (External interrupt configuration register 1) ********************************/
+#define SYSCFG_EXTICR1_EXTI0_Pos                (0U)
+#define SYSCFG_EXTICR1_EXTI0_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI0_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR1_EXTI0                    SYSCFG_EXTICR1_EXTI0_Msk                        /*!< External Interrupt Line 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1_Pos                (4U)
+#define SYSCFG_EXTICR1_EXTI1_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI1_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR1_EXTI1                    SYSCFG_EXTICR1_EXTI1_Msk                        /*!< External Interrupt Line 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2_Pos                (8U)
+#define SYSCFG_EXTICR1_EXTI2_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI2_Pos)             /*!< 0x00000700 */
+#define SYSCFG_EXTICR1_EXTI2                    SYSCFG_EXTICR1_EXTI2_Msk                        /*!< External Interrupt Line 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3_Pos                (12U)
+#define SYSCFG_EXTICR1_EXTI3_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI3_Pos)             /*!< 0x00007000 */
+#define SYSCFG_EXTICR1_EXTI3                    SYSCFG_EXTICR1_EXTI3_Msk                        /*!< External Interrupt Line 3 configuration */
+
+/**
+  * @brief  External Interrupt Line 0 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA                 (0x00000000UL)  /*!< PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB                 (0x00000001UL)  /*!< PB[0] pin */
+
+/**
+  * @brief  External Interrupt Line 1 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA                 (0x00000000UL)  /*!< PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB                 (0x00000010UL)  /*!< PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC                 (0x00000020UL)  /*!< PC[1] pin */
+
+/**
+  * @brief  External Interrupt Line 2 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA                 (0x00000000UL)  /*!< PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB                 (0x00000100UL)  /*!< PB[2] pin */
+
+/**
+  * @brief  External Interrupt Line 3 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA                 (0x00000000UL)  /*!< PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB                 (0x00001000UL)  /*!< PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH                 (0x00007000UL)  /*!< PH[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  (External interrupt configuration register 2) ********************************/
+#define SYSCFG_EXTICR2_EXTI4_Pos                (0U)
+#define SYSCFG_EXTICR2_EXTI4_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI4_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR2_EXTI4                    SYSCFG_EXTICR2_EXTI4_Msk                        /*!< External Interrupt Line 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5_Pos                (4U)
+#define SYSCFG_EXTICR2_EXTI5_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI5_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR2_EXTI5                    SYSCFG_EXTICR2_EXTI5_Msk                        /*!< External Interrupt Line 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6_Pos                (8U)
+#define SYSCFG_EXTICR2_EXTI6_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI6_Pos)             /*!< 0x00000700 */
+#define SYSCFG_EXTICR2_EXTI6                    SYSCFG_EXTICR2_EXTI6_Msk                        /*!< External Interrupt Line 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7_Pos                (12U)
+#define SYSCFG_EXTICR2_EXTI7_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI7_Pos)             /*!< 0x00007000 */
+#define SYSCFG_EXTICR2_EXTI7                    SYSCFG_EXTICR2_EXTI7_Msk                        /*!< External Interrupt Line 7 configuration */
+
+/**
+  * @brief  External Interrupt Line 4 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA                 (0x00000000UL)  /*!< PA[4] pin  */
+#define SYSCFG_EXTICR2_EXTI4_PB                 (0x00000001UL)  /*!< PB[4] pin  */
+#define SYSCFG_EXTICR2_EXTI4_PE                 (0x00000004UL)  /*!< PE[4] pin  */
+
+/**
+  * @brief  External Interrupt Line 5 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA                 (0x00000000UL)  /*!< PA[5] pin  */
+#define SYSCFG_EXTICR2_EXTI5_PB                 (0x00000010UL)  /*!< PB[5] pin  */
+
+/**
+  * @brief  External Interrupt Line 6 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA                 (0x00000000UL)  /*!< PA[6] pin  */
+#define SYSCFG_EXTICR2_EXTI6_PB                 (0x00000100UL)  /*!< PB[6] pin  */
+
+/**
+  * @brief  External Interrupt Line 7 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA                 (0x00000000UL)  /*!< PA[7] pin  */
+#define SYSCFG_EXTICR2_EXTI7_PB                 (0x00001000UL)  /*!< PB[7] pin  */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  (External interrupt configuration register 3) ********************************/
+#define SYSCFG_EXTICR3_EXTI8_Pos                (0U)
+#define SYSCFG_EXTICR3_EXTI8_Msk                (0x7UL << SYSCFG_EXTICR3_EXTI8_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR3_EXTI8                    SYSCFG_EXTICR3_EXTI8_Msk                        /*!< External Interrupt Line 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9_Pos                (4U)
+#define SYSCFG_EXTICR3_EXTI9_Msk                (0x7UL << SYSCFG_EXTICR3_EXTI9_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR3_EXTI9                    SYSCFG_EXTICR3_EXTI9_Msk                        /*!< External Interrupt Line 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10_Pos               (8U)
+#define SYSCFG_EXTICR3_EXTI10_Msk               (0x7UL << SYSCFG_EXTICR3_EXTI10_Pos)            /*!< 0x00000700 */
+#define SYSCFG_EXTICR3_EXTI10                   SYSCFG_EXTICR3_EXTI10_Msk                       /*!< External Interrupt Line 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11_Pos               (12U)
+#define SYSCFG_EXTICR3_EXTI11_Msk               (0xFUL << SYSCFG_EXTICR3_EXTI11_Pos)            /*!< 0x0000F000 */
+#define SYSCFG_EXTICR3_EXTI11                   SYSCFG_EXTICR3_EXTI11_Msk                       /*!< External Interrupt Line 11 configuration */
+
+/**
+  * @brief  External Interrupt Line 8 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA                 (0x00000000UL)  /*!< PA[8] pin  */
+#define SYSCFG_EXTICR3_EXTI8_PB                 (0x00000001UL)  /*!< PB[8] pin  */
+
+/**
+  * @brief  External Interrupt Line 9 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA                 (0x00000000UL)  /*!< PA[9] pin  */
+#define SYSCFG_EXTICR3_EXTI9_PB                 (0x00000010UL)  /*!< PB[9] pin  */
+
+/**
+  * @brief  External Interrupt Line 10 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA                (0x00000000UL)  /*!< PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB                (0x00000100UL)  /*!< PB[10] pin */
+
+/**
+  * @brief  External Interrupt Line 11 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA                (0x00000000UL)  /*!< PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB                (0x00001000UL)  /*!< PB[11] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  (External interrupt configuration register 4) *********************************/
+#define SYSCFG_EXTICR4_EXTI12_Pos               (0U)
+#define SYSCFG_EXTICR4_EXTI12_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI12_Pos)            /*!< 0x00000007 */
+#define SYSCFG_EXTICR4_EXTI12                   SYSCFG_EXTICR4_EXTI12_Msk                       /*!< External Interrupt Line 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13_Pos               (4U)
+#define SYSCFG_EXTICR4_EXTI13_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI13_Pos)            /*!< 0x00000070 */
+#define SYSCFG_EXTICR4_EXTI13                   SYSCFG_EXTICR4_EXTI13_Msk                       /*!< External Interrupt Line 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14_Pos               (8U)
+#define SYSCFG_EXTICR4_EXTI14_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI14_Pos)            /*!< 0x00000700 */
+#define SYSCFG_EXTICR4_EXTI14                   SYSCFG_EXTICR4_EXTI14_Msk                       /*!< External Interrupt Line 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15_Pos               (12U)
+#define SYSCFG_EXTICR4_EXTI15_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI15_Pos)            /*!< 0x00007000 */
+#define SYSCFG_EXTICR4_EXTI15                   SYSCFG_EXTICR4_EXTI15_Msk                       /*!< External Interrupt Line 15 configuration */
+
+/**
+  * @brief  External Interrupt Line 12 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA                (0x00000000UL)  /*!< PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB                (0x00000001UL)  /*!< PB[12] pin */
+
+/**
+  * @brief  External Interrupt Line 13 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA                (0x00000000UL)  /*!< PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB                (0x00000010UL)  /*!< PB[13] pin */
+
+/**
+  * @brief  External Interrupt Line 14 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA                (0x00000000UL)  /*!< PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB                (0x00000100UL)  /*!< PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC                (0x00000200UL)  /*!< PC[14] pin */
+
+/**
+  * @brief  External Interrupt Line 15 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA                (0x00000000UL)  /*!< PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB                (0x00001000UL)  /*!< PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC                (0x00002000UL)  /*!< PC[15] pin */
+
+/*****************  Bit definition for SYSCFG_SCSR register  (SYSCFG SRAM2 control and status register) *********************************************************/
+#define SYSCFG_SCSR_SRAM2ER_Pos                 (0U)
+#define SYSCFG_SCSR_SRAM2ER_Msk                 (0x1UL << SYSCFG_SCSR_SRAM2ER_Pos)              /*!< 0x00000001 */
+#define SYSCFG_SCSR_SRAM2ER                     SYSCFG_SCSR_SRAM2ER_Msk                         /*!< SRAM2 and PKA RAM Erase                                    */
+#define SYSCFG_SCSR_SRAM2BSY_Pos                (1U)
+#define SYSCFG_SCSR_SRAM2BSY_Msk                (0x1UL << SYSCFG_SCSR_SRAM2BSY_Pos)             /*!< 0x00000002 */
+#define SYSCFG_SCSR_SRAM2BSY                    SYSCFG_SCSR_SRAM2BSY_Msk                        /*!< SRAM2 and PKA RAM busy by erase operation                  */
+#define SYSCFG_SCSR_C2RFD_Pos                   (31U)
+#define SYSCFG_SCSR_C2RFD_Msk                   (0x1UL << SYSCFG_SCSR_C2RFD_Pos)                /*!< 0x80000000 */
+#define SYSCFG_SCSR_C2RFD                       SYSCFG_SCSR_C2RFD_Msk                           /*!< CPU2 SRAM fetch (execution) disable                        */
+
+/*****************  Bit definition for SYSCFG_CFGR2 register  (SYSCFG configuration register 2) *****************************************************************/
+#define SYSCFG_CFGR2_CLL_Pos                    (0U)
+#define SYSCFG_CFGR2_CLL_Msk                    (0x1UL << SYSCFG_CFGR2_CLL_Pos)                 /*!< 0x00000001 */
+#define SYSCFG_CFGR2_CLL                        SYSCFG_CFGR2_CLL_Msk                            /*!< Cortex M4 LOCKUP (hardfault) output enable                 */
+#define SYSCFG_CFGR2_SPL_Pos                    (1U)
+#define SYSCFG_CFGR2_SPL_Msk                    (0x1UL << SYSCFG_CFGR2_SPL_Pos)                 /*!< 0x00000002 */
+#define SYSCFG_CFGR2_SPL                        SYSCFG_CFGR2_SPL_Msk                            /*!< SRAM2 Parity Lock                                          */
+#define SYSCFG_CFGR2_PVDL_Pos                   (2U)
+#define SYSCFG_CFGR2_PVDL_Msk                   (0x1UL << SYSCFG_CFGR2_PVDL_Pos)                /*!< 0x00000004 */
+#define SYSCFG_CFGR2_PVDL                       SYSCFG_CFGR2_PVDL_Msk                           /*!< PVD Lock                                                   */
+#define SYSCFG_CFGR2_ECCL_Pos                   (3U)
+#define SYSCFG_CFGR2_ECCL_Msk                   (0x1UL << SYSCFG_CFGR2_ECCL_Pos)                /*!< 0x00000008 */
+#define SYSCFG_CFGR2_ECCL                       SYSCFG_CFGR2_ECCL_Msk                           /*!< ECC Lock                                                   */
+#define SYSCFG_CFGR2_SPF_Pos                    (8U)
+#define SYSCFG_CFGR2_SPF_Msk                    (0x1UL << SYSCFG_CFGR2_SPF_Pos)                 /*!< 0x00000100 */
+#define SYSCFG_CFGR2_SPF                        SYSCFG_CFGR2_SPF_Msk                            /*!< SRAM2 Parity Lock                                          */
+
+/*****************  Bit definition for SYSCFG_SWPR1 register  (SYSCFG SRAM2A write protection register) *********************************************************/
+#define SYSCFG_SWPR1_PAGE0_Pos                  (0U)
+#define SYSCFG_SWPR1_PAGE0_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE0_Pos)               /*!< 0x00000001 */
+#define SYSCFG_SWPR1_PAGE0                      SYSCFG_SWPR1_PAGE0_Msk                          /*!< SRAM2A Write protection page 0 (0x20030000 - 0x200303FF)   */
+#define SYSCFG_SWPR1_PAGE1_Pos                  (1U)
+#define SYSCFG_SWPR1_PAGE1_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE1_Pos)               /*!< 0x00000002 */
+#define SYSCFG_SWPR1_PAGE1                      SYSCFG_SWPR1_PAGE1_Msk                          /*!< SRAM2A Write protection page 1 (0x20030400 - 0x200307FF)   */
+#define SYSCFG_SWPR1_PAGE2_Pos                  (2U)
+#define SYSCFG_SWPR1_PAGE2_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE2_Pos)               /*!< 0x00000004 */
+#define SYSCFG_SWPR1_PAGE2                      SYSCFG_SWPR1_PAGE2_Msk                          /*!< SRAM2A Write protection page 2 (0x20030800 - 0x20030BFF)   */
+#define SYSCFG_SWPR1_PAGE3_Pos                  (3U)
+#define SYSCFG_SWPR1_PAGE3_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE3_Pos)               /*!< 0x00000008 */
+#define SYSCFG_SWPR1_PAGE3                      SYSCFG_SWPR1_PAGE3_Msk                          /*!< SRAM2A Write protection page 3 (0x20030C00 - 0x20030FFF)   */
+#define SYSCFG_SWPR1_PAGE4_Pos                  (4U)
+#define SYSCFG_SWPR1_PAGE4_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE4_Pos)               /*!< 0x00000010 */
+#define SYSCFG_SWPR1_PAGE4                      SYSCFG_SWPR1_PAGE4_Msk                          /*!< SRAM2A Write protection page 4 (0x20031000 - 0x200313FF)   */
+#define SYSCFG_SWPR1_PAGE5_Pos                  (5U)
+#define SYSCFG_SWPR1_PAGE5_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE5_Pos)               /*!< 0x00000020 */
+#define SYSCFG_SWPR1_PAGE5                      SYSCFG_SWPR1_PAGE5_Msk                          /*!< SRAM2A Write protection page 5 (0x20031400 - 0x200317FF)   */
+#define SYSCFG_SWPR1_PAGE6_Pos                  (6U)
+#define SYSCFG_SWPR1_PAGE6_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE6_Pos)               /*!< 0x00000040 */
+#define SYSCFG_SWPR1_PAGE6                      SYSCFG_SWPR1_PAGE6_Msk                          /*!< SRAM2A Write protection page 6 (0x20031800 - 0x20031BFF)   */
+#define SYSCFG_SWPR1_PAGE7_Pos                  (7U)
+#define SYSCFG_SWPR1_PAGE7_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE7_Pos)               /*!< 0x00000080 */
+#define SYSCFG_SWPR1_PAGE7                      SYSCFG_SWPR1_PAGE7_Msk                          /*!< SRAM2A Write protection page 7 (0x20031C00 - 0x20031FFF)   */
+#define SYSCFG_SWPR1_PAGE8_Pos                  (8U)
+#define SYSCFG_SWPR1_PAGE8_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE8_Pos)               /*!< 0x00000100 */
+#define SYSCFG_SWPR1_PAGE8                      SYSCFG_SWPR1_PAGE8_Msk                          /*!< SRAM2A Write protection page 8 (0x20032000 - 0x200323FF)   */
+#define SYSCFG_SWPR1_PAGE9_Pos                  (9U)
+#define SYSCFG_SWPR1_PAGE9_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE9_Pos)               /*!< 0x00000200 */
+#define SYSCFG_SWPR1_PAGE9                      SYSCFG_SWPR1_PAGE9_Msk                          /*!< SRAM2A Write protection page 9 (0x20032400 - 0x200327FF)   */
+#define SYSCFG_SWPR1_PAGE10_Pos                 (10U)
+#define SYSCFG_SWPR1_PAGE10_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE10_Pos)              /*!< 0x00000400 */
+#define SYSCFG_SWPR1_PAGE10                     SYSCFG_SWPR1_PAGE10_Msk                         /*!< SRAM2A Write protection page 10 (0x20032800 - 0x20032BFF)  */
+#define SYSCFG_SWPR1_PAGE11_Pos                 (11U)
+#define SYSCFG_SWPR1_PAGE11_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE11_Pos)              /*!< 0x00000800 */
+#define SYSCFG_SWPR1_PAGE11                     SYSCFG_SWPR1_PAGE11_Msk                         /*!< SRAM2A Write protection page 11 (0x20032C00 - 0x20032FFF)  */
+#define SYSCFG_SWPR1_PAGE12_Pos                 (12U)
+#define SYSCFG_SWPR1_PAGE12_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE12_Pos)              /*!< 0x00001000 */
+#define SYSCFG_SWPR1_PAGE12                     SYSCFG_SWPR1_PAGE12_Msk                         /*!< SRAM2A Write protection page 12 (0x20033000 - 0x200333FF)  */
+#define SYSCFG_SWPR1_PAGE13_Pos                 (13U)
+#define SYSCFG_SWPR1_PAGE13_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE13_Pos)              /*!< 0x00002000 */
+#define SYSCFG_SWPR1_PAGE13                     SYSCFG_SWPR1_PAGE13_Msk                         /*!< SRAM2A Write protection page 13 (0x20033400 - 0x200337FF)  */
+#define SYSCFG_SWPR1_PAGE14_Pos                 (14U)
+#define SYSCFG_SWPR1_PAGE14_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE14_Pos)              /*!< 0x00004000 */
+#define SYSCFG_SWPR1_PAGE14                     SYSCFG_SWPR1_PAGE14_Msk                         /*!< SRAM2A Write protection page 14 (0x20033800 - 0x20033BFF)  */
+#define SYSCFG_SWPR1_PAGE15_Pos                 (15U)
+#define SYSCFG_SWPR1_PAGE15_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE15_Pos)              /*!< 0x00008000 */
+#define SYSCFG_SWPR1_PAGE15                     SYSCFG_SWPR1_PAGE15_Msk                         /*!< SRAM2A Write protection page 15 (0x20033C00 - 0x20033FFF)  */
+#define SYSCFG_SWPR1_PAGE16_Pos                 (16U)
+#define SYSCFG_SWPR1_PAGE16_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE16_Pos)              /*!< 0x00010000 */
+#define SYSCFG_SWPR1_PAGE16                     SYSCFG_SWPR1_PAGE16_Msk                         /*!< SRAM2A Write protection page 16 (0x20034000 - 0x200343FF)  */
+#define SYSCFG_SWPR1_PAGE17_Pos                 (17U)
+#define SYSCFG_SWPR1_PAGE17_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE17_Pos)              /*!< 0x00020000 */
+#define SYSCFG_SWPR1_PAGE17                     SYSCFG_SWPR1_PAGE17_Msk                         /*!< SRAM2A Write protection page 17 (0x20034400 - 0x200347FF)  */
+#define SYSCFG_SWPR1_PAGE18_Pos                 (18U)
+#define SYSCFG_SWPR1_PAGE18_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE18_Pos)              /*!< 0x00040000 */
+#define SYSCFG_SWPR1_PAGE18                     SYSCFG_SWPR1_PAGE18_Msk                         /*!< SRAM2A Write protection page 18 (0x20034800 - 0x20034BFF)  */
+#define SYSCFG_SWPR1_PAGE19_Pos                 (19U)
+#define SYSCFG_SWPR1_PAGE19_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE19_Pos)              /*!< 0x00080000 */
+#define SYSCFG_SWPR1_PAGE19                     SYSCFG_SWPR1_PAGE19_Msk                         /*!< SRAM2A Write protection page 19 (0x20034C00 - 0x20034FFF)  */
+#define SYSCFG_SWPR1_PAGE20_Pos                 (20U)
+#define SYSCFG_SWPR1_PAGE20_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE20_Pos)              /*!< 0x00100000 */
+#define SYSCFG_SWPR1_PAGE20                     SYSCFG_SWPR1_PAGE20_Msk                         /*!< SRAM2A Write protection page 20 (0x20035000 - 0x200353FF)  */
+#define SYSCFG_SWPR1_PAGE21_Pos                 (21U)
+#define SYSCFG_SWPR1_PAGE21_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE21_Pos)              /*!< 0x00200000 */
+#define SYSCFG_SWPR1_PAGE21                     SYSCFG_SWPR1_PAGE21_Msk                         /*!< SRAM2A Write protection page 21 (0x20035400 - 0x200357FF)  */
+#define SYSCFG_SWPR1_PAGE22_Pos                 (22U)
+#define SYSCFG_SWPR1_PAGE22_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE22_Pos)              /*!< 0x00400000 */
+#define SYSCFG_SWPR1_PAGE22                     SYSCFG_SWPR1_PAGE22_Msk                         /*!< SRAM2A Write protection page 22 (0x20035800 - 0x20035BFF)  */
+#define SYSCFG_SWPR1_PAGE23_Pos                 (23U)
+#define SYSCFG_SWPR1_PAGE23_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE23_Pos)              /*!< 0x00800000 */
+#define SYSCFG_SWPR1_PAGE23                     SYSCFG_SWPR1_PAGE23_Msk                         /*!< SRAM2A Write protection page 23 (0x20035C00 - 0x20035FFF)  */
+#define SYSCFG_SWPR1_PAGE24_Pos                 (24U)
+#define SYSCFG_SWPR1_PAGE24_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE24_Pos)              /*!< 0x01000000 */
+#define SYSCFG_SWPR1_PAGE24                     SYSCFG_SWPR1_PAGE24_Msk                         /*!< SRAM2A Write protection page 24 (0x20036000 - 0x200363FF)  */
+#define SYSCFG_SWPR1_PAGE25_Pos                 (25U)
+#define SYSCFG_SWPR1_PAGE25_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE25_Pos)              /*!< 0x02000000 */
+#define SYSCFG_SWPR1_PAGE25                     SYSCFG_SWPR1_PAGE25_Msk                         /*!< SRAM2A Write protection page 25 (0x20036400 - 0x200367FF)  */
+#define SYSCFG_SWPR1_PAGE26_Pos                 (26U)
+#define SYSCFG_SWPR1_PAGE26_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE26_Pos)              /*!< 0x04000000 */
+#define SYSCFG_SWPR1_PAGE26                     SYSCFG_SWPR1_PAGE26_Msk                         /*!< SRAM2A Write protection page 26 (0x20036800 - 0x20036BFF)  */
+#define SYSCFG_SWPR1_PAGE27_Pos                 (27U)
+#define SYSCFG_SWPR1_PAGE27_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE27_Pos)              /*!< 0x08000000 */
+#define SYSCFG_SWPR1_PAGE27                     SYSCFG_SWPR1_PAGE27_Msk                         /*!< SRAM2A Write protection page 27 (0x20036C00 - 0x20036FFF)  */
+#define SYSCFG_SWPR1_PAGE28_Pos                 (28U)
+#define SYSCFG_SWPR1_PAGE28_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE28_Pos)              /*!< 0x10000000 */
+#define SYSCFG_SWPR1_PAGE28                     SYSCFG_SWPR1_PAGE28_Msk                         /*!< SRAM2A Write protection page 28 (0x20037000 - 0x200373FF)  */
+#define SYSCFG_SWPR1_PAGE29_Pos                 (29U)
+#define SYSCFG_SWPR1_PAGE29_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE29_Pos)              /*!< 0x20000000 */
+#define SYSCFG_SWPR1_PAGE29                     SYSCFG_SWPR1_PAGE29_Msk                         /*!< SRAM2A Write protection page 29 (0x20037400 - 0x200377FF)  */
+#define SYSCFG_SWPR1_PAGE30_Pos                 (30U)
+#define SYSCFG_SWPR1_PAGE30_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE30_Pos)              /*!< 0x40000000 */
+#define SYSCFG_SWPR1_PAGE30                     SYSCFG_SWPR1_PAGE30_Msk                         /*!< SRAM2A Write protection page 30 (0x20037800 - 0x20037BFF)  */
+#define SYSCFG_SWPR1_PAGE31_Pos                 (31U)
+#define SYSCFG_SWPR1_PAGE31_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE31_Pos)              /*!< 0x80000000 */
+#define SYSCFG_SWPR1_PAGE31                     SYSCFG_SWPR1_PAGE31_Msk                         /*!< SRAM2A Write protection page 31 (0x20037C00 - 0x20037FFF)  */
+
+/*****************  Bit definition for SYSCFG_SKR register  (SYSCFG SRAM2 key register) *************************************************************************/
+#define SYSCFG_SKR_KEY_Pos                      (0U)
+#define SYSCFG_SKR_KEY_Msk                      (0xFFUL << SYSCFG_SKR_KEY_Pos)                  /*!< 0x000000FF */
+#define SYSCFG_SKR_KEY                          SYSCFG_SKR_KEY_Msk                              /*!< SRAM2 write protection key for software erase              */
+
+/*****************  Bit definition for SYSCFG_SWPR2 register  (SYSCFG SRAM2 write protection register) **********************************************************/
+#define SYSCFG_SWPR2_PAGE32_Pos                 (0U)
+#define SYSCFG_SWPR2_PAGE32_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE32_Pos)              /*!< 0x00000001 */
+#define SYSCFG_SWPR2_PAGE32                     SYSCFG_SWPR2_PAGE32_Msk                         /*!< SRAM2B Write protection page 0 (0x20038000 - 0x200383FF)   */
+#define SYSCFG_SWPR2_PAGE33_Pos                 (1U)
+#define SYSCFG_SWPR2_PAGE33_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE33_Pos)              /*!< 0x00000002 */
+#define SYSCFG_SWPR2_PAGE33                     SYSCFG_SWPR2_PAGE33_Msk                         /*!< SRAM2B Write protection page 1 (0x20038400 - 0x200387FF)   */
+#define SYSCFG_SWPR2_PAGE34_Pos                 (2U)
+#define SYSCFG_SWPR2_PAGE34_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE34_Pos)              /*!< 0x00000004 */
+#define SYSCFG_SWPR2_PAGE34                     SYSCFG_SWPR2_PAGE34_Msk                         /*!< SRAM2B Write protection page 2 (0x20038800 - 0x20038bFF)   */
+#define SYSCFG_SWPR2_PAGE35_Pos                 (3U)
+#define SYSCFG_SWPR2_PAGE35_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE35_Pos)              /*!< 0x00000008 */
+#define SYSCFG_SWPR2_PAGE35                     SYSCFG_SWPR2_PAGE35_Msk                         /*!< SRAM2B Write protection page 3 (0x20038C00 - 0x20038FFF)   */
+
+/*****************  Bit definition for SYSCFG_IMR1 register (Interrupt masks control and status register on CPU1 - part 1) *******************************************/
+#define SYSCFG_IMR1_TIM1IM_Pos                  (13U)
+#define SYSCFG_IMR1_TIM1IM_Msk                  (0x1UL << SYSCFG_IMR1_TIM1IM_Pos)             /*!< 0x00002000 */
+#define SYSCFG_IMR1_TIM1IM                      SYSCFG_IMR1_TIM1IM_Msk                        /*!< Enabling of interrupt from Timer 1 to CPU1                        */
+#define SYSCFG_IMR1_EXTI5IM_Pos                 (21U)
+#define SYSCFG_IMR1_EXTI5IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI5IM_Pos)            /*!< 0x00200000 */
+#define SYSCFG_IMR1_EXTI5IM                     SYSCFG_IMR1_EXTI5IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 5 to CPU1      */
+#define SYSCFG_IMR1_EXTI6IM_Pos                 (22U)
+#define SYSCFG_IMR1_EXTI6IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI6IM_Pos)            /*!< 0x00400000 */
+#define SYSCFG_IMR1_EXTI6IM                     SYSCFG_IMR1_EXTI6IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 6 to CPU1      */
+#define SYSCFG_IMR1_EXTI7IM_Pos                 (23U)
+#define SYSCFG_IMR1_EXTI7IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI7IM_Pos)            /*!< 0x00800000 */
+#define SYSCFG_IMR1_EXTI7IM                     SYSCFG_IMR1_EXTI7IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 7 to CPU1      */
+#define SYSCFG_IMR1_EXTI8IM_Pos                 (24U)
+#define SYSCFG_IMR1_EXTI8IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI8IM_Pos)            /*!< 0x01000000 */
+#define SYSCFG_IMR1_EXTI8IM                     SYSCFG_IMR1_EXTI8IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 8 to CPU1      */
+#define SYSCFG_IMR1_EXTI9IM_Pos                 (25U)
+#define SYSCFG_IMR1_EXTI9IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI9IM_Pos)            /*!< 0x02000000 */
+#define SYSCFG_IMR1_EXTI9IM                     SYSCFG_IMR1_EXTI9IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 9 to CPU1      */
+#define SYSCFG_IMR1_EXTI10IM_Pos                (26U)
+#define SYSCFG_IMR1_EXTI10IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI10IM_Pos)           /*!< 0x04000000 */
+#define SYSCFG_IMR1_EXTI10IM                    SYSCFG_IMR1_EXTI10IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 10 to CPU1     */
+#define SYSCFG_IMR1_EXTI11IM_Pos                (27U)
+#define SYSCFG_IMR1_EXTI11IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI11IM_Pos)           /*!< 0x08000000 */
+#define SYSCFG_IMR1_EXTI11IM                    SYSCFG_IMR1_EXTI11IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 11 to CPU1     */
+#define SYSCFG_IMR1_EXTI12IM_Pos                (28U)
+#define SYSCFG_IMR1_EXTI12IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI12IM_Pos)           /*!< 0x10000000 */
+#define SYSCFG_IMR1_EXTI12IM                    SYSCFG_IMR1_EXTI12IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 12 to CPU1     */
+#define SYSCFG_IMR1_EXTI13IM_Pos                (29U)
+#define SYSCFG_IMR1_EXTI13IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI13IM_Pos)           /*!< 0x20000000 */
+#define SYSCFG_IMR1_EXTI13IM                    SYSCFG_IMR1_EXTI13IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 13 to CPU1     */
+#define SYSCFG_IMR1_EXTI14IM_Pos                (30U)
+#define SYSCFG_IMR1_EXTI14IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI14IM_Pos)           /*!< 0x40000000 */
+#define SYSCFG_IMR1_EXTI14IM                    SYSCFG_IMR1_EXTI14IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 14 to CPU1     */
+#define SYSCFG_IMR1_EXTI15IM_Pos                (31U)
+#define SYSCFG_IMR1_EXTI15IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI15IM_Pos)           /*!< 0x80000000 */
+#define SYSCFG_IMR1_EXTI15IM                    SYSCFG_IMR1_EXTI15IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 15 to CPU1     */
+
+/*****************  Bit definition for SYSCFG_IMR2 register (Interrupt masks control and status register on CPU1 - part 2) *******************************************/
+#define SYSCFG_IMR2_PVM3IM_Pos                  (18U)
+#define SYSCFG_IMR2_PVM3IM_Msk                  (0x1UL << SYSCFG_IMR2_PVM3IM_Pos)             /*!< 0x00040000 */
+#define SYSCFG_IMR2_PVM3IM                      SYSCFG_IMR2_PVM3IM_Msk                        /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU1     */
+#define SYSCFG_IMR2_PVDIM_Pos                   (20U)
+#define SYSCFG_IMR2_PVDIM_Msk                   (0x1UL << SYSCFG_IMR2_PVDIM_Pos)              /*!< 0x00100000 */
+#define SYSCFG_IMR2_PVDIM                       SYSCFG_IMR2_PVDIM_Msk                         /*!< Enabling of interrupt from Power Voltage Detector to CPU1         */
+
+/*****************  Bit definition for SYSCFG_C2IMR1 register (Interrupt masks control and status register on CPU2 - part 1) *******************************************/
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Pos    (0U)
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Msk    (0x1UL << SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Pos) /*!< 0x00000001 */
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM        SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Msk            /* !< Enabling of interrupt from RTC TimeStamp, RTC Tampers
+                                                                                                      and LSE Clock Security System to CPU2                            */
+#define SYSCFG_C2IMR1_RTCWKUPIM_Pos             (3U)
+#define SYSCFG_C2IMR1_RTCWKUPIM_Msk             (0x1UL << SYSCFG_C2IMR1_RTCWKUPIM_Pos)          /*!< 0x00000008 */
+#define SYSCFG_C2IMR1_RTCWKUPIM                 SYSCFG_C2IMR1_RTCWKUPIM_Msk                     /*!< Enabling of interrupt from RTC Wakeup to CPU2                     */
+#define SYSCFG_C2IMR1_RTCALARMIM_Pos            (4U)
+#define SYSCFG_C2IMR1_RTCALARMIM_Msk            (0x1UL << SYSCFG_C2IMR1_RTCALARMIM_Pos)         /*!< 0x00000010 */
+#define SYSCFG_C2IMR1_RTCALARMIM                SYSCFG_C2IMR1_RTCALARMIM_Msk                    /*!< Enabling of interrupt from RTC Alarms to CPU2                     */
+#define SYSCFG_C2IMR1_RCCIM_Pos                 (5U)
+#define SYSCFG_C2IMR1_RCCIM_Msk                 (0x1UL << SYSCFG_C2IMR1_RCCIM_Pos)              /*!< 0x00000020 */
+#define SYSCFG_C2IMR1_RCCIM                     SYSCFG_C2IMR1_RCCIM_Msk                         /*!< Enabling of interrupt from RCC to CPU2                            */
+#define SYSCFG_C2IMR1_FLASHIM_Pos               (6U)
+#define SYSCFG_C2IMR1_FLASHIM_Msk               (0x1UL << SYSCFG_C2IMR1_FLASHIM_Pos)            /*!< 0x00000040 */
+#define SYSCFG_C2IMR1_FLASHIM                   SYSCFG_C2IMR1_FLASHIM_Msk                       /*!< Enabling of interrupt from FLASH to CPU2                          */
+#define SYSCFG_C2IMR1_PKAIM_Pos                 (8U)
+#define SYSCFG_C2IMR1_PKAIM_Msk                 (0x1UL << SYSCFG_C2IMR1_PKAIM_Pos)              /*!< 0x00000100 */
+#define SYSCFG_C2IMR1_PKAIM                     SYSCFG_C2IMR1_PKAIM_Msk                         /*!< Enabling of interrupt from Public Key Accelerator to CPU2         */
+#define SYSCFG_C2IMR1_RNGIM_Pos                 (9U)
+#define SYSCFG_C2IMR1_RNGIM_Msk                 (0x1UL << SYSCFG_C2IMR1_RNGIM_Pos)              /*!< 0x00000200 */
+#define SYSCFG_C2IMR1_RNGIM                     SYSCFG_C2IMR1_RNGIM_Msk                         /*!< Enabling of interrupt from Random Number Generator to CPU2        */
+#define SYSCFG_C2IMR1_COMPIM_Pos                (11U)
+#define SYSCFG_C2IMR1_COMPIM_Msk                (0x1UL << SYSCFG_C2IMR1_COMPIM_Pos)             /*!< 0x00000800 */
+#define SYSCFG_C2IMR1_COMPIM                    SYSCFG_C2IMR1_COMPIM_Msk                        /*!< Enabling of interrupt from Comparator to CPU2                     */
+#define SYSCFG_C2IMR1_ADCIM_Pos                 (12U)
+#define SYSCFG_C2IMR1_ADCIM_Msk                 (0x1UL << SYSCFG_C2IMR1_ADCIM_Pos)              /*!< 0x00001000 */
+#define SYSCFG_C2IMR1_ADCIM                     SYSCFG_C2IMR1_ADCIM_Msk                         /*!< Enabling of interrupt from Analog Digital Converter to CPU2       */
+#define SYSCFG_C2IMR1_EXTI0IM_Pos               (16U)
+#define SYSCFG_C2IMR1_EXTI0IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI0IM_Pos)            /*!< 0x00010000 */
+#define SYSCFG_C2IMR1_EXTI0IM                   SYSCFG_C2IMR1_EXTI0IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 0 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI1IM_Pos               (17U)
+#define SYSCFG_C2IMR1_EXTI1IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI1IM_Pos)            /*!< 0x00020000 */
+#define SYSCFG_C2IMR1_EXTI1IM                   SYSCFG_C2IMR1_EXTI1IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 1 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI2IM_Pos               (18U)
+#define SYSCFG_C2IMR1_EXTI2IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI2IM_Pos)            /*!< 0x00040000 */
+#define SYSCFG_C2IMR1_EXTI2IM                   SYSCFG_C2IMR1_EXTI2IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 2 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI3IM_Pos               (19U)
+#define SYSCFG_C2IMR1_EXTI3IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI3IM_Pos)            /*!< 0x00080000 */
+#define SYSCFG_C2IMR1_EXTI3IM                   SYSCFG_C2IMR1_EXTI3IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 3 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI4IM_Pos               (20U)
+#define SYSCFG_C2IMR1_EXTI4IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI4IM_Pos)            /*!< 0x00100000 */
+#define SYSCFG_C2IMR1_EXTI4IM                   SYSCFG_C2IMR1_EXTI4IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 4 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI5IM_Pos               (21U)
+#define SYSCFG_C2IMR1_EXTI5IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI5IM_Pos)            /*!< 0x00200000 */
+#define SYSCFG_C2IMR1_EXTI5IM                   SYSCFG_C2IMR1_EXTI5IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 5 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI6IM_Pos               (22U)
+#define SYSCFG_C2IMR1_EXTI6IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI6IM_Pos)            /*!< 0x00400000 */
+#define SYSCFG_C2IMR1_EXTI6IM                   SYSCFG_C2IMR1_EXTI6IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 6 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI7IM_Pos               (23U)
+#define SYSCFG_C2IMR1_EXTI7IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI7IM_Pos)            /*!< 0x00800000 */
+#define SYSCFG_C2IMR1_EXTI7IM                   SYSCFG_C2IMR1_EXTI7IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 7 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI8IM_Pos               (24U)
+#define SYSCFG_C2IMR1_EXTI8IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI8IM_Pos)            /*!< 0x01000000 */
+#define SYSCFG_C2IMR1_EXTI8IM                   SYSCFG_C2IMR1_EXTI8IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 8 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI9IM_Pos               (25U)
+#define SYSCFG_C2IMR1_EXTI9IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI9IM_Pos)            /*!< 0x02000000 */
+#define SYSCFG_C2IMR1_EXTI9IM                   SYSCFG_C2IMR1_EXTI9IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 9 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI10IM_Pos              (26U)
+#define SYSCFG_C2IMR1_EXTI10IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI10IM_Pos)           /*!< 0x04000000 */
+#define SYSCFG_C2IMR1_EXTI10IM                  SYSCFG_C2IMR1_EXTI10IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 10 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI11IM_Pos              (27U)
+#define SYSCFG_C2IMR1_EXTI11IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI11IM_Pos)           /*!< 0x08000000 */
+#define SYSCFG_C2IMR1_EXTI11IM                  SYSCFG_C2IMR1_EXTI11IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 11 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI12IM_Pos              (28U)
+#define SYSCFG_C2IMR1_EXTI12IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI12IM_Pos)           /*!< 0x10000000 */
+#define SYSCFG_C2IMR1_EXTI12IM                  SYSCFG_C2IMR1_EXTI12IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 12 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI13IM_Pos              (29U)
+#define SYSCFG_C2IMR1_EXTI13IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI13IM_Pos)           /*!< 0x20000000 */
+#define SYSCFG_C2IMR1_EXTI13IM                  SYSCFG_C2IMR1_EXTI13IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 13 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI14IM_Pos              (30U)
+#define SYSCFG_C2IMR1_EXTI14IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI14IM_Pos)           /*!< 0x40000000 */
+#define SYSCFG_C2IMR1_EXTI14IM                  SYSCFG_C2IMR1_EXTI14IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 14 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI15IM_Pos              (31U)
+#define SYSCFG_C2IMR1_EXTI15IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI15IM_Pos)           /*!< 0x80000000 */
+#define SYSCFG_C2IMR1_EXTI15IM                  SYSCFG_C2IMR1_EXTI15IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 15 to CPU2     */
+
+/*****************  Bit definition for SYSCFG_C2IMR2 register (Interrupt masks control and status register on CPU2 - part 2) *******************************************/
+#define SYSCFG_C2IMR2_DMA1CH1IM_Pos             (0U)
+#define SYSCFG_C2IMR2_DMA1CH1IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH1IM_Pos)          /*!< 0x00000001 */
+#define SYSCFG_C2IMR2_DMA1CH1IM                 SYSCFG_C2IMR2_DMA1CH1IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 1 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH2IM_Pos             (1U)
+#define SYSCFG_C2IMR2_DMA1CH2IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH2IM_Pos)          /*!< 0x00000002 */
+#define SYSCFG_C2IMR2_DMA1CH2IM                 SYSCFG_C2IMR2_DMA1CH2IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 2 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH3IM_Pos             (2U)
+#define SYSCFG_C2IMR2_DMA1CH3IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH3IM_Pos)          /*!< 0x00000004 */
+#define SYSCFG_C2IMR2_DMA1CH3IM                 SYSCFG_C2IMR2_DMA1CH3IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 3 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH4IM_Pos             (3U)
+#define SYSCFG_C2IMR2_DMA1CH4IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH4IM_Pos)          /*!< 0x00000008 */
+#define SYSCFG_C2IMR2_DMA1CH4IM                 SYSCFG_C2IMR2_DMA1CH4IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 4 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH5IM_Pos             (4U)
+#define SYSCFG_C2IMR2_DMA1CH5IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH5IM_Pos)          /*!< 0x00000010 */
+#define SYSCFG_C2IMR2_DMA1CH5IM                 SYSCFG_C2IMR2_DMA1CH5IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 5 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH6IM_Pos             (5U)
+#define SYSCFG_C2IMR2_DMA1CH6IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH6IM_Pos)          /*!< 0x00000020 */
+#define SYSCFG_C2IMR2_DMA1CH6IM                 SYSCFG_C2IMR2_DMA1CH6IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 6 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH7IM_Pos             (6U)
+#define SYSCFG_C2IMR2_DMA1CH7IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH7IM_Pos)          /*!< 0x00000040 */
+#define SYSCFG_C2IMR2_DMA1CH7IM                 SYSCFG_C2IMR2_DMA1CH7IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 7 to CPU2                 */
+#define SYSCFG_C2IMR2_DMAMUX1IM_Pos             (15U)
+#define SYSCFG_C2IMR2_DMAMUX1IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMAMUX1IM_Pos)          /*!< 0x00008000 */
+#define SYSCFG_C2IMR2_DMAMUX1IM                 SYSCFG_C2IMR2_DMAMUX1IM_Msk                     /*!< Enabling of interrupt from DMAMUX1 to CPU2                        */
+#define SYSCFG_C2IMR2_PVM3IM_Pos                (18U)
+#define SYSCFG_C2IMR2_PVM3IM_Msk                (0x1UL << SYSCFG_C2IMR2_PVM3IM_Pos)             /*!< 0x00040000 */
+#define SYSCFG_C2IMR2_PVM3IM                    SYSCFG_C2IMR2_PVM3IM_Msk                        /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU2     */
+#define SYSCFG_C2IMR2_PVDIM_Pos                 (20U)
+#define SYSCFG_C2IMR2_PVDIM_Msk                 (0x1UL << SYSCFG_C2IMR2_PVDIM_Pos)              /*!< 0x00100000 */
+#define SYSCFG_C2IMR2_PVDIM                     SYSCFG_C2IMR2_PVDIM_Msk                         /*!< Enabling of interrupt from Power Voltage Detector to CPU2         */
+#define SYSCFG_C2IMR2_TSCIM_Pos                 (21U)
+#define SYSCFG_C2IMR2_TSCIM_Msk                 (0x1UL << SYSCFG_C2IMR2_TSCIM_Pos)              /*!< 0x00200000 */
+#define SYSCFG_C2IMR2_TSCIM                     SYSCFG_C2IMR2_TSCIM_Msk                         /*!< Enabling of interrupt from Touch Sensing Controller to CPU2       */
+
+/*****************  Bit definition for SYSCFG_SIPCR register (SYSCFG secure IP control register) *****************************************************************************/
+#define SYSCFG_SIPCR_SAES2_Pos                  (1U)
+#define SYSCFG_SIPCR_SAES2_Msk                  (0x1UL << SYSCFG_SIPCR_SAES2_Pos)               /*!< 0x00000002 */
+#define SYSCFG_SIPCR_SAES2                      SYSCFG_SIPCR_SAES2_Msk                          /*!< Enabling the security access of Advanced Encryption Standard 2          */
+#define SYSCFG_SIPCR_SPKA_Pos                   (2U)
+#define SYSCFG_SIPCR_SPKA_Msk                   (0x1UL << SYSCFG_SIPCR_SPKA_Pos)                /*!< 0x00000004 */
+#define SYSCFG_SIPCR_SPKA                       SYSCFG_SIPCR_SPKA_Msk                           /*!< Enabling the security access of Public Key Accelerator                  */
+#define SYSCFG_SIPCR_SRNG_Pos                   (3U)
+#define SYSCFG_SIPCR_SRNG_Msk                   (0x1UL << SYSCFG_SIPCR_SRNG_Pos)                /*!< 0x00000008 */
+#define SYSCFG_SIPCR_SRNG                       SYSCFG_SIPCR_SRNG_Msk                           /*!< Enabling the security access of Random Number Generator                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                   /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable */
+#define TIM_CR1_UDIS_Pos          (1U)
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                  /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable */
+#define TIM_CR1_URS_Pos           (2U)
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                   /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode */
+#define TIM_CR1_DIR_Pos           (4U)
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                   /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction */
+
+#define TIM_CR1_CMS_Pos           (5U)
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1U << TIM_CR1_CMS_Pos)                    /*!< 0x00000020 */
+#define TIM_CR1_CMS_1             (0x2U << TIM_CR1_CMS_Pos)                    /*!< 0x00000040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                  /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable */
+
+#define TIM_CR1_CKD_Pos           (8U)
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1U << TIM_CR1_CKD_Pos)                    /*!< 0x00000100 */
+#define TIM_CR1_CKD_1             (0x2U << TIM_CR1_CKD_Pos)                    /*!< 0x00000200 */
+
+#define TIM_CR1_UIFREMAP_Pos      (11U)
+#define TIM_CR1_UIFREMAP_Msk      (0x1UL << TIM_CR1_UIFREMAP_Pos)              /*!< 0x00000800 */
+#define TIM_CR1_UIFREMAP          TIM_CR1_UIFREMAP_Msk                         /*!<Update interrupt flag remap */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                  /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control */
+#define TIM_CR2_CCUS_Pos          (2U)
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                  /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                  /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection */
+
+#define TIM_CR2_MMS_Pos           (4U)
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1U << TIM_CR2_MMS_Pos)                    /*!< 0x00000010 */
+#define TIM_CR2_MMS_1             (0x2U << TIM_CR2_MMS_Pos)                    /*!< 0x00000020 */
+#define TIM_CR2_MMS_2             (0x4U << TIM_CR2_MMS_Pos)                    /*!< 0x00000040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                  /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                  /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output) */
+#define TIM_CR2_OIS1N_Pos         (9U)
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                 /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                  /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output) */
+#define TIM_CR2_OIS2N_Pos         (11U)
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                 /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                  /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output) */
+#define TIM_CR2_OIS3N_Pos         (13U)
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                 /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                  /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output) */
+#define TIM_CR2_OIS5_Pos          (16U)
+#define TIM_CR2_OIS5_Msk          (0x1UL << TIM_CR2_OIS5_Pos)                  /*!< 0x00010000 */
+#define TIM_CR2_OIS5              TIM_CR2_OIS5_Msk                             /*!<Output Idle state 5 (OC5 output) */
+#define TIM_CR2_OIS6_Pos          (18U)
+#define TIM_CR2_OIS6_Msk          (0x1UL << TIM_CR2_OIS6_Pos)                  /*!< 0x00040000 */
+#define TIM_CR2_OIS6              TIM_CR2_OIS6_Msk                             /*!<Output Idle state 6 (OC6 output) */
+
+#define TIM_CR2_MMS2_Pos          (20U)
+#define TIM_CR2_MMS2_Msk          (0xFUL << TIM_CR2_MMS2_Pos)                  /*!< 0x00F00000 */
+#define TIM_CR2_MMS2              TIM_CR2_MMS2_Msk                             /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS2_0            (0x1U << TIM_CR2_MMS2_Pos)                   /*!< 0x00100000 */
+#define TIM_CR2_MMS2_1            (0x2U << TIM_CR2_MMS2_Pos)                   /*!< 0x00200000 */
+#define TIM_CR2_MMS2_2            (0x4U << TIM_CR2_MMS2_Pos)                   /*!< 0x00400000 */
+#define TIM_CR2_MMS2_3            (0x8U << TIM_CR2_MMS2_Pos)                   /*!< 0x00800000 */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)
+#define TIM_SMCR_SMS_Msk          (0x10007UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMCR_SMS_0            (0x00001U << TIM_SMCR_SMS_Pos)               /*!< 0x00000001 */
+#define TIM_SMCR_SMS_1            (0x00002U << TIM_SMCR_SMS_Pos)               /*!< 0x00000002 */
+#define TIM_SMCR_SMS_2            (0x00004U << TIM_SMCR_SMS_Pos)               /*!< 0x00000004 */
+#define TIM_SMCR_SMS_3            (0x10000U << TIM_SMCR_SMS_Pos)               /*!< 0x00010000 */
+
+#define TIM_SMCR_OCCS_Pos         (3U)
+#define TIM_SMCR_OCCS_Msk         (0x1UL << TIM_SMCR_OCCS_Pos)                 /*!< 0x00000008 */
+#define TIM_SMCR_OCCS             TIM_SMCR_OCCS_Msk                            /*!< OCREF clear selection */
+
+#define TIM_SMCR_TS_Pos           (4U)
+#define TIM_SMCR_TS_Msk           (0x30007UL << TIM_SMCR_TS_Pos)               /*!< 0x00300070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection) */
+#define TIM_SMCR_TS_0             (0x00001U << TIM_SMCR_TS_Pos)                /*!< 0x00000010 */
+#define TIM_SMCR_TS_1             (0x00002U << TIM_SMCR_TS_Pos)                /*!< 0x00000020 */
+#define TIM_SMCR_TS_2             (0x00004U << TIM_SMCR_TS_Pos)                /*!< 0x00000040 */
+#define TIM_SMCR_TS_3             (0x10000U << TIM_SMCR_TS_Pos)                /*!< 0x00100000 */
+#define TIM_SMCR_TS_4             (0x20000U << TIM_SMCR_TS_Pos)                /*!< 0x00200000 */
+
+#define TIM_SMCR_MSM_Pos          (7U)
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                  /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode */
+
+#define TIM_SMCR_ETF_Pos          (8U)
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000100 */
+#define TIM_SMCR_ETF_1            (0x2U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000200 */
+#define TIM_SMCR_ETF_2            (0x4U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000400 */
+#define TIM_SMCR_ETF_3            (0x8U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1U << TIM_SMCR_ETPS_Pos)                  /*!< 0x00001000 */
+#define TIM_SMCR_ETPS_1           (0x2U << TIM_SMCR_ETPS_Pos)                  /*!< 0x00002000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                  /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable */
+#define TIM_SMCR_ETP_Pos          (15U)
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                  /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                  /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable */
+#define TIM_DIER_CC2IE_Pos        (2U)
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable */
+#define TIM_DIER_CC3IE_Pos        (3U)
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable */
+#define TIM_DIER_CC4IE_Pos        (4U)
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable */
+#define TIM_DIER_COMIE_Pos        (5U)
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable */
+#define TIM_DIER_TIE_Pos          (6U)
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                  /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable */
+#define TIM_DIER_BIE_Pos          (7U)
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                  /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable */
+#define TIM_DIER_UDE_Pos          (8U)
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                  /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable */
+#define TIM_DIER_CC1DE_Pos        (9U)
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable */
+#define TIM_DIER_TDE_Pos          (14U)
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                  /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                    /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag */
+#define TIM_SR_CC1IF_Pos          (1U)
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                  /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag */
+#define TIM_SR_CC2IF_Pos          (2U)
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                  /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag */
+#define TIM_SR_CC3IF_Pos          (3U)
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                  /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag */
+#define TIM_SR_CC4IF_Pos          (4U)
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                  /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag */
+#define TIM_SR_COMIF_Pos          (5U)
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                  /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag */
+#define TIM_SR_TIF_Pos            (6U)
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                    /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag */
+#define TIM_SR_BIF_Pos            (7U)
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                    /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag */
+#define TIM_SR_B2IF_Pos           (8U)
+#define TIM_SR_B2IF_Msk           (0x1UL << TIM_SR_B2IF_Pos)                   /*!< 0x00000100 */
+#define TIM_SR_B2IF               TIM_SR_B2IF_Msk                              /*!<Break 2 interrupt Flag */
+#define TIM_SR_CC1OF_Pos          (9U)
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                  /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                  /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                  /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                  /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+#define TIM_SR_SBIF_Pos           (13U)
+#define TIM_SR_SBIF_Msk           (0x1UL << TIM_SR_SBIF_Pos)                   /*!< 0x00002000 */
+#define TIM_SR_SBIF               TIM_SR_SBIF_Msk                              /*!<System Break interrupt Flag */
+#define TIM_SR_CC5IF_Pos          (16U)
+#define TIM_SR_CC5IF_Msk          (0x1UL << TIM_SR_CC5IF_Pos)                  /*!< 0x00010000 */
+#define TIM_SR_CC5IF              TIM_SR_CC5IF_Msk                             /*!<Capture/Compare 5 interrupt Flag */
+#define TIM_SR_CC6IF_Pos          (17U)
+#define TIM_SR_CC6IF_Msk          (0x1UL << TIM_SR_CC6IF_Pos)                  /*!< 0x00020000 */
+#define TIM_SR_CC6IF              TIM_SR_CC6IF_Msk                             /*!<Capture/Compare 6 interrupt Flag */
+
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                    /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation */
+#define TIM_EGR_CC1G_Pos          (1U)
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                  /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation */
+#define TIM_EGR_CC2G_Pos          (2U)
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                  /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation */
+#define TIM_EGR_CC3G_Pos          (3U)
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                  /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation */
+#define TIM_EGR_CC4G_Pos          (4U)
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                  /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation */
+#define TIM_EGR_COMG_Pos          (5U)
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                  /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                    /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation */
+#define TIM_EGR_BG_Pos            (7U)
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                    /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation */
+#define TIM_EGR_B2G_Pos           (8U)
+#define TIM_EGR_B2G_Msk           (0x1UL << TIM_EGR_B2G_Pos)                   /*!< 0x00000100 */
+#define TIM_EGR_B2G               TIM_EGR_B2G_Msk                              /*!<Break 2 Generation */
+
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1U << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000001 */
+#define TIM_CCMR1_CC1S_1          (0x2U << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable */
+#define TIM_CCMR1_OC1PE_Pos       (3U)
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)
+#define TIM_CCMR1_OC1M_Msk        (0x1007UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_CCMR1_OC1M_0          (0x0001U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR1_OC1M_1          (0x0002U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR1_OC1M_2          (0x0004U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR1_OC1M_3          (0x1000U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1 Clear Enable */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1U << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000100 */
+#define TIM_CCMR1_CC2S_1          (0x2U << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable */
+#define TIM_CCMR1_OC2PE_Pos       (11U)
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)
+#define TIM_CCMR1_OC2M_Msk        (0x1007UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_CCMR1_OC2M_0          (0x0001U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR1_OC2M_1          (0x0002U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR1_OC2M_2          (0x0004U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR1_OC2M_3          (0x1000U << TIM_CCMR1_OC2M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR1_IC1PSC_Pos      (2U)
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1U << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2U << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x00000008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_CCMR1_IC1F_0          (0x1U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000010 */
+#define TIM_CCMR1_IC1F_1          (0x2U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000020 */
+#define TIM_CCMR1_IC1F_2          (0x4U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000040 */
+#define TIM_CCMR1_IC1F_3          (0x8U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_CCMR1_IC2PSC_0        (0x1U << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2U << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_CCMR1_IC2F_0          (0x1U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00001000 */
+#define TIM_CCMR1_IC2F_1          (0x2U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00002000 */
+#define TIM_CCMR1_IC2F_2          (0x4U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00004000 */
+#define TIM_CCMR1_IC2F_3          (0x8U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CCMR2_CC3S_0          (0x1U << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000001 */
+#define TIM_CCMR2_CC3S_1          (0x2U << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable */
+#define TIM_CCMR2_OC3PE_Pos       (3U)
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)
+#define TIM_CCMR2_OC3M_Msk        (0x1007UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x0001U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR2_OC3M_1          (0x0002U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR2_OC3M_2          (0x0004U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR2_OC3M_3          (0x1000U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1U << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000100 */
+#define TIM_CCMR2_CC4S_1          (0x2U << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable */
+#define TIM_CCMR2_OC4PE_Pos       (11U)
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)
+#define TIM_CCMR2_OC4M_Msk        (0x1007UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x0001U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR2_OC4M_1          (0x0002U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR2_OC4M_2          (0x0004U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR2_OC4M_3          (0x1000U << TIM_CCMR2_OC4M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR2_IC3PSC_Pos      (2U)
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1U << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2U << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x00000008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000010 */
+#define TIM_CCMR2_IC3F_1          (0x2U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000020 */
+#define TIM_CCMR2_IC3F_2          (0x4U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000040 */
+#define TIM_CCMR2_IC3F_3          (0x8U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1U << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2U << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00001000 */
+#define TIM_CCMR2_IC4F_1          (0x2U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00002000 */
+#define TIM_CCMR2_IC4F_2          (0x4U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00004000 */
+#define TIM_CCMR2_IC4F_3          (0x8U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define TIM_CCMR3_OC5FE_Pos       (2U)
+#define TIM_CCMR3_OC5FE_Msk       (0x1UL << TIM_CCMR3_OC5FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR3_OC5FE           TIM_CCMR3_OC5FE_Msk                          /*!<Output Compare 5 Fast enable */
+#define TIM_CCMR3_OC5PE_Pos       (3U)
+#define TIM_CCMR3_OC5PE_Msk       (0x1UL << TIM_CCMR3_OC5PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR3_OC5PE           TIM_CCMR3_OC5PE_Msk                          /*!<Output Compare 5 Preload enable */
+
+#define TIM_CCMR3_OC5M_Pos        (4U)
+#define TIM_CCMR3_OC5M_Msk        (0x1007UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR3_OC5M            TIM_CCMR3_OC5M_Msk                           /*!<OC5M[3:0] bits (Output Compare 5 Mode) */
+#define TIM_CCMR3_OC5M_0          (0x0001U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR3_OC5M_1          (0x0002U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR3_OC5M_2          (0x0004U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR3_OC5M_3          (0x1000U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR3_OC5CE_Pos       (7U)
+#define TIM_CCMR3_OC5CE_Msk       (0x1UL << TIM_CCMR3_OC5CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR3_OC5CE           TIM_CCMR3_OC5CE_Msk                          /*!<Output Compare 5 Clear Enable */
+
+#define TIM_CCMR3_OC6FE_Pos       (10U)
+#define TIM_CCMR3_OC6FE_Msk       (0x1UL << TIM_CCMR3_OC6FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR3_OC6FE           TIM_CCMR3_OC6FE_Msk                          /*!<Output Compare 6 Fast enable */
+#define TIM_CCMR3_OC6PE_Pos       (11U)
+#define TIM_CCMR3_OC6PE_Msk       (0x1UL << TIM_CCMR3_OC6PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR3_OC6PE           TIM_CCMR3_OC6PE_Msk                          /*!<Output Compare 6 Preload enable */
+
+#define TIM_CCMR3_OC6M_Pos        (12U)
+#define TIM_CCMR3_OC6M_Msk        (0x1007UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR3_OC6M            TIM_CCMR3_OC6M_Msk                           /*!<OC6M[3:0] bits (Output Compare 6 Mode) */
+#define TIM_CCMR3_OC6M_0          (0x0001U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR3_OC6M_1          (0x0002U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR3_OC6M_2          (0x0004U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR3_OC6M_3          (0x1000U << TIM_CCMR3_OC6M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR3_OC6CE_Pos       (15U)
+#define TIM_CCMR3_OC6CE_Msk       (0x1UL << TIM_CCMR3_OC6CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR3_OC6CE           TIM_CCMR3_OC6CE_Msk                          /*!<Output Compare 6 Clear Enable */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                 /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable */
+#define TIM_CCER_CC1P_Pos         (1U)
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                 /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity */
+#define TIM_CCER_CC1NE_Pos        (2U)
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable */
+#define TIM_CCER_CC1NP_Pos        (3U)
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                 /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable */
+#define TIM_CCER_CC2P_Pos         (5U)
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                 /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity */
+#define TIM_CCER_CC2NE_Pos        (6U)
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable */
+#define TIM_CCER_CC2NP_Pos        (7U)
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                 /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable */
+#define TIM_CCER_CC3P_Pos         (9U)
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                 /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity */
+#define TIM_CCER_CC3NE_Pos        (10U)
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable */
+#define TIM_CCER_CC3NP_Pos        (11U)
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                 /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable */
+#define TIM_CCER_CC4P_Pos         (13U)
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                 /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity */
+#define TIM_CCER_CC4NP_Pos        (15U)
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+#define TIM_CCER_CC5E_Pos         (16U)
+#define TIM_CCER_CC5E_Msk         (0x1UL << TIM_CCER_CC5E_Pos)                 /*!< 0x00010000 */
+#define TIM_CCER_CC5E             TIM_CCER_CC5E_Msk                            /*!<Capture/Compare 5 output enable */
+#define TIM_CCER_CC5P_Pos         (17U)
+#define TIM_CCER_CC5P_Msk         (0x1UL << TIM_CCER_CC5P_Pos)                 /*!< 0x00020000 */
+#define TIM_CCER_CC5P             TIM_CCER_CC5P_Msk                            /*!<Capture/Compare 5 output Polarity */
+#define TIM_CCER_CC6E_Pos         (20U)
+#define TIM_CCER_CC6E_Msk         (0x1UL << TIM_CCER_CC6E_Pos)                 /*!< 0x00100000 */
+#define TIM_CCER_CC6E             TIM_CCER_CC6E_Msk                            /*!<Capture/Compare 6 output enable */
+#define TIM_CCER_CC6P_Pos         (21U)
+#define TIM_CCER_CC6P_Msk         (0x1UL << TIM_CCER_CC6P_Pos)                 /*!< 0x00200000 */
+#define TIM_CCER_CC6P             TIM_CCER_CC6P_Msk                            /*!<Capture/Compare 6 output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                              /*!<Counter Value */
+#define TIM_CNT_UIFCPY_Pos        (31U)
+#define TIM_CNT_UIFCPY_Msk        (0x1UL << TIM_CNT_UIFCPY_Pos)                /*!< 0x80000000 */
+#define TIM_CNT_UIFCPY            TIM_CNT_UIFCPY_Msk                           /*!<Update interrupt flag copy (if UIFREMAP=1) */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<Actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)
+#define TIM_RCR_REP_Msk           (0xFFFFUL << TIM_RCR_REP_Pos)                /*!< 0x0000FFFF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define TIM_CCR5_CCR5_Pos         (0U)
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
+#define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
+#define TIM_CCR5_GC5C1_Pos        (29U)
+#define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
+#define TIM_CCR5_GC5C1            TIM_CCR5_GC5C1_Msk                           /*!<Group Channel 5 and Channel 1 */
+#define TIM_CCR5_GC5C2_Pos        (30U)
+#define TIM_CCR5_GC5C2_Msk        (0x1UL << TIM_CCR5_GC5C2_Pos)                /*!< 0x40000000 */
+#define TIM_CCR5_GC5C2            TIM_CCR5_GC5C2_Msk                           /*!<Group Channel 5 and Channel 2 */
+#define TIM_CCR5_GC5C3_Pos        (31U)
+#define TIM_CCR5_GC5C3_Msk        (0x1UL << TIM_CCR5_GC5C3_Pos)                /*!< 0x80000000 */
+#define TIM_CCR5_GC5C3            TIM_CCR5_GC5C3_Msk                           /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define TIM_CCR6_CCR6_Pos         (0U)
+#define TIM_CCR6_CCR6_Msk         (0xFFFFUL << TIM_CCR6_CCR6_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6             TIM_CCR6_CCR6_Msk                            /*!<Capture/Compare 6 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                 /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000001 */
+#define TIM_BDTR_DTG_1            (0x02U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000002 */
+#define TIM_BDTR_DTG_2            (0x04U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000004 */
+#define TIM_BDTR_DTG_3            (0x08U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000008 */
+#define TIM_BDTR_DTG_4            (0x10U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000010 */
+#define TIM_BDTR_DTG_5            (0x20U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000020 */
+#define TIM_BDTR_DTG_6            (0x40U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000040 */
+#define TIM_BDTR_DTG_7            (0x80U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1U << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000100 */
+#define TIM_BDTR_LOCK_1           (0x2U << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                 /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                 /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode */
+#define TIM_BDTR_BKE_Pos          (12U)
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                  /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable for Break 1 */
+#define TIM_BDTR_BKP_Pos          (13U)
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                  /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity for Break 1 */
+#define TIM_BDTR_AOE_Pos          (14U)
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                  /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable */
+#define TIM_BDTR_MOE_Pos          (15U)
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                  /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable */
+
+#define TIM_BDTR_BKF_Pos          (16U)
+#define TIM_BDTR_BKF_Msk          (0xFUL << TIM_BDTR_BKF_Pos)                  /*!< 0x000F0000 */
+#define TIM_BDTR_BKF              TIM_BDTR_BKF_Msk                             /*!<Break Filter for Break 1 */
+#define TIM_BDTR_BK2F_Pos         (20U)
+#define TIM_BDTR_BK2F_Msk         (0xFUL << TIM_BDTR_BK2F_Pos)                 /*!< 0x00F00000 */
+#define TIM_BDTR_BK2F             TIM_BDTR_BK2F_Msk                            /*!<Break Filter for Break 2 */
+
+#define TIM_BDTR_BK2E_Pos         (24U)
+#define TIM_BDTR_BK2E_Msk         (0x1UL << TIM_BDTR_BK2E_Pos)                 /*!< 0x01000000 */
+#define TIM_BDTR_BK2E             TIM_BDTR_BK2E_Msk                            /*!<Break enable for Break 2 */
+#define TIM_BDTR_BK2P_Pos         (25U)
+#define TIM_BDTR_BK2P_Msk         (0x1UL << TIM_BDTR_BK2P_Pos)                 /*!< 0x02000000 */
+#define TIM_BDTR_BK2P             TIM_BDTR_BK2P_Msk                            /*!<Break Polarity for Break 2 */
+
+#define TIM_BDTR_BKDSRM_Pos       (26U)
+#define TIM_BDTR_BKDSRM_Msk       (0x1UL << TIM_BDTR_BKDSRM_Pos)               /*!< 0x04000000 */
+#define TIM_BDTR_BKDSRM           TIM_BDTR_BKDSRM_Msk                          /*!<Break disarming/re-arming */
+#define TIM_BDTR_BK2DSRM_Pos      (27U)
+#define TIM_BDTR_BK2DSRM_Msk      (0x1UL << TIM_BDTR_BK2DSRM_Pos)              /*!< 0x08000000 */
+#define TIM_BDTR_BK2DSRM          TIM_BDTR_BK2DSRM_Msk                         /*!<Break2 disarming/re-arming */
+
+#define TIM_BDTR_BKBID_Pos        (28U)
+#define TIM_BDTR_BKBID_Msk        (0x1UL << TIM_BDTR_BKBID_Pos)                /*!< 0x10000000 */
+#define TIM_BDTR_BKBID            TIM_BDTR_BKBID_Msk                           /*!<Break BIDirectional */
+#define TIM_BDTR_BK2BID_Pos       (29U)
+#define TIM_BDTR_BK2BID_Msk       (0x1UL << TIM_BDTR_BK2BID_Pos)               /*!< 0x20000000 */
+#define TIM_BDTR_BK2BID           TIM_BDTR_BK2BID_Msk                          /*!<Break2 BIDirectional */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                  /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01U << TIM_DCR_DBA_Pos)                   /*!< 0x00000001 */
+#define TIM_DCR_DBA_1             (0x02U << TIM_DCR_DBA_Pos)                   /*!< 0x00000002 */
+#define TIM_DCR_DBA_2             (0x04U << TIM_DCR_DBA_Pos)                   /*!< 0x00000004 */
+#define TIM_DCR_DBA_3             (0x08U << TIM_DCR_DBA_Pos)                   /*!< 0x00000008 */
+#define TIM_DCR_DBA_4             (0x10U << TIM_DCR_DBA_Pos)                   /*!< 0x00000010 */
+
+#define TIM_DCR_DBL_Pos           (8U)
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                  /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01U << TIM_DCR_DBL_Pos)                   /*!< 0x00000100 */
+#define TIM_DCR_DBL_1             (0x02U << TIM_DCR_DBL_Pos)                   /*!< 0x00000200 */
+#define TIM_DCR_DBL_2             (0x04U << TIM_DCR_DBL_Pos)                   /*!< 0x00000400 */
+#define TIM_DCR_DBL_3             (0x08U << TIM_DCR_DBL_Pos)                   /*!< 0x00000800 */
+#define TIM_DCR_DBL_4             (0x10U << TIM_DCR_DBL_Pos)                   /*!< 0x00001000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)              /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM1_OR register  *******************/
+#define TIM1_OR_ETR_ADC1_RMP_Pos      (0U)
+#define TIM1_OR_ETR_ADC1_RMP_Msk      (0x3UL << TIM1_OR_ETR_ADC1_RMP_Pos)    /*!< 0x00000003 */
+#define TIM1_OR_ETR_ADC1_RMP          TIM1_OR_ETR_ADC1_RMP_Msk               /*!< TIM1_ETR_ADC1 remapping capability*/
+#define TIM1_OR_ETR_ADC1_RMP_0        (0x1U << TIM1_OR_ETR_ADC1_RMP_Pos)     /*!< 0x00000001 */
+#define TIM1_OR_ETR_ADC1_RMP_1        (0x2U << TIM1_OR_ETR_ADC1_RMP_Pos)     /*!< 0x00000002 */
+#define TIM1_OR_TI1_RMP_Pos            (4U)
+#define TIM1_OR_TI1_RMP_Msk            (0x1UL << TIM1_OR_TI1_RMP_Pos)          /*!< 0x00000010 */
+#define TIM1_OR_TI1_RMP                TIM1_OR_TI1_RMP_Msk                     /*!< Input Capture 1 remap*/
+
+/*******************  Bit definition for TIM2_OR register  *******************/
+#define TIM2_OR_TI4_RMP_Pos      (2U)
+#define TIM2_OR_TI4_RMP_Msk      (0x3UL << TIM2_OR_TI4_RMP_Pos)              /*!< 0x0000000C */
+#define TIM2_OR_TI4_RMP          TIM2_OR_TI4_RMP_Msk                         /*!< TI4 Input capture 4 remap*/
+#define TIM2_OR_TI4_RMP_0        (0x1U << TIM2_OR_TI4_RMP_Pos)               /*!< 0x00000004 */
+#define TIM2_OR_ETR_RMP_Pos      (1U)
+#define TIM2_OR_ETR_RMP_Msk      (0x1UL << TIM2_OR_ETR_RMP_Pos)              /*!< 0x00000002 */
+#define TIM2_OR_ETR_RMP          TIM2_OR_ETR_RMP_Msk                         /*!< External trigger remap*/
+
+/*******************  Bit definition for TIM1_AF1 register  *******************/
+#define TIM1_AF1_BKINE_Pos             (0U)
+#define TIM1_AF1_BKINE_Msk             (0x1UL << TIM1_AF1_BKINE_Pos)           /*!< 0x00000001 */
+#define TIM1_AF1_BKINE                 TIM1_AF1_BKINE_Msk                      /*!<BRK BKIN input enable */
+#define TIM1_AF1_BKCMP1E_Pos           (1U)
+#define TIM1_AF1_BKCMP1E_Msk           (0x1UL << TIM1_AF1_BKCMP1E_Pos)         /*!< 0x00000002 */
+#define TIM1_AF1_BKCMP1E               TIM1_AF1_BKCMP1E_Msk                    /*!<BRK COMP1 enable */
+#define TIM1_AF1_BKINP_Pos             (9U)
+#define TIM1_AF1_BKINP_Msk             (0x1UL << TIM1_AF1_BKINP_Pos)           /*!< 0x00000200 */
+#define TIM1_AF1_BKINP                 TIM1_AF1_BKINP_Msk                      /*!<BRK BKIN input polarity */
+#define TIM1_AF1_BKCMP1P_Pos           (10U)
+#define TIM1_AF1_BKCMP1P_Msk           (0x1UL << TIM1_AF1_BKCMP1P_Pos)         /*!< 0x00000400 */
+#define TIM1_AF1_BKCMP1P               TIM1_AF1_BKCMP1P_Msk                    /*!<BRK COMP1 input polarity */
+#define TIM1_AF1_ETRSEL_Pos            (14U)
+#define TIM1_AF1_ETRSEL_Msk            (0x7UL << TIM1_AF1_ETRSEL_Pos)          /*!< 0x0001C000 */
+#define TIM1_AF1_ETRSEL                TIM1_AF1_ETRSEL_Msk                     /*!<ETRSEL[2:0] bits (TIM1 ETR source selection) */
+#define TIM1_AF1_ETRSEL_0              (0x1U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00004000 */
+#define TIM1_AF1_ETRSEL_1              (0x2U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00008000 */
+#define TIM1_AF1_ETRSEL_2              (0x4U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00010000 */
+
+/*******************  Bit definition for TIM2_AF1 register  *******************/
+#define TIM2_AF1_ETRSEL_Pos       (14U)
+#define TIM2_AF1_ETRSEL_Msk       (0x7UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x0001C000 */
+#define TIM2_AF1_ETRSEL           (0x00001C000)                                /*!< External trigger source selection */
+#define TIM2_AF1_ETRSEL_0         (0x000004000)                                /*!< Bit_0 */
+#define TIM2_AF1_ETRSEL_1         (0x000008000)                                /*!< Bit_1 */
+#define TIM2_AF1_ETRSEL_2         (0x000010000)                                /*!< Bit_2 */
+
+/*******************  Bit definition for TIM17_AF1 register  *******************/
+#define TIM17_AF1_BKINE_Pos             (0U)
+#define TIM17_AF1_BKINE_Msk             (0x1UL << TIM17_AF1_BKINE_Pos)           /*!< 0x00000001 */
+#define TIM17_AF1_BKINE                 TIM17_AF1_BKINE_Msk                      /*!<BRK BKIN input enable */
+#define TIM17_AF1_BKINP_Pos            (9U)
+#define TIM17_AF1_BKINP_Msk            (0x1UL << TIM17_AF1_BKINP_Pos)          /*!< 0x00000200 */
+#define TIM17_AF1_BKINP                TIM17_AF1_BKINP_Msk                     /*!<BRK BKIN2 input polarity */
+
+/*******************  Bit definition for TIM1_AF2 register  *******************/
+#define TIM1_AF2_BK2INE_Pos            (0U)
+#define TIM1_AF2_BK2INE_Msk            (0x1UL << TIM1_AF2_BK2INE_Pos)          /*!< 0x00000001 */
+#define TIM1_AF2_BK2INE                TIM1_AF2_BK2INE_Msk                     /*!<BRK2 BKIN2 input enable */
+#define TIM1_AF2_BK2CMP1E_Pos          (1U)
+#define TIM1_AF2_BK2CMP1E_Msk          (0x1UL << TIM1_AF2_BK2CMP1E_Pos)        /*!< 0x00000002 */
+#define TIM1_AF2_BK2CMP1E              TIM1_AF2_BK2CMP1E_Msk                   /*!<BRK2 COMP1 enable */
+#define TIM1_AF2_BK2INP_Pos            (9U)
+#define TIM1_AF2_BK2INP_Msk            (0x1UL << TIM1_AF2_BK2INP_Pos)          /*!< 0x00000200 */
+#define TIM1_AF2_BK2INP                TIM1_AF2_BK2INP_Msk                     /*!<BRK2 BKIN2 input polarity */
+#define TIM1_AF2_BK2CMP1P_Pos          (10U)
+#define TIM1_AF2_BK2CMP1P_Msk          (0x1UL << TIM1_AF2_BK2CMP1P_Pos)        /*!< 0x00000400 */
+#define TIM1_AF2_BK2CMP1P              TIM1_AF2_BK2CMP1P_Msk                   /*!<BRK2 COMP1 input polarity */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define LPTIM_ISR_CMPM_Pos          (0U)
+#define LPTIM_ISR_CMPM_Msk          (0x1UL << LPTIM_ISR_CMPM_Pos)              /*!< 0x00000001 */
+#define LPTIM_ISR_CMPM              LPTIM_ISR_CMPM_Msk                         /*!< Compare match */
+#define LPTIM_ISR_ARRM_Pos          (1U)
+#define LPTIM_ISR_ARRM_Msk          (0x1UL << LPTIM_ISR_ARRM_Pos)              /*!< 0x00000002 */
+#define LPTIM_ISR_ARRM              LPTIM_ISR_ARRM_Msk                         /*!< Autoreload match */
+#define LPTIM_ISR_EXTTRIG_Pos       (2U)
+#define LPTIM_ISR_EXTTRIG_Msk       (0x1UL << LPTIM_ISR_EXTTRIG_Pos)           /*!< 0x00000004 */
+#define LPTIM_ISR_EXTTRIG           LPTIM_ISR_EXTTRIG_Msk                      /*!< External trigger edge event */
+#define LPTIM_ISR_CMPOK_Pos         (3U)
+#define LPTIM_ISR_CMPOK_Msk         (0x1UL << LPTIM_ISR_CMPOK_Pos)             /*!< 0x00000008 */
+#define LPTIM_ISR_CMPOK             LPTIM_ISR_CMPOK_Msk                        /*!< Compare register update OK */
+#define LPTIM_ISR_ARROK_Pos         (4U)
+#define LPTIM_ISR_ARROK_Msk         (0x1UL << LPTIM_ISR_ARROK_Pos)             /*!< 0x00000010 */
+#define LPTIM_ISR_ARROK             LPTIM_ISR_ARROK_Msk                        /*!< Autoreload register update OK */
+#define LPTIM_ISR_UP_Pos            (5U)
+#define LPTIM_ISR_UP_Msk            (0x1UL << LPTIM_ISR_UP_Pos)                /*!< 0x00000020 */
+#define LPTIM_ISR_UP                LPTIM_ISR_UP_Msk                           /*!< Counter direction change down to up */
+#define LPTIM_ISR_DOWN_Pos          (6U)
+#define LPTIM_ISR_DOWN_Msk          (0x1UL << LPTIM_ISR_DOWN_Pos)              /*!< 0x00000040 */
+#define LPTIM_ISR_DOWN              LPTIM_ISR_DOWN_Msk                         /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define LPTIM_ICR_CMPMCF_Pos        (0U)
+#define LPTIM_ICR_CMPMCF_Msk        (0x1UL << LPTIM_ICR_CMPMCF_Pos)            /*!< 0x00000001 */
+#define LPTIM_ICR_CMPMCF            LPTIM_ICR_CMPMCF_Msk                       /*!< Compare match Clear Flag */
+#define LPTIM_ICR_ARRMCF_Pos        (1U)
+#define LPTIM_ICR_ARRMCF_Msk        (0x1UL << LPTIM_ICR_ARRMCF_Pos)            /*!< 0x00000002 */
+#define LPTIM_ICR_ARRMCF            LPTIM_ICR_ARRMCF_Msk                       /*!< Autoreload match Clear Flag */
+#define LPTIM_ICR_EXTTRIGCF_Pos     (2U)
+#define LPTIM_ICR_EXTTRIGCF_Msk     (0x1UL << LPTIM_ICR_EXTTRIGCF_Pos)         /*!< 0x00000004 */
+#define LPTIM_ICR_EXTTRIGCF         LPTIM_ICR_EXTTRIGCF_Msk                    /*!< External trigger edge event Clear Flag */
+#define LPTIM_ICR_CMPOKCF_Pos       (3U)
+#define LPTIM_ICR_CMPOKCF_Msk       (0x1UL << LPTIM_ICR_CMPOKCF_Pos)           /*!< 0x00000008 */
+#define LPTIM_ICR_CMPOKCF           LPTIM_ICR_CMPOKCF_Msk                      /*!< Compare register update OK Clear Flag */
+#define LPTIM_ICR_ARROKCF_Pos       (4U)
+#define LPTIM_ICR_ARROKCF_Msk       (0x1UL << LPTIM_ICR_ARROKCF_Pos)           /*!< 0x00000010 */
+#define LPTIM_ICR_ARROKCF           LPTIM_ICR_ARROKCF_Msk                      /*!< Autoreload register update OK Clear Flag */
+#define LPTIM_ICR_UPCF_Pos          (5U)
+#define LPTIM_ICR_UPCF_Msk          (0x1UL << LPTIM_ICR_UPCF_Pos)              /*!< 0x00000020 */
+#define LPTIM_ICR_UPCF              LPTIM_ICR_UPCF_Msk                         /*!< Counter direction change down to up Clear Flag */
+#define LPTIM_ICR_DOWNCF_Pos        (6U)
+#define LPTIM_ICR_DOWNCF_Msk        (0x1UL << LPTIM_ICR_DOWNCF_Pos)            /*!< 0x00000040 */
+#define LPTIM_ICR_DOWNCF            LPTIM_ICR_DOWNCF_Msk                       /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define LPTIM_IER_CMPMIE_Pos        (0U)
+#define LPTIM_IER_CMPMIE_Msk        (0x1UL << LPTIM_IER_CMPMIE_Pos)            /*!< 0x00000001 */
+#define LPTIM_IER_CMPMIE            LPTIM_IER_CMPMIE_Msk                       /*!< Compare match Interrupt Enable */
+#define LPTIM_IER_ARRMIE_Pos        (1U)
+#define LPTIM_IER_ARRMIE_Msk        (0x1UL << LPTIM_IER_ARRMIE_Pos)            /*!< 0x00000002 */
+#define LPTIM_IER_ARRMIE            LPTIM_IER_ARRMIE_Msk                       /*!< Autoreload match Interrupt Enable */
+#define LPTIM_IER_EXTTRIGIE_Pos     (2U)
+#define LPTIM_IER_EXTTRIGIE_Msk     (0x1UL << LPTIM_IER_EXTTRIGIE_Pos)         /*!< 0x00000004 */
+#define LPTIM_IER_EXTTRIGIE         LPTIM_IER_EXTTRIGIE_Msk                    /*!< External trigger edge event Interrupt Enable */
+#define LPTIM_IER_CMPOKIE_Pos       (3U)
+#define LPTIM_IER_CMPOKIE_Msk       (0x1UL << LPTIM_IER_CMPOKIE_Pos)           /*!< 0x00000008 */
+#define LPTIM_IER_CMPOKIE           LPTIM_IER_CMPOKIE_Msk                      /*!< Compare register update OK Interrupt Enable */
+#define LPTIM_IER_ARROKIE_Pos       (4U)
+#define LPTIM_IER_ARROKIE_Msk       (0x1UL << LPTIM_IER_ARROKIE_Pos)           /*!< 0x00000010 */
+#define LPTIM_IER_ARROKIE           LPTIM_IER_ARROKIE_Msk                      /*!< Autoreload register update OK Interrupt Enable */
+#define LPTIM_IER_UPIE_Pos          (5U)
+#define LPTIM_IER_UPIE_Msk          (0x1UL << LPTIM_IER_UPIE_Pos)              /*!< 0x00000020 */
+#define LPTIM_IER_UPIE              LPTIM_IER_UPIE_Msk                         /*!< Counter direction change down to up Interrupt Enable */
+#define LPTIM_IER_DOWNIE_Pos        (6U)
+#define LPTIM_IER_DOWNIE_Msk        (0x1UL << LPTIM_IER_DOWNIE_Pos)            /*!< 0x00000040 */
+#define LPTIM_IER_DOWNIE            LPTIM_IER_DOWNIE_Msk                       /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define LPTIM_CFGR_CKSEL_Pos        (0U)
+#define LPTIM_CFGR_CKSEL_Msk        (0x1UL << LPTIM_CFGR_CKSEL_Pos)            /*!< 0x00000001 */
+#define LPTIM_CFGR_CKSEL            LPTIM_CFGR_CKSEL_Msk                       /*!< Clock selector */
+
+#define LPTIM_CFGR_CKPOL_Pos        (1U)
+#define LPTIM_CFGR_CKPOL_Msk        (0x3UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000006 */
+#define LPTIM_CFGR_CKPOL            LPTIM_CFGR_CKPOL_Msk                       /*!< CKPOL[1:0] bits (Clock polarity) */
+#define LPTIM_CFGR_CKPOL_0          (0x1U << LPTIM_CFGR_CKPOL_Pos)             /*!< 0x00000002 */
+#define LPTIM_CFGR_CKPOL_1          (0x2U << LPTIM_CFGR_CKPOL_Pos)             /*!< 0x00000004 */
+
+#define LPTIM_CFGR_CKFLT_Pos        (3U)
+#define LPTIM_CFGR_CKFLT_Msk        (0x3UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000018 */
+#define LPTIM_CFGR_CKFLT            LPTIM_CFGR_CKFLT_Msk                       /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define LPTIM_CFGR_CKFLT_0          (0x1U << LPTIM_CFGR_CKFLT_Pos)             /*!< 0x00000008 */
+#define LPTIM_CFGR_CKFLT_1          (0x2U << LPTIM_CFGR_CKFLT_Pos)             /*!< 0x00000010 */
+
+#define LPTIM_CFGR_TRGFLT_Pos       (6U)
+#define LPTIM_CFGR_TRGFLT_Msk       (0x3UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x000000C0 */
+#define LPTIM_CFGR_TRGFLT           LPTIM_CFGR_TRGFLT_Msk                      /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define LPTIM_CFGR_TRGFLT_0         (0x1U << LPTIM_CFGR_TRGFLT_Pos)            /*!< 0x00000040 */
+#define LPTIM_CFGR_TRGFLT_1         (0x2U << LPTIM_CFGR_TRGFLT_Pos)            /*!< 0x00000080 */
+
+#define LPTIM_CFGR_PRESC_Pos        (9U)
+#define LPTIM_CFGR_PRESC_Msk        (0x7UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000E00 */
+#define LPTIM_CFGR_PRESC            LPTIM_CFGR_PRESC_Msk                       /*!< PRESC[2:0] bits (Clock prescaler) */
+#define LPTIM_CFGR_PRESC_0          (0x1U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000200 */
+#define LPTIM_CFGR_PRESC_1          (0x2U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000400 */
+#define LPTIM_CFGR_PRESC_2          (0x4U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000800 */
+
+#define LPTIM_CFGR_TRIGSEL_Pos      (13U)
+#define LPTIM_CFGR_TRIGSEL_Msk      (0x7UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x0000E000 */
+#define LPTIM_CFGR_TRIGSEL          LPTIM_CFGR_TRIGSEL_Msk                     /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define LPTIM_CFGR_TRIGSEL_0        (0x1U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00002000 */
+#define LPTIM_CFGR_TRIGSEL_1        (0x2U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00004000 */
+#define LPTIM_CFGR_TRIGSEL_2        (0x4U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00008000 */
+
+#define LPTIM_CFGR_TRIGEN_Pos       (17U)
+#define LPTIM_CFGR_TRIGEN_Msk       (0x3UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00060000 */
+#define LPTIM_CFGR_TRIGEN           LPTIM_CFGR_TRIGEN_Msk                      /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define LPTIM_CFGR_TRIGEN_0         (0x1U << LPTIM_CFGR_TRIGEN_Pos)            /*!< 0x00020000 */
+#define LPTIM_CFGR_TRIGEN_1         (0x2U << LPTIM_CFGR_TRIGEN_Pos)            /*!< 0x00040000 */
+
+#define LPTIM_CFGR_TIMOUT_Pos       (19U)
+#define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
+#define LPTIM_CFGR_WAVE_Pos         (20U)
+#define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
+#define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
+#define LPTIM_CFGR_WAVPOL_Pos       (21U)
+#define LPTIM_CFGR_WAVPOL_Msk       (0x1UL << LPTIM_CFGR_WAVPOL_Pos)           /*!< 0x00200000 */
+#define LPTIM_CFGR_WAVPOL           LPTIM_CFGR_WAVPOL_Msk                      /*!< Waveform shape polarity */
+#define LPTIM_CFGR_PRELOAD_Pos      (22U)
+#define LPTIM_CFGR_PRELOAD_Msk      (0x1UL << LPTIM_CFGR_PRELOAD_Pos)          /*!< 0x00400000 */
+#define LPTIM_CFGR_PRELOAD          LPTIM_CFGR_PRELOAD_Msk                     /*!< Reg update mode */
+#define LPTIM_CFGR_COUNTMODE_Pos    (23U)
+#define LPTIM_CFGR_COUNTMODE_Msk    (0x1UL << LPTIM_CFGR_COUNTMODE_Pos)        /*!< 0x00800000 */
+#define LPTIM_CFGR_COUNTMODE        LPTIM_CFGR_COUNTMODE_Msk                   /*!< Counter mode enable */
+#define LPTIM_CFGR_ENC_Pos          (24U)
+#define LPTIM_CFGR_ENC_Msk          (0x1UL << LPTIM_CFGR_ENC_Pos)              /*!< 0x01000000 */
+#define LPTIM_CFGR_ENC              LPTIM_CFGR_ENC_Msk                         /*!< Encoder mode enable */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define LPTIM_CR_ENABLE_Pos         (0U)
+#define LPTIM_CR_ENABLE_Msk         (0x1UL << LPTIM_CR_ENABLE_Pos)             /*!< 0x00000001 */
+#define LPTIM_CR_ENABLE             LPTIM_CR_ENABLE_Msk                        /*!< LPTIMer enable */
+#define LPTIM_CR_SNGSTRT_Pos        (1U)
+#define LPTIM_CR_SNGSTRT_Msk        (0x1UL << LPTIM_CR_SNGSTRT_Pos)            /*!< 0x00000002 */
+#define LPTIM_CR_SNGSTRT            LPTIM_CR_SNGSTRT_Msk                       /*!< Timer start in single mode */
+#define LPTIM_CR_CNTSTRT_Pos        (2U)
+#define LPTIM_CR_CNTSTRT_Msk        (0x1UL << LPTIM_CR_CNTSTRT_Pos)            /*!< 0x00000004 */
+#define LPTIM_CR_CNTSTRT            LPTIM_CR_CNTSTRT_Msk                       /*!< Timer start in continuous mode */
+#define LPTIM_CR_COUNTRST_Pos       (3U)
+#define LPTIM_CR_COUNTRST_Msk       (0x1UL << LPTIM_CR_COUNTRST_Pos)           /*!< 0x00000008 */
+#define LPTIM_CR_COUNTRST           LPTIM_CR_COUNTRST_Msk                      /*!< Counter reset */
+#define LPTIM_CR_RSTARE_Pos         (4U)
+#define LPTIM_CR_RSTARE_Msk         (0x1UL << LPTIM_CR_RSTARE_Pos)             /*!< 0x00000010 */
+#define LPTIM_CR_RSTARE             LPTIM_CR_RSTARE_Msk                        /*!< Reset after read enable */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define LPTIM_CMP_CMP_Pos           (0U)
+#define LPTIM_CMP_CMP_Msk           (0xFFFFUL << LPTIM_CMP_CMP_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CMP_CMP               LPTIM_CMP_CMP_Msk                          /*!< Compare register */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define LPTIM_ARR_ARR_Pos           (0U)
+#define LPTIM_ARR_ARR_Msk           (0xFFFFUL << LPTIM_ARR_ARR_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_ARR_ARR               LPTIM_ARR_ARR_Msk                          /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define LPTIM_CNT_CNT_Pos           (0U)
+#define LPTIM_CNT_CNT_Msk           (0xFFFFUL << LPTIM_CNT_CNT_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CNT_CNT               LPTIM_CNT_CNT_Msk                          /*!< Counter register */
+
+/******************  Bit definition for LPTIM_OR register  *******************/
+#define LPTIM_OR_OR_Pos             (0U)
+#define LPTIM_OR_OR_Msk             (0x1UL << LPTIM_OR_OR_Pos)                 /*!< 0x00000001 */
+#define LPTIM_OR_OR                 LPTIM_OR_OR_Msk                            /*!< OR[1:0] bits (Remap selection) */
+#define LPTIM_OR_OR_0               (0x1U << LPTIM_OR_OR_Pos)                  /*!< 0x00000001 */
+
+/******************************************************************************/
+/*                                                                            */
+/*         Inter-Processor Communication Controller (IPCC)                    */
+/*                                                                            */
+/******************************************************************************/
+
+/**********************  Bit definition for IPCC_C1CR register  ***************/
+#define IPCC_C1CR_RXOIE_Pos      (0U)
+#define IPCC_C1CR_RXOIE_Msk      (0x1UL << IPCC_C1CR_RXOIE_Pos)                /*!< 0x00000001 */
+#define IPCC_C1CR_RXOIE          IPCC_C1CR_RXOIE_Msk                           /*!< Processor M4 Receive channel occupied interrupt enable */
+#define IPCC_C1CR_TXFIE_Pos      (16U)
+#define IPCC_C1CR_TXFIE_Msk      (0x1UL << IPCC_C1CR_TXFIE_Pos)                /*!< 0x00010000 */
+#define IPCC_C1CR_TXFIE          IPCC_C1CR_TXFIE_Msk                           /*!< Processor M4 Transmit channel free interrupt enable */
+
+/**********************  Bit definition for IPCC_C1MR register  **************/
+#define IPCC_C1MR_CH1OM_Pos      (0U)
+#define IPCC_C1MR_CH1OM_Msk      (0x1UL << IPCC_C1MR_CH1OM_Pos)                /*!< 0x00000001 */
+#define IPCC_C1MR_CH1OM          IPCC_C1MR_CH1OM_Msk                           /*!< M4 Channel1 occupied interrupt mask */
+#define IPCC_C1MR_CH2OM_Pos      (1U)
+#define IPCC_C1MR_CH2OM_Msk      (0x1UL << IPCC_C1MR_CH2OM_Pos)                /*!< 0x00000002 */
+#define IPCC_C1MR_CH2OM          IPCC_C1MR_CH2OM_Msk                           /*!< M4 Channel2 occupied interrupt mask */
+#define IPCC_C1MR_CH3OM_Pos      (2U)
+#define IPCC_C1MR_CH3OM_Msk      (0x1UL << IPCC_C1MR_CH3OM_Pos)                /*!< 0x00000004 */
+#define IPCC_C1MR_CH3OM          IPCC_C1MR_CH3OM_Msk                           /*!< M4 Channel3 occupied interrupt mask */
+#define IPCC_C1MR_CH4OM_Pos      (3U)
+#define IPCC_C1MR_CH4OM_Msk      (0x1UL << IPCC_C1MR_CH4OM_Pos)                /*!< 0x00000008 */
+#define IPCC_C1MR_CH4OM          IPCC_C1MR_CH4OM_Msk                           /*!< M4 Channel4 occupied interrupt mask */
+#define IPCC_C1MR_CH5OM_Pos      (4U)
+#define IPCC_C1MR_CH5OM_Msk      (0x1UL << IPCC_C1MR_CH5OM_Pos)                /*!< 0x00000010 */
+#define IPCC_C1MR_CH5OM          IPCC_C1MR_CH5OM_Msk                           /*!< M4 Channel5 occupied interrupt mask */
+#define IPCC_C1MR_CH6OM_Pos      (5U)
+#define IPCC_C1MR_CH6OM_Msk      (0x1UL << IPCC_C1MR_CH6OM_Pos)                /*!< 0x00000020 */
+#define IPCC_C1MR_CH6OM          IPCC_C1MR_CH6OM_Msk                           /*!< M4 Channel6 occupied interrupt mask */
+
+#define IPCC_C1MR_CH1FM_Pos      (16U)
+#define IPCC_C1MR_CH1FM_Msk      (0x1UL << IPCC_C1MR_CH1FM_Pos)                /*!< 0x00010000 */
+#define IPCC_C1MR_CH1FM          IPCC_C1MR_CH1FM_Msk                           /*!< M4 Transmit Channel1 free interrupt mask */
+#define IPCC_C1MR_CH2FM_Pos      (17U)
+#define IPCC_C1MR_CH2FM_Msk      (0x1UL << IPCC_C1MR_CH2FM_Pos)                /*!< 0x00020000 */
+#define IPCC_C1MR_CH2FM          IPCC_C1MR_CH2FM_Msk                           /*!< M4 Transmit Channel2 free interrupt mask */
+#define IPCC_C1MR_CH3FM_Pos      (18U)
+#define IPCC_C1MR_CH3FM_Msk      (0x1UL << IPCC_C1MR_CH3FM_Pos)                /*!< 0x00040000 */
+#define IPCC_C1MR_CH3FM          IPCC_C1MR_CH3FM_Msk                           /*!< M4 Transmit Channel3 free interrupt mask */
+#define IPCC_C1MR_CH4FM_Pos      (19U)
+#define IPCC_C1MR_CH4FM_Msk      (0x1UL << IPCC_C1MR_CH4FM_Pos)                /*!< 0x00080000 */
+#define IPCC_C1MR_CH4FM          IPCC_C1MR_CH4FM_Msk                           /*!< M4 Transmit Channel4 free interrupt mask */
+#define IPCC_C1MR_CH5FM_Pos      (20U)
+#define IPCC_C1MR_CH5FM_Msk      (0x1UL << IPCC_C1MR_CH5FM_Pos)                /*!< 0x00100000 */
+#define IPCC_C1MR_CH5FM          IPCC_C1MR_CH5FM_Msk                           /*!< M4 Transmit Channel5 free interrupt mask */
+#define IPCC_C1MR_CH6FM_Pos      (21U)
+#define IPCC_C1MR_CH6FM_Msk      (0x1UL << IPCC_C1MR_CH6FM_Pos)                /*!< 0x00200000 */
+#define IPCC_C1MR_CH6FM          IPCC_C1MR_CH6FM_Msk                           /*!< M4 Transmit Channel6 free interrupt mask */
+
+/**********************  Bit definition for IPCC_C1SCR register  ***************/
+#define IPCC_C1SCR_CH1C_Pos      (0U)
+#define IPCC_C1SCR_CH1C_Msk      (0x1UL << IPCC_C1SCR_CH1C_Pos)                /*!< 0x00000001 */
+#define IPCC_C1SCR_CH1C          IPCC_C1SCR_CH1C_Msk                           /*!< M4 receive Channel1 status clear */
+#define IPCC_C1SCR_CH2C_Pos      (1U)
+#define IPCC_C1SCR_CH2C_Msk      (0x1UL << IPCC_C1SCR_CH2C_Pos)                /*!< 0x00000002 */
+#define IPCC_C1SCR_CH2C          IPCC_C1SCR_CH2C_Msk                           /*!< M4 receive Channel2 status clear */
+#define IPCC_C1SCR_CH3C_Pos      (2U)
+#define IPCC_C1SCR_CH3C_Msk      (0x1UL << IPCC_C1SCR_CH3C_Pos)                /*!< 0x00000004 */
+#define IPCC_C1SCR_CH3C          IPCC_C1SCR_CH3C_Msk                           /*!< M4 receive Channel3 status clear */
+#define IPCC_C1SCR_CH4C_Pos      (3U)
+#define IPCC_C1SCR_CH4C_Msk      (0x1UL << IPCC_C1SCR_CH4C_Pos)                /*!< 0x00000008 */
+#define IPCC_C1SCR_CH4C          IPCC_C1SCR_CH4C_Msk                           /*!< M4 receive Channel4 status clear */
+#define IPCC_C1SCR_CH5C_Pos      (4U)
+#define IPCC_C1SCR_CH5C_Msk      (0x1UL << IPCC_C1SCR_CH5C_Pos)                /*!< 0x00000010 */
+#define IPCC_C1SCR_CH5C          IPCC_C1SCR_CH5C_Msk                           /*!< M4 receive Channel5 status clear */
+#define IPCC_C1SCR_CH6C_Pos      (5U)
+#define IPCC_C1SCR_CH6C_Msk      (0x1UL << IPCC_C1SCR_CH6C_Pos)                /*!< 0x00000020 */
+#define IPCC_C1SCR_CH6C          IPCC_C1SCR_CH6C_Msk                           /*!< M4 receive Channel6 status clear */
+
+#define IPCC_C1SCR_CH1S_Pos      (16U)
+#define IPCC_C1SCR_CH1S_Msk      (0x1UL << IPCC_C1SCR_CH1S_Pos)                /*!< 0x00010000 */
+#define IPCC_C1SCR_CH1S          IPCC_C1SCR_CH1S_Msk                           /*!< M4 transmit Channel1 status set */
+#define IPCC_C1SCR_CH2S_Pos      (17U)
+#define IPCC_C1SCR_CH2S_Msk      (0x1UL << IPCC_C1SCR_CH2S_Pos)                /*!< 0x00020000 */
+#define IPCC_C1SCR_CH2S          IPCC_C1SCR_CH2S_Msk                           /*!< M4 transmit Channel2 status set  */
+#define IPCC_C1SCR_CH3S_Pos      (18U)
+#define IPCC_C1SCR_CH3S_Msk      (0x1UL << IPCC_C1SCR_CH3S_Pos)                /*!< 0x00040000 */
+#define IPCC_C1SCR_CH3S          IPCC_C1SCR_CH3S_Msk                           /*!< M4 transmit Channel3 status set  */
+#define IPCC_C1SCR_CH4S_Pos      (19U)
+#define IPCC_C1SCR_CH4S_Msk      (0x1UL << IPCC_C1SCR_CH4S_Pos)                /*!< 0x00080000 */
+#define IPCC_C1SCR_CH4S          IPCC_C1SCR_CH4S_Msk                           /*!< M4 transmit Channel4 status set  */
+#define IPCC_C1SCR_CH5S_Pos      (20U)
+#define IPCC_C1SCR_CH5S_Msk      (0x1UL << IPCC_C1SCR_CH5S_Pos)                /*!< 0x00100000 */
+#define IPCC_C1SCR_CH5S          IPCC_C1SCR_CH5S_Msk                           /*!< M4 transmit Channel5 status set  */
+#define IPCC_C1SCR_CH6S_Pos      (21U)
+#define IPCC_C1SCR_CH6S_Msk      (0x1UL << IPCC_C1SCR_CH6S_Pos)                /*!< 0x00200000 */
+#define IPCC_C1SCR_CH6S          IPCC_C1SCR_CH6S_Msk                           /*!< M4 transmit Channel6 status set  */
+
+/**********************  Bit definition for IPCC_C1TOC2SR register  ***************/
+#define IPCC_C1TOC2SR_CH1F_Pos    (0U)
+#define IPCC_C1TOC2SR_CH1F_Msk    (0x1UL << IPCC_C1TOC2SR_CH1F_Pos)            /*!< 0x00000001 */
+#define IPCC_C1TOC2SR_CH1F        IPCC_C1TOC2SR_CH1F_Msk                       /*!< M4 transmit to M4 receive Channel1 status flag before masking */
+#define IPCC_C1TOC2SR_CH2F_Pos    (1U)
+#define IPCC_C1TOC2SR_CH2F_Msk    (0x1UL << IPCC_C1TOC2SR_CH2F_Pos)            /*!< 0x00000002 */
+#define IPCC_C1TOC2SR_CH2F        IPCC_C1TOC2SR_CH2F_Msk                       /*!< M4 transmit to M4 receive Channel2 status flag before masking */
+#define IPCC_C1TOC2SR_CH3F_Pos    (2U)
+#define IPCC_C1TOC2SR_CH3F_Msk    (0x1UL << IPCC_C1TOC2SR_CH3F_Pos)            /*!< 0x00000004 */
+#define IPCC_C1TOC2SR_CH3F        IPCC_C1TOC2SR_CH3F_Msk                       /*!< M4 transmit to M4 receive Channel3 status flag before masking */
+#define IPCC_C1TOC2SR_CH4F_Pos    (3U)
+#define IPCC_C1TOC2SR_CH4F_Msk    (0x1UL << IPCC_C1TOC2SR_CH4F_Pos)            /*!< 0x00000008 */
+#define IPCC_C1TOC2SR_CH4F        IPCC_C1TOC2SR_CH4F_Msk                       /*!< M4 transmit to M4 receive Channel4 status flag before masking */
+#define IPCC_C1TOC2SR_CH5F_Pos    (4U)
+#define IPCC_C1TOC2SR_CH5F_Msk    (0x1UL << IPCC_C1TOC2SR_CH5F_Pos)            /*!< 0x00000010 */
+#define IPCC_C1TOC2SR_CH5F        IPCC_C1TOC2SR_CH5F_Msk                       /*!< M4 transmit to M4 receive Channel5 status flag before masking */
+#define IPCC_C1TOC2SR_CH6F_Pos    (5U)
+#define IPCC_C1TOC2SR_CH6F_Msk    (0x1UL << IPCC_C1TOC2SR_CH6F_Pos)            /*!< 0x00000020 */
+#define IPCC_C1TOC2SR_CH6F        IPCC_C1TOC2SR_CH6F_Msk                       /*!< M4 transmit to M4 receive Channel6 status flag before masking */
+
+/**********************  Bit definition for IPCC_C2CR register  ***************/
+#define IPCC_C2CR_RXOIE_Pos      (0U)
+#define IPCC_C2CR_RXOIE_Msk      (0x1UL << IPCC_C2CR_RXOIE_Pos)                /*!< 0x00000001 */
+#define IPCC_C2CR_RXOIE          IPCC_C2CR_RXOIE_Msk                           /*!< Processor M0+ Receive channel occupied interrupt enable */
+#define IPCC_C2CR_TXFIE_Pos      (16U)
+#define IPCC_C2CR_TXFIE_Msk      (0x1UL << IPCC_C2CR_TXFIE_Pos)                /*!< 0x00010000 */
+#define IPCC_C2CR_TXFIE          IPCC_C2CR_TXFIE_Msk                           /*!< Processor M0+ Transmit channel free interrupt enable */
+
+/**********************  Bit definition for IPCC_C2MR register  ***************/
+#define IPCC_C2MR_CH1OM_Pos      (0U)
+#define IPCC_C2MR_CH1OM_Msk      (0x1UL << IPCC_C2MR_CH1OM_Pos)                /*!< 0x00000001 */
+#define IPCC_C2MR_CH1OM          IPCC_C2MR_CH1OM_Msk                           /*!< M0+ Channel1 occupied interrupt mask */
+#define IPCC_C2MR_CH2OM_Pos      (1U)
+#define IPCC_C2MR_CH2OM_Msk      (0x1UL << IPCC_C2MR_CH2OM_Pos)                /*!< 0x00000002 */
+#define IPCC_C2MR_CH2OM          IPCC_C2MR_CH2OM_Msk                           /*!< M0+ Channel2 occupied interrupt mask */
+#define IPCC_C2MR_CH3OM_Pos      (2U)
+#define IPCC_C2MR_CH3OM_Msk      (0x1UL << IPCC_C2MR_CH3OM_Pos)                /*!< 0x00000004 */
+#define IPCC_C2MR_CH3OM          IPCC_C2MR_CH3OM_Msk                           /*!< M0+ Channel3 occupied interrupt mask */
+#define IPCC_C2MR_CH4OM_Pos      (3U)
+#define IPCC_C2MR_CH4OM_Msk      (0x1UL << IPCC_C2MR_CH4OM_Pos)                /*!< 0x00000008 */
+#define IPCC_C2MR_CH4OM          IPCC_C2MR_CH4OM_Msk                           /*!< M0+ Channel4 occupied interrupt mask */
+#define IPCC_C2MR_CH5OM_Pos      (4U)
+#define IPCC_C2MR_CH5OM_Msk      (0x1UL << IPCC_C2MR_CH5OM_Pos)                /*!< 0x00000010 */
+#define IPCC_C2MR_CH5OM          IPCC_C2MR_CH5OM_Msk                           /*!< M0+ Channel5 occupied interrupt mask */
+#define IPCC_C2MR_CH6OM_Pos      (5U)
+#define IPCC_C2MR_CH6OM_Msk      (0x1UL << IPCC_C2MR_CH6OM_Pos)                /*!< 0x00000020 */
+#define IPCC_C2MR_CH6OM          IPCC_C2MR_CH6OM_Msk                           /*!< M0+ Channel6 occupied interrupt mask */
+
+#define IPCC_C2MR_CH1FM_Pos      (16U)
+#define IPCC_C2MR_CH1FM_Msk      (0x1UL << IPCC_C2MR_CH1FM_Pos)                /*!< 0x00010000 */
+#define IPCC_C2MR_CH1FM          IPCC_C2MR_CH1FM_Msk                           /*!< M0+ Transmit Channel1 free interrupt mask */
+#define IPCC_C2MR_CH2FM_Pos      (17U)
+#define IPCC_C2MR_CH2FM_Msk      (0x1UL << IPCC_C2MR_CH2FM_Pos)                /*!< 0x00020000 */
+#define IPCC_C2MR_CH2FM          IPCC_C2MR_CH2FM_Msk                           /*!< M0+ Transmit Channel2 free interrupt mask */
+#define IPCC_C2MR_CH3FM_Pos      (18U)
+#define IPCC_C2MR_CH3FM_Msk      (0x1UL << IPCC_C2MR_CH3FM_Pos)                /*!< 0x00040000 */
+#define IPCC_C2MR_CH3FM          IPCC_C2MR_CH3FM_Msk                           /*!< M0+ Transmit Channel3 free interrupt mask */
+#define IPCC_C2MR_CH4FM_Pos      (19U)
+#define IPCC_C2MR_CH4FM_Msk      (0x1UL << IPCC_C2MR_CH4FM_Pos)                /*!< 0x00080000 */
+#define IPCC_C2MR_CH4FM          IPCC_C2MR_CH4FM_Msk                           /*!< M0+ Transmit Channel4 free interrupt mask */
+#define IPCC_C2MR_CH5FM_Pos      (20U)
+#define IPCC_C2MR_CH5FM_Msk      (0x1UL << IPCC_C2MR_CH5FM_Pos)                /*!< 0x00100000 */
+#define IPCC_C2MR_CH5FM          IPCC_C2MR_CH5FM_Msk                           /*!< M0+ Transmit Channel5 free interrupt mask */
+#define IPCC_C2MR_CH6FM_Pos      (21U)
+#define IPCC_C2MR_CH6FM_Msk      (0x1UL << IPCC_C2MR_CH6FM_Pos)                /*!< 0x00200000 */
+#define IPCC_C2MR_CH6FM          IPCC_C2MR_CH6FM_Msk                           /*!< M0+ Transmit Channel6 free interrupt mask */
+
+/**********************  Bit definition for IPCC_C2SCR register  ***************/
+#define IPCC_C2SCR_CH1C_Pos      (0U)
+#define IPCC_C2SCR_CH1C_Msk      (0x1UL << IPCC_C2SCR_CH1C_Pos)                /*!< 0x00000001 */
+#define IPCC_C2SCR_CH1C          IPCC_C2SCR_CH1C_Msk                           /*!< M0+ receive Channel1 status clear */
+#define IPCC_C2SCR_CH2C_Pos      (1U)
+#define IPCC_C2SCR_CH2C_Msk      (0x1UL << IPCC_C2SCR_CH2C_Pos)                /*!< 0x00000002 */
+#define IPCC_C2SCR_CH2C          IPCC_C2SCR_CH2C_Msk                           /*!< M0+ receive Channel2 status clear */
+#define IPCC_C2SCR_CH3C_Pos      (2U)
+#define IPCC_C2SCR_CH3C_Msk      (0x1UL << IPCC_C2SCR_CH3C_Pos)                /*!< 0x00000004 */
+#define IPCC_C2SCR_CH3C          IPCC_C2SCR_CH3C_Msk                           /*!< M0+ receive Channel3 status clear */
+#define IPCC_C2SCR_CH4C_Pos      (3U)
+#define IPCC_C2SCR_CH4C_Msk      (0x1UL << IPCC_C2SCR_CH4C_Pos)                /*!< 0x00000008 */
+#define IPCC_C2SCR_CH4C          IPCC_C2SCR_CH4C_Msk                           /*!< M0+ receive Channel4 status clear */
+#define IPCC_C2SCR_CH5C_Pos      (4U)
+#define IPCC_C2SCR_CH5C_Msk      (0x1UL << IPCC_C2SCR_CH5C_Pos)                /*!< 0x00000010 */
+#define IPCC_C2SCR_CH5C          IPCC_C2SCR_CH5C_Msk                           /*!< M0+ receive Channel5 status clear */
+#define IPCC_C2SCR_CH6C_Pos      (5U)
+#define IPCC_C2SCR_CH6C_Msk      (0x1UL << IPCC_C2SCR_CH6C_Pos)                /*!< 0x00000020 */
+#define IPCC_C2SCR_CH6C          IPCC_C2SCR_CH6C_Msk                           /*!< M0+ receive Channel6 status clear */
+
+#define IPCC_C2SCR_CH1S_Pos      (16U)
+#define IPCC_C2SCR_CH1S_Msk      (0x1UL << IPCC_C2SCR_CH1S_Pos)                /*!< 0x00010000 */
+#define IPCC_C2SCR_CH1S          IPCC_C2SCR_CH1S_Msk                           /*!< M0+ transmit Channel1 status set  */
+#define IPCC_C2SCR_CH2S_Pos      (17U)
+#define IPCC_C2SCR_CH2S_Msk      (0x1UL << IPCC_C2SCR_CH2S_Pos)                /*!< 0x00020000 */
+#define IPCC_C2SCR_CH2S          IPCC_C2SCR_CH2S_Msk                           /*!< M0+ transmit Channel2 status set  */
+#define IPCC_C2SCR_CH3S_Pos      (18U)
+#define IPCC_C2SCR_CH3S_Msk      (0x1UL << IPCC_C2SCR_CH3S_Pos)                /*!< 0x00040000 */
+#define IPCC_C2SCR_CH3S          IPCC_C2SCR_CH3S_Msk                           /*!< M0+ transmit Channel3 status set  */
+#define IPCC_C2SCR_CH4S_Pos      (19U)
+#define IPCC_C2SCR_CH4S_Msk      (0x1UL << IPCC_C2SCR_CH4S_Pos)                /*!< 0x00080000 */
+#define IPCC_C2SCR_CH4S          IPCC_C2SCR_CH4S_Msk                           /*!< M0+ transmit Channel4 status set  */
+#define IPCC_C2SCR_CH5S_Pos      (20U)
+#define IPCC_C2SCR_CH5S_Msk      (0x1UL << IPCC_C2SCR_CH5S_Pos)                /*!< 0x00100000 */
+#define IPCC_C2SCR_CH5S          IPCC_C2SCR_CH5S_Msk                           /*!< M0+ transmit Channel5 status set  */
+#define IPCC_C2SCR_CH6S_Pos      (21U)
+#define IPCC_C2SCR_CH6S_Msk      (0x1UL << IPCC_C2SCR_CH6S_Pos)                /*!< 0x00200000 */
+#define IPCC_C2SCR_CH6S          IPCC_C2SCR_CH6S_Msk                           /*!< M0+ transmit Channel6 status set  */
+
+/**********************  Bit definition for IPCC_C2TOC1SR register  ***************/
+#define IPCC_C2TOC1SR_CH1F_Pos    (0U)
+#define IPCC_C2TOC1SR_CH1F_Msk    (0x1UL << IPCC_C2TOC1SR_CH1F_Pos)            /*!< 0x00000001 */
+#define IPCC_C2TOC1SR_CH1F        IPCC_C2TOC1SR_CH1F_Msk                       /*!< M0+ transmit to M0 receive Channel1 status flag before masking */
+#define IPCC_C2TOC1SR_CH2F_Pos    (1U)
+#define IPCC_C2TOC1SR_CH2F_Msk    (0x1UL << IPCC_C2TOC1SR_CH2F_Pos)            /*!< 0x00000002 */
+#define IPCC_C2TOC1SR_CH2F        IPCC_C2TOC1SR_CH2F_Msk                       /*!< M0+ transmit to M0 receive Channel2 status flag before masking */
+#define IPCC_C2TOC1SR_CH3F_Pos    (2U)
+#define IPCC_C2TOC1SR_CH3F_Msk    (0x1UL << IPCC_C2TOC1SR_CH3F_Pos)            /*!< 0x00000004 */
+#define IPCC_C2TOC1SR_CH3F        IPCC_C2TOC1SR_CH3F_Msk                       /*!< M0+ transmit to M0 receive Channel3 status flag before masking */
+#define IPCC_C2TOC1SR_CH4F_Pos    (3U)
+#define IPCC_C2TOC1SR_CH4F_Msk    (0x1UL << IPCC_C2TOC1SR_CH4F_Pos)            /*!< 0x00000008 */
+#define IPCC_C2TOC1SR_CH4F        IPCC_C2TOC1SR_CH4F_Msk                       /*!< M0+ transmit to M0 receive Channel4 status flag before masking */
+#define IPCC_C2TOC1SR_CH5F_Pos    (4U)
+#define IPCC_C2TOC1SR_CH5F_Msk    (0x1UL << IPCC_C2TOC1SR_CH5F_Pos)            /*!< 0x00000010 */
+#define IPCC_C2TOC1SR_CH5F        IPCC_C2TOC1SR_CH5F_Msk                       /*!< M0+ transmit to M0 receive Channel5 status flag before masking */
+#define IPCC_C2TOC1SR_CH6F_Pos    (5U)
+#define IPCC_C2TOC1SR_CH6F_Msk    (0x1UL << IPCC_C2TOC1SR_CH6F_Pos)            /*!< 0x00000020 */
+#define IPCC_C2TOC1SR_CH6F        IPCC_C2TOC1SR_CH6F_Msk                       /*!< M0+ transmit to M0 receive Channel6 status flag before masking */
+
+/**********************  Bit definition for IPCC_C1CR register  ***************/
+#define IPCC_CR_RXOIE_Pos         IPCC_C1CR_RXOIE_Pos
+#define IPCC_CR_RXOIE_Msk         IPCC_C1CR_RXOIE_Msk
+#define IPCC_CR_RXOIE             IPCC_C1CR_RXOIE
+#define IPCC_CR_TXFIE_Pos         IPCC_C1CR_TXFIE_Pos
+#define IPCC_CR_TXFIE_Msk         IPCC_C1CR_TXFIE_Msk
+#define IPCC_CR_TXFIE             IPCC_C1CR_TXFIE
+
+/**********************  Bit definition for IPCC_C1MR register  **************/
+#define IPCC_MR_CH1OM_Pos         IPCC_C1MR_CH1OM_Pos
+#define IPCC_MR_CH1OM_Msk         IPCC_C1MR_CH1OM_Msk
+#define IPCC_MR_CH1OM             IPCC_C1MR_CH1OM
+#define IPCC_MR_CH2OM_Pos         IPCC_C1MR_CH2OM_Pos
+#define IPCC_MR_CH2OM_Msk         IPCC_C1MR_CH2OM_Msk
+#define IPCC_MR_CH2OM             IPCC_C1MR_CH2OM
+#define IPCC_MR_CH3OM_Pos         IPCC_C1MR_CH3OM_Pos
+#define IPCC_MR_CH3OM_Msk         IPCC_C1MR_CH3OM_Msk
+#define IPCC_MR_CH3OM             IPCC_C1MR_CH3OM
+#define IPCC_MR_CH4OM_Pos         IPCC_C1MR_CH4OM_Pos
+#define IPCC_MR_CH4OM_Msk         IPCC_C1MR_CH4OM_Msk
+#define IPCC_MR_CH4OM             IPCC_C1MR_CH4OM
+#define IPCC_MR_CH5OM_Pos         IPCC_C1MR_CH5OM_Pos
+#define IPCC_MR_CH5OM_Msk         IPCC_C1MR_CH5OM_Msk
+#define IPCC_MR_CH5OM             IPCC_C1MR_CH5OM
+#define IPCC_MR_CH6OM_Pos         IPCC_C1MR_CH6OM_Pos
+#define IPCC_MR_CH6OM_Msk         IPCC_C1MR_CH6OM_Msk
+#define IPCC_MR_CH6OM             IPCC_C1MR_CH6OM
+
+#define IPCC_MR_CH1FM_Pos         IPCC_C1MR_CH1FM_Pos
+#define IPCC_MR_CH1FM_Msk         IPCC_C1MR_CH1FM_Msk
+#define IPCC_MR_CH1FM             IPCC_C1MR_CH1FM
+#define IPCC_MR_CH2FM_Pos         IPCC_C1MR_CH2FM_Pos
+#define IPCC_MR_CH2FM_Msk         IPCC_C1MR_CH2FM_Msk
+#define IPCC_MR_CH2FM             IPCC_C1MR_CH2FM
+#define IPCC_MR_CH3FM_Pos         IPCC_C1MR_CH3FM_Pos
+#define IPCC_MR_CH3FM_Msk         IPCC_C1MR_CH3FM_Msk
+#define IPCC_MR_CH3FM             IPCC_C1MR_CH3FM
+#define IPCC_MR_CH4FM_Pos         IPCC_C1MR_CH4FM_Pos
+#define IPCC_MR_CH4FM_Msk         IPCC_C1MR_CH4FM_Msk
+#define IPCC_MR_CH4FM             IPCC_C1MR_CH4FM
+#define IPCC_MR_CH5FM_Pos         IPCC_C1MR_CH5FM_Pos
+#define IPCC_MR_CH5FM_Msk         IPCC_C1MR_CH5FM_Msk
+#define IPCC_MR_CH5FM             IPCC_C1MR_CH5FM
+#define IPCC_MR_CH6FM_Pos         IPCC_C1MR_CH6FM_Pos
+#define IPCC_MR_CH6FM_Msk         IPCC_C1MR_CH6FM_Msk
+#define IPCC_MR_CH6FM             IPCC_C1MR_CH6FM
+
+/**********************  Bit definition for IPCC_C1SCR register  ***************/
+#define IPCC_SCR_CH1C_Pos         IPCC_C1SCR_CH1C_Pos
+#define IPCC_SCR_CH1C_Msk         IPCC_C1SCR_CH1C_Msk
+#define IPCC_SCR_CH1C             IPCC_C1SCR_CH1C
+#define IPCC_SCR_CH2C_Pos         IPCC_C1SCR_CH2C_Pos
+#define IPCC_SCR_CH2C_Msk         IPCC_C1SCR_CH2C_Msk
+#define IPCC_SCR_CH2C             IPCC_C1SCR_CH2C
+#define IPCC_SCR_CH3C_Pos         IPCC_C1SCR_CH3C_Pos
+#define IPCC_SCR_CH3C_Msk         IPCC_C1SCR_CH3C_Msk
+#define IPCC_SCR_CH3C             IPCC_C1SCR_CH3C
+#define IPCC_SCR_CH4C_Pos         IPCC_C1SCR_CH4C_Pos
+#define IPCC_SCR_CH4C_Msk         IPCC_C1SCR_CH4C_Msk
+#define IPCC_SCR_CH4C             IPCC_C1SCR_CH4C
+#define IPCC_SCR_CH5C_Pos         IPCC_C1SCR_CH5C_Pos
+#define IPCC_SCR_CH5C_Msk         IPCC_C1SCR_CH5C_Msk
+#define IPCC_SCR_CH5C             IPCC_C1SCR_CH5C
+#define IPCC_SCR_CH6C_Pos         IPCC_C1SCR_CH6C_Pos
+#define IPCC_SCR_CH6C_Msk         IPCC_C1SCR_CH6C_Msk
+#define IPCC_SCR_CH6C             IPCC_C1SCR_CH6C
+
+#define IPCC_SCR_CH1S_Pos         IPCC_C1SCR_CH1S_Pos
+#define IPCC_SCR_CH1S_Msk         IPCC_C1SCR_CH1S_Msk
+#define IPCC_SCR_CH1S             IPCC_C1SCR_CH1S
+#define IPCC_SCR_CH2S_Pos         IPCC_C1SCR_CH2S_Pos
+#define IPCC_SCR_CH2S_Msk         IPCC_C1SCR_CH2S_Msk
+#define IPCC_SCR_CH2S             IPCC_C1SCR_CH2S
+#define IPCC_SCR_CH3S_Pos         IPCC_C1SCR_CH3S_Pos
+#define IPCC_SCR_CH3S_Msk         IPCC_C1SCR_CH3S_Msk
+#define IPCC_SCR_CH3S             IPCC_C1SCR_CH3S
+#define IPCC_SCR_CH4S_Pos         IPCC_C1SCR_CH4S_Pos
+#define IPCC_SCR_CH4S_Msk         IPCC_C1SCR_CH4S_Msk
+#define IPCC_SCR_CH4S             IPCC_C1SCR_CH4S
+#define IPCC_SCR_CH5S_Pos         IPCC_C1SCR_CH5S_Pos
+#define IPCC_SCR_CH5S_Msk         IPCC_C1SCR_CH5S_Msk
+#define IPCC_SCR_CH5S             IPCC_C1SCR_CH5S
+#define IPCC_SCR_CH6S_Pos         IPCC_C1SCR_CH6S_Pos
+#define IPCC_SCR_CH6S_Msk         IPCC_C1SCR_CH6S_Msk
+#define IPCC_SCR_CH6S             IPCC_C1SCR_CH6S
+
+/**********************  Bit definition for IPCC_C1TOC2SR register  ***************/
+#define IPCC_SR_CH1F_Pos          IPCC_C1TOC2SR_CH1F_Pos
+#define IPCC_SR_CH1F_Msk          IPCC_C1TOC2SR_CH1F_Msk
+#define IPCC_SR_CH1F              IPCC_C1TOC2SR_CH1F
+#define IPCC_SR_CH2F_Pos          IPCC_C1TOC2SR_CH2F_Pos
+#define IPCC_SR_CH2F_Msk          IPCC_C1TOC2SR_CH2F_Msk
+#define IPCC_SR_CH2F              IPCC_C1TOC2SR_CH2F
+#define IPCC_SR_CH3F_Pos          IPCC_C1TOC2SR_CH3F_Pos
+#define IPCC_SR_CH3F_Msk          IPCC_C1TOC2SR_CH3F_Msk
+#define IPCC_SR_CH3F              IPCC_C1TOC2SR_CH3F
+#define IPCC_SR_CH4F_Pos          IPCC_C1TOC2SR_CH4F_Pos
+#define IPCC_SR_CH4F_Msk          IPCC_C1TOC2SR_CH4F_Msk
+#define IPCC_SR_CH4F              IPCC_C1TOC2SR_CH4F
+#define IPCC_SR_CH5F_Pos          IPCC_C1TOC2SR_CH5F_Pos
+#define IPCC_SR_CH5F_Msk          IPCC_C1TOC2SR_CH5F_Msk
+#define IPCC_SR_CH5F              IPCC_C1TOC2SR_CH5F
+#define IPCC_SR_CH6F_Pos          IPCC_C1TOC2SR_CH6F_Pos
+#define IPCC_SR_CH6F_Msk          IPCC_C1TOC2SR_CH6F_Msk
+#define IPCC_SR_CH6F              IPCC_C1TOC2SR_CH6F
+
+/******************** Number of IPCC channels ******************************/
+#define IPCC_CHANNEL_NUMBER       6U
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_UE_Pos                (0U)
+#define USART_CR1_UE_Msk                (0x1UL << USART_CR1_UE_Pos)            /*!< 0x00000001 */
+#define USART_CR1_UE                    USART_CR1_UE_Msk                        /*!< USART Enable */
+#define USART_CR1_UESM_Pos              (1U)
+#define USART_CR1_UESM_Msk              (0x1UL << USART_CR1_UESM_Pos)           /*!< 0x00000002 */
+#define USART_CR1_UESM                  USART_CR1_UESM_Msk                      /*!< USART Enable in STOP Mode */
+#define USART_CR1_RE_Pos                (2U)
+#define USART_CR1_RE_Msk                (0x1UL << USART_CR1_RE_Pos)             /*!< 0x00000004 */
+#define USART_CR1_RE                    USART_CR1_RE_Msk                        /*!< Receiver Enable */
+#define USART_CR1_TE_Pos                (3U)
+#define USART_CR1_TE_Msk                (0x1UL << USART_CR1_TE_Pos)             /*!< 0x00000008 */
+#define USART_CR1_TE                    USART_CR1_TE_Msk                        /*!< Transmitter Enable */
+#define USART_CR1_IDLEIE_Pos            (4U)
+#define USART_CR1_IDLEIE_Msk            (0x1UL << USART_CR1_IDLEIE_Pos)         /*!< 0x00000010 */
+#define USART_CR1_IDLEIE                USART_CR1_IDLEIE_Msk                    /*!< IDLE Interrupt Enable */
+#define USART_CR1_RXNEIE_Pos            (5U)
+#define USART_CR1_RXNEIE_Msk            (0x1UL << USART_CR1_RXNEIE_Pos)         /*!< 0x00000020 */
+#define USART_CR1_RXNEIE                USART_CR1_RXNEIE_Msk                    /*!< RXNE Interrupt Enable */
+#define USART_CR1_RXNEIE_RXFNEIE_Pos    USART_CR1_RXNEIE_Pos
+#define USART_CR1_RXNEIE_RXFNEIE_Msk    USART_CR1_RXNEIE_Msk                    /*!< 0x00000020 */
+#define USART_CR1_RXNEIE_RXFNEIE        USART_CR1_RXNEIE_Msk                    /*!< RXNE and RX FIFO Not Empty Interrupt Enable */
+#define USART_CR1_TCIE_Pos              (6U)
+#define USART_CR1_TCIE_Msk              (0x1UL << USART_CR1_TCIE_Pos)           /*!< 0x00000040 */
+#define USART_CR1_TCIE                  USART_CR1_TCIE_Msk                      /*!< Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_Pos             (7U)
+#define USART_CR1_TXEIE_Msk             (0x1UL << USART_CR1_TXEIE_Pos)          /*!< 0x00000080 */
+#define USART_CR1_TXEIE                 USART_CR1_TXEIE_Msk                     /*!< TXE Interrupt Enable */
+#define USART_CR1_TXEIE_TXFNFIE_Pos     (7U)
+#define USART_CR1_TXEIE_TXFNFIE_Msk     (0x1UL << USART_CR1_TXEIE_Pos)          /*!< 0x00000080 */
+#define USART_CR1_TXEIE_TXFNFIE         USART_CR1_TXEIE                         /*!< TXE and TX FIFO Not Full Interrupt Enable */
+#define USART_CR1_PEIE_Pos              (8U)
+#define USART_CR1_PEIE_Msk              (0x1UL << USART_CR1_PEIE_Pos)           /*!< 0x00000100 */
+#define USART_CR1_PEIE                  USART_CR1_PEIE_Msk                      /*!< PE Interrupt Enable */
+#define USART_CR1_PS_Pos                (9U)
+#define USART_CR1_PS_Msk                (0x1UL << USART_CR1_PS_Pos)             /*!< 0x00000200 */
+#define USART_CR1_PS                    USART_CR1_PS_Msk                        /*!< Parity Selection */
+#define USART_CR1_PCE_Pos               (10U)
+#define USART_CR1_PCE_Msk               (0x1UL << USART_CR1_PCE_Pos)            /*!< 0x00000400 */
+#define USART_CR1_PCE                   USART_CR1_PCE_Msk                       /*!< Parity Control Enable */
+#define USART_CR1_WAKE_Pos              (11U)
+#define USART_CR1_WAKE_Msk              (0x1UL << USART_CR1_WAKE_Pos)           /*!< 0x00000800 */
+#define USART_CR1_WAKE                  USART_CR1_WAKE_Msk                      /*!< Receiver Wakeup method */
+#define USART_CR1_M0_Pos                (12U)
+#define USART_CR1_M0_Msk                (0x1UL << USART_CR1_M0_Pos)             /*!< 0x00001000 */
+#define USART_CR1_M0                    USART_CR1_M0_Msk                        /*!< Word length - Bit 0 */
+#define USART_CR1_MME_Pos               (13U)
+#define USART_CR1_MME_Msk               (0x1UL << USART_CR1_MME_Pos)            /*!< 0x00002000 */
+#define USART_CR1_MME                   USART_CR1_MME_Msk                       /*!< Mute Mode Enable */
+#define USART_CR1_CMIE_Pos              (14U)
+#define USART_CR1_CMIE_Msk              (0x1UL << USART_CR1_CMIE_Pos)           /*!< 0x00004000 */
+#define USART_CR1_CMIE                  USART_CR1_CMIE_Msk                      /*!< Character match interrupt enable */
+#define USART_CR1_OVER8_Pos             (15U)
+#define USART_CR1_OVER8_Msk             (0x1UL << USART_CR1_OVER8_Pos)          /*!< 0x00008000 */
+#define USART_CR1_OVER8                 USART_CR1_OVER8_Msk                     /*!< Oversampling by 8-bit or 16-bit mode */
+#define USART_CR1_DEDT_Pos              (16U)
+#define USART_CR1_DEDT_Msk              (0x1FUL << USART_CR1_DEDT_Pos)          /*!< 0x001F0000 */
+#define USART_CR1_DEDT                  USART_CR1_DEDT_Msk                      /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define USART_CR1_DEDT_0                (0x01U << USART_CR1_DEDT_Pos)           /*!< 0x00010000 */
+#define USART_CR1_DEDT_1                (0x02U << USART_CR1_DEDT_Pos)           /*!< 0x00020000 */
+#define USART_CR1_DEDT_2                (0x04U << USART_CR1_DEDT_Pos)           /*!< 0x00040000 */
+#define USART_CR1_DEDT_3                (0x08U << USART_CR1_DEDT_Pos)           /*!< 0x00080000 */
+#define USART_CR1_DEDT_4                (0x10U << USART_CR1_DEDT_Pos)           /*!< 0x00100000 */
+#define USART_CR1_DEAT_Pos              (21U)
+#define USART_CR1_DEAT_Msk              (0x1FUL << USART_CR1_DEAT_Pos)          /*!< 0x03E00000 */
+#define USART_CR1_DEAT                  USART_CR1_DEAT_Msk                      /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define USART_CR1_DEAT_0                (0x01U << USART_CR1_DEAT_Pos)           /*!< 0x00200000 */
+#define USART_CR1_DEAT_1                (0x02U << USART_CR1_DEAT_Pos)           /*!< 0x00400000 */
+#define USART_CR1_DEAT_2                (0x04U << USART_CR1_DEAT_Pos)           /*!< 0x00800000 */
+#define USART_CR1_DEAT_3                (0x08U << USART_CR1_DEAT_Pos)           /*!< 0x01000000 */
+#define USART_CR1_DEAT_4                (0x10U << USART_CR1_DEAT_Pos)           /*!< 0x02000000 */
+#define USART_CR1_RTOIE_Pos             (26U)
+#define USART_CR1_RTOIE_Msk             (0x1UL << USART_CR1_RTOIE_Pos)          /*!< 0x04000000 */
+#define USART_CR1_RTOIE                 USART_CR1_RTOIE_Msk                     /*!< Receive Time Out Interrupt Enable */
+#define USART_CR1_EOBIE_Pos             (27U)
+#define USART_CR1_EOBIE_Msk             (0x1UL << USART_CR1_EOBIE_Pos)          /*!< 0x08000000 */
+#define USART_CR1_EOBIE                 USART_CR1_EOBIE_Msk                     /*!< End of Block Interrupt Enable */
+#define USART_CR1_M1_Pos                (28U)
+#define USART_CR1_M1_Msk                (0x1UL << USART_CR1_M1_Pos)             /*!< 0x10000000 */
+#define USART_CR1_M1                    USART_CR1_M1_Msk                        /*!< Word length - Bit 1 */
+#define USART_CR1_M                     (uint32_t)(USART_CR1_M1 | USART_CR1_M0) /*!< Word length */
+#define USART_CR1_FIFOEN_Pos            (29U)
+#define USART_CR1_FIFOEN_Msk            (0x1UL << USART_CR1_FIFOEN_Pos)         /*!< 0x20000000 */
+#define USART_CR1_FIFOEN                USART_CR1_FIFOEN_Msk                    /*!< FIFO mode enable */
+#define USART_CR1_TXFEIE_Pos            (30U)
+#define USART_CR1_TXFEIE_Msk            (0x1UL << USART_CR1_TXFEIE_Pos)         /*!< 0x40000000 */
+#define USART_CR1_TXFEIE                USART_CR1_TXFEIE_Msk                    /*!< TX FIFO Empty Interrupt Enable */
+#define USART_CR1_RXFFIE_Pos            (31U)
+#define USART_CR1_RXFFIE_Msk            (0x1UL << USART_CR1_RXFFIE_Pos)         /*!< 0x80000000 */
+#define USART_CR1_RXFFIE                USART_CR1_RXFFIE_Msk                    /*!< RX FIFO Full Interrupt Enable */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_SLVEN_Pos             (0U)
+#define USART_CR2_SLVEN_Msk             (0x1UL << USART_CR2_SLVEN_Pos)          /*!< 0x00000001 */
+#define USART_CR2_SLVEN                 USART_CR2_SLVEN_Msk                     /*!< Synchronous Slave mode enable */
+#define USART_CR2_DIS_NSS_Pos           (3U)
+#define USART_CR2_DIS_NSS_Msk           (0x1UL << USART_CR2_DIS_NSS_Pos)        /*!< 0x00000008 */
+#define USART_CR2_DIS_NSS               USART_CR2_DIS_NSS_Msk                   /*!< Slave Select (NSS) pin management */
+#define USART_CR2_ADDM7_Pos             (4U)
+#define USART_CR2_ADDM7_Msk             (0x1UL << USART_CR2_ADDM7_Pos)          /*!< 0x00000010 */
+#define USART_CR2_ADDM7                 USART_CR2_ADDM7_Msk                     /*!< 7-bit or 4-bit Address Detection */
+#define USART_CR2_LBDL_Pos              (5U)
+#define USART_CR2_LBDL_Msk              (0x1UL << USART_CR2_LBDL_Pos)           /*!< 0x00000020 */
+#define USART_CR2_LBDL                  USART_CR2_LBDL_Msk                      /*!< LIN Break Detection Length */
+#define USART_CR2_LBDIE_Pos             (6U)
+#define USART_CR2_LBDIE_Msk             (0x1UL << USART_CR2_LBDIE_Pos)          /*!< 0x00000040 */
+#define USART_CR2_LBDIE                 USART_CR2_LBDIE_Msk                     /*!< LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos              (8U)
+#define USART_CR2_LBCL_Msk              (0x1UL << USART_CR2_LBCL_Pos)           /*!< 0x00000100 */
+#define USART_CR2_LBCL                  USART_CR2_LBCL_Msk                      /*!< Last Bit Clock pulse */
+#define USART_CR2_CPHA_Pos              (9U)
+#define USART_CR2_CPHA_Msk              (0x1UL << USART_CR2_CPHA_Pos)           /*!< 0x00000200 */
+#define USART_CR2_CPHA                  USART_CR2_CPHA_Msk                      /*!< Clock Phase */
+#define USART_CR2_CPOL_Pos              (10U)
+#define USART_CR2_CPOL_Msk              (0x1UL << USART_CR2_CPOL_Pos)           /*!< 0x00000400 */
+#define USART_CR2_CPOL                  USART_CR2_CPOL_Msk                      /*!< Clock Polarity */
+#define USART_CR2_CLKEN_Pos             (11U)
+#define USART_CR2_CLKEN_Msk             (0x1UL << USART_CR2_CLKEN_Pos)          /*!< 0x00000800 */
+#define USART_CR2_CLKEN                 USART_CR2_CLKEN_Msk                     /*!< Clock Enable */
+#define USART_CR2_STOP_Pos              (12U)
+#define USART_CR2_STOP_Msk              (0x3UL << USART_CR2_STOP_Pos)           /*!< 0x00003000 */
+#define USART_CR2_STOP                  USART_CR2_STOP_Msk                      /*!< STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0                (0x1U << USART_CR2_STOP_Pos)            /*!< 0x00001000 */
+#define USART_CR2_STOP_1                (0x2U << USART_CR2_STOP_Pos)            /*!< 0x00002000 */
+#define USART_CR2_LINEN_Pos             (14U)
+#define USART_CR2_LINEN_Msk             (0x1UL << USART_CR2_LINEN_Pos)          /*!< 0x00004000 */
+#define USART_CR2_LINEN                 USART_CR2_LINEN_Msk                     /*!< LIN mode enable */
+#define USART_CR2_SWAP_Pos              (15U)
+#define USART_CR2_SWAP_Msk              (0x1UL << USART_CR2_SWAP_Pos)           /*!< 0x00008000 */
+#define USART_CR2_SWAP                  USART_CR2_SWAP_Msk                      /*!< SWAP TX/RX pins */
+#define USART_CR2_RXINV_Pos             (16U)
+#define USART_CR2_RXINV_Msk             (0x1UL << USART_CR2_RXINV_Pos)          /*!< 0x00010000 */
+#define USART_CR2_RXINV                 USART_CR2_RXINV_Msk                     /*!< RX pin active level inversion */
+#define USART_CR2_TXINV_Pos             (17U)
+#define USART_CR2_TXINV_Msk             (0x1UL << USART_CR2_TXINV_Pos)          /*!< 0x00020000 */
+#define USART_CR2_TXINV                 USART_CR2_TXINV_Msk                     /*!< TX pin active level inversion */
+#define USART_CR2_DATAINV_Pos           (18U)
+#define USART_CR2_DATAINV_Msk           (0x1UL << USART_CR2_DATAINV_Pos)        /*!< 0x00040000 */
+#define USART_CR2_DATAINV               USART_CR2_DATAINV_Msk                   /*!< Binary data inversion */
+#define USART_CR2_MSBFIRST_Pos          (19U)
+#define USART_CR2_MSBFIRST_Msk          (0x1UL << USART_CR2_MSBFIRST_Pos)       /*!< 0x00080000 */
+#define USART_CR2_MSBFIRST              USART_CR2_MSBFIRST_Msk                  /*!< Most Significant Bit First */
+#define USART_CR2_ABREN_Pos             (20U)
+#define USART_CR2_ABREN_Msk             (0x1UL << USART_CR2_ABREN_Pos)          /*!< 0x00100000 */
+#define USART_CR2_ABREN                 USART_CR2_ABREN_Msk                     /*!< Auto Baud-Rate Enable*/
+#define USART_CR2_ABRMODE_Pos           (21U)
+#define USART_CR2_ABRMODE_Msk           (0x3UL << USART_CR2_ABRMODE_Pos)        /*!< 0x00600000 */
+#define USART_CR2_ABRMODE               USART_CR2_ABRMODE_Msk                   /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define USART_CR2_ABRMODE_0             (0x1U << USART_CR2_ABRMODE_Pos)         /*!< 0x00200000 */
+#define USART_CR2_ABRMODE_1             (0x2U << USART_CR2_ABRMODE_Pos)         /*!< 0x00400000 */
+#define USART_CR2_RTOEN_Pos             (23U)
+#define USART_CR2_RTOEN_Msk             (0x1UL << USART_CR2_RTOEN_Pos)          /*!< 0x00800000 */
+#define USART_CR2_RTOEN                 USART_CR2_RTOEN_Msk                     /*!< Receiver Time-Out enable */
+#define USART_CR2_ADD_Pos               (24U)
+#define USART_CR2_ADD_Msk               (0xFFUL << USART_CR2_ADD_Pos)           /*!< 0xFF000000 */
+#define USART_CR2_ADD                   USART_CR2_ADD_Msk                       /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos               (0U)
+#define USART_CR3_EIE_Msk               (0x1UL << USART_CR3_EIE_Pos)            /*!< 0x00000001 */
+#define USART_CR3_EIE                   USART_CR3_EIE_Msk                       /*!< Error Interrupt Enable */
+#define USART_CR3_IREN_Pos              (1U)
+#define USART_CR3_IREN_Msk              (0x1UL << USART_CR3_IREN_Pos)           /*!< 0x00000002 */
+#define USART_CR3_IREN                  USART_CR3_IREN_Msk                      /*!< IrDA mode Enable */
+#define USART_CR3_IRLP_Pos              (2U)
+#define USART_CR3_IRLP_Msk              (0x1UL << USART_CR3_IRLP_Pos)           /*!< 0x00000004 */
+#define USART_CR3_IRLP                  USART_CR3_IRLP_Msk                      /*!< IrDA Low-Power */
+#define USART_CR3_HDSEL_Pos             (3U)
+#define USART_CR3_HDSEL_Msk             (0x1UL << USART_CR3_HDSEL_Pos)          /*!< 0x00000008 */
+#define USART_CR3_HDSEL                 USART_CR3_HDSEL_Msk                     /*!< Half-Duplex Selection */
+#define USART_CR3_NACK_Pos              (4U)
+#define USART_CR3_NACK_Msk              (0x1UL << USART_CR3_NACK_Pos)           /*!< 0x00000010 */
+#define USART_CR3_NACK                  USART_CR3_NACK_Msk                      /*!< SmartCard NACK enable */
+#define USART_CR3_SCEN_Pos              (5U)
+#define USART_CR3_SCEN_Msk              (0x1UL << USART_CR3_SCEN_Pos)           /*!< 0x00000020 */
+#define USART_CR3_SCEN                  USART_CR3_SCEN_Msk                      /*!< SmartCard mode enable */
+#define USART_CR3_DMAR_Pos              (6U)
+#define USART_CR3_DMAR_Msk              (0x1UL << USART_CR3_DMAR_Pos)           /*!< 0x00000040 */
+#define USART_CR3_DMAR                  USART_CR3_DMAR_Msk                      /*!< DMA Enable Receiver */
+#define USART_CR3_DMAT_Pos              (7U)
+#define USART_CR3_DMAT_Msk              (0x1UL << USART_CR3_DMAT_Pos)           /*!< 0x00000080 */
+#define USART_CR3_DMAT                  USART_CR3_DMAT_Msk                      /*!< DMA Enable Transmitter */
+#define USART_CR3_RTSE_Pos              (8U)
+#define USART_CR3_RTSE_Msk              (0x1UL << USART_CR3_RTSE_Pos)           /*!< 0x00000100 */
+#define USART_CR3_RTSE                  USART_CR3_RTSE_Msk                      /*!< RTS Enable */
+#define USART_CR3_CTSE_Pos              (9U)
+#define USART_CR3_CTSE_Msk              (0x1UL << USART_CR3_CTSE_Pos)           /*!< 0x00000200 */
+#define USART_CR3_CTSE                  USART_CR3_CTSE_Msk
+#define USART_CR3_CTSIE_Pos             (10U)
+#define USART_CR3_CTSIE_Msk             (0x1UL << USART_CR3_CTSIE_Pos)          /*!< 0x00000400 */
+#define USART_CR3_CTSIE                 USART_CR3_CTSIE_Msk                     /*!< CTS Interrupt Enable */
+#define USART_CR3_ONEBIT_Pos            (11U)
+#define USART_CR3_ONEBIT_Msk            (0x1UL << USART_CR3_ONEBIT_Pos)         /*!< 0x00000800 */
+#define USART_CR3_ONEBIT                USART_CR3_ONEBIT_Msk                    /*!< One sample bit method enable */
+#define USART_CR3_OVRDIS_Pos            (12U)
+#define USART_CR3_OVRDIS_Msk            (0x1UL << USART_CR3_OVRDIS_Pos)         /*!< 0x00001000 */
+#define USART_CR3_OVRDIS                USART_CR3_OVRDIS_Msk                    /*!< Overrun Disable */
+#define USART_CR3_DDRE_Pos              (13U)
+#define USART_CR3_DDRE_Msk              (0x1UL << USART_CR3_DDRE_Pos)           /*!< 0x00002000 */
+#define USART_CR3_DDRE                  USART_CR3_DDRE_Msk                      /*!< DMA Disable on Reception Error */
+#define USART_CR3_DEM_Pos               (14U)
+#define USART_CR3_DEM_Msk               (0x1UL << USART_CR3_DEM_Pos)            /*!< 0x00004000 */
+#define USART_CR3_DEM                   USART_CR3_DEM_Msk                       /*!< Driver Enable Mode */
+#define USART_CR3_DEP_Pos               (15U)
+#define USART_CR3_DEP_Msk               (0x1UL << USART_CR3_DEP_Pos)            /*!< 0x00008000 */
+#define USART_CR3_DEP                   USART_CR3_DEP_Msk                       /*!< Driver Enable Polarity Selection */
+#define USART_CR3_SCARCNT_Pos           (17U)
+#define USART_CR3_SCARCNT_Msk           (0x7UL << USART_CR3_SCARCNT_Pos)        /*!< 0x000E0000 */
+#define USART_CR3_SCARCNT               USART_CR3_SCARCNT_Msk                   /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define USART_CR3_SCARCNT_0             (0x1U << USART_CR3_SCARCNT_Pos)         /*!< 0x00020000 */
+#define USART_CR3_SCARCNT_1             (0x2U << USART_CR3_SCARCNT_Pos)         /*!< 0x00040000 */
+#define USART_CR3_SCARCNT_2             (0x4U << USART_CR3_SCARCNT_Pos)         /*!< 0x00080000 */
+#define USART_CR3_WUS_Pos               (20U)
+#define USART_CR3_WUS_Msk               (0x3UL << USART_CR3_WUS_Pos)            /*!< 0x00300000 */
+#define USART_CR3_WUS                   USART_CR3_WUS_Msk                       /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define USART_CR3_WUS_0                 (0x1U << USART_CR3_WUS_Pos)             /*!< 0x00100000 */
+#define USART_CR3_WUS_1                 (0x2U << USART_CR3_WUS_Pos)             /*!< 0x00200000 */
+#define USART_CR3_WUFIE_Pos             (22U)
+#define USART_CR3_WUFIE_Msk             (0x1UL << USART_CR3_WUFIE_Pos)          /*!< 0x00400000 */
+#define USART_CR3_WUFIE                 USART_CR3_WUFIE_Msk                     /*!< Wake Up Interrupt Enable */
+#define USART_CR3_TXFTIE_Pos            (23U)
+#define USART_CR3_TXFTIE_Msk            (0x1UL << USART_CR3_TXFTIE_Pos)         /*!< 0x00800000 */
+#define USART_CR3_TXFTIE                USART_CR3_TXFTIE_Msk                    /*!< TX FIFO Threshold Interrupt Enable */
+#define USART_CR3_TCBGTIE_Pos           (24U)
+#define USART_CR3_TCBGTIE_Msk           (0x1UL << USART_CR3_TCBGTIE_Pos)        /*!< 0x01000000 */
+#define USART_CR3_TCBGTIE               USART_CR3_TCBGTIE_Msk                   /*!< Transmission Complete Before Guard Time Interrupt Enable */
+#define USART_CR3_RXFTCFG_Pos           (25U)
+#define USART_CR3_RXFTCFG_Msk           (0x7UL << USART_CR3_RXFTCFG_Pos)        /*!< 0x0E000000 */
+#define USART_CR3_RXFTCFG               USART_CR3_RXFTCFG_Msk                   /*!< RX FIFO Threshold Configuration */
+#define USART_CR3_RXFTCFG_0             (0x1U << USART_CR3_RXFTCFG_Pos)         /*!< 0x02000000 */
+#define USART_CR3_RXFTCFG_1             (0x2U << USART_CR3_RXFTCFG_Pos)         /*!< 0x04000000 */
+#define USART_CR3_RXFTCFG_2             (0x4U << USART_CR3_RXFTCFG_Pos)         /*!< 0x08000000 */
+#define USART_CR3_RXFTIE_Pos            (28U)
+#define USART_CR3_RXFTIE_Msk            (0x1UL << USART_CR3_RXFTIE_Pos)         /*!< 0x10000000 */
+#define USART_CR3_RXFTIE                USART_CR3_RXFTIE_Msk                    /*!< RX FIFO Threshold Interrupt Enable */
+#define USART_CR3_TXFTCFG_Pos           (29U)
+#define USART_CR3_TXFTCFG_Msk           (0x7UL << USART_CR3_TXFTCFG_Pos)        /*!< 0xE0000000 */
+#define USART_CR3_TXFTCFG               USART_CR3_TXFTCFG_Msk                   /*!< TX FIFO Threshold configuration */
+#define USART_CR3_TXFTCFG_0             (0x1U << USART_CR3_TXFTCFG_Pos)         /*!< 0x20000000 */
+#define USART_CR3_TXFTCFG_1             (0x2U << USART_CR3_TXFTCFG_Pos)         /*!< 0x40000000 */
+#define USART_CR3_TXFTCFG_2             (0x4U << USART_CR3_TXFTCFG_Pos)         /*!< 0x80000000 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_BRR                   ((uint16_t)0xFFFF)                      /*!< USART  Baud rate register [15:0] */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos              (0U)
+#define USART_GTPR_PSC_Msk              (0xFFUL << USART_GTPR_PSC_Pos)          /*!< 0x000000FF */
+#define USART_GTPR_PSC                  USART_GTPR_PSC_Msk                      /*!< PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_GT_Pos               (8U)
+#define USART_GTPR_GT_Msk               (0xFFUL << USART_GTPR_GT_Pos)           /*!< 0x0000FF00 */
+#define USART_GTPR_GT                   USART_GTPR_GT_Msk                       /*!< GT[7:0] bits (Guard time value) */
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define USART_RTOR_RTO_Pos              (0U)
+#define USART_RTOR_RTO_Msk              (0xFFFFFFUL << USART_RTOR_RTO_Pos)      /*!< 0x00FFFFFF */
+#define USART_RTOR_RTO                  USART_RTOR_RTO_Msk                      /*!< Receiver Timeout Value */
+#define USART_RTOR_BLEN_Pos             (24U)
+#define USART_RTOR_BLEN_Msk             (0xFFUL << USART_RTOR_BLEN_Pos)         /*!< 0xFF000000 */
+#define USART_RTOR_BLEN                 USART_RTOR_BLEN_Msk                     /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define USART_RQR_ABRRQ_Pos             (0U)
+#define USART_RQR_ABRRQ_Msk             (0x1UL << USART_RQR_ABRRQ_Pos)          /*!< 0x00000001 */
+#define USART_RQR_ABRRQ                 USART_RQR_ABRRQ_Msk                     /*!< Auto-Baud Rate Request */
+#define USART_RQR_SBKRQ_Pos             (1U)
+#define USART_RQR_SBKRQ_Msk             (0x1UL << USART_RQR_SBKRQ_Pos)          /*!< 0x00000002 */
+#define USART_RQR_SBKRQ                 USART_RQR_SBKRQ_Msk                     /*!< Send Break Request */
+#define USART_RQR_MMRQ_Pos              (2U)
+#define USART_RQR_MMRQ_Msk              (0x1UL << USART_RQR_MMRQ_Pos)           /*!< 0x00000004 */
+#define USART_RQR_MMRQ                  USART_RQR_MMRQ_Msk                      /*!< Mute Mode Request */
+#define USART_RQR_RXFRQ_Pos             (3U)
+#define USART_RQR_RXFRQ_Msk             (0x1UL << USART_RQR_RXFRQ_Pos)          /*!< 0x00000008 */
+#define USART_RQR_RXFRQ                 USART_RQR_RXFRQ_Msk                     /*!< Receive Data flush Request */
+#define USART_RQR_TXFRQ_Pos             (4U)
+#define USART_RQR_TXFRQ_Msk             (0x1UL << USART_RQR_TXFRQ_Pos)          /*!< 0x00000010 */
+#define USART_RQR_TXFRQ                 USART_RQR_TXFRQ_Msk                     /*!< Transmit Data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define USART_ISR_PE_Pos                (0U)
+#define USART_ISR_PE_Msk                (0x1UL << USART_ISR_PE_Pos)             /*!< 0x00000001 */
+#define USART_ISR_PE                    USART_ISR_PE_Msk                        /*!< Parity Error */
+#define USART_ISR_FE_Pos                (1U)
+#define USART_ISR_FE_Msk                (0x1UL << USART_ISR_FE_Pos)             /*!< 0x00000002 */
+#define USART_ISR_FE                    USART_ISR_FE_Msk                        /*!< Framing Error */
+#define USART_ISR_NE_Pos                (2U)
+#define USART_ISR_NE_Msk                (0x1UL << USART_ISR_NE_Pos)             /*!< 0x00000004 */
+#define USART_ISR_NE                    USART_ISR_NE_Msk                        /*!< START bit Noise Error detection Flag */
+#define USART_ISR_ORE_Pos               (3U)
+#define USART_ISR_ORE_Msk               (0x1UL << USART_ISR_ORE_Pos)            /*!< 0x00000008 */
+#define USART_ISR_ORE                   USART_ISR_ORE_Msk                       /*!< OverRun Error */
+#define USART_ISR_IDLE_Pos              (4U)
+#define USART_ISR_IDLE_Msk              (0x1UL << USART_ISR_IDLE_Pos)           /*!< 0x00000010 */
+#define USART_ISR_IDLE                  USART_ISR_IDLE_Msk                      /*!< IDLE line detected */
+#define USART_ISR_RXNE_Pos              (5U)
+#define USART_ISR_RXNE_Msk              (0x1UL << USART_ISR_RXNE_Pos)           /*!< 0x00000020 */
+#define USART_ISR_RXNE                  USART_ISR_RXNE_Msk                      /*!< Read Data Register Not Empty */
+#define USART_ISR_RXNE_RXFNE_Pos        USART_ISR_RXNE_Pos
+#define USART_ISR_RXNE_RXFNE_Msk        USART_ISR_RXNE_Msk                      /*!< 0x00000020 */
+#define USART_ISR_RXNE_RXFNE            USART_ISR_RXNE_Msk                      /*!< Read Data Register or RX FIFO Not Empty */
+#define USART_ISR_TC_Pos                (6U)
+#define USART_ISR_TC_Msk                (0x1UL << USART_ISR_TC_Pos)             /*!< 0x00000040 */
+#define USART_ISR_TC                    USART_ISR_TC_Msk                        /*!< Transmission Complete */
+#define USART_ISR_TXE_Pos               (7U)
+#define USART_ISR_TXE_Msk               (0x1UL << USART_ISR_TXE_Pos)            /*!< 0x00000080 */
+#define USART_ISR_TXE                   USART_ISR_TXE_Msk                       /*!< Transmit Data Register Empty */
+#define USART_ISR_TXE_TXFNF_Pos         USART_ISR_TXE_Pos
+#define USART_ISR_TXE_TXFNF_Msk         USART_ISR_TXE_Msk                       /*!< 0x00000080 */
+#define USART_ISR_TXE_TXFNF             USART_ISR_TXE_Msk                       /*!< Transmit Data Register Empty or TX FIFO Not Full Flag */
+#define USART_ISR_LBDF_Pos              (8U)
+#define USART_ISR_LBDF_Msk              (0x1UL << USART_ISR_LBDF_Pos)           /*!< 0x00000100 */
+#define USART_ISR_LBDF                  USART_ISR_LBDF_Msk                      /*!< LIN Break Detection Flag */
+#define USART_ISR_CTSIF_Pos             (9U)
+#define USART_ISR_CTSIF_Msk             (0x1UL << USART_ISR_CTSIF_Pos)          /*!< 0x00000200 */
+#define USART_ISR_CTSIF                 USART_ISR_CTSIF_Msk                     /*!< CTS interrupt Flag */
+#define USART_ISR_CTS_Pos               (10U)
+#define USART_ISR_CTS_Msk               (0x1UL << USART_ISR_CTS_Pos)            /*!< 0x00000400 */
+#define USART_ISR_CTS                   USART_ISR_CTS_Msk                       /*!< CTS Flag */
+#define USART_ISR_RTOF_Pos              (11U)
+#define USART_ISR_RTOF_Msk              (0x1UL << USART_ISR_RTOF_Pos)           /*!< 0x00000800 */
+#define USART_ISR_RTOF                  USART_ISR_RTOF_Msk                      /*!< Receiver Timeout */
+#define USART_ISR_EOBF_Pos              (12U)
+#define USART_ISR_EOBF_Msk              (0x1UL << USART_ISR_EOBF_Pos)           /*!< 0x00001000 */
+#define USART_ISR_EOBF                  USART_ISR_EOBF_Msk                      /*!< End Of Block Flag */
+#define USART_ISR_UDR_Pos               (13U)
+#define USART_ISR_UDR_Msk               (0x1UL << USART_ISR_UDR_Pos)            /*!< 0x00002000 */
+#define USART_ISR_UDR                   USART_ISR_UDR_Msk                       /*!< SPI Slave Underrun error Flag */
+#define USART_ISR_ABRE_Pos              (14U)
+#define USART_ISR_ABRE_Msk              (0x1UL << USART_ISR_ABRE_Pos)           /*!< 0x00004000 */
+#define USART_ISR_ABRE                  USART_ISR_ABRE_Msk                      /*!< Auto-Baud Rate Error */
+#define USART_ISR_ABRF_Pos              (15U)
+#define USART_ISR_ABRF_Msk              (0x1UL << USART_ISR_ABRF_Pos)           /*!< 0x00008000 */
+#define USART_ISR_ABRF                  USART_ISR_ABRF_Msk                      /*!< Auto-Baud Rate Flag */
+#define USART_ISR_BUSY_Pos              (16U)
+#define USART_ISR_BUSY_Msk              (0x1UL << USART_ISR_BUSY_Pos)           /*!< 0x00010000 */
+#define USART_ISR_BUSY                  USART_ISR_BUSY_Msk                      /*!< Busy Flag */
+#define USART_ISR_CMF_Pos               (17U)
+#define USART_ISR_CMF_Msk               (0x1UL << USART_ISR_CMF_Pos)            /*!< 0x00020000 */
+#define USART_ISR_CMF                   USART_ISR_CMF_Msk                       /*!< Character Match Flag */
+#define USART_ISR_SBKF_Pos              (18U)
+#define USART_ISR_SBKF_Msk              (0x1UL << USART_ISR_SBKF_Pos)           /*!< 0x00040000 */
+#define USART_ISR_SBKF                  USART_ISR_SBKF_Msk                      /*!< Send Break Flag */
+#define USART_ISR_RWU_Pos               (19U)
+#define USART_ISR_RWU_Msk               (0x1UL << USART_ISR_RWU_Pos)            /*!< 0x00080000 */
+#define USART_ISR_RWU                   USART_ISR_RWU_Msk                       /*!< Receive Wake Up from mute mode Flag */
+#define USART_ISR_WUF_Pos               (20U)
+#define USART_ISR_WUF_Msk               (0x1UL << USART_ISR_WUF_Pos)            /*!< 0x00100000 */
+#define USART_ISR_WUF                   USART_ISR_WUF_Msk                       /*!< Wake Up from stop mode Flag */
+#define USART_ISR_TEACK_Pos             (21U)
+#define USART_ISR_TEACK_Msk             (0x1UL << USART_ISR_TEACK_Pos)          /*!< 0x00200000 */
+#define USART_ISR_TEACK                 USART_ISR_TEACK_Msk                     /*!< Transmit Enable Acknowledge Flag */
+#define USART_ISR_REACK_Pos             (22U)
+#define USART_ISR_REACK_Msk             (0x1UL << USART_ISR_REACK_Pos)          /*!< 0x00400000 */
+#define USART_ISR_REACK                 USART_ISR_REACK_Msk                     /*!< Receive Enable Acknowledge Flag */
+#define USART_ISR_TXFE_Pos              (23U)
+#define USART_ISR_TXFE_Msk              (0x1UL << USART_ISR_TXFE_Pos)           /*!< 0x00800000 */
+#define USART_ISR_TXFE                  USART_ISR_TXFE_Msk                      /*!< TX FIFO Empty Flag */
+#define USART_ISR_RXFF_Pos              (24U)
+#define USART_ISR_RXFF_Msk              (0x1UL << USART_ISR_RXFF_Pos)           /*!< 0x01000000 */
+#define USART_ISR_RXFF                  USART_ISR_RXFF_Msk                      /*!< RX FIFO Full Flag */
+#define USART_ISR_TCBGT_Pos             (25U)
+#define USART_ISR_TCBGT_Msk             (0x1UL << USART_ISR_TCBGT_Pos)          /*!< 0x02000000 */
+#define USART_ISR_TCBGT                 USART_ISR_TCBGT_Msk                     /*!< Transmission Complete Before Guard Time completion */
+#define USART_ISR_RXFT_Pos              (26U)
+#define USART_ISR_RXFT_Msk              (0x1UL << USART_ISR_RXFT_Pos)           /*!< 0x04000000 */
+#define USART_ISR_RXFT                  USART_ISR_RXFT_Msk                      /*!< RX FIFO Threshold Flag */
+#define USART_ISR_TXFT_Pos              (27U)
+#define USART_ISR_TXFT_Msk              (0x1UL << USART_ISR_TXFT_Pos)           /*!< 0x08000000 */
+#define USART_ISR_TXFT                  USART_ISR_TXFT_Msk                      /*!< TX FIFO Threshold Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define USART_ICR_PECF_Pos              (0U)
+#define USART_ICR_PECF_Msk              (0x1UL << USART_ICR_PECF_Pos)           /*!< 0x00000001 */
+#define USART_ICR_PECF                  USART_ICR_PECF_Msk                      /*!< Parity Error Clear Flag */
+#define USART_ICR_FECF_Pos              (1U)
+#define USART_ICR_FECF_Msk              (0x1UL << USART_ICR_FECF_Pos)           /*!< 0x00000002 */
+#define USART_ICR_FECF                  USART_ICR_FECF_Msk                      /*!< Framing Error Clear Flag */
+#define USART_ICR_NECF_Pos              (2U)
+#define USART_ICR_NECF_Msk              (0x1UL << USART_ICR_NECF_Pos)           /*!< 0x00000004 */
+#define USART_ICR_NECF                  USART_ICR_NECF_Msk                      /*!< Noise Error detected Clear Flag */
+#define USART_ICR_ORECF_Pos             (3U)
+#define USART_ICR_ORECF_Msk             (0x1UL << USART_ICR_ORECF_Pos)          /*!< 0x00000008 */
+#define USART_ICR_ORECF                 USART_ICR_ORECF_Msk                     /*!< OverRun Error Clear Flag */
+#define USART_ICR_IDLECF_Pos            (4U)
+#define USART_ICR_IDLECF_Msk            (0x1UL << USART_ICR_IDLECF_Pos)         /*!< 0x00000010 */
+#define USART_ICR_IDLECF                USART_ICR_IDLECF_Msk                    /*!< IDLE line detected Clear Flag */
+#define USART_ICR_TXFECF_Pos            (5U)
+#define USART_ICR_TXFECF_Msk            (0x1UL << USART_ICR_TXFECF_Pos)         /*!< 0x00000020 */
+#define USART_ICR_TXFECF                USART_ICR_TXFECF_Msk                    /*!< TX FIFO Empty Clear Flag */
+#define USART_ICR_TCCF_Pos              (6U)
+#define USART_ICR_TCCF_Msk              (0x1UL << USART_ICR_TCCF_Pos)           /*!< 0x00000040 */
+#define USART_ICR_TCCF                  USART_ICR_TCCF_Msk                      /*!< Transmission Complete Clear Flag */
+#define USART_ICR_TCBGTCF_Pos           (7U)
+#define USART_ICR_TCBGTCF_Msk           (0x1UL << USART_ICR_TCBGTCF_Pos)        /*!< 0x00000080 */
+#define USART_ICR_TCBGTCF               USART_ICR_TCBGTCF_Msk                   /*!< Transmission Complete Before Guard Time Clear Flag */
+#define USART_ICR_LBDCF_Pos             (8U)
+#define USART_ICR_LBDCF_Msk             (0x1UL << USART_ICR_LBDCF_Pos)          /*!< 0x00000100 */
+#define USART_ICR_LBDCF                 USART_ICR_LBDCF_Msk                     /*!< LIN Break Detection Clear Flag */
+#define USART_ICR_CTSCF_Pos             (9U)
+#define USART_ICR_CTSCF_Msk             (0x1UL << USART_ICR_CTSCF_Pos)          /*!< 0x00000200 */
+#define USART_ICR_CTSCF                 USART_ICR_CTSCF_Msk                     /*!< CTS Interrupt Clear Flag */
+#define USART_ICR_RTOCF_Pos             (11U)
+#define USART_ICR_RTOCF_Msk             (0x1UL << USART_ICR_RTOCF_Pos)          /*!< 0x00000800 */
+#define USART_ICR_RTOCF                 USART_ICR_RTOCF_Msk                     /*!< Receiver Time Out Clear Flag */
+#define USART_ICR_EOBCF_Pos             (12U)
+#define USART_ICR_EOBCF_Msk             (0x1UL << USART_ICR_EOBCF_Pos)          /*!< 0x00001000 */
+#define USART_ICR_EOBCF                 USART_ICR_EOBCF_Msk                     /*!< End Of Block Clear Flag */
+#define USART_ICR_UDRCF_Pos             (13U)
+#define USART_ICR_UDRCF_Msk             (0x1UL << USART_ICR_UDRCF_Pos)          /*!< 0x00002000 */
+#define USART_ICR_UDRCF                 USART_ICR_UDRCF_Msk                     /*!< SPI Slave Underrun Clear Flag */
+#define USART_ICR_CMCF_Pos              (17U)
+#define USART_ICR_CMCF_Msk              (0x1UL << USART_ICR_CMCF_Pos)           /*!< 0x00020000 */
+#define USART_ICR_CMCF                  USART_ICR_CMCF_Msk                      /*!< Character Match Clear Flag */
+#define USART_ICR_WUCF_Pos              (20U)
+#define USART_ICR_WUCF_Msk              (0x1UL << USART_ICR_WUCF_Pos)           /*!< 0x00100000 */
+#define USART_ICR_WUCF                  USART_ICR_WUCF_Msk                      /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define USART_RDR_RDR_Pos               (0U)
+#define USART_RDR_RDR_Msk               (0x01FFUL << USART_RDR_RDR_Pos)         /*!< 0x000001FF */
+#define USART_RDR_RDR                   USART_RDR_RDR_Msk                       /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define USART_TDR_TDR_Pos               (0U)
+#define USART_TDR_TDR_Msk               (0x01FFUL << USART_TDR_TDR_Pos)         /*!< 0x000001FF */
+#define USART_TDR_TDR                   USART_TDR_TDR_Msk                       /*!< TDR[8:0] bits (Transmit Data value) */
+
+/*******************  Bit definition for USART_PRESC register  ******************/
+#define USART_PRESC_PRESCALER_Pos       (0U)
+#define USART_PRESC_PRESCALER_Msk       (0xFUL << USART_PRESC_PRESCALER_Pos)    /*!< 0x0000000F */
+#define USART_PRESC_PRESCALER           USART_PRESC_PRESCALER_Msk               /*!< PRESCALER[3:0] bits (Clock prescaler) */
+#define USART_PRESC_PRESCALER_0         (0x1U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000001 */
+#define USART_PRESC_PRESCALER_1         (0x2U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000002 */
+#define USART_PRESC_PRESCALER_2         (0x4U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000004 */
+#define USART_PRESC_PRESCALER_3         (0x8U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000008 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                      /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01U << WWDG_CR_T_Pos)                       /*!< 0x00000001 */
+#define WWDG_CR_T_1             (0x02U << WWDG_CR_T_Pos)                       /*!< 0x00000002 */
+#define WWDG_CR_T_2             (0x04U << WWDG_CR_T_Pos)                       /*!< 0x00000004 */
+#define WWDG_CR_T_3             (0x08U << WWDG_CR_T_Pos)                       /*!< 0x00000008 */
+#define WWDG_CR_T_4             (0x10U << WWDG_CR_T_Pos)                       /*!< 0x00000010 */
+#define WWDG_CR_T_5             (0x20U << WWDG_CR_T_Pos)                       /*!< 0x00000020 */
+#define WWDG_CR_T_6             (0x40U << WWDG_CR_T_Pos)                       /*!< 0x00000040 */
+
+#define WWDG_CR_WDGA_Pos        (7U)
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                    /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                     /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01U << WWDG_CFR_W_Pos)                      /*!< 0x00000001 */
+#define WWDG_CFR_W_1            (0x02U << WWDG_CFR_W_Pos)                      /*!< 0x00000002 */
+#define WWDG_CFR_W_2            (0x04U << WWDG_CFR_W_Pos)                      /*!< 0x00000004 */
+#define WWDG_CFR_W_3            (0x08U << WWDG_CFR_W_Pos)                      /*!< 0x00000008 */
+#define WWDG_CFR_W_4            (0x10U << WWDG_CFR_W_Pos)                      /*!< 0x00000010 */
+#define WWDG_CFR_W_5            (0x20U << WWDG_CFR_W_Pos)                      /*!< 0x00000020 */
+#define WWDG_CFR_W_6            (0x40U << WWDG_CFR_W_Pos)                      /*!< 0x00000040 */
+
+#define WWDG_CFR_WDGTB_Pos      (11U)
+#define WWDG_CFR_WDGTB_Msk      (0x7UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00003800 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[2:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00000800 */
+#define WWDG_CFR_WDGTB_1        (0x2U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00001000 */
+#define WWDG_CFR_WDGTB_2        (0x4U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00002000 */
+
+#define WWDG_CFR_EWI_Pos        (9U)
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                    /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                    /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                Debug MCU                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define DBGMCU_IDCODE_DEV_ID_Pos                          (0U)
+#define DBGMCU_IDCODE_DEV_ID_Msk                          (0xFFFUL << DBGMCU_IDCODE_DEV_ID_Pos) /*!< 0x00000FFF */
+#define DBGMCU_IDCODE_DEV_ID                              DBGMCU_IDCODE_DEV_ID_Msk
+#define DBGMCU_IDCODE_REV_ID_Pos                          (16U)
+#define DBGMCU_IDCODE_REV_ID_Msk                          (0xFFFFUL << DBGMCU_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBGMCU_IDCODE_REV_ID                              DBGMCU_IDCODE_REV_ID_Msk
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define DBGMCU_CR_DBG_SLEEP_Pos                           (0U)
+#define DBGMCU_CR_DBG_SLEEP_Msk                           (0x1UL << DBGMCU_CR_DBG_SLEEP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_CR_DBG_SLEEP                               DBGMCU_CR_DBG_SLEEP_Msk
+#define DBGMCU_CR_DBG_STOP_Pos                            (1U)
+#define DBGMCU_CR_DBG_STOP_Msk                            (0x1UL << DBGMCU_CR_DBG_STOP_Pos)   /*!< 0x00000002 */
+#define DBGMCU_CR_DBG_STOP                                DBGMCU_CR_DBG_STOP_Msk
+#define DBGMCU_CR_DBG_STANDBY_Pos                         (2U)
+#define DBGMCU_CR_DBG_STANDBY_Msk                         (0x1UL << DBGMCU_CR_DBG_STANDBY_Pos) /*!< 0x00000004 */
+#define DBGMCU_CR_DBG_STANDBY                             DBGMCU_CR_DBG_STANDBY_Msk
+#define DBGMCU_CR_TRACE_IOEN_Pos                          (5U)
+#define DBGMCU_CR_TRACE_IOEN_Msk                          (0x1UL << DBGMCU_CR_TRACE_IOEN_Pos) /*!< 0x00000020 */
+#define DBGMCU_CR_TRACE_IOEN                              DBGMCU_CR_TRACE_IOEN_Msk
+#define DBGMCU_CR_TRGOEN_Pos                              (28U)
+#define DBGMCU_CR_TRGOEN_Msk                              (0x1UL << DBGMCU_CR_TRGOEN_Pos)      /*!< 0x10000000 */
+#define DBGMCU_CR_TRGOEN                                  DBGMCU_CR_TRGOEN_Msk
+
+/********************  Bit definition for DBGMCU_APB1FZR1 register  ***********/
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP_Pos                 (0U)
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_TIM2_STOP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP                     DBGMCU_APB1FZR1_DBG_TIM2_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP_Pos                  (10U)
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP_Msk                  (0x1UL << DBGMCU_APB1FZR1_DBG_RTC_STOP_Pos)   /*!< 0x00000400 */
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP                      DBGMCU_APB1FZR1_DBG_RTC_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos                 (11U)
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos)  /*!< 0x00000800 */
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP                     DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP_Pos                 (12U)
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_IWDG_STOP_Pos)  /*!< 0x00001000 */
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP                     DBGMCU_APB1FZR1_DBG_IWDG_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP_Pos                 (21U)
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_I2C1_STOP_Pos)  /*!< 0x00200000 */
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP                     DBGMCU_APB1FZR1_DBG_I2C1_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Pos               (31U)
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Msk               (0x1UL << DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP                   DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB1FZR1 register  ***********/
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Pos               (0U)
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP                   DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Pos                (10U)
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Msk                (0x1UL << DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Pos)   /*!< 0x00000400 */
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP                    DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Pos               (12U)
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Pos)  /*!< 0x00001000 */
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP                   DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Pos               (21U)
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Pos)  /*!< 0x00200000 */
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP                   DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Pos             (31U)
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Msk             (0x1UL << DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP                 DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_APB1FZR2 register  ***********/
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Pos               (5U)
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Msk               (0x1UL << DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Pos) /*!< 0x00000020 */
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP                   DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB1FZR2 register  ***********/
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Pos             (5U)
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Msk             (0x1UL << DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Pos) /*!< 0x00000020 */
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP                 DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Msk
+
+/********************  Bit definition for DBGMCU_APB2FZR register  ************/
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP_Pos                  (11U)
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP_Msk                  (0x1UL << DBGMCU_APB2FZR_DBG_TIM1_STOP_Pos) /*!< 0x000000800 */
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP                      DBGMCU_APB2FZR_DBG_TIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB2FZR register  ************/
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Pos                (11U)
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Msk                (0x1UL << DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Pos) /*!< 0x000000800 */
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP                    DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Msk
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+
+/*********************** UART Instances : Asynchronous mode *******************/
+#define IS_UART_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : FIFO mode ***************************/
+#define IS_UART_FIFO_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : SPI Slave mode **********************/
+#define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** USART Instances : Synchronous mode *******************/
+#define IS_USART_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** USART Instances : Auto Baud Rate detection ***********/
+
+#define IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Half-Duplex mode ********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : LIN mode ****************************/
+#define IS_UART_LIN_INSTANCE(INSTANCE)    ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Wake-up from Stop mode **************/
+#define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Hardware Flow control ***************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Smard card mode *********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Driver Enable ***********************/
+#define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/******************** LPUART Instance *****************************************/
+#define IS_LPUART_INSTANCE(INSTANCE)    (0)
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+
+/******************************* AES Instances ********************************/
+#define IS_AES_ALL_INSTANCE(INSTANCE) ((INSTANCE) == AES2)
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Channel1) || \
+                                       ((INSTANCE) == DMA1_Channel2) || \
+                                       ((INSTANCE) == DMA1_Channel3) || \
+                                       ((INSTANCE) == DMA1_Channel4) || \
+                                       ((INSTANCE) == DMA1_Channel5) || \
+                                       ((INSTANCE) == DMA1_Channel6) || \
+                                       ((INSTANCE) == DMA1_Channel7))
+
+/******************************** DMAMUX Instances ****************************/
+#define IS_DMAMUX_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DMAMUX1)
+
+#define IS_DMAMUX_REQUEST_GEN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMAMUX1_RequestGenerator0) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator1) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator2) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator3))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOE) || \
+                                        ((INSTANCE) == GPIOH))
+
+/******************************* GPIO AF Instances ****************************/
+#define IS_GPIO_AF_INSTANCE(INSTANCE)   IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/**************************** GPIO Lock Instances *****************************/
+#define IS_GPIO_LOCK_INSTANCE(INSTANCE) IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) ((INSTANCE) == I2C1)
+
+/****************** I2C Instances : wakeup capability from stop modes *********/
+#define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
+
+/******************************* SMBUS Instances ******************************/
+#define IS_SMBUS_ALL_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
+
+/******************************* IPCC Instances ********************************/
+#define IS_IPCC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IPCC)
+
+/******************************** HSEM Instances *******************************/
+#define IS_HSEM_ALL_INSTANCE(INSTANCE) ((INSTANCE) == HSEM)
+
+#define HSEM_CPU1_COREID        (0x00000004UL)/* Semaphore Core ID */
+#define HSEM_CPU2_COREID        (0x00000008UL)/* Semaphore Core ID */
+
+#define HSEM_SEMID_MIN     (0U)       /* HSEM ID Min*/
+#define HSEM_SEMID_MAX     (31U)      /* HSEM ID Max */
+
+#define HSEM_PROCESSID_MIN (0U)       /* HSEM Process ID Min */
+#define HSEM_PROCESSID_MAX (255U)     /* HSEM Process ID Max */
+
+#define HSEM_CLEAR_KEY_MIN (0U)       /* HSEM clear Key Min value */
+#define HSEM_CLEAR_KEY_MAX (0xFFFFU)  /* HSEM clear Key Max value */
+
+/******************************** PKA Instances *******************************/
+#define IS_PKA_ALL_INSTANCE(INSTANCE) ((INSTANCE) == PKA)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) ((INSTANCE) == SPI1)
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
+                                         ((INSTANCE) == LPTIM2))
+
+/****************** LPTIM Instances : Encoder mode ****************************/
+#define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) ((INSTANCE) == LPTIM1)
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+/****************** TIM Instances : supporting 32 bits counter ****************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) ((INSTANCE) == TIM2)
+
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/************** TIM Instances : supporting Break source selection *************/
+#define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BKIN2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(INSTANCE)      ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(INSTANCE)      ((INSTANCE) == TIM1)
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.COMDE) *******/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : DMA requests generation (TIMx_DIER.UDE) ***/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/******************* TIM Instances : Timer input selection ********************/
+#define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4))))
+
+/****************** TIM Instances : supporting complementary output(s) ********/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+  (((INSTANCE) == TIM1) &&                    \
+   (((CHANNEL) == TIM_CHANNEL_1) ||           \
+    ((CHANNEL) == TIM_CHANNEL_2) ||           \
+    ((CHANNEL) == TIM_CHANNEL_3)))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
+                                                    ((INSTANCE) == TIM2))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting commutation event generation ***/
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                      ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)  || \
+                                                         ((INSTANCE) == TIM2))
+
+/**************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/************* TIM Instances : supporting ETR source selection ***************/
+#define IS_TIM_ETRSEL_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                             ((INSTANCE) == TIM2))
+
+/****** TIM Instances : Master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/************ TIM Instances : Advanced timers  ********************************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/****************************** TSC Instances *********************************/
+#define IS_TSC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == TSC)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+ */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32WB10xx_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb15xx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb15xx.h
@@ -1,0 +1,11029 @@
+/**
+  ******************************************************************************
+  * @file    stm32wb15xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for stm32wb15xx devices.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral's registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32wb15xx
+  * @{
+  */
+
+#ifndef __STM32WB15xx_H
+#define __STM32WB15xx_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+/**
+  * @brief Configuration of the Cortex-M4 Processor and Core Peripherals
+  */
+#define __CM4_REV                 1U /*!< Core Revision r0p1                            */
+#define __MPU_PRESENT             1U /*!< M4 provides an MPU                            */
+#define __VTOR_PRESENT            1U /*!< Vector Table Register supported               */
+#define __NVIC_PRIO_BITS          4U /*!< STM32WBxx uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1U /*!< FPU present                                   */
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+  * @brief stm32wb15xx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
+/*!< Interrupt Number Definition for M4 */
+typedef enum
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
+  HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
+  MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
+  BusFault_IRQn                       = -11,    /*!< Cortex-M4 Bus Fault Interrupt                                     */
+  UsageFault_IRQn                     = -10,    /*!< Cortex-M4 Usage Fault Interrupt                                   */
+  SVCall_IRQn                         = -5,     /*!< Cortex-M4 SV Call Interrupt                                       */
+  DebugMonitor_IRQn                   = -4,     /*!< Cortex-M4 Debug Monitor Interrupt                                 */
+  PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
+  SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
+
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
+  TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
+  RTC_WKUP_IRQn                       = 3,      /*!< RTC Wakeup Interrupt                                              */
+  FLASH_IRQn                          = 4,      /*!< FLASH (CFI)  global Interrupt                                     */
+  RCC_IRQn                            = 5,      /*!< RCC Interrupt                                                     */
+  EXTI0_IRQn                          = 6,      /*!< EXTI Line 0 Interrupt                                             */
+  EXTI1_IRQn                          = 7,      /*!< EXTI Line 1 Interrupt                                             */
+  EXTI2_IRQn                          = 8,      /*!< EXTI Line 2 Interrupt                                             */
+  EXTI3_IRQn                          = 9,      /*!< EXTI Line 3 Interrupt                                             */
+  EXTI4_IRQn                          = 10,     /*!< EXTI Line 4 Interrupt                                             */
+  DMA1_Channel1_IRQn                  = 11,     /*!< DMA1 Channel 1 Interrupt                                          */
+  DMA1_Channel2_IRQn                  = 12,     /*!< DMA1 Channel 2 Interrupt                                          */
+  DMA1_Channel3_IRQn                  = 13,     /*!< DMA1 Channel 3 Interrupt                                          */
+  DMA1_Channel4_IRQn                  = 14,     /*!< DMA1 Channel 4 Interrupt                                          */
+  DMA1_Channel5_IRQn                  = 15,     /*!< DMA1 Channel 5 Interrupt                                          */
+  DMA1_Channel6_IRQn                  = 16,     /*!< DMA1 Channel 6 Interrupt                                          */
+  DMA1_Channel7_IRQn                  = 17,     /*!< DMA1 Channel 7 Interrupt                                          */
+  ADC1_IRQn                           = 18,     /*!< ADC1 Interrupt                                                    */
+  C2SEV_PWR_C2H_IRQn                  = 21,     /*!< CPU2 SEV Interrupt                                                */
+  COMP_IRQn                           = 22,     /*!< COMP1 Interrupt                                                   */
+  EXTI9_5_IRQn                        = 23,     /*!< EXTI Lines [9:5] Interrupt                                        */
+  TIM1_BRK_IRQn                       = 24,     /*!< TIM1 Break Interrupt                                              */
+  TIM1_UP_IRQn                        = 25,     /*!< TIM1 Update Interrupt                                             */
+  TIM1_TRG_COM_IRQn                   = 26,     /*!< TIM1 Trigger and Communication Interrupts                         */
+  TIM1_CC_IRQn                        = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                           = 28,     /*!< TIM2 Global Interrupt                                             */
+  PKA_IRQn                            = 29,     /*!< PKA Interrupt                                                     */
+  I2C1_EV_IRQn                        = 30,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                        = 31,     /*!< I2C1 Error Interrupt                                              */
+  SPI1_IRQn                           = 34,     /*!< SPI1 Interrupt                                                    */
+  USART1_IRQn                         = 36,     /*!< USART1 Interrupt                                                  */
+  LPUART1_IRQn                        = 37,     /*!< LPUART1 Interrupt                                                 */
+  TSC_IRQn                            = 39,     /*!< TSC Interrupt                                                     */
+  EXTI15_10_IRQn                      = 40,     /*!< EXTI Lines1[15:10 ]Interrupts                                     */
+  RTC_Alarm_IRQn                      = 41,     /*!< RTC Alarms (A and B) Interrupt                                    */
+  PWR_SOTF_BLEACT_RFPHASE_IRQn        = 43,     /*!< PWR switching on the fly interrupt
+                                                     PWR end of BLE activity interrupt
+                                                     PWR end of critical radio phase interrupt                         */
+  IPCC_C1_RX_IRQn                     = 44,     /*!< IPCC RX Occupied Interrupt                                        */
+  IPCC_C1_TX_IRQn                     = 45,     /*!< IPCC TX Free Interrupt                                            */
+  HSEM_IRQn                           = 46,     /*!< HSEM Interrupt                                                    */
+  LPTIM1_IRQn                         = 47,     /*!< LPTIM1 Interrupt                                                  */
+  LPTIM2_IRQn                         = 48,     /*!< LPTIM2 Interrupt                                                  */
+  AES2_IRQn                           = 52,     /*!< AES2 Interrupt                                                    */
+  RNG_IRQn                            = 53,     /*!< RNG Interrupt                                                     */
+  FPU_IRQn                            = 54,     /*!< FPU Interrupt                                                     */
+  DMAMUX1_OVR_IRQn                    = 62      /*!< DMAMUX1 overrun Interrupt                                         */
+} IRQn_Type;
+/**
+  * @}
+  */
+
+#include "core_cm4.h"                /* Cortex-M4 processor and core peripherals */
+#include "system_stm32wbxx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC interrupt and status register,             Address offset: 0x00 */
+  __IO uint32_t IER;          /*!< ADC interrupt enable register,                 Address offset: 0x04 */
+  __IO uint32_t CR;           /*!< ADC control register,                          Address offset: 0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC configuration register 1,                  Address offset: 0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC configuration register 2,                  Address offset: 0x10 */
+  __IO uint32_t SMPR;         /*!< ADC sampling time register,                    Address offset: 0x14 */
+       uint32_t RESERVED1;    /*!< Reserved,                                                      0x18 */
+       uint32_t RESERVED2;    /*!< Reserved,                                                      0x1C */
+  __IO uint32_t TR;           /*!< ADC analog watchdog 1 threshold register,      Address offset: 0x20 */
+  __IO uint32_t RESERVED3;    /*!< Reserved,                                                      0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC group regular sequencer register,          Address offset: 0x28 */
+  __IO uint32_t RESERVED4;    /*!< Reserved,                                                      0x2C */
+       uint32_t RESERVED5[4]; /*!< Reserved,                                               0x30 - 0x3C */
+  __IO uint32_t DR;           /*!< ADC group regular data register,               Address offset: 0x40 */
+       uint32_t RESERVED6[23];/*!< Reserved,                                               0x44 - 0x9C */
+  __IO uint32_t RESERVED7;    /*!< Reserved,                                                      0xA0 */
+  __IO uint32_t RESERVED8;    /*!< Reserved,                                                      0xA4 */
+       uint32_t RESERVED9[3]; /*!< Reserved,                                               0xA8 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC Calibration factor register,               Address offset: 0xB4 */
+} ADC_TypeDef;
+
+/* Legacy registers naming */
+#define TR1     TR
+
+
+typedef struct
+{
+  uint32_t      RESERVED1;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x300 */
+  uint32_t      RESERVED2;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CCR;          /*!< ADC common configuration register,             Address offset: ADC1 base address + 0x308 */
+  uint32_t      RESERVED3;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x30C */
+} ADC_Common_TypeDef;
+
+/**
+  * @brief Comparator
+  */
+typedef struct
+{
+  __IO uint32_t CSR;         /*!< COMP control and status register,               Address offset: 0x00 */
+} COMP_TypeDef;
+
+/**
+  * @brief CRC calculation unit
+  */
+typedef struct
+{
+  __IO uint32_t DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint32_t IDR;         /*!< CRC Independent data register,               Address offset: 0x04 */
+  __IO uint32_t CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+       uint32_t RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+typedef struct
+{
+  __IO uint32_t IDCODE;      /*!< MCU device ID code,                          Address offset: 0x00 */
+  __IO uint32_t CR;          /*!< Debug MCU configuration register,            Address offset: 0x04 */
+  uint32_t RESERVED1[13];    /*!< Reserved,                                               0x08-0x38 */
+  __IO uint32_t APB1FZR1;    /*!< Debug MCU CPU1 APB1 freeze register,         Address offset: 0x3C */
+  __IO uint32_t C2APB1FZR1;  /*!< Debug MCU CPU2 APB1 freeze register,         Address offset: 0x40 */
+  __IO uint32_t APB1FZR2;    /*!< Debug MCU CPU1 APB1 freeze register,         Address offset: 0x44 */
+  __IO uint32_t C2APB1FZR2;  /*!< Debug MCU CPU2 APB1 freeze register,         Address offset: 0x48 */
+  __IO uint32_t APB2FZR;     /*!< Debug MCU CPU1 APB2 freeze register,         Address offset: 0x4C */
+  __IO uint32_t C2APB2FZR;   /*!< Debug MCU CPU2 APB2 freeze register,         Address offset: 0x50 */
+} DBGMCU_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+typedef struct
+{
+  __IO uint32_t CCR;         /*!< DMA channel x configuration register        0x00 */
+  __IO uint32_t CNDTR;       /*!< DMA channel x number of data register       0x04 */
+  __IO uint32_t CPAR;        /*!< DMA channel x peripheral address register   0x08 */
+  __IO uint32_t CMAR;        /*!< DMA channel x memory address register       0x0C */
+  uint32_t RESERVED;         /*!< Reserved,                                   0x10 */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< DMA interrupt status register,                 Address offset: 0x00 */
+  __IO uint32_t IFCR;        /*!< DMA interrupt flag clear register,             Address offset: 0x04 */
+} DMA_TypeDef;
+
+/**
+  * @brief DMA Multiplexer
+  */
+typedef struct
+{
+  __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
+} DMAMUX_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
+  __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
+} DMAMUX_ChannelStatus_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
+} DMAMUX_RequestGen_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
+  __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
+} DMAMUX_RequestGenStatus_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;           /*!< FLASH Access control register,                      Address offset: 0x00      */
+  __IO uint32_t RESERVED;      /*!< Reserved,                                           Address offset: 0x04      */
+  __IO uint32_t KEYR;          /*!< FLASH Key register,                                 Address offset: 0x08      */
+  __IO uint32_t OPTKEYR;       /*!< FLASH Option Key register,                          Address offset: 0x0C      */
+  __IO uint32_t SR;            /*!< FLASH Status register,                              Address offset: 0x10      */
+  __IO uint32_t CR;            /*!< FLASH Control register,                             Address offset: 0x14      */
+  __IO uint32_t ECCR;          /*!< FLASH ECC register,                                 Address offset: 0x18      */
+  uint32_t RESERVED1;          /*!< Reserved,                                           Address offset: 0x1C      */
+  __IO uint32_t OPTR;          /*!< FLASH Option register,                              Address offset: 0x20      */
+  __IO uint32_t PCROP1ASR;     /*!< FLASH Bank 1 PCROP area A Start address register,   Address offset: 0x24      */
+  __IO uint32_t PCROP1AER;     /*!< FLASH Bank 1 PCROP area A End address register,     Address offset: 0x28      */
+  __IO uint32_t WRP1AR;        /*!< FLASH Bank 1 WRP area A address register,           Address offset: 0x2C      */
+  __IO uint32_t WRP1BR;        /*!< FLASH Bank 1 WRP area B address register,           Address offset: 0x30      */
+  __IO uint32_t PCROP1BSR;     /*!< FLASH Bank 1 PCROP area B Start address register,   Address offset: 0x34      */
+  __IO uint32_t PCROP1BER;     /*!< FLASH Bank 1 PCROP area B End address register,     Address offset: 0x38      */
+  __IO uint32_t IPCCBR;        /*!< FLASH IPCC data buffer address,                     Address offset: 0x3C      */
+  uint32_t RESERVED2[7];       /*!< Reserved,                                           Address offset: 0x40-0x58 */
+  __IO uint32_t C2ACR;         /*!< FLASH Core MO+ Access Control Register ,            Address offset: 0x5C      */
+  __IO uint32_t C2SR;          /*!< FLASH Core MO+ Status Register,                     Address offset: 0x60      */
+  __IO uint32_t C2CR;          /*!< FLASH Core MO+ Control register,                    Address offset: 0x64      */
+  uint32_t RESERVED3[6];       /*!< Reserved,                                           Address offset: 0x68-0x7C */
+  __IO uint32_t SFR;           /*!< FLASH secure start address,                         Address offset: 0x80      */
+  __IO uint32_t SRRVR;         /*!< FlASH secure SRAM2 start addr and CPU2 reset vector Address offset: 0x84      */
+} FLASH_TypeDef;
+
+/**
+  * @brief General Purpose I/O
+  */
+typedef struct
+{
+  __IO uint32_t MODER;       /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;      /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;     /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;       /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;         /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;         /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;        /*!< GPIO port bit set/reset  register,     Address offset: 0x18      */
+  __IO uint32_t LCKR;        /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];      /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;         /*!< GPIO Bit Reset register,               Address offset: 0x28      */
+} GPIO_TypeDef;
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;          /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;          /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;         /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;          /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR;        /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+/**
+  * @brief LPTIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+} LPTIM_TypeDef;
+
+/**
+  * @brief Power Control
+  */
+typedef struct
+{
+  __IO uint32_t CR1;          /*!< PWR Power Control Register 1,                     Address offset: 0x00 */
+  __IO uint32_t CR2;          /*!< PWR Power Control Register 2,                     Address offset: 0x04 */
+  __IO uint32_t CR3;          /*!< PWR Power Control Register 3,                     Address offset: 0x08 */
+  __IO uint32_t CR4;          /*!< PWR Power Control Register 4,                     Address offset: 0x0C */
+  __IO uint32_t SR1;          /*!< PWR Power Status Register 1,                      Address offset: 0x10 */
+  __IO uint32_t SR2;          /*!< PWR Power Status Register 2,                      Address offset: 0x14 */
+  __IO uint32_t SCR;          /*!< PWR Power Status Reset Register,                  Address offset: 0x18 */
+  __IO uint32_t CR5;          /*!< PWR Power Control Register 5,                     Address offset: 0x1C */
+  __IO uint32_t PUCRA;        /*!< PWR Pull-Up Control Register of port A,           Address offset: 0x20 */
+  __IO uint32_t PDCRA;        /*!< PWR Pull-Down Control Register of port A,         Address offset: 0x24 */
+  __IO uint32_t PUCRB;        /*!< PWR Pull-Up Control Register of port B,           Address offset: 0x28 */
+  __IO uint32_t PDCRB;        /*!< PWR Pull-Down Control Register of port B,         Address offset: 0x2C */
+  __IO uint32_t PUCRC;        /*!< PWR Pull-Up Control Register of port C,           Address offset: 0x30 */
+  __IO uint32_t PDCRC;        /*!< PWR Pull-Down Control Register of port C,         Address offset: 0x34 */
+       uint32_t RESERVED2[2]; /*!< Reserved,                                         Address offset: 0x38-0x3C */
+  __IO uint32_t PUCRE;        /*!< PWR Pull-Up Control Register of port E,           Address offset: 0x40 */
+  __IO uint32_t PDCRE;        /*!< PWR Pull-Down Control Register of port E,         Address offset: 0x44 */
+       uint32_t RESERVED0[4]; /*!< Reserved,                                         Address offset: 0x48-0x54 */
+  __IO uint32_t PUCRH;        /*!< PWR Pull-Up Control Register of port H,           Address offset: 0x58 */
+  __IO uint32_t PDCRH;        /*!< PWR Pull-Down Control Register of port H,         Address offset: 0x5C */
+       uint32_t RESERVED1[8]; /*!< Reserved,                                         Address offset: 0x60-0x7C */
+  __IO uint32_t C2CR1;        /*!< PWR Power Control Register 1 for CPU2,            Address offset: 0x80 */
+  __IO uint32_t C2CR3;        /*!< PWR Power Control Register 3 for CPU2,            Address offset: 0x84 */
+  __IO uint32_t EXTSCR;       /*!< PWR Power Status Reset Register for CPU2,         Address offset: 0x88 */
+} PWR_TypeDef;
+
+/**
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock  Control Register,                                                    Address offset: 0x00 */
+  __IO uint32_t ICSCR;         /*!< RCC Internal Clock Sources Calibration Register,                                Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
+  __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
+       uint32_t RESERVED0[2];  /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
+  __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
+  __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
+  __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
+  __IO uint32_t SMPSCR;        /*!< RCC SMPS step-down converter control register,                                  Address offset: 0x24 */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
+  __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
+  __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
+  __IO uint32_t APB3RSTR;      /*!< RCC APB3 peripheral reset register,                                             Address offset: 0x44 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
+  __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
+  __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
+  __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
+  __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
+  __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
+  __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
+  __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
+  __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
+  __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
+  __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
+  __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
+  __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
+  __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+  __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
+  __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
+  __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
+  __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
+  __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
+  __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
+  __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
+  __IO uint32_t C2APB3ENR;     /*!< RCC APB3 peripheral CPU2 clocks enable register 1,                              Address offset: 0x164 */
+  __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
+  __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
+  __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
+  __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
+  __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
+  __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
+  __IO uint32_t C2APB3SMENR;   /*!< RCC APB3 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x184 */
+} RCC_TypeDef;
+
+
+
+/**
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t RESERVED;   /*!< Reserved,                                                  Address offset: 0x18 */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset  0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+  __IO uint32_t BKP5R;      /*!< RTC backup register 5,                                     Address offset: 0x64 */
+  __IO uint32_t BKP6R;      /*!< RTC backup register 6,                                     Address offset: 0x68 */
+  __IO uint32_t BKP7R;      /*!< RTC backup register 7,                                     Address offset: 0x6C */
+  __IO uint32_t BKP8R;      /*!< RTC backup register 8,                                     Address offset: 0x70 */
+  __IO uint32_t BKP9R;      /*!< RTC backup register 9,                                     Address offset: 0x74 */
+  __IO uint32_t BKP10R;     /*!< RTC backup register 10,                                    Address offset: 0x78 */
+  __IO uint32_t BKP11R;     /*!< RTC backup register 11,                                    Address offset: 0x7C */
+  __IO uint32_t BKP12R;     /*!< RTC backup register 12,                                    Address offset: 0x80 */
+  __IO uint32_t BKP13R;     /*!< RTC backup register 13,                                    Address offset: 0x84 */
+  __IO uint32_t BKP14R;     /*!< RTC backup register 14,                                    Address offset: 0x88 */
+  __IO uint32_t BKP15R;     /*!< RTC backup register 15,                                    Address offset: 0x8C */
+  __IO uint32_t BKP16R;     /*!< RTC backup register 16,                                    Address offset: 0x90 */
+  __IO uint32_t BKP17R;     /*!< RTC backup register 17,                                    Address offset: 0x94 */
+  __IO uint32_t BKP18R;     /*!< RTC backup register 18,                                    Address offset: 0x98 */
+  __IO uint32_t BKP19R;     /*!< RTC backup register 19,                                    Address offset: 0x9C */
+} RTC_TypeDef;
+
+
+
+
+/**
+  * @brief Serial Peripheral Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1,       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,       Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,          Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,            Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register,  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register,          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register,          Address offset: 0x18 */
+} SPI_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+typedef struct
+{
+  __IO uint32_t MEMRMP;            /*!< SYSCFG memory remap register                                            Address offset: 0x00       */
+  __IO uint32_t CFGR1;             /*!< SYSCFG configuration register 1,                                        Address offset: 0x04       */
+  __IO uint32_t EXTICR[4];         /*!< SYSCFG external interrupt configuration registers,                      Address offset: 0x08-0x14  */
+  __IO uint32_t SCSR;              /*!< SYSCFG SRAM2 control and status register,                               Address offset: 0x18       */
+  __IO uint32_t CFGR2;             /*!< SYSCFG configuration register 2,                                        Address offset: 0x1C       */
+  __IO uint32_t SWPR1;             /*!< SYSCFG SRAM2 write protection register part 1,                          Address offset: 0x20       */
+  __IO uint32_t SKR;               /*!< SYSCFG SRAM2 key register,                                              Address offset: 0x24       */
+  __IO uint32_t SWPR2;             /*!< SYSCFG write protection register part 2,                                Address offset: 0x28       */
+       uint32_t RESERVED1[53];     /*!< Reserved,                                                               Address offset: 0x2C-0xFC  */
+  __IO uint32_t IMR1;              /*!< SYSCFG CPU1 (CORTEX M4) interrupt masks control-status register part 1, Address offset: 0x100      */
+  __IO uint32_t IMR2;              /*!< SYSCFG CPU1 (CORTEX M4) interrupt masks control-status register part 2, Address offset: 0x104      */
+  __IO uint32_t C2IMR1;            /*!< SYSCFG CPU2 (CORTEX M0) interrupt masks control-status register part 1, Address offset: 0x108      */
+  __IO uint32_t C2IMR2;            /*!< SYSCFG CPU2 (CORTEX M0) interrupt masks control-status register part 2, Address offset: 0x10C      */
+  __IO uint32_t SIPCR;             /*!< SYSCFG secure IP control register,                                      Address offset: 0x110      */
+
+} SYSCFG_TypeDef;
+
+/**
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,                   Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,                   Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,          Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,        Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                      Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,            Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1,      Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2,      Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register,      Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                     Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register                       Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare register5,            Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare register6,            Address offset: 0x5C */
+  __IO uint32_t AF1;         /*!< TIM Alternate function option register 1, Address offset: 0x60 */
+  __IO uint32_t AF2;         /*!< TIM Alternate function option register 2, Address offset: 0x64 */
+} TIM_TypeDef;
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< USART Control register 1,                 Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< USART Control register 2,                 Address offset: 0x04 */
+  __IO uint32_t CR3;         /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;         /*!< USART Baud rate register,                 Address offset: 0x0C */
+  __IO uint32_t GTPR;        /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;        /*!< USART Receiver Time Out register,         Address offset: 0x14 */
+  __IO uint32_t RQR;         /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;         /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;         /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;         /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;         /*!< USART Transmit Data register,             Address offset: 0x28 */
+  __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;         /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+
+/**
+  * @brief AES hardware accelerator
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
+  __IO uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
+  __IO uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
+  __IO uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
+  __IO uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
+  __IO uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
+  __IO uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
+  __IO uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
+  __IO uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
+  __IO uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
+  __IO uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
+  __IO uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
+  __IO uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
+  __IO uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
+  __IO uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
+  __IO uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
+  __IO uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
+  __IO uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
+  __IO uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
+  __IO uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
+  __IO uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
+  __IO uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
+  __IO uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x6C */
+} AES_TypeDef;
+
+/**
+  * @brief RNG
+  */
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+/**
+  * @brief Touch Sensing Controller (TSC)
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< TSC control register,                     Address offset: 0x00 */
+  __IO uint32_t IER;           /*!< TSC interrupt enable register,            Address offset: 0x04 */
+  __IO uint32_t ICR;           /*!< TSC interrupt clear register,             Address offset: 0x08 */
+  __IO uint32_t ISR;           /*!< TSC interrupt status register,            Address offset: 0x0C */
+  __IO uint32_t IOHCR;         /*!< TSC I/O hysteresis control register,      Address offset: 0x10 */
+  uint32_t      RESERVED1;     /*!< Reserved,                                 Address offset: 0x14 */
+  __IO uint32_t IOASCR;        /*!< TSC I/O analog switch control register,   Address offset: 0x18 */
+  uint32_t      RESERVED2;     /*!< Reserved,                                 Address offset: 0x1C */
+  __IO uint32_t IOSCR;         /*!< TSC I/O sampling control register,        Address offset: 0x20 */
+  uint32_t      RESERVED3;     /*!< Reserved,                                 Address offset: 0x24 */
+  __IO uint32_t IOCCR;         /*!< TSC I/O channel control register,         Address offset: 0x28 */
+  uint32_t      RESERVED4;     /*!< Reserved,                                 Address offset: 0x2C */
+  __IO uint32_t IOGCSR;        /*!< TSC I/O group control status register,    Address offset: 0x30 */
+  __IO uint32_t IOGXCR[7];     /*!< TSC I/O group x counter register,         Address offset: 0x34-4C */
+} TSC_TypeDef;
+
+/**
+  * @brief Inter-Processor Communication
+  */
+typedef struct
+{
+  __IO uint32_t C1CR;             /*!< Inter-Processor Communication: C1 control register,                  Address offset: 0x000 */
+  __IO uint32_t C1MR ;            /*!< Inter-Processor Communication: C1 mask register,                     Address offset: 0x004 */
+  __IO uint32_t C1SCR;            /*!< Inter-Processor Communication: C1 status set clear register,         Address offset: 0x008 */
+  __IO uint32_t C1TOC2SR;         /*!< Inter-Processor Communication: C1 to processor M4  status register,  Address offset: 0x00C */
+  __IO uint32_t C2CR;             /*!< Inter-Processor Communication: C2 control register,                  Address offset: 0x010 */
+  __IO uint32_t C2MR ;            /*!< Inter-Processor Communication: C2 mask register,                     Address offset: 0x014 */
+  __IO uint32_t C2SCR;            /*!< Inter-Processor Communication: C2 status set clear register,         Address offset: 0x018 */
+  __IO uint32_t C2TOC1SR;         /*!< Inter-Processor Communication: C2 to processor M4 status register,   Address offset: 0x01C */
+} IPCC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR;               /*!< Control register,                                                    Address offset: 0x000 */
+  __IO uint32_t MR;               /*!< Mask register,                                                       Address offset: 0x004 */
+  __IO uint32_t SCR;              /*!< Status set clear register,                                           Address offset: 0x008 */
+  __IO uint32_t SR;               /*!< Status register,                                                     Address offset: 0x00C */
+} IPCC_CommonTypeDef;
+
+/**
+  * @brief Async Interrupts and Events Controller
+  */
+typedef struct
+{
+  __IO uint32_t RTSR1;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x08 */
+  __IO uint32_t PR1;            /*!< EXTI pending register [31:0],                             Address offset: 0x0C */
+  __IO uint32_t RESERVED1[4];   /*!< Reserved,                                                 Address offset: 0x10 - 0x1C */
+  __IO uint32_t RTSR2;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x20 */
+  __IO uint32_t FTSR2;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x24 */
+  __IO uint32_t SWIER2;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x28 */
+  __IO uint32_t PR2;            /*!< EXTI pending register [31:0],                             Address offset: 0x2C */
+  __IO uint32_t RESERVED2[4];   /*!< Reserved,                                                 Address offset: 0x30 - 0x3C */
+  __IO uint32_t RESERVED3[8];   /*!< Reserved,                                                 Address offset: 0x40 - 0x5C */
+  __IO uint32_t RESERVED4[8];   /*!< Reserved,                                                 Address offset: 0x60 - 0x7C */
+  __IO uint32_t IMR1;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x84 */
+  __IO uint32_t RESERVED5[2];   /*!< Reserved,                                                 Address offset: 0x88 - 0x8C */
+  __IO uint32_t IMR2;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x90 */
+  __IO uint32_t EMR2;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x94 */
+  __IO uint32_t RESERVED8[10];  /*!< Reserved,                                                 Address offset: 0x98 - 0xBC */
+  __IO uint32_t C2IMR1;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xC0 */
+  __IO uint32_t C2EMR1;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xC4 */
+  __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
+  __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
+  __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
+} EXTI_TypeDef;
+
+/**
+  * @brief Public Key Accelerator (PKA)
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< PKA control register,                 Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< PKA status register,                  Address offset: 0x04 */
+  __IO uint32_t CLRFR;       /*!< PKA clear flag register,              Address offset: 0x08 */
+  uint32_t  Reserved1[253];  /*!< Reserved                              Address offset: 0x000C-0x03FC*/
+  __IO uint32_t RAM[894];    /*!< PKA RAM,                              Address offset: 0x0400-0x11F4 */
+} PKA_TypeDef;
+
+/**
+  * @brief HW Semaphore HSEM
+  */
+typedef struct
+{
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+} HSEM_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t IER;        /*!< HSEM interrupt enable register ,                Address offset:   0h     */
+  __IO uint32_t ICR;        /*!< HSEM interrupt clear register ,                 Address offset:   4h     */
+  __IO uint32_t ISR;        /*!< HSEM interrupt status register ,                Address offset:   8h     */
+  __IO uint32_t MISR;       /*!< HSEM masked interrupt status register ,         Address offset:   Ch     */
+} HSEM_Common_TypeDef;
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+
+/*!< Boundary memory map */
+#define FLASH_BASE             (0x08000000UL)/*!< FLASH(up to 320KB) base address */
+#define SRAM_BASE              (0x20000000UL)/*!< SRAM(up to 12 KB) base address */
+#define PERIPH_BASE            (0x40000000UL)/*!< Peripheral base address */
+
+/*!< Memory, OTP and Option bytes */
+
+/* Base addresses */
+#define SYSTEM_MEMORY_BASE     (0x1FFF0000UL)  /*!< System Memory : 28Kb (0x1FFF0000 - 0x1FFF6FFF) */
+#define OTP_AREA_BASE          (0x1FFF7000UL)  /*!< OTP area : 1kB (0x1FFF7000 - 0x1FFF73FF)       */
+#define OPTION_BYTE_BASE       (0x1FFF7800UL)  /*!< Option Bytes : 128B (0x1FFF7800 - 0x1FFF787F)   */
+#define ENGI_BYTE_BASE         (0x1FFF7400UL)  /*!< Engi Bytes : 3kB (0x1FFF7400 - 0x1FFF7FFF)     */
+
+#define SRAM1_BASE             SRAM_BASE                 /*!< SRAM1(up to 12 KB) base address */
+#define SRAM2A_BASE            (SRAM_BASE + 0x00030000UL)/*!< SRAM2A(32 KB) base address      */
+#define SRAM2B_BASE            (SRAM_BASE + 0x00038000UL)/*!< SRAM2B(4 KB) base address       */
+
+/* Memory Size */
+#define FLASH_SIZE              (((uint32_t)(*((uint16_t *)FLASHSIZE_BASE)) & (0x07FFUL)) << 10U)
+#define SRAM1_SIZE              0x00003000UL   /*!< SRAM1 default size  : 12 KB */
+#define SRAM2A_SIZE             0x00008000UL   /*!< SRAM2a default size : 32 KB */
+#define SRAM2B_SIZE             0x00001000UL   /*!< SRAM2b default size :  4 KB */
+
+/* End addresses */
+#define SRAM1_END_ADDR         (0x20002FFFUL)  /*!< SRAM1               :  12KB (0x20000000 - 0x20002FFF) */
+#define SRAM2A_END_ADDR        (0x20037FFFUL)  /*!< SRAM2a (backup)     :  32KB (0x20030000 - 0x20037FFF) */
+#define SRAM2B_END_ADDR        (0x20038FFFUL)  /*!< SRAM2b (backup)     :   4KB (0x20038000 - 0x20038FFF) */
+
+#define SYSTEM_MEMORY_END_ADDR (0x1FFF6FFFUL)  /*!< System Memory : 28KB (0x1FFF0000 - 0x1FFF6FFF)  */
+#define OTP_AREA_END_ADDR      (0x1FFF73FFUL)  /*!< OTP area : 1KB (0x1FFF7000 - 0x1FFF73FF)        */
+#define OPTION_BYTE_END_ADDR   (0x1FFF8FFFUL)  /*!< Option Bytes : 4KB (0x1FFF8000 - 0x1FFF8FFF)    */
+#define ENGI_BYTE_END_ADDR     (0x1FFF7FFFUL)  /*!< Engi Bytes : 3kB (0x1FFF7400 - 0x1FFF7FFF)      */
+
+/*!< Peripheral memory map */
+#define APB1PERIPH_BASE       PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000UL)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000UL)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x08000000UL)
+#define AHB4PERIPH_BASE       (PERIPH_BASE + 0x18000000UL)
+#define APB3PERIPH_BASE       (PERIPH_BASE + 0x20000000UL)
+
+/*!< APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x00000000UL)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x00002800UL)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x00002C00UL)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x00003000UL)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x00005400UL)
+#define LPTIM1_BASE           (APB1PERIPH_BASE + 0x00007C00UL)
+#define LPUART1_BASE          (APB1PERIPH_BASE + 0x00008000UL)
+#define LPTIM2_BASE           (APB1PERIPH_BASE + 0x00009400UL)
+
+/*!< APB2 peripherals */
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x00000000UL)
+#define COMP1_BASE            (APB2PERIPH_BASE + 0x00000200UL)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x00002400UL)
+#define ADC1_COMMON_BASE      (APB2PERIPH_BASE + 0x00002700UL)
+
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x00002C00UL)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x00003000UL)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x00003800UL)
+
+/*!< AHB1 peripherals */
+#define DMA1_BASE                (AHB1PERIPH_BASE + 0x00000000UL)
+#define DMAMUX1_BASE             (AHB1PERIPH_BASE + 0x00000800UL)
+#define CRC_BASE                 (AHB1PERIPH_BASE + 0x00003000UL)
+#define TSC_BASE                 (AHB1PERIPH_BASE + 0x00004000UL)
+
+#define DMA1_Channel1_BASE       (DMA1_BASE + 0x00000008UL)
+#define DMA1_Channel2_BASE       (DMA1_BASE + 0x0000001CUL)
+#define DMA1_Channel3_BASE       (DMA1_BASE + 0x00000030UL)
+#define DMA1_Channel4_BASE       (DMA1_BASE + 0x00000044UL)
+#define DMA1_Channel5_BASE       (DMA1_BASE + 0x00000058UL)
+#define DMA1_Channel6_BASE       (DMA1_BASE + 0x0000006CUL)
+#define DMA1_Channel7_BASE       (DMA1_BASE + 0x00000080UL)
+
+#define DMAMUX1_Channel0_BASE    (DMAMUX1_BASE)
+#define DMAMUX1_Channel1_BASE    (DMAMUX1_BASE + 0x00000004UL)
+#define DMAMUX1_Channel2_BASE    (DMAMUX1_BASE + 0x00000008UL)
+#define DMAMUX1_Channel3_BASE    (DMAMUX1_BASE + 0x0000000CUL)
+#define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
+#define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
+#define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+
+#define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
+#define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
+#define DMAMUX1_RequestGenerator2_BASE  (DMAMUX1_BASE + 0x00000108UL)
+#define DMAMUX1_RequestGenerator3_BASE  (DMAMUX1_BASE + 0x0000010CUL)
+
+#define DMAMUX1_ChannelStatus_BASE      (DMAMUX1_BASE + 0x00000080UL)
+#define DMAMUX1_RequestGenStatus_BASE   (DMAMUX1_BASE + 0x00000140UL)
+
+/*!< AHB2 peripherals */
+#define IOPORT_BASE         (AHB2PERIPH_BASE + 0x00000000UL)
+#define GPIOA_BASE          (IOPORT_BASE + 0x00000000UL)
+#define GPIOB_BASE          (IOPORT_BASE + 0x00000400UL)
+#define GPIOC_BASE          (IOPORT_BASE + 0x00000800UL)
+#define GPIOE_BASE          (IOPORT_BASE + 0x00001000UL)
+#define GPIOH_BASE          (IOPORT_BASE + 0x00001C00UL)
+
+/*!< AHB Shared peripherals */
+#define RCC_BASE              (AHB4PERIPH_BASE + 0x00000000UL)
+#define PWR_BASE              (AHB4PERIPH_BASE + 0x00000400UL)
+#define EXTI_BASE             (AHB4PERIPH_BASE + 0x00000800UL)
+#define IPCC_BASE             (AHB4PERIPH_BASE + 0x00000C00UL)
+#define RNG_BASE              (AHB4PERIPH_BASE + 0x00001000UL)
+#define HSEM_BASE             (AHB4PERIPH_BASE + 0x00001400UL)
+#define AES2_BASE             (AHB4PERIPH_BASE + 0x00001800UL)
+#define PKA_BASE              (AHB4PERIPH_BASE + 0x00002000UL)
+#define FLASH_REG_BASE        (AHB4PERIPH_BASE + 0x00004000UL)
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           (0xE0042000UL)
+
+
+/*!< AHB3 peripherals */
+
+/*!< Device Electronic Signature */
+#define PACKAGE_BASE          ((uint32_t)0x1FFF7500UL)       /*!< Package data register base address     */
+#define UID64_BASE            ((uint32_t)0x1FFF7580UL)       /*!< 64-bit Unique device Identification    */
+#define UID_BASE              ((uint32_t)0x1FFF7590UL)       /*!< Unique device ID register base address */
+#define FLASHSIZE_BASE        ((uint32_t)0x1FFF75E0UL)       /*!< Flash size data register base address  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+
+/* Peripherals available on APB1 bus */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define LPUART1             ((USART_TypeDef *) LPUART1_BASE)
+#define LPTIM2              ((LPTIM_TypeDef *) LPTIM2_BASE)
+
+/* Peripherals available on APB2 bus */
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define COMP1               ((COMP_TypeDef *) COMP1_BASE)
+#define COMP1_COMMON        ((COMP_Common_TypeDef *) COMP1_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+
+/* Peripherals available on AHB1 bus */
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+
+#define DMAMUX1             ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
+#define DMAMUX1_Channel0    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
+#define DMAMUX1_Channel1    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel1_BASE)
+#define DMAMUX1_Channel2    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel2_BASE)
+#define DMAMUX1_Channel3    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel3_BASE)
+#define DMAMUX1_Channel4    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
+#define DMAMUX1_Channel5    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
+#define DMAMUX1_Channel6    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+
+#define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
+#define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
+#define DMAMUX1_RequestGenerator2  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator2_BASE)
+#define DMAMUX1_RequestGenerator3  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator3_BASE)
+
+#define DMAMUX1_ChannelStatus      ((DMAMUX_ChannelStatus_TypeDef *) DMAMUX1_ChannelStatus_BASE)
+#define DMAMUX1_RequestGenStatus   ((DMAMUX_RequestGenStatus_TypeDef *) DMAMUX1_RequestGenStatus_BASE)
+
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define TSC                 ((TSC_TypeDef *) TSC_BASE)
+
+/* Peripherals available on AHB2 bus */
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOE               ((GPIO_TypeDef *) GPIOE_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) ADC1_COMMON_BASE)
+
+
+/* Peripherals available on AHB shared bus */
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define IPCC                ((IPCC_TypeDef *) IPCC_BASE)
+#define IPCC_C1             ((IPCC_CommonTypeDef *) IPCC_BASE)
+#define IPCC_C2             ((IPCC_CommonTypeDef *) (IPCC_BASE + 0x10U))
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+#define HSEM                ((HSEM_TypeDef *) HSEM_BASE)
+#define HSEM_COMMON         ((HSEM_Common_TypeDef *) (HSEM_BASE + 0x100U))
+#define AES2                ((AES_TypeDef *) AES2_BASE)
+#define PKA                 ((PKA_TypeDef *) PKA_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_REG_BASE)
+
+/* Peripherals available on AHB3 bus */
+
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+
+#define ADC_SUPPORT_2_5_MSPS /* ADC sampling rate 2.5 Msamples/sec */
+
+/********************  Bit definition for ADC_ISR register  *******************/
+#define ADC_ISR_ADRDY_Pos              (0U)
+#define ADC_ISR_ADRDY_Msk              (0x1UL << ADC_ISR_ADRDY_Pos)            /*!< 0x00000001 */
+#define ADC_ISR_ADRDY                  ADC_ISR_ADRDY_Msk                       /*!< ADC ready flag */
+#define ADC_ISR_EOSMP_Pos              (1U)
+#define ADC_ISR_EOSMP_Msk              (0x1UL << ADC_ISR_EOSMP_Pos)            /*!< 0x00000002 */
+#define ADC_ISR_EOSMP                  ADC_ISR_EOSMP_Msk                       /*!< ADC group regular end of sampling flag */
+#define ADC_ISR_EOC_Pos                (2U)
+#define ADC_ISR_EOC_Msk                (0x1UL << ADC_ISR_EOC_Pos)              /*!< 0x00000004 */
+#define ADC_ISR_EOC                    ADC_ISR_EOC_Msk                         /*!< ADC group regular end of unitary conversion flag */
+#define ADC_ISR_EOS_Pos                (3U)
+#define ADC_ISR_EOS_Msk                (0x1UL << ADC_ISR_EOS_Pos)              /*!< 0x00000008 */
+#define ADC_ISR_EOS                    ADC_ISR_EOS_Msk                         /*!< ADC group regular end of sequence conversions flag */
+#define ADC_ISR_OVR_Pos                (4U)
+#define ADC_ISR_OVR_Msk                (0x1UL << ADC_ISR_OVR_Pos)              /*!< 0x00000010 */
+#define ADC_ISR_OVR                    ADC_ISR_OVR_Msk                         /*!< ADC group regular overrun flag */
+#define ADC_ISR_AWD1_Pos               (7U)
+#define ADC_ISR_AWD1_Msk               (0x1UL << ADC_ISR_AWD1_Pos)             /*!< 0x00000080 */
+#define ADC_ISR_AWD1                   ADC_ISR_AWD1_Msk                        /*!< ADC analog watchdog 1 flag */
+#define ADC_ISR_AWD2_Pos               (8U)
+#define ADC_ISR_AWD2_Msk               (0x1UL << ADC_ISR_AWD2_Pos)             /*!< 0x00000100 */
+#define ADC_ISR_AWD2                   ADC_ISR_AWD2_Msk                        /*!< ADC analog watchdog 2 flag */
+#define ADC_ISR_AWD3_Pos               (9U)
+#define ADC_ISR_AWD3_Msk               (0x1UL << ADC_ISR_AWD3_Pos)             /*!< 0x00000200 */
+#define ADC_ISR_AWD3                   ADC_ISR_AWD3_Msk                        /*!< ADC analog watchdog 3 flag */
+#define ADC_ISR_EOCAL_Pos              (11U)
+#define ADC_ISR_EOCAL_Msk              (0x1UL << ADC_ISR_EOCAL_Pos)            /*!< 0x00000800 */
+#define ADC_ISR_EOCAL                  ADC_ISR_EOCAL_Msk                       /*!< ADC end of calibration flag */
+#define ADC_ISR_CCRDY_Pos              (13U)
+#define ADC_ISR_CCRDY_Msk              (0x1UL << ADC_ISR_CCRDY_Pos)            /*!< 0x00002000 */
+#define ADC_ISR_CCRDY                  ADC_ISR_CCRDY_Msk                       /*!< ADC channel configuration ready flag */
+
+/********************  Bit definition for ADC_IER register  *******************/
+#define ADC_IER_ADRDYIE_Pos            (0U)
+#define ADC_IER_ADRDYIE_Msk            (0x1UL << ADC_IER_ADRDYIE_Pos)          /*!< 0x00000001 */
+#define ADC_IER_ADRDYIE                ADC_IER_ADRDYIE_Msk                     /*!< ADC ready interrupt */
+#define ADC_IER_EOSMPIE_Pos            (1U)
+#define ADC_IER_EOSMPIE_Msk            (0x1UL << ADC_IER_EOSMPIE_Pos)          /*!< 0x00000002 */
+#define ADC_IER_EOSMPIE                ADC_IER_EOSMPIE_Msk                     /*!< ADC group regular end of sampling interrupt */
+#define ADC_IER_EOCIE_Pos              (2U)
+#define ADC_IER_EOCIE_Msk              (0x1UL << ADC_IER_EOCIE_Pos)            /*!< 0x00000004 */
+#define ADC_IER_EOCIE                  ADC_IER_EOCIE_Msk                       /*!< ADC group regular end of unitary conversion interrupt */
+#define ADC_IER_EOSIE_Pos              (3U)
+#define ADC_IER_EOSIE_Msk              (0x1UL << ADC_IER_EOSIE_Pos)            /*!< 0x00000008 */
+#define ADC_IER_EOSIE                  ADC_IER_EOSIE_Msk                       /*!< ADC group regular end of sequence conversions interrupt */
+#define ADC_IER_OVRIE_Pos              (4U)
+#define ADC_IER_OVRIE_Msk              (0x1UL << ADC_IER_OVRIE_Pos)            /*!< 0x00000010 */
+#define ADC_IER_OVRIE                  ADC_IER_OVRIE_Msk                       /*!< ADC group regular overrun interrupt */
+#define ADC_IER_AWD1IE_Pos             (7U)
+#define ADC_IER_AWD1IE_Msk             (0x1UL << ADC_IER_AWD1IE_Pos)           /*!< 0x00000080 */
+#define ADC_IER_AWD1IE                 ADC_IER_AWD1IE_Msk                      /*!< ADC analog watchdog 1 interrupt */
+#define ADC_IER_AWD2IE_Pos             (8U)
+#define ADC_IER_AWD2IE_Msk             (0x1UL << ADC_IER_AWD2IE_Pos)           /*!< 0x00000100 */
+#define ADC_IER_AWD2IE                 ADC_IER_AWD2IE_Msk                      /*!< ADC analog watchdog 2 interrupt */
+#define ADC_IER_AWD3IE_Pos             (9U)
+#define ADC_IER_AWD3IE_Msk             (0x1UL << ADC_IER_AWD3IE_Pos)           /*!< 0x00000200 */
+#define ADC_IER_AWD3IE                 ADC_IER_AWD3IE_Msk                      /*!< ADC analog watchdog 3 interrupt */
+#define ADC_IER_EOCALIE_Pos            (11U)
+#define ADC_IER_EOCALIE_Msk            (0x1UL << ADC_IER_EOCALIE_Pos)          /*!< 0x00000800 */
+#define ADC_IER_EOCALIE                ADC_IER_EOCALIE_Msk                     /*!< ADC end of calibration interrupt */
+#define ADC_IER_CCRDYIE_Pos            (13U)
+#define ADC_IER_CCRDYIE_Msk            (0x1UL << ADC_IER_CCRDYIE_Pos)          /*!< 0x00002000 */
+#define ADC_IER_CCRDYIE                ADC_IER_CCRDYIE_Msk                     /*!< ADC channel configuration ready interrupt */
+
+/********************  Bit definition for ADC_CR register  ********************/
+#define ADC_CR_ADEN_Pos                (0U)
+#define ADC_CR_ADEN_Msk                (0x1UL << ADC_CR_ADEN_Pos)              /*!< 0x00000001 */
+#define ADC_CR_ADEN                    ADC_CR_ADEN_Msk                         /*!< ADC enable */
+#define ADC_CR_ADDIS_Pos               (1U)
+#define ADC_CR_ADDIS_Msk               (0x1UL << ADC_CR_ADDIS_Pos)             /*!< 0x00000002 */
+#define ADC_CR_ADDIS                   ADC_CR_ADDIS_Msk                        /*!< ADC disable */
+#define ADC_CR_ADSTART_Pos             (2U)
+#define ADC_CR_ADSTART_Msk             (0x1UL << ADC_CR_ADSTART_Pos)           /*!< 0x00000004 */
+#define ADC_CR_ADSTART                 ADC_CR_ADSTART_Msk                      /*!< ADC group regular conversion start */
+#define ADC_CR_ADSTP_Pos               (4U)
+#define ADC_CR_ADSTP_Msk               (0x1UL << ADC_CR_ADSTP_Pos)             /*!< 0x00000010 */
+#define ADC_CR_ADSTP                   ADC_CR_ADSTP_Msk                        /*!< ADC group regular conversion stop */
+#define ADC_CR_ADVREGEN_Pos            (28U)
+#define ADC_CR_ADVREGEN_Msk            (0x1UL << ADC_CR_ADVREGEN_Pos)          /*!< 0x10000000 */
+#define ADC_CR_ADVREGEN                ADC_CR_ADVREGEN_Msk                     /*!< ADC voltage regulator enable */
+#define ADC_CR_ADCAL_Pos               (31U)
+#define ADC_CR_ADCAL_Msk               (0x1UL << ADC_CR_ADCAL_Pos)             /*!< 0x80000000 */
+#define ADC_CR_ADCAL                   ADC_CR_ADCAL_Msk                        /*!< ADC calibration */
+
+/********************  Bit definition for ADC_CFGR1 register  *****************/
+#define ADC_CFGR1_DMAEN_Pos            (0U)
+#define ADC_CFGR1_DMAEN_Msk            (0x1UL << ADC_CFGR1_DMAEN_Pos)          /*!< 0x00000001 */
+#define ADC_CFGR1_DMAEN                ADC_CFGR1_DMAEN_Msk                     /*!< ADC DMA transfer enable */
+#define ADC_CFGR1_DMACFG_Pos           (1U)
+#define ADC_CFGR1_DMACFG_Msk           (0x1UL << ADC_CFGR1_DMACFG_Pos)         /*!< 0x00000002 */
+#define ADC_CFGR1_DMACFG               ADC_CFGR1_DMACFG_Msk                    /*!< ADC DMA transfer configuration */
+
+#define ADC_CFGR1_SCANDIR_Pos          (2U)
+#define ADC_CFGR1_SCANDIR_Msk          (0x1UL << ADC_CFGR1_SCANDIR_Pos)        /*!< 0x00000004 */
+#define ADC_CFGR1_SCANDIR              ADC_CFGR1_SCANDIR_Msk                   /*!< ADC group regular sequencer scan direction */
+
+#define ADC_CFGR1_RES_Pos              (3U)
+#define ADC_CFGR1_RES_Msk              (0x3UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000018 */
+#define ADC_CFGR1_RES                  ADC_CFGR1_RES_Msk                       /*!< ADC data resolution */
+#define ADC_CFGR1_RES_0                (0x1UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000008 */
+#define ADC_CFGR1_RES_1                (0x2UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000010 */
+
+#define ADC_CFGR1_ALIGN_Pos            (5U)
+#define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
+
+#define ADC_CFGR1_EXTSEL_Pos           (6U)
+#define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
+#define ADC_CFGR1_EXTSEL               ADC_CFGR1_EXTSEL_Msk                    /*!< ADC group regular external trigger source */
+#define ADC_CFGR1_EXTSEL_0             (0x1UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000040 */
+#define ADC_CFGR1_EXTSEL_1             (0x2UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000080 */
+#define ADC_CFGR1_EXTSEL_2             (0x4UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000100 */
+
+#define ADC_CFGR1_EXTEN_Pos            (10U)
+#define ADC_CFGR1_EXTEN_Msk            (0x3UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000C00 */
+#define ADC_CFGR1_EXTEN                ADC_CFGR1_EXTEN_Msk                     /*!< ADC group regular external trigger polarity */
+#define ADC_CFGR1_EXTEN_0              (0x1UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000400 */
+#define ADC_CFGR1_EXTEN_1              (0x2UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000800 */
+
+#define ADC_CFGR1_OVRMOD_Pos           (12U)
+#define ADC_CFGR1_OVRMOD_Msk           (0x1UL << ADC_CFGR1_OVRMOD_Pos)         /*!< 0x00001000 */
+#define ADC_CFGR1_OVRMOD               ADC_CFGR1_OVRMOD_Msk                    /*!< ADC group regular overrun configuration */
+#define ADC_CFGR1_CONT_Pos             (13U)
+#define ADC_CFGR1_CONT_Msk             (0x1UL << ADC_CFGR1_CONT_Pos)           /*!< 0x00002000 */
+#define ADC_CFGR1_CONT                 ADC_CFGR1_CONT_Msk                      /*!< ADC group regular continuous conversion mode */
+#define ADC_CFGR1_WAIT_Pos             (14U)
+#define ADC_CFGR1_WAIT_Msk             (0x1UL << ADC_CFGR1_WAIT_Pos)           /*!< 0x00004000 */
+#define ADC_CFGR1_WAIT                 ADC_CFGR1_WAIT_Msk                      /*!< ADC low power auto wait */
+#define ADC_CFGR1_AUTOFF_Pos           (15U)
+#define ADC_CFGR1_AUTOFF_Msk           (0x1UL << ADC_CFGR1_AUTOFF_Pos)         /*!< 0x00008000 */
+#define ADC_CFGR1_AUTOFF               ADC_CFGR1_AUTOFF_Msk                    /*!< ADC low power auto power off */
+#define ADC_CFGR1_DISCEN_Pos           (16U)
+#define ADC_CFGR1_DISCEN_Msk           (0x1UL << ADC_CFGR1_DISCEN_Pos)         /*!< 0x00010000 */
+#define ADC_CFGR1_DISCEN               ADC_CFGR1_DISCEN_Msk                    /*!< ADC group regular sequencer discontinuous mode */
+#define ADC_CFGR1_CHSELRMOD_Pos        (21U)
+#define ADC_CFGR1_CHSELRMOD_Msk        (0x1UL << ADC_CFGR1_CHSELRMOD_Pos)      /*!< 0x00200000 */
+#define ADC_CFGR1_CHSELRMOD            ADC_CFGR1_CHSELRMOD_Msk                 /*!< ADC group regular sequencer mode */
+
+#define ADC_CFGR1_AWD1SGL_Pos          (22U)
+#define ADC_CFGR1_AWD1SGL_Msk          (0x1UL << ADC_CFGR1_AWD1SGL_Pos)        /*!< 0x00400000 */
+#define ADC_CFGR1_AWD1SGL              ADC_CFGR1_AWD1SGL_Msk                   /*!< ADC analog watchdog 1 monitoring a single channel or all channels */
+#define ADC_CFGR1_AWD1EN_Pos           (23U)
+#define ADC_CFGR1_AWD1EN_Msk           (0x1UL << ADC_CFGR1_AWD1EN_Pos)         /*!< 0x00800000 */
+#define ADC_CFGR1_AWD1EN               ADC_CFGR1_AWD1EN_Msk                    /*!< ADC analog watchdog 1 enable on scope ADC group regular */
+
+#define ADC_CFGR1_AWD1CH_Pos           (26U)
+#define ADC_CFGR1_AWD1CH_Msk           (0x1FUL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x7C000000 */
+#define ADC_CFGR1_AWD1CH               ADC_CFGR1_AWD1CH_Msk                    /*!< ADC analog watchdog 1 monitored channel selection */
+#define ADC_CFGR1_AWD1CH_0             (0x01UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x04000000 */
+#define ADC_CFGR1_AWD1CH_1             (0x02UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x08000000 */
+#define ADC_CFGR1_AWD1CH_2             (0x04UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x10000000 */
+#define ADC_CFGR1_AWD1CH_3             (0x08UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x20000000 */
+#define ADC_CFGR1_AWD1CH_4             (0x10UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x40000000 */
+
+/* Definitions for cohabitation of ADC peripherals 2.5Ms/sec and 5Ms/sec across STM32WB series */
+#define ADC_CFGR_DMAEN_Pos             ADC_CFGR1_DMAEN_Pos
+#define ADC_CFGR_DMAEN_Msk             ADC_CFGR1_DMAEN_Msk
+#define ADC_CFGR_DMAEN                 ADC_CFGR1_DMAEN
+#define ADC_CFGR_DMACFG_Pos            ADC_CFGR1_DMACFG_Pos
+#define ADC_CFGR_DMACFG_Msk            ADC_CFGR1_DMACFG_Msk
+#define ADC_CFGR_DMACFG                ADC_CFGR1_DMACFG
+
+#define ADC_CFGR_SCANDIR_Pos           ADC_CFGR1_SCANDIR_Pos
+#define ADC_CFGR_SCANDIR_Msk           ADC_CFGR1_SCANDIR_Msk
+#define ADC_CFGR_SCANDIR               ADC_CFGR1_SCANDIR
+
+#define ADC_CFGR_RES_Pos               ADC_CFGR1_RES_Pos
+#define ADC_CFGR_RES_Msk               ADC_CFGR1_RES_Msk
+#define ADC_CFGR_RES                   ADC_CFGR1_RES
+#define ADC_CFGR_RES_0                 ADC_CFGR1_RES_0
+#define ADC_CFGR_RES_1                 ADC_CFGR1_RES_1
+
+#define ADC_CFGR_ALIGN_Pos             ADC_CFGR1_ALIGN_Pos
+#define ADC_CFGR_ALIGN_Msk             ADC_CFGR1_ALIGN_Msk
+#define ADC_CFGR_ALIGN                 ADC_CFGR1_ALIGN
+
+#define ADC_CFGR_EXTSEL_Pos            ADC_CFGR1_EXTSEL_Pos
+#define ADC_CFGR_EXTSEL_Msk            ADC_CFGR1_EXTSEL_Msk
+#define ADC_CFGR_EXTSEL                ADC_CFGR1_EXTSEL
+#define ADC_CFGR_EXTSEL_0              ADC_CFGR1_EXTSEL_0
+#define ADC_CFGR_EXTSEL_1              ADC_CFGR1_EXTSEL_1
+#define ADC_CFGR_EXTSEL_2              ADC_CFGR1_EXTSEL_2
+
+#define ADC_CFGR_EXTEN_Pos             ADC_CFGR1_EXTEN_Pos
+#define ADC_CFGR_EXTEN_Msk             ADC_CFGR1_EXTEN_Msk
+#define ADC_CFGR_EXTEN                 ADC_CFGR1_EXTEN
+#define ADC_CFGR_EXTEN_0               ADC_CFGR1_EXTEN_0
+#define ADC_CFGR_EXTEN_1               ADC_CFGR1_EXTEN_1
+
+#define ADC_CFGR_OVRMOD_Pos            ADC_CFGR1_OVRMOD_Pos
+#define ADC_CFGR_OVRMOD_Msk            ADC_CFGR1_OVRMOD_Msk
+#define ADC_CFGR_OVRMOD                ADC_CFGR1_OVRMOD
+#define ADC_CFGR_CONT_Pos              ADC_CFGR1_CONT_Pos
+#define ADC_CFGR_CONT_Msk              ADC_CFGR1_CONT_Msk
+#define ADC_CFGR_CONT                  ADC_CFGR1_CONT
+#define ADC_CFGR_AUTDLY_Pos            ADC_CFGR1_WAIT_Pos
+#define ADC_CFGR_AUTDLY_Msk            ADC_CFGR1_WAIT_Msk
+#define ADC_CFGR_AUTDLY                ADC_CFGR1_WAIT
+#define ADC_CFGR_AUTOFF_Pos            ADC_CFGR1_AUTOFF_Pos
+#define ADC_CFGR_AUTOFF_Msk            ADC_CFGR1_AUTOFF_Msk
+#define ADC_CFGR_AUTOFF                ADC_CFGR1_AUTOFF
+#define ADC_CFGR_DISCEN_Pos            ADC_CFGR1_DISCEN_Pos
+#define ADC_CFGR_DISCEN_Msk            ADC_CFGR1_DISCEN_Msk
+#define ADC_CFGR_DISCEN                ADC_CFGR1_DISCEN
+#define ADC_CFGR_CHSELRMOD_Pos         ADC_CFGR1_CHSELRMOD_Pos
+#define ADC_CFGR_CHSELRMOD_Msk         ADC_CFGR1_CHSELRMOD_Msk
+#define ADC_CFGR_CHSELRMOD             ADC_CFGR1_CHSELRMOD
+
+#define ADC_CFGR_AWD1SGL_Pos           ADC_CFGR1_AWD1SGL_Pos
+#define ADC_CFGR_AWD1SGL_Msk           ADC_CFGR1_AWD1SGL_Msk
+#define ADC_CFGR_AWD1SGL               ADC_CFGR1_AWD1SGL
+#define ADC_CFGR_AWD1EN_Pos            ADC_CFGR1_AWD1EN_Pos
+#define ADC_CFGR_AWD1EN_Msk            ADC_CFGR1_AWD1EN_Msk
+#define ADC_CFGR_AWD1EN                ADC_CFGR1_AWD1EN
+
+#define ADC_CFGR_AWD1CH_Pos            ADC_CFGR1_AWD1CH_Pos
+#define ADC_CFGR_AWD1CH_Msk            ADC_CFGR1_AWD1CH_Msk
+#define ADC_CFGR_AWD1CH                ADC_CFGR1_AWD1CH
+#define ADC_CFGR_AWD1CH_0              ADC_CFGR1_AWD1CH_0
+#define ADC_CFGR_AWD1CH_1              ADC_CFGR1_AWD1CH_1
+#define ADC_CFGR_AWD1CH_2              ADC_CFGR1_AWD1CH_2
+#define ADC_CFGR_AWD1CH_3              ADC_CFGR1_AWD1CH_3
+#define ADC_CFGR_AWD1CH_4              ADC_CFGR1_AWD1CH_4
+
+/********************  Bit definition for ADC_CFGR2 register  *****************/
+#define ADC_CFGR2_LFTRIG_Pos           (29U)
+#define ADC_CFGR2_LFTRIG_Msk           (0x1UL << ADC_CFGR2_LFTRIG_Pos)         /*!< 0x20000000 */
+#define ADC_CFGR2_LFTRIG               ADC_CFGR2_LFTRIG_Msk                    /*!< ADC low frequency trigger mode */
+
+#define ADC_CFGR2_CKMODE_Pos           (30U)
+#define ADC_CFGR2_CKMODE_Msk           (0x3UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0xC0000000 */
+#define ADC_CFGR2_CKMODE               ADC_CFGR2_CKMODE_Msk                    /*!< ADC clock source and prescaler (prescaler only for clock source synchronous) */
+#define ADC_CFGR2_CKMODE_1             (0x2UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x80000000 */
+#define ADC_CFGR2_CKMODE_0             (0x1UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x40000000 */
+
+/********************  Bit definition for ADC_SMPR register  ******************/
+#define ADC_SMPR_SMP1_Pos              (0U)
+#define ADC_SMPR_SMP1_Msk              (0x7UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000007 */
+#define ADC_SMPR_SMP1                  ADC_SMPR_SMP1_Msk                       /*!< ADC group of channels sampling time 1 */
+#define ADC_SMPR_SMP1_0                (0x1UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000001 */
+#define ADC_SMPR_SMP1_1                (0x2UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000002 */
+#define ADC_SMPR_SMP1_2                (0x4UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000004 */
+
+#define ADC_SMPR_SMP2_Pos              (4U)
+#define ADC_SMPR_SMP2_Msk              (0x7UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000070 */
+#define ADC_SMPR_SMP2                  ADC_SMPR_SMP2_Msk                       /*!< ADC group of channels sampling time 2 */
+#define ADC_SMPR_SMP2_0                (0x1UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000010 */
+#define ADC_SMPR_SMP2_1                (0x2UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000020 */
+#define ADC_SMPR_SMP2_2                (0x4UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000040 */
+
+#define ADC_SMPR_SMPSEL_Pos            (8U)
+#define ADC_SMPR_SMPSEL_Msk            (0x7FFFFUL << ADC_SMPR_SMPSEL_Pos)      /*!< 0x07FFFF00 */
+#define ADC_SMPR_SMPSEL                ADC_SMPR_SMPSEL_Msk                     /*!< ADC all channels sampling time selection */
+#define ADC_SMPR_SMPSEL0_Pos           (8U)
+#define ADC_SMPR_SMPSEL0_Msk           (0x1UL << ADC_SMPR_SMPSEL0_Pos)         /*!< 0x00000100 */
+#define ADC_SMPR_SMPSEL0               ADC_SMPR_SMPSEL0_Msk                    /*!< ADC channel 0 sampling time selection */
+#define ADC_SMPR_SMPSEL1_Pos           (9U)
+#define ADC_SMPR_SMPSEL1_Msk           (0x1UL << ADC_SMPR_SMPSEL1_Pos)         /*!< 0x00000200 */
+#define ADC_SMPR_SMPSEL1               ADC_SMPR_SMPSEL1_Msk                    /*!< ADC channel 1 sampling time selection */
+#define ADC_SMPR_SMPSEL2_Pos           (10U)
+#define ADC_SMPR_SMPSEL2_Msk           (0x1UL << ADC_SMPR_SMPSEL2_Pos)         /*!< 0x00000400 */
+#define ADC_SMPR_SMPSEL2               ADC_SMPR_SMPSEL2_Msk                    /*!< ADC channel 2 sampling time selection */
+#define ADC_SMPR_SMPSEL3_Pos           (11U)
+#define ADC_SMPR_SMPSEL3_Msk           (0x1UL << ADC_SMPR_SMPSEL3_Pos)         /*!< 0x00000800 */
+#define ADC_SMPR_SMPSEL3               ADC_SMPR_SMPSEL3_Msk                    /*!< ADC channel 3 sampling time selection */
+#define ADC_SMPR_SMPSEL4_Pos           (12U)
+#define ADC_SMPR_SMPSEL4_Msk           (0x1UL << ADC_SMPR_SMPSEL4_Pos)         /*!< 0x00001000 */
+#define ADC_SMPR_SMPSEL4               ADC_SMPR_SMPSEL4_Msk                    /*!< ADC channel 4 sampling time selection */
+#define ADC_SMPR_SMPSEL5_Pos           (13U)
+#define ADC_SMPR_SMPSEL5_Msk           (0x1UL << ADC_SMPR_SMPSEL5_Pos)         /*!< 0x00002000 */
+#define ADC_SMPR_SMPSEL5               ADC_SMPR_SMPSEL5_Msk                    /*!< ADC channel 5 sampling time selection */
+#define ADC_SMPR_SMPSEL6_Pos           (14U)
+#define ADC_SMPR_SMPSEL6_Msk           (0x1UL << ADC_SMPR_SMPSEL6_Pos)         /*!< 0x00004000 */
+#define ADC_SMPR_SMPSEL6               ADC_SMPR_SMPSEL6_Msk                    /*!< ADC channel 6 sampling time selection */
+#define ADC_SMPR_SMPSEL7_Pos           (15U)
+#define ADC_SMPR_SMPSEL7_Msk           (0x1UL << ADC_SMPR_SMPSEL7_Pos)         /*!< 0x00008000 */
+#define ADC_SMPR_SMPSEL7               ADC_SMPR_SMPSEL7_Msk                    /*!< ADC channel 7 sampling time selection */
+#define ADC_SMPR_SMPSEL8_Pos           (16U)
+#define ADC_SMPR_SMPSEL8_Msk           (0x1UL << ADC_SMPR_SMPSEL8_Pos)         /*!< 0x00010000 */
+#define ADC_SMPR_SMPSEL8               ADC_SMPR_SMPSEL8_Msk                    /*!< ADC channel 8 sampling time selection */
+#define ADC_SMPR_SMPSEL9_Pos           (17U)
+#define ADC_SMPR_SMPSEL9_Msk           (0x1UL << ADC_SMPR_SMPSEL9_Pos)         /*!< 0x00020000 */
+#define ADC_SMPR_SMPSEL9               ADC_SMPR_SMPSEL9_Msk                    /*!< ADC channel 9 sampling time selection */
+#define ADC_SMPR_SMPSEL10_Pos          (18U)
+#define ADC_SMPR_SMPSEL10_Msk          (0x1UL << ADC_SMPR_SMPSEL10_Pos)        /*!< 0x00040000 */
+#define ADC_SMPR_SMPSEL10              ADC_SMPR_SMPSEL10_Msk                   /*!< ADC channel 10 sampling time selection */
+#define ADC_SMPR_SMPSEL11_Pos          (19U)
+#define ADC_SMPR_SMPSEL11_Msk          (0x1UL << ADC_SMPR_SMPSEL11_Pos)        /*!< 0x00080000 */
+#define ADC_SMPR_SMPSEL11              ADC_SMPR_SMPSEL11_Msk                   /*!< ADC channel 11 sampling time selection */
+#define ADC_SMPR_SMPSEL12_Pos          (20U)
+#define ADC_SMPR_SMPSEL12_Msk          (0x1UL << ADC_SMPR_SMPSEL12_Pos)        /*!< 0x00100000 */
+#define ADC_SMPR_SMPSEL12              ADC_SMPR_SMPSEL12_Msk                   /*!< ADC channel 12 sampling time selection */
+#define ADC_SMPR_SMPSEL13_Pos          (21U)
+#define ADC_SMPR_SMPSEL13_Msk          (0x1UL << ADC_SMPR_SMPSEL13_Pos)        /*!< 0x00200000 */
+#define ADC_SMPR_SMPSEL13              ADC_SMPR_SMPSEL13_Msk                   /*!< ADC channel 13 sampling time selection */
+#define ADC_SMPR_SMPSEL14_Pos          (22U)
+#define ADC_SMPR_SMPSEL14_Msk          (0x1UL << ADC_SMPR_SMPSEL14_Pos)        /*!< 0x00400000 */
+#define ADC_SMPR_SMPSEL14              ADC_SMPR_SMPSEL14_Msk                   /*!< ADC channel 14 sampling time selection */
+#define ADC_SMPR_SMPSEL15_Pos          (23U)
+#define ADC_SMPR_SMPSEL15_Msk          (0x1UL << ADC_SMPR_SMPSEL15_Pos)        /*!< 0x00800000 */
+#define ADC_SMPR_SMPSEL15              ADC_SMPR_SMPSEL15_Msk                   /*!< ADC channel 15 sampling time selection */
+#define ADC_SMPR_SMPSEL16_Pos          (24U)
+#define ADC_SMPR_SMPSEL16_Msk          (0x1UL << ADC_SMPR_SMPSEL16_Pos)        /*!< 0x01000000 */
+#define ADC_SMPR_SMPSEL16              ADC_SMPR_SMPSEL16_Msk                   /*!< ADC channel 16 sampling time selection */
+#define ADC_SMPR_SMPSEL17_Pos          (25U)
+#define ADC_SMPR_SMPSEL17_Msk          (0x1UL << ADC_SMPR_SMPSEL17_Pos)        /*!< 0x02000000 */
+#define ADC_SMPR_SMPSEL17              ADC_SMPR_SMPSEL17_Msk                   /*!< ADC channel 17 sampling time selection */
+#define ADC_SMPR_SMPSEL18_Pos          (25U)
+#define ADC_SMPR_SMPSEL18_Msk          (0x1UL << ADC_SMPR_SMPSEL18_Pos)        /*!< 0x04000000 */
+#define ADC_SMPR_SMPSEL18              ADC_SMPR_SMPSEL18_Msk                   /*!< ADC channel 18 sampling time selection */
+
+/********************  Bit definition for ADC_TR register  *******************/
+#define ADC_TR_LT_Pos             (0U)
+#define ADC_TR_LT_Msk             (0xFFFUL << ADC_TR_LT_Pos)         /*!< 0x00000FFF */
+#define ADC_TR_LT                 ADC_TR_LT_Msk                      /*!< ADC analog watchdog 1 threshold low */
+#define ADC_TR_LT_0               (0x001UL << ADC_TR_LT_Pos)         /*!< 0x00000001 */
+#define ADC_TR_LT_1               (0x002UL << ADC_TR_LT_Pos)         /*!< 0x00000002 */
+#define ADC_TR_LT_2               (0x004UL << ADC_TR_LT_Pos)         /*!< 0x00000004 */
+#define ADC_TR_LT_3               (0x008UL << ADC_TR_LT_Pos)         /*!< 0x00000008 */
+#define ADC_TR_LT_4               (0x010UL << ADC_TR_LT_Pos)         /*!< 0x00000010 */
+#define ADC_TR_LT_5               (0x020UL << ADC_TR_LT_Pos)         /*!< 0x00000020 */
+#define ADC_TR_LT_6               (0x040UL << ADC_TR_LT_Pos)         /*!< 0x00000040 */
+#define ADC_TR_LT_7               (0x080UL << ADC_TR_LT_Pos)         /*!< 0x00000080 */
+#define ADC_TR_LT_8               (0x100UL << ADC_TR_LT_Pos)         /*!< 0x00000100 */
+#define ADC_TR_LT_9               (0x200UL << ADC_TR_LT_Pos)         /*!< 0x00000200 */
+#define ADC_TR_LT_10              (0x400UL << ADC_TR_LT_Pos)         /*!< 0x00000400 */
+#define ADC_TR_LT_11              (0x800UL << ADC_TR_LT_Pos)         /*!< 0x00000800 */
+
+#define ADC_TR_HT_Pos             (16U)
+#define ADC_TR_HT_Msk             (0xFFFUL << ADC_TR_HT_Pos)         /*!< 0x0FFF0000 */
+#define ADC_TR_HT                 ADC_TR_HT_Msk                      /*!< ADC Analog watchdog 1 threshold high */
+#define ADC_TR_HT_0               (0x001UL << ADC_TR_HT_Pos)         /*!< 0x00010000 */
+#define ADC_TR_HT_1               (0x002UL << ADC_TR_HT_Pos)         /*!< 0x00020000 */
+#define ADC_TR_HT_2               (0x004UL << ADC_TR_HT_Pos)         /*!< 0x00040000 */
+#define ADC_TR_HT_3               (0x008UL << ADC_TR_HT_Pos)         /*!< 0x00080000 */
+#define ADC_TR_HT_4               (0x010UL << ADC_TR_HT_Pos)         /*!< 0x00100000 */
+#define ADC_TR_HT_5               (0x020UL << ADC_TR_HT_Pos)         /*!< 0x00200000 */
+#define ADC_TR_HT_6               (0x040UL << ADC_TR_HT_Pos)         /*!< 0x00400000 */
+#define ADC_TR_HT_7               (0x080UL << ADC_TR_HT_Pos)         /*!< 0x00800000 */
+#define ADC_TR_HT_8               (0x100UL << ADC_TR_HT_Pos)         /*!< 0x01000000 */
+#define ADC_TR_HT_9               (0x200UL << ADC_TR_HT_Pos)         /*!< 0x02000000 */
+#define ADC_TR_HT_10              (0x400UL << ADC_TR_HT_Pos)         /*!< 0x04000000 */
+#define ADC_TR_HT_11              (0x800UL << ADC_TR_HT_Pos)         /*!< 0x08000000 */
+
+/* Legacy definitions */
+#define ADC_TR1_LT1             ADC_TR_LT
+#define ADC_TR1_LT1_0           ADC_TR_LT_0
+#define ADC_TR1_LT1_1           ADC_TR_LT_1
+#define ADC_TR1_LT1_2           ADC_TR_LT_2
+#define ADC_TR1_LT1_3           ADC_TR_LT_3
+#define ADC_TR1_LT1_4           ADC_TR_LT_4
+#define ADC_TR1_LT1_5           ADC_TR_LT_5
+#define ADC_TR1_LT1_6           ADC_TR_LT_6
+#define ADC_TR1_LT1_7           ADC_TR_LT_7
+#define ADC_TR1_LT1_8           ADC_TR_LT_8
+#define ADC_TR1_LT1_9           ADC_TR_LT_9
+#define ADC_TR1_LT1_10          ADC_TR_LT_10
+#define ADC_TR1_LT1_11          ADC_TR_LT_11
+
+#define ADC_TR1_HT1             ADC_TR_HT
+#define ADC_TR1_HT1_0           ADC_TR_HT_0
+#define ADC_TR1_HT1_1           ADC_TR_HT_1
+#define ADC_TR1_HT1_2           ADC_TR_HT_2
+#define ADC_TR1_HT1_3           ADC_TR_HT_3
+#define ADC_TR1_HT1_4           ADC_TR_HT_4
+#define ADC_TR1_HT1_5           ADC_TR_HT_5
+#define ADC_TR1_HT1_6           ADC_TR_HT_6
+#define ADC_TR1_HT1_7           ADC_TR_HT_7
+#define ADC_TR1_HT1_8           ADC_TR_HT_8
+#define ADC_TR1_HT1_9           ADC_TR_HT_9
+#define ADC_TR1_HT1_10          ADC_TR_HT_10
+#define ADC_TR1_HT1_11          ADC_TR_HT_11
+
+/********************  Bit definition for ADC_CHSELR register  ****************/
+#define ADC_CHSELR_CHSEL_Pos           (0U)
+#define ADC_CHSELR_CHSEL_Msk           (0x7FFFFUL << ADC_CHSELR_CHSEL_Pos)     /*!< 0x0007FFFF */
+#define ADC_CHSELR_CHSEL               ADC_CHSELR_CHSEL_Msk                    /*!< ADC group regular sequencer channels, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL18_Pos         (18U)
+#define ADC_CHSELR_CHSEL18_Msk         (0x1UL << ADC_CHSELR_CHSEL18_Pos)       /*!< 0x00040000 */
+#define ADC_CHSELR_CHSEL18             ADC_CHSELR_CHSEL18_Msk                  /*!< ADC group regular sequencer channel 18, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL17_Pos         (17U)
+#define ADC_CHSELR_CHSEL17_Msk         (0x1UL << ADC_CHSELR_CHSEL17_Pos)       /*!< 0x00020000 */
+#define ADC_CHSELR_CHSEL17             ADC_CHSELR_CHSEL17_Msk                  /*!< ADC group regular sequencer channel 17, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL16_Pos         (16U)
+#define ADC_CHSELR_CHSEL16_Msk         (0x1UL << ADC_CHSELR_CHSEL16_Pos)       /*!< 0x00010000 */
+#define ADC_CHSELR_CHSEL16             ADC_CHSELR_CHSEL16_Msk                  /*!< ADC group regular sequencer channel 16, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL15_Pos         (15U)
+#define ADC_CHSELR_CHSEL15_Msk         (0x1UL << ADC_CHSELR_CHSEL15_Pos)       /*!< 0x00008000 */
+#define ADC_CHSELR_CHSEL15             ADC_CHSELR_CHSEL15_Msk                  /*!< ADC group regular sequencer channel 15, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL14_Pos         (14U)
+#define ADC_CHSELR_CHSEL14_Msk         (0x1UL << ADC_CHSELR_CHSEL14_Pos)       /*!< 0x00004000 */
+#define ADC_CHSELR_CHSEL14             ADC_CHSELR_CHSEL14_Msk                  /*!< ADC group regular sequencer channel 14, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL13_Pos         (13U)
+#define ADC_CHSELR_CHSEL13_Msk         (0x1UL << ADC_CHSELR_CHSEL13_Pos)       /*!< 0x00002000 */
+#define ADC_CHSELR_CHSEL13             ADC_CHSELR_CHSEL13_Msk                  /*!< ADC group regular sequencer channel 13, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL12_Pos         (12U)
+#define ADC_CHSELR_CHSEL12_Msk         (0x1UL << ADC_CHSELR_CHSEL12_Pos)       /*!< 0x00001000 */
+#define ADC_CHSELR_CHSEL12             ADC_CHSELR_CHSEL12_Msk                  /*!< ADC group regular sequencer channel 12, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL11_Pos         (11U)
+#define ADC_CHSELR_CHSEL11_Msk         (0x1UL << ADC_CHSELR_CHSEL11_Pos)       /*!< 0x00000800 */
+#define ADC_CHSELR_CHSEL11             ADC_CHSELR_CHSEL11_Msk                  /*!< ADC group regular sequencer channel 11, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL10_Pos         (10U)
+#define ADC_CHSELR_CHSEL10_Msk         (0x1UL << ADC_CHSELR_CHSEL10_Pos)       /*!< 0x00000400 */
+#define ADC_CHSELR_CHSEL10             ADC_CHSELR_CHSEL10_Msk                  /*!< ADC group regular sequencer channel 10, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL9_Pos          (9U)
+#define ADC_CHSELR_CHSEL9_Msk          (0x1UL << ADC_CHSELR_CHSEL9_Pos)        /*!< 0x00000200 */
+#define ADC_CHSELR_CHSEL9              ADC_CHSELR_CHSEL9_Msk                   /*!< ADC group regular sequencer channel 9, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL8_Pos          (8U)
+#define ADC_CHSELR_CHSEL8_Msk          (0x1UL << ADC_CHSELR_CHSEL8_Pos)        /*!< 0x00000100 */
+#define ADC_CHSELR_CHSEL8              ADC_CHSELR_CHSEL8_Msk                   /*!< ADC group regular sequencer channel 8, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL7_Pos          (7U)
+#define ADC_CHSELR_CHSEL7_Msk          (0x1UL << ADC_CHSELR_CHSEL7_Pos)        /*!< 0x00000080 */
+#define ADC_CHSELR_CHSEL7              ADC_CHSELR_CHSEL7_Msk                   /*!< ADC group regular sequencer channel 7, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL6_Pos          (6U)
+#define ADC_CHSELR_CHSEL6_Msk          (0x1UL << ADC_CHSELR_CHSEL6_Pos)        /*!< 0x00000040 */
+#define ADC_CHSELR_CHSEL6              ADC_CHSELR_CHSEL6_Msk                   /*!< ADC group regular sequencer channel 6, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL5_Pos          (5U)
+#define ADC_CHSELR_CHSEL5_Msk          (0x1UL << ADC_CHSELR_CHSEL5_Pos)        /*!< 0x00000020 */
+#define ADC_CHSELR_CHSEL5              ADC_CHSELR_CHSEL5_Msk                   /*!< ADC group regular sequencer channel 5, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL4_Pos          (4U)
+#define ADC_CHSELR_CHSEL4_Msk          (0x1UL << ADC_CHSELR_CHSEL4_Pos)        /*!< 0x00000010 */
+#define ADC_CHSELR_CHSEL4              ADC_CHSELR_CHSEL4_Msk                   /*!< ADC group regular sequencer channel 4, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL3_Pos          (3U)
+#define ADC_CHSELR_CHSEL3_Msk          (0x1UL << ADC_CHSELR_CHSEL3_Pos)        /*!< 0x00000008 */
+#define ADC_CHSELR_CHSEL3              ADC_CHSELR_CHSEL3_Msk                   /*!< ADC group regular sequencer channel 3, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL2_Pos          (2U)
+#define ADC_CHSELR_CHSEL2_Msk          (0x1UL << ADC_CHSELR_CHSEL2_Pos)        /*!< 0x00000004 */
+#define ADC_CHSELR_CHSEL2              ADC_CHSELR_CHSEL2_Msk                   /*!< ADC group regular sequencer channel 2, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL1_Pos          (1U)
+#define ADC_CHSELR_CHSEL1_Msk          (0x1UL << ADC_CHSELR_CHSEL1_Pos)        /*!< 0x00000002 */
+#define ADC_CHSELR_CHSEL1              ADC_CHSELR_CHSEL1_Msk                   /*!< ADC group regular sequencer channel 1, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL0_Pos          (0U)
+#define ADC_CHSELR_CHSEL0_Msk          (0x1UL << ADC_CHSELR_CHSEL0_Pos)        /*!< 0x00000001 */
+#define ADC_CHSELR_CHSEL0              ADC_CHSELR_CHSEL0_Msk                   /*!< ADC group regular sequencer channel 0, available when ADC_CFGR1_CHSELRMOD is reset */
+
+#define ADC_CHSELR_SQ_ALL_Pos          (0U)
+#define ADC_CHSELR_SQ_ALL_Msk          (0xFFFFFFFFUL << ADC_CHSELR_SQ_ALL_Pos) /*!< 0xFFFFFFFF */
+#define ADC_CHSELR_SQ_ALL              ADC_CHSELR_SQ_ALL_Msk                   /*!< ADC group regular sequencer all ranks, available when ADC_CFGR1_CHSELRMOD is set */
+
+#define ADC_CHSELR_SQ8_Pos             (28U)
+#define ADC_CHSELR_SQ8_Msk             (0xFUL << ADC_CHSELR_SQ8_Pos)           /*!< 0xF0000000 */
+#define ADC_CHSELR_SQ8                 ADC_CHSELR_SQ8_Msk                      /*!< ADC group regular sequencer rank 8, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ8_0               (0x1UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x10000000 */
+#define ADC_CHSELR_SQ8_1               (0x2UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x20000000 */
+#define ADC_CHSELR_SQ8_2               (0x4UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x40000000 */
+#define ADC_CHSELR_SQ8_3               (0x8UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x80000000 */
+
+#define ADC_CHSELR_SQ7_Pos             (24U)
+#define ADC_CHSELR_SQ7_Msk             (0xFUL << ADC_CHSELR_SQ7_Pos)           /*!< 0x0F000000 */
+#define ADC_CHSELR_SQ7                 ADC_CHSELR_SQ7_Msk                      /*!< ADC group regular sequencer rank 7, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ7_0               (0x1UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x01000000 */
+#define ADC_CHSELR_SQ7_1               (0x2UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x02000000 */
+#define ADC_CHSELR_SQ7_2               (0x4UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x04000000 */
+#define ADC_CHSELR_SQ7_3               (0x8UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x08000000 */
+
+#define ADC_CHSELR_SQ6_Pos             (20U)
+#define ADC_CHSELR_SQ6_Msk             (0xFUL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00F00000 */
+#define ADC_CHSELR_SQ6                 ADC_CHSELR_SQ6_Msk                      /*!< ADC group regular sequencer rank 6, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ6_0               (0x1UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00100000 */
+#define ADC_CHSELR_SQ6_1               (0x2UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00200000 */
+#define ADC_CHSELR_SQ6_2               (0x4UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00400000 */
+#define ADC_CHSELR_SQ6_3               (0x8UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00800000 */
+
+#define ADC_CHSELR_SQ5_Pos             (16U)
+#define ADC_CHSELR_SQ5_Msk             (0xFUL << ADC_CHSELR_SQ5_Pos)           /*!< 0x000F0000 */
+#define ADC_CHSELR_SQ5                 ADC_CHSELR_SQ5_Msk                      /*!< ADC group regular sequencer rank 5, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ5_0               (0x1UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00010000 */
+#define ADC_CHSELR_SQ5_1               (0x2UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00020000 */
+#define ADC_CHSELR_SQ5_2               (0x4UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00040000 */
+#define ADC_CHSELR_SQ5_3               (0x8UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00080000 */
+
+#define ADC_CHSELR_SQ4_Pos             (12U)
+#define ADC_CHSELR_SQ4_Msk             (0xFUL << ADC_CHSELR_SQ4_Pos)           /*!< 0x0000F000 */
+#define ADC_CHSELR_SQ4                 ADC_CHSELR_SQ4_Msk                      /*!< ADC group regular sequencer rank 4, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ4_0               (0x1UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00001000 */
+#define ADC_CHSELR_SQ4_1               (0x2UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00002000 */
+#define ADC_CHSELR_SQ4_2               (0x4UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00004000 */
+#define ADC_CHSELR_SQ4_3               (0x8UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00008000 */
+
+#define ADC_CHSELR_SQ3_Pos             (8U)
+#define ADC_CHSELR_SQ3_Msk             (0xFUL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000F00 */
+#define ADC_CHSELR_SQ3                 ADC_CHSELR_SQ3_Msk                      /*!< ADC group regular sequencer rank 3, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ3_0               (0x1UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000100 */
+#define ADC_CHSELR_SQ3_1               (0x2UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000200 */
+#define ADC_CHSELR_SQ3_2               (0x4UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000400 */
+#define ADC_CHSELR_SQ3_3               (0x8UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000800 */
+
+#define ADC_CHSELR_SQ2_Pos             (4U)
+#define ADC_CHSELR_SQ2_Msk             (0xFUL << ADC_CHSELR_SQ2_Pos)           /*!< 0x000000F0 */
+#define ADC_CHSELR_SQ2                 ADC_CHSELR_SQ2_Msk                      /*!< ADC group regular sequencer rank 2, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ2_0               (0x1UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000010 */
+#define ADC_CHSELR_SQ2_1               (0x2UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000020 */
+#define ADC_CHSELR_SQ2_2               (0x4UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000040 */
+#define ADC_CHSELR_SQ2_3               (0x8UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000080 */
+
+#define ADC_CHSELR_SQ1_Pos             (0U)
+#define ADC_CHSELR_SQ1_Msk             (0xFUL << ADC_CHSELR_SQ1_Pos)           /*!< 0x0000000F */
+#define ADC_CHSELR_SQ1                 ADC_CHSELR_SQ1_Msk                      /*!< ADC group regular sequencer rank 1, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ1_0               (0x1UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000001 */
+#define ADC_CHSELR_SQ1_1               (0x2UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000002 */
+#define ADC_CHSELR_SQ1_2               (0x4UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000004 */
+#define ADC_CHSELR_SQ1_3               (0x8UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000008 */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos                (0U)
+#define ADC_DR_DATA_Msk                (0xFFFFUL << ADC_DR_DATA_Pos)           /*!< 0x0000FFFF */
+#define ADC_DR_DATA                    ADC_DR_DATA_Msk                         /*!< ADC group regular conversion data */
+#define ADC_DR_DATA_0                  (0x0001UL << ADC_DR_DATA_Pos)           /*!< 0x00000001 */
+#define ADC_DR_DATA_1                  (0x0002UL << ADC_DR_DATA_Pos)           /*!< 0x00000002 */
+#define ADC_DR_DATA_2                  (0x0004UL << ADC_DR_DATA_Pos)           /*!< 0x00000004 */
+#define ADC_DR_DATA_3                  (0x0008UL << ADC_DR_DATA_Pos)           /*!< 0x00000008 */
+#define ADC_DR_DATA_4                  (0x0010UL << ADC_DR_DATA_Pos)           /*!< 0x00000010 */
+#define ADC_DR_DATA_5                  (0x0020UL << ADC_DR_DATA_Pos)           /*!< 0x00000020 */
+#define ADC_DR_DATA_6                  (0x0040UL << ADC_DR_DATA_Pos)           /*!< 0x00000040 */
+#define ADC_DR_DATA_7                  (0x0080UL << ADC_DR_DATA_Pos)           /*!< 0x00000080 */
+#define ADC_DR_DATA_8                  (0x0100UL << ADC_DR_DATA_Pos)           /*!< 0x00000100 */
+#define ADC_DR_DATA_9                  (0x0200UL << ADC_DR_DATA_Pos)           /*!< 0x00000200 */
+#define ADC_DR_DATA_10                 (0x0400UL << ADC_DR_DATA_Pos)           /*!< 0x00000400 */
+#define ADC_DR_DATA_11                 (0x0800UL << ADC_DR_DATA_Pos)           /*!< 0x00000800 */
+#define ADC_DR_DATA_12                 (0x1000UL << ADC_DR_DATA_Pos)           /*!< 0x00001000 */
+#define ADC_DR_DATA_13                 (0x2000UL << ADC_DR_DATA_Pos)           /*!< 0x00002000 */
+#define ADC_DR_DATA_14                 (0x4000UL << ADC_DR_DATA_Pos)           /*!< 0x00004000 */
+#define ADC_DR_DATA_15                 (0x8000UL << ADC_DR_DATA_Pos)           /*!< 0x00008000 */
+
+/* Definitions for cohabitation of ADC peripherals 2.5Ms/sec and 5Ms/sec across STM32WB series */
+#define ADC_DR_RDATA_Pos               ADC_DR_DATA_Pos
+#define ADC_DR_RDATA_Msk               ADC_DR_DATA_Msk
+#define ADC_DR_RDATA                   ADC_DR_DATA
+
+/********************  Bit definition for ADC_CALFACT register  ***************/
+#define ADC_CALFACT_CALFACT_Pos        (0U)
+#define ADC_CALFACT_CALFACT_Msk        (0x7FUL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x0000007F */
+#define ADC_CALFACT_CALFACT            ADC_CALFACT_CALFACT_Msk                 /*!< ADC calibration factor in single-ended mode */
+#define ADC_CALFACT_CALFACT_0          (0x01UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000001 */
+#define ADC_CALFACT_CALFACT_1          (0x02UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000002 */
+#define ADC_CALFACT_CALFACT_2          (0x04UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000004 */
+#define ADC_CALFACT_CALFACT_3          (0x08UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000008 */
+#define ADC_CALFACT_CALFACT_4          (0x10UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000010 */
+#define ADC_CALFACT_CALFACT_5          (0x20UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000020 */
+#define ADC_CALFACT_CALFACT_6          (0x40UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000040 */
+
+/*************************  ADC Common registers  *****************************/
+/********************  Bit definition for ADC_CCR register  *******************/
+#define ADC_CCR_PRESC_Pos              (18U)
+#define ADC_CCR_PRESC_Msk              (0xFUL << ADC_CCR_PRESC_Pos)            /*!< 0x003C0000 */
+#define ADC_CCR_PRESC                  ADC_CCR_PRESC_Msk                       /*!< ADC common clock prescaler, only for clock source asynchronous */
+#define ADC_CCR_PRESC_0                (0x1UL << ADC_CCR_PRESC_Pos)            /*!< 0x00040000 */
+#define ADC_CCR_PRESC_1                (0x2UL << ADC_CCR_PRESC_Pos)            /*!< 0x00080000 */
+#define ADC_CCR_PRESC_2                (0x4UL << ADC_CCR_PRESC_Pos)            /*!< 0x00100000 */
+#define ADC_CCR_PRESC_3                (0x8UL << ADC_CCR_PRESC_Pos)            /*!< 0x00200000 */
+
+#define ADC_CCR_VREFEN_Pos             (22U)
+#define ADC_CCR_VREFEN_Msk             (0x1UL << ADC_CCR_VREFEN_Pos)           /*!< 0x00400000 */
+#define ADC_CCR_VREFEN                 ADC_CCR_VREFEN_Msk                      /*!< ADC internal path to VrefInt enable */
+#define ADC_CCR_TSEN_Pos               (23U)
+#define ADC_CCR_TSEN_Msk               (0x1UL << ADC_CCR_TSEN_Pos)             /*!< 0x00800000 */
+#define ADC_CCR_TSEN                   ADC_CCR_TSEN_Msk                        /*!< ADC internal path to temperature sensor enable */
+#define ADC_CCR_VBATEN_Pos             (24U)
+#define ADC_CCR_VBATEN_Msk             (0x1UL << ADC_CCR_VBATEN_Pos)           /*!< 0x01000000 */
+#define ADC_CCR_VBATEN                 ADC_CCR_VBATEN_Msk                      /*!< ADC internal path to battery voltage enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog Comparators (COMP)                             */
+/*                                                                            */
+/******************************************************************************/
+/**********************  Bit definition for COMP_CSR register  ***************/
+#define COMP_CSR_EN_Pos            (0U)
+#define COMP_CSR_EN_Msk            (0x1UL << COMP_CSR_EN_Pos)                  /*!< 0x00000001 */
+#define COMP_CSR_EN                COMP_CSR_EN_Msk                             /*!< Comparator enable */
+#define COMP_CSR_PWRMODE_Pos       (2U)
+#define COMP_CSR_PWRMODE_Msk       (0x3UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x0000000C */
+#define COMP_CSR_PWRMODE           COMP_CSR_PWRMODE_Msk                        /*!< Comparator power mode */
+#define COMP_CSR_PWRMODE_0         (0x1UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00000004 */
+#define COMP_CSR_PWRMODE_1         (0x2UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00000008 */
+#define COMP_CSR_INMSEL_Pos        (4U)
+#define COMP_CSR_INMSEL_Msk        (0x7UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000070 */
+#define COMP_CSR_INMSEL            COMP_CSR_INMSEL_Msk                         /*!< Comparator input minus selection */
+#define COMP_CSR_INMSEL_0          (0x1UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000010 */
+#define COMP_CSR_INMSEL_1          (0x2UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000020 */
+#define COMP_CSR_INMSEL_2          (0x4UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000040 */
+#define COMP_CSR_INPSEL_Pos        (7U)
+#define COMP_CSR_INPSEL_Msk        (0x3UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000180 */
+#define COMP_CSR_INPSEL            COMP_CSR_INPSEL_Msk                         /*!< Comparator input plus selection */
+#define COMP_CSR_INPSEL_0          (0x1UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000080 */
+#define COMP_CSR_INPSEL_1          (0x2UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000100 */
+#define COMP_CSR_POLARITY_Pos      (15U)
+#define COMP_CSR_POLARITY_Msk      (0x1UL << COMP_CSR_POLARITY_Pos)            /*!< 0x00008000 */
+#define COMP_CSR_POLARITY          COMP_CSR_POLARITY_Msk                       /*!< Comparator output polarity */
+#define COMP_CSR_HYST_Pos          (16U)
+#define COMP_CSR_HYST_Msk          (0x3UL << COMP_CSR_HYST_Pos)                /*!< 0x00030000 */
+#define COMP_CSR_HYST              COMP_CSR_HYST_Msk                           /*!< Comparator hysteresis */
+#define COMP_CSR_HYST_0            (0x1UL << COMP_CSR_HYST_Pos)                /*!< 0x00010000 */
+#define COMP_CSR_HYST_1            (0x2UL << COMP_CSR_HYST_Pos)                /*!< 0x00020000 */
+#define COMP_CSR_BLANKING_Pos      (18U)
+#define COMP_CSR_BLANKING_Msk      (0x7UL << COMP_CSR_BLANKING_Pos)            /*!< 0x001C0000 */
+#define COMP_CSR_BLANKING          COMP_CSR_BLANKING_Msk                       /*!< Comparator blanking source */
+#define COMP_CSR_BLANKING_0        (0x1UL << COMP_CSR_BLANKING_Pos)            /*!< 0x00040000 */
+#define COMP_CSR_BLANKING_1        (0x2UL << COMP_CSR_BLANKING_Pos)            /*!< 0x00080000 */
+#define COMP_CSR_BLANKING_2        (0x4UL << COMP_CSR_BLANKING_Pos)            /*!< 0x00100000 */
+#define COMP_CSR_BRGEN_Pos         (22U)
+#define COMP_CSR_BRGEN_Msk         (0x1UL << COMP_CSR_BRGEN_Pos)               /*!< 0x00400000 */
+#define COMP_CSR_BRGEN             COMP_CSR_BRGEN_Msk                          /*!< Comparator voltage scaler enable */
+#define COMP_CSR_SCALEN_Pos        (23U)
+#define COMP_CSR_SCALEN_Msk        (0x1UL << COMP_CSR_SCALEN_Pos)              /*!< 0x00800000 */
+#define COMP_CSR_SCALEN            COMP_CSR_SCALEN_Msk                         /*!< Comparator scaler bridge enable */
+#define COMP_CSR_INMESEL_Pos       (25U)
+#define COMP_CSR_INMESEL_Msk       (0x3UL << COMP_CSR_INMESEL_Pos)             /*!< 0x06000000 */
+#define COMP_CSR_INMESEL           COMP_CSR_INMESEL_Msk                        /*!< Comparator input minus extended selection */
+#define COMP_CSR_INMESEL_0         (0x1UL << COMP_CSR_INMESEL_Pos)             /*!< 0x02000000 */
+#define COMP_CSR_INMESEL_1         (0x2UL << COMP_CSR_INMESEL_Pos)             /*!< 0x04000000 */
+#define COMP_CSR_VALUE_Pos         (30U)
+#define COMP_CSR_VALUE_Msk         (0x1UL << COMP_CSR_VALUE_Pos)               /*!< 0x40000000 */
+#define COMP_CSR_VALUE             COMP_CSR_VALUE_Msk                          /*!< Comparator output level */
+#define COMP_CSR_LOCK_Pos          (31U)
+#define COMP_CSR_LOCK_Msk          (0x1UL << COMP_CSR_LOCK_Pos)                /*!< 0x80000000 */
+#define COMP_CSR_LOCK              COMP_CSR_LOCK_Msk                           /*!< Comparator lock */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos            (0U)
+#define CRC_DR_DR_Msk            (0xFFFFFFFFUL << CRC_DR_DR_Pos)               /*!< 0xFFFFFFFF */
+#define CRC_DR_DR                CRC_DR_DR_Msk                                 /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos          (0U)
+#define CRC_IDR_IDR_Msk          (0xFFFFFFFFUL << CRC_IDR_IDR_Pos)                   /*!< 0x000000FF */
+#define CRC_IDR_IDR              CRC_IDR_IDR_Msk                               /*!< General-purpose 8-bits data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos         (0U)
+#define CRC_CR_RESET_Msk         (0x1UL << CRC_CR_RESET_Pos)                   /*!< 0x00000001 */
+#define CRC_CR_RESET             CRC_CR_RESET_Msk                              /*!< RESET the CRC computation unit bit */
+#define CRC_CR_POLYSIZE_Pos      (3U)
+#define CRC_CR_POLYSIZE_Msk      (0x3UL << CRC_CR_POLYSIZE_Pos)                /*!< 0x00000018 */
+#define CRC_CR_POLYSIZE          CRC_CR_POLYSIZE_Msk                           /*!< Polynomial size bits */
+#define CRC_CR_POLYSIZE_0        (0x1U << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000008 */
+#define CRC_CR_POLYSIZE_1        (0x2U << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000010 */
+#define CRC_CR_REV_IN_Pos        (5U)
+#define CRC_CR_REV_IN_Msk        (0x3UL << CRC_CR_REV_IN_Pos)                  /*!< 0x00000060 */
+#define CRC_CR_REV_IN            CRC_CR_REV_IN_Msk                             /*!< REV_IN Reverse Input Data bits */
+#define CRC_CR_REV_IN_0          (0x1U << CRC_CR_REV_IN_Pos)                   /*!< 0x00000020 */
+#define CRC_CR_REV_IN_1          (0x2U << CRC_CR_REV_IN_Pos)                   /*!< 0x00000040 */
+#define CRC_CR_REV_OUT_Pos       (7U)
+#define CRC_CR_REV_OUT_Msk       (0x1UL << CRC_CR_REV_OUT_Pos)                 /*!< 0x00000080 */
+#define CRC_CR_REV_OUT           CRC_CR_REV_OUT_Msk                            /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define CRC_INIT_INIT_Pos        (0U)
+#define CRC_INIT_INIT_Msk        (0xFFFFFFFFUL << CRC_INIT_INIT_Pos)           /*!< 0xFFFFFFFF */
+#define CRC_INIT_INIT            CRC_INIT_INIT_Msk                             /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define CRC_POL_POL_Pos          (0U)
+#define CRC_POL_POL_Msk          (0xFFFFFFFFUL << CRC_POL_POL_Pos)             /*!< 0xFFFFFFFF */
+#define CRC_POL_POL              CRC_POL_POL_Msk                               /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Advanced Encryption Standard (AES)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for AES_CR register  *********************/
+#define AES_CR_EN_Pos            (0U)
+#define AES_CR_EN_Msk            (0x1UL << AES_CR_EN_Pos)                      /*!< 0x00000001 */
+#define AES_CR_EN                AES_CR_EN_Msk                                 /*!< AES Enable */
+#define AES_CR_DATATYPE_Pos      (1U)
+#define AES_CR_DATATYPE_Msk      (0x3UL << AES_CR_DATATYPE_Pos)                /*!< 0x00000006 */
+#define AES_CR_DATATYPE          AES_CR_DATATYPE_Msk                           /*!< Data type selection */
+#define AES_CR_DATATYPE_0        (0x1U << AES_CR_DATATYPE_Pos)                 /*!< 0x00000002 */
+#define AES_CR_DATATYPE_1        (0x2U << AES_CR_DATATYPE_Pos)                 /*!< 0x00000004 */
+
+#define AES_CR_MODE_Pos          (3U)
+#define AES_CR_MODE_Msk          (0x3UL << AES_CR_MODE_Pos)                    /*!< 0x00000018 */
+#define AES_CR_MODE              AES_CR_MODE_Msk                               /*!< AES Mode Of Operation */
+#define AES_CR_MODE_0            (0x1U << AES_CR_MODE_Pos)                     /*!< 0x00000008 */
+#define AES_CR_MODE_1            (0x2U << AES_CR_MODE_Pos)                     /*!< 0x00000010 */
+
+#define AES_CR_CHMOD_Pos         (5U)
+#define AES_CR_CHMOD_Msk         (0x803UL << AES_CR_CHMOD_Pos)                 /*!< 0x00010060 */
+#define AES_CR_CHMOD             AES_CR_CHMOD_Msk                              /*!< AES Chaining Mode */
+#define AES_CR_CHMOD_0           (0x001U << AES_CR_CHMOD_Pos)                  /*!< 0x00000020 */
+#define AES_CR_CHMOD_1           (0x002U << AES_CR_CHMOD_Pos)                  /*!< 0x00000040 */
+#define AES_CR_CHMOD_2           (0x800U << AES_CR_CHMOD_Pos)                  /*!< 0x00010000 */
+
+#define AES_CR_CCFC_Pos          (7U)
+#define AES_CR_CCFC_Msk          (0x1UL << AES_CR_CCFC_Pos)                    /*!< 0x00000080 */
+#define AES_CR_CCFC              AES_CR_CCFC_Msk                               /*!< Computation Complete Flag Clear */
+#define AES_CR_ERRC_Pos          (8U)
+#define AES_CR_ERRC_Msk          (0x1UL << AES_CR_ERRC_Pos)                    /*!< 0x00000100 */
+#define AES_CR_ERRC              AES_CR_ERRC_Msk                               /*!< Error Clear */
+#define AES_CR_CCFIE_Pos         (9U)
+#define AES_CR_CCFIE_Msk         (0x1UL << AES_CR_CCFIE_Pos)                   /*!< 0x00000200 */
+#define AES_CR_CCFIE             AES_CR_CCFIE_Msk                              /*!< Computation Complete Flag Interrupt Enable */
+#define AES_CR_ERRIE_Pos         (10U)
+#define AES_CR_ERRIE_Msk         (0x1UL << AES_CR_ERRIE_Pos)                   /*!< 0x00000400 */
+#define AES_CR_ERRIE             AES_CR_ERRIE_Msk                              /*!< Error Interrupt Enable */
+#define AES_CR_DMAINEN_Pos       (11U)
+#define AES_CR_DMAINEN_Msk       (0x1UL << AES_CR_DMAINEN_Pos)                 /*!< 0x00000800 */
+#define AES_CR_DMAINEN           AES_CR_DMAINEN_Msk                            /*!< Enable data input phase DMA management  */
+#define AES_CR_DMAOUTEN_Pos      (12U)
+#define AES_CR_DMAOUTEN_Msk      (0x1UL << AES_CR_DMAOUTEN_Pos)                /*!< 0x00001000 */
+#define AES_CR_DMAOUTEN          AES_CR_DMAOUTEN_Msk                           /*!< Enable data output phase DMA management */
+
+#define AES_CR_GCMPH_Pos         (13U)
+#define AES_CR_GCMPH_Msk         (0x3UL << AES_CR_GCMPH_Pos)                   /*!< 0x00006000 */
+#define AES_CR_GCMPH             AES_CR_GCMPH_Msk                              /*!< GCM Phase */
+#define AES_CR_GCMPH_0           (0x1U << AES_CR_GCMPH_Pos)                    /*!< 0x00002000 */
+#define AES_CR_GCMPH_1           (0x2U << AES_CR_GCMPH_Pos)                    /*!< 0x00004000 */
+
+#define AES_CR_KEYSIZE_Pos       (18U)
+#define AES_CR_KEYSIZE_Msk       (0x1UL << AES_CR_KEYSIZE_Pos)                 /*!< 0x00040000 */
+#define AES_CR_KEYSIZE           AES_CR_KEYSIZE_Msk                            /*!< Key size selection */
+
+#define AES_CR_NPBLB_Pos         (20U)
+#define AES_CR_NPBLB_Msk         (0xFUL << AES_CR_NPBLB_Pos)                   /*!< 0x00F00000 */
+#define AES_CR_NPBLB             AES_CR_NPBLB_Msk                              /*!< Number of padding bytes in last payload block */
+#define AES_CR_NPBLB_0           (0x1U << AES_CR_NPBLB_Pos)                    /*!< 0x00100000 */
+#define AES_CR_NPBLB_1           (0x2U << AES_CR_NPBLB_Pos)                    /*!< 0x00200000 */
+#define AES_CR_NPBLB_2           (0x4U << AES_CR_NPBLB_Pos)                    /*!< 0x00400000 */
+#define AES_CR_NPBLB_3           (0x8U << AES_CR_NPBLB_Pos)                    /*!< 0x00800000 */
+
+/*******************  Bit definition for AES_SR register  *********************/
+#define AES_SR_CCF_Pos           (0U)
+#define AES_SR_CCF_Msk           (0x1UL << AES_SR_CCF_Pos)                     /*!< 0x00000001 */
+#define AES_SR_CCF               AES_SR_CCF_Msk                                /*!< Computation Complete Flag */
+#define AES_SR_RDERR_Pos         (1U)
+#define AES_SR_RDERR_Msk         (0x1UL << AES_SR_RDERR_Pos)                   /*!< 0x00000002 */
+#define AES_SR_RDERR             AES_SR_RDERR_Msk                              /*!< Read Error Flag */
+#define AES_SR_WRERR_Pos         (2U)
+#define AES_SR_WRERR_Msk         (0x1UL << AES_SR_WRERR_Pos)                   /*!< 0x00000004 */
+#define AES_SR_WRERR             AES_SR_WRERR_Msk                              /*!< Write Error Flag */
+#define AES_SR_BUSY_Pos          (3U)
+#define AES_SR_BUSY_Msk          (0x1UL << AES_SR_BUSY_Pos)                    /*!< 0x00000008 */
+#define AES_SR_BUSY              AES_SR_BUSY_Msk                               /*!< Busy Flag */
+
+/*******************  Bit definition for AES_DINR register  *******************/
+#define AES_DINR_Pos             (0U)
+#define AES_DINR_Msk             (0xFFFFFFFFUL << AES_DINR_Pos)                /*!< 0xFFFFFFFF */
+#define AES_DINR                 AES_DINR_Msk                                  /*!< AES Data Input Register */
+
+/*******************  Bit definition for AES_DOUTR register  ******************/
+#define AES_DOUTR_Pos            (0U)
+#define AES_DOUTR_Msk            (0xFFFFFFFFUL << AES_DOUTR_Pos)               /*!< 0xFFFFFFFF */
+#define AES_DOUTR                AES_DOUTR_Msk                                 /*!< AES Data Output Register */
+
+/*******************  Bit definition for AES_KEYR0 register  ******************/
+#define AES_KEYR0_Pos            (0U)
+#define AES_KEYR0_Msk            (0xFFFFFFFFUL << AES_KEYR0_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR0                AES_KEYR0_Msk                                 /*!< AES Key Register 0 */
+
+/*******************  Bit definition for AES_KEYR1 register  ******************/
+#define AES_KEYR1_Pos            (0U)
+#define AES_KEYR1_Msk            (0xFFFFFFFFUL << AES_KEYR1_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR1                AES_KEYR1_Msk                                 /*!< AES Key Register 1 */
+
+/*******************  Bit definition for AES_KEYR2 register  ******************/
+#define AES_KEYR2_Pos            (0U)
+#define AES_KEYR2_Msk            (0xFFFFFFFFUL << AES_KEYR2_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR2                AES_KEYR2_Msk                                 /*!< AES Key Register 2 */
+
+/*******************  Bit definition for AES_KEYR3 register  ******************/
+#define AES_KEYR3_Pos            (0U)
+#define AES_KEYR3_Msk            (0xFFFFFFFFUL << AES_KEYR3_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR3                AES_KEYR3_Msk                                 /*!< AES Key Register 3 */
+
+/*******************  Bit definition for AES_KEYR4 register  ******************/
+#define AES_KEYR4_Pos            (0U)
+#define AES_KEYR4_Msk            (0xFFFFFFFFUL << AES_KEYR4_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR4                AES_KEYR4_Msk                                 /*!< AES Key Register 4 */
+
+/*******************  Bit definition for AES_KEYR5 register  ******************/
+#define AES_KEYR5_Pos            (0U)
+#define AES_KEYR5_Msk            (0xFFFFFFFFUL << AES_KEYR5_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR5                AES_KEYR5_Msk                                 /*!< AES Key Register 5 */
+
+/*******************  Bit definition for AES_KEYR6 register  ******************/
+#define AES_KEYR6_Pos            (0U)
+#define AES_KEYR6_Msk            (0xFFFFFFFFUL << AES_KEYR6_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR6                AES_KEYR6_Msk                                 /*!< AES Key Register 6 */
+
+/*******************  Bit definition for AES_KEYR7 register  ******************/
+#define AES_KEYR7_Pos            (0U)
+#define AES_KEYR7_Msk            (0xFFFFFFFFUL << AES_KEYR7_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR7                AES_KEYR7_Msk                                 /*!< AES Key Register 7 */
+
+/*******************  Bit definition for AES_IVR0 register   ******************/
+#define AES_IVR0_Pos             (0U)
+#define AES_IVR0_Msk             (0xFFFFFFFFUL << AES_IVR0_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR0                 AES_IVR0_Msk                                  /*!< AES Initialization Vector Register 0 */
+
+/*******************  Bit definition for AES_IVR1 register   ******************/
+#define AES_IVR1_Pos             (0U)
+#define AES_IVR1_Msk             (0xFFFFFFFFUL << AES_IVR1_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR1                 AES_IVR1_Msk                                  /*!< AES Initialization Vector Register 1 */
+
+/*******************  Bit definition for AES_IVR2 register   ******************/
+#define AES_IVR2_Pos             (0U)
+#define AES_IVR2_Msk             (0xFFFFFFFFUL << AES_IVR2_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR2                 AES_IVR2_Msk                                  /*!< AES Initialization Vector Register 2 */
+
+/*******************  Bit definition for AES_IVR3 register   ******************/
+#define AES_IVR3_Pos             (0U)
+#define AES_IVR3_Msk             (0xFFFFFFFFUL << AES_IVR3_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR3                 AES_IVR3_Msk                                  /*!< AES Initialization Vector Register 3 */
+
+/*******************  Bit definition for AES_SUSP0R register  ******************/
+#define AES_SUSP0R_Pos           (0U)
+#define AES_SUSP0R_Msk           (0xFFFFFFFFUL << AES_SUSP0R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP0R               AES_SUSP0R_Msk                                /*!< AES Suspend registers 0 */
+
+/*******************  Bit definition for AES_SUSP1R register  ******************/
+#define AES_SUSP1R_Pos           (0U)
+#define AES_SUSP1R_Msk           (0xFFFFFFFFUL << AES_SUSP1R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP1R               AES_SUSP1R_Msk                                /*!< AES Suspend registers 1 */
+
+/*******************  Bit definition for AES_SUSP2R register  ******************/
+#define AES_SUSP2R_Pos           (0U)
+#define AES_SUSP2R_Msk           (0xFFFFFFFFUL << AES_SUSP2R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP2R               AES_SUSP2R_Msk                                /*!< AES Suspend registers 2 */
+
+/*******************  Bit definition for AES_SUSP3R register  ******************/
+#define AES_SUSP3R_Pos           (0U)
+#define AES_SUSP3R_Msk           (0xFFFFFFFFUL << AES_SUSP3R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP3R               AES_SUSP3R_Msk                                /*!< AES Suspend registers 3 */
+
+/*******************  Bit definition for AES_SUSP4R register  ******************/
+#define AES_SUSP4R_Pos           (0U)
+#define AES_SUSP4R_Msk           (0xFFFFFFFFUL << AES_SUSP4R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP4R               AES_SUSP4R_Msk                                /*!< AES Suspend registers 4 */
+
+/*******************  Bit definition for AES_SUSP5R register  ******************/
+#define AES_SUSP5R_Pos           (0U)
+#define AES_SUSP5R_Msk           (0xFFFFFFFFUL << AES_SUSP5R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP5R               AES_SUSP5R_Msk                                /*!< AES Suspend registers 5 */
+
+/*******************  Bit definition for AES_SUSP6R register  ******************/
+#define AES_SUSP6R_Pos           (0U)
+#define AES_SUSP6R_Msk           (0xFFFFFFFFUL << AES_SUSP6R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP6R               AES_SUSP6R_Msk                                /*!< AES Suspend registers 6 */
+
+/*******************  Bit definition for AES_SUSP7R register  ******************/
+#define AES_SUSP7R_Pos           (0U)
+#define AES_SUSP7R_Msk           (0xFFFFFFFFUL << AES_SUSP7R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP7R               AES_SUSP7R_Msk                                /*!< AES Suspend registers 7 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define DMA_ISR_GIF1_Pos       (0U)
+#define DMA_ISR_GIF1_Msk       (0x1UL << DMA_ISR_GIF1_Pos)                     /*!< 0x00000001 */
+#define DMA_ISR_GIF1           DMA_ISR_GIF1_Msk                                /*!< Channel 1 Global interrupt flag */
+#define DMA_ISR_TCIF1_Pos      (1U)
+#define DMA_ISR_TCIF1_Msk      (0x1UL << DMA_ISR_TCIF1_Pos)                    /*!< 0x00000002 */
+#define DMA_ISR_TCIF1          DMA_ISR_TCIF1_Msk                               /*!< Channel 1 Transfer Complete flag */
+#define DMA_ISR_HTIF1_Pos      (2U)
+#define DMA_ISR_HTIF1_Msk      (0x1UL << DMA_ISR_HTIF1_Pos)                    /*!< 0x00000004 */
+#define DMA_ISR_HTIF1          DMA_ISR_HTIF1_Msk                               /*!< Channel 1 Half Transfer flag */
+#define DMA_ISR_TEIF1_Pos      (3U)
+#define DMA_ISR_TEIF1_Msk      (0x1UL << DMA_ISR_TEIF1_Pos)                    /*!< 0x00000008 */
+#define DMA_ISR_TEIF1          DMA_ISR_TEIF1_Msk                               /*!< Channel 1 Transfer Error flag */
+#define DMA_ISR_GIF2_Pos       (4U)
+#define DMA_ISR_GIF2_Msk       (0x1UL << DMA_ISR_GIF2_Pos)                     /*!< 0x00000010 */
+#define DMA_ISR_GIF2           DMA_ISR_GIF2_Msk                                /*!< Channel 2 Global interrupt flag */
+#define DMA_ISR_TCIF2_Pos      (5U)
+#define DMA_ISR_TCIF2_Msk      (0x1UL << DMA_ISR_TCIF2_Pos)                    /*!< 0x00000020 */
+#define DMA_ISR_TCIF2          DMA_ISR_TCIF2_Msk                               /*!< Channel 2 Transfer Complete flag */
+#define DMA_ISR_HTIF2_Pos      (6U)
+#define DMA_ISR_HTIF2_Msk      (0x1UL << DMA_ISR_HTIF2_Pos)                    /*!< 0x00000040 */
+#define DMA_ISR_HTIF2          DMA_ISR_HTIF2_Msk                               /*!< Channel 2 Half Transfer flag */
+#define DMA_ISR_TEIF2_Pos      (7U)
+#define DMA_ISR_TEIF2_Msk      (0x1UL << DMA_ISR_TEIF2_Pos)                    /*!< 0x00000080 */
+#define DMA_ISR_TEIF2          DMA_ISR_TEIF2_Msk                               /*!< Channel 2 Transfer Error flag */
+#define DMA_ISR_GIF3_Pos       (8U)
+#define DMA_ISR_GIF3_Msk       (0x1UL << DMA_ISR_GIF3_Pos)                     /*!< 0x00000100 */
+#define DMA_ISR_GIF3           DMA_ISR_GIF3_Msk                                /*!< Channel 3 Global interrupt flag */
+#define DMA_ISR_TCIF3_Pos      (9U)
+#define DMA_ISR_TCIF3_Msk      (0x1UL << DMA_ISR_TCIF3_Pos)                    /*!< 0x00000200 */
+#define DMA_ISR_TCIF3          DMA_ISR_TCIF3_Msk                               /*!< Channel 3 Transfer Complete flag */
+#define DMA_ISR_HTIF3_Pos      (10U)
+#define DMA_ISR_HTIF3_Msk      (0x1UL << DMA_ISR_HTIF3_Pos)                    /*!< 0x00000400 */
+#define DMA_ISR_HTIF3          DMA_ISR_HTIF3_Msk                               /*!< Channel 3 Half Transfer flag */
+#define DMA_ISR_TEIF3_Pos      (11U)
+#define DMA_ISR_TEIF3_Msk      (0x1UL << DMA_ISR_TEIF3_Pos)                    /*!< 0x00000800 */
+#define DMA_ISR_TEIF3          DMA_ISR_TEIF3_Msk                               /*!< Channel 3 Transfer Error flag */
+#define DMA_ISR_GIF4_Pos       (12U)
+#define DMA_ISR_GIF4_Msk       (0x1UL << DMA_ISR_GIF4_Pos)                     /*!< 0x00001000 */
+#define DMA_ISR_GIF4           DMA_ISR_GIF4_Msk                                /*!< Channel 4 Global interrupt flag */
+#define DMA_ISR_TCIF4_Pos      (13U)
+#define DMA_ISR_TCIF4_Msk      (0x1UL << DMA_ISR_TCIF4_Pos)                    /*!< 0x00002000 */
+#define DMA_ISR_TCIF4          DMA_ISR_TCIF4_Msk                               /*!< Channel 4 Transfer Complete flag */
+#define DMA_ISR_HTIF4_Pos      (14U)
+#define DMA_ISR_HTIF4_Msk      (0x1UL << DMA_ISR_HTIF4_Pos)                    /*!< 0x00004000 */
+#define DMA_ISR_HTIF4          DMA_ISR_HTIF4_Msk                               /*!< Channel 4 Half Transfer flag */
+#define DMA_ISR_TEIF4_Pos      (15U)
+#define DMA_ISR_TEIF4_Msk      (0x1UL << DMA_ISR_TEIF4_Pos)                    /*!< 0x00008000 */
+#define DMA_ISR_TEIF4          DMA_ISR_TEIF4_Msk                               /*!< Channel 4 Transfer Error flag */
+#define DMA_ISR_GIF5_Pos       (16U)
+#define DMA_ISR_GIF5_Msk       (0x1UL << DMA_ISR_GIF5_Pos)                     /*!< 0x00010000 */
+#define DMA_ISR_GIF5           DMA_ISR_GIF5_Msk                                /*!< Channel 5 Global interrupt flag */
+#define DMA_ISR_TCIF5_Pos      (17U)
+#define DMA_ISR_TCIF5_Msk      (0x1UL << DMA_ISR_TCIF5_Pos)                    /*!< 0x00020000 */
+#define DMA_ISR_TCIF5          DMA_ISR_TCIF5_Msk                               /*!< Channel 5 Transfer Complete flag */
+#define DMA_ISR_HTIF5_Pos      (18U)
+#define DMA_ISR_HTIF5_Msk      (0x1UL << DMA_ISR_HTIF5_Pos)                    /*!< 0x00040000 */
+#define DMA_ISR_HTIF5          DMA_ISR_HTIF5_Msk                               /*!< Channel 5 Half Transfer flag */
+#define DMA_ISR_TEIF5_Pos      (19U)
+#define DMA_ISR_TEIF5_Msk      (0x1UL << DMA_ISR_TEIF5_Pos)                    /*!< 0x00080000 */
+#define DMA_ISR_TEIF5          DMA_ISR_TEIF5_Msk                               /*!< Channel 5 Transfer Error flag */
+#define DMA_ISR_GIF6_Pos       (20U)
+#define DMA_ISR_GIF6_Msk       (0x1UL << DMA_ISR_GIF6_Pos)                     /*!< 0x00100000 */
+#define DMA_ISR_GIF6           DMA_ISR_GIF6_Msk                                /*!< Channel 6 Global interrupt flag */
+#define DMA_ISR_TCIF6_Pos      (21U)
+#define DMA_ISR_TCIF6_Msk      (0x1UL << DMA_ISR_TCIF6_Pos)                    /*!< 0x00200000 */
+#define DMA_ISR_TCIF6          DMA_ISR_TCIF6_Msk                               /*!< Channel 6 Transfer Complete flag */
+#define DMA_ISR_HTIF6_Pos      (22U)
+#define DMA_ISR_HTIF6_Msk      (0x1UL << DMA_ISR_HTIF6_Pos)                    /*!< 0x00400000 */
+#define DMA_ISR_HTIF6          DMA_ISR_HTIF6_Msk                               /*!< Channel 6 Half Transfer flag */
+#define DMA_ISR_TEIF6_Pos      (23U)
+#define DMA_ISR_TEIF6_Msk      (0x1UL << DMA_ISR_TEIF6_Pos)                    /*!< 0x00800000 */
+#define DMA_ISR_TEIF6          DMA_ISR_TEIF6_Msk                               /*!< Channel 6 Transfer Error flag */
+#define DMA_ISR_GIF7_Pos       (24U)
+#define DMA_ISR_GIF7_Msk       (0x1UL << DMA_ISR_GIF7_Pos)                     /*!< 0x01000000 */
+#define DMA_ISR_GIF7           DMA_ISR_GIF7_Msk                                /*!< Channel 7 Global interrupt flag */
+#define DMA_ISR_TCIF7_Pos      (25U)
+#define DMA_ISR_TCIF7_Msk      (0x1UL << DMA_ISR_TCIF7_Pos)                    /*!< 0x02000000 */
+#define DMA_ISR_TCIF7          DMA_ISR_TCIF7_Msk                               /*!< Channel 7 Transfer Complete flag */
+#define DMA_ISR_HTIF7_Pos      (26U)
+#define DMA_ISR_HTIF7_Msk      (0x1UL << DMA_ISR_HTIF7_Pos)                    /*!< 0x04000000 */
+#define DMA_ISR_HTIF7          DMA_ISR_HTIF7_Msk                               /*!< Channel 7 Half Transfer flag */
+#define DMA_ISR_TEIF7_Pos      (27U)
+#define DMA_ISR_TEIF7_Msk      (0x1UL << DMA_ISR_TEIF7_Pos)                    /*!< 0x08000000 */
+#define DMA_ISR_TEIF7          DMA_ISR_TEIF7_Msk                               /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define DMA_IFCR_CGIF1_Pos     (0U)
+#define DMA_IFCR_CGIF1_Msk     (0x1UL << DMA_IFCR_CGIF1_Pos)                   /*!< 0x00000001 */
+#define DMA_IFCR_CGIF1         DMA_IFCR_CGIF1_Msk                              /*!< Channel 1 Global interrupt clear */
+#define DMA_IFCR_CTCIF1_Pos    (1U)
+#define DMA_IFCR_CTCIF1_Msk    (0x1UL << DMA_IFCR_CTCIF1_Pos)                  /*!< 0x00000002 */
+#define DMA_IFCR_CTCIF1        DMA_IFCR_CTCIF1_Msk                             /*!< Channel 1 Transfer Complete clear */
+#define DMA_IFCR_CHTIF1_Pos    (2U)
+#define DMA_IFCR_CHTIF1_Msk    (0x1UL << DMA_IFCR_CHTIF1_Pos)                  /*!< 0x00000004 */
+#define DMA_IFCR_CHTIF1        DMA_IFCR_CHTIF1_Msk                             /*!< Channel 1 Half Transfer clear */
+#define DMA_IFCR_CTEIF1_Pos    (3U)
+#define DMA_IFCR_CTEIF1_Msk    (0x1UL << DMA_IFCR_CTEIF1_Pos)                  /*!< 0x00000008 */
+#define DMA_IFCR_CTEIF1        DMA_IFCR_CTEIF1_Msk                             /*!< Channel 1 Transfer Error clear */
+#define DMA_IFCR_CGIF2_Pos     (4U)
+#define DMA_IFCR_CGIF2_Msk     (0x1UL << DMA_IFCR_CGIF2_Pos)                   /*!< 0x00000010 */
+#define DMA_IFCR_CGIF2         DMA_IFCR_CGIF2_Msk                              /*!< Channel 2 Global interrupt clear */
+#define DMA_IFCR_CTCIF2_Pos    (5U)
+#define DMA_IFCR_CTCIF2_Msk    (0x1UL << DMA_IFCR_CTCIF2_Pos)                  /*!< 0x00000020 */
+#define DMA_IFCR_CTCIF2        DMA_IFCR_CTCIF2_Msk                             /*!< Channel 2 Transfer Complete clear */
+#define DMA_IFCR_CHTIF2_Pos    (6U)
+#define DMA_IFCR_CHTIF2_Msk    (0x1UL << DMA_IFCR_CHTIF2_Pos)                  /*!< 0x00000040 */
+#define DMA_IFCR_CHTIF2        DMA_IFCR_CHTIF2_Msk                             /*!< Channel 2 Half Transfer clear */
+#define DMA_IFCR_CTEIF2_Pos    (7U)
+#define DMA_IFCR_CTEIF2_Msk    (0x1UL << DMA_IFCR_CTEIF2_Pos)                  /*!< 0x00000080 */
+#define DMA_IFCR_CTEIF2        DMA_IFCR_CTEIF2_Msk                             /*!< Channel 2 Transfer Error clear */
+#define DMA_IFCR_CGIF3_Pos     (8U)
+#define DMA_IFCR_CGIF3_Msk     (0x1UL << DMA_IFCR_CGIF3_Pos)                   /*!< 0x00000100 */
+#define DMA_IFCR_CGIF3         DMA_IFCR_CGIF3_Msk                              /*!< Channel 3 Global interrupt clear */
+#define DMA_IFCR_CTCIF3_Pos    (9U)
+#define DMA_IFCR_CTCIF3_Msk    (0x1UL << DMA_IFCR_CTCIF3_Pos)                  /*!< 0x00000200 */
+#define DMA_IFCR_CTCIF3        DMA_IFCR_CTCIF3_Msk                             /*!< Channel 3 Transfer Complete clear */
+#define DMA_IFCR_CHTIF3_Pos    (10U)
+#define DMA_IFCR_CHTIF3_Msk    (0x1UL << DMA_IFCR_CHTIF3_Pos)                  /*!< 0x00000400 */
+#define DMA_IFCR_CHTIF3        DMA_IFCR_CHTIF3_Msk                             /*!< Channel 3 Half Transfer clear */
+#define DMA_IFCR_CTEIF3_Pos    (11U)
+#define DMA_IFCR_CTEIF3_Msk    (0x1UL << DMA_IFCR_CTEIF3_Pos)                  /*!< 0x00000800 */
+#define DMA_IFCR_CTEIF3        DMA_IFCR_CTEIF3_Msk                             /*!< Channel 3 Transfer Error clear */
+#define DMA_IFCR_CGIF4_Pos     (12U)
+#define DMA_IFCR_CGIF4_Msk     (0x1UL << DMA_IFCR_CGIF4_Pos)                   /*!< 0x00001000 */
+#define DMA_IFCR_CGIF4         DMA_IFCR_CGIF4_Msk                              /*!< Channel 4 Global interrupt clear */
+#define DMA_IFCR_CTCIF4_Pos    (13U)
+#define DMA_IFCR_CTCIF4_Msk    (0x1UL << DMA_IFCR_CTCIF4_Pos)                  /*!< 0x00002000 */
+#define DMA_IFCR_CTCIF4        DMA_IFCR_CTCIF4_Msk                             /*!< Channel 4 Transfer Complete clear */
+#define DMA_IFCR_CHTIF4_Pos    (14U)
+#define DMA_IFCR_CHTIF4_Msk    (0x1UL << DMA_IFCR_CHTIF4_Pos)                  /*!< 0x00004000 */
+#define DMA_IFCR_CHTIF4        DMA_IFCR_CHTIF4_Msk                             /*!< Channel 4 Half Transfer clear */
+#define DMA_IFCR_CTEIF4_Pos    (15U)
+#define DMA_IFCR_CTEIF4_Msk    (0x1UL << DMA_IFCR_CTEIF4_Pos)                  /*!< 0x00008000 */
+#define DMA_IFCR_CTEIF4        DMA_IFCR_CTEIF4_Msk                             /*!< Channel 4 Transfer Error clear */
+#define DMA_IFCR_CGIF5_Pos     (16U)
+#define DMA_IFCR_CGIF5_Msk     (0x1UL << DMA_IFCR_CGIF5_Pos)                   /*!< 0x00010000 */
+#define DMA_IFCR_CGIF5         DMA_IFCR_CGIF5_Msk                              /*!< Channel 5 Global interrupt clear */
+#define DMA_IFCR_CTCIF5_Pos    (17U)
+#define DMA_IFCR_CTCIF5_Msk    (0x1UL << DMA_IFCR_CTCIF5_Pos)                  /*!< 0x00020000 */
+#define DMA_IFCR_CTCIF5        DMA_IFCR_CTCIF5_Msk                             /*!< Channel 5 Transfer Complete clear */
+#define DMA_IFCR_CHTIF5_Pos    (18U)
+#define DMA_IFCR_CHTIF5_Msk    (0x1UL << DMA_IFCR_CHTIF5_Pos)                  /*!< 0x00040000 */
+#define DMA_IFCR_CHTIF5        DMA_IFCR_CHTIF5_Msk                             /*!< Channel 5 Half Transfer clear */
+#define DMA_IFCR_CTEIF5_Pos    (19U)
+#define DMA_IFCR_CTEIF5_Msk    (0x1UL << DMA_IFCR_CTEIF5_Pos)                  /*!< 0x00080000 */
+#define DMA_IFCR_CTEIF5        DMA_IFCR_CTEIF5_Msk                             /*!< Channel 5 Transfer Error clear */
+#define DMA_IFCR_CGIF6_Pos     (20U)
+#define DMA_IFCR_CGIF6_Msk     (0x1UL << DMA_IFCR_CGIF6_Pos)                   /*!< 0x00100000 */
+#define DMA_IFCR_CGIF6         DMA_IFCR_CGIF6_Msk                              /*!< Channel 6 Global interrupt clear */
+#define DMA_IFCR_CTCIF6_Pos    (21U)
+#define DMA_IFCR_CTCIF6_Msk    (0x1UL << DMA_IFCR_CTCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_IFCR_CTCIF6        DMA_IFCR_CTCIF6_Msk                             /*!< Channel 6 Transfer Complete clear */
+#define DMA_IFCR_CHTIF6_Pos    (22U)
+#define DMA_IFCR_CHTIF6_Msk    (0x1UL << DMA_IFCR_CHTIF6_Pos)                  /*!< 0x00400000 */
+#define DMA_IFCR_CHTIF6        DMA_IFCR_CHTIF6_Msk                             /*!< Channel 6 Half Transfer clear */
+#define DMA_IFCR_CTEIF6_Pos    (23U)
+#define DMA_IFCR_CTEIF6_Msk    (0x1UL << DMA_IFCR_CTEIF6_Pos)                  /*!< 0x00800000 */
+#define DMA_IFCR_CTEIF6        DMA_IFCR_CTEIF6_Msk                             /*!< Channel 6 Transfer Error clear */
+#define DMA_IFCR_CGIF7_Pos     (24U)
+#define DMA_IFCR_CGIF7_Msk     (0x1UL << DMA_IFCR_CGIF7_Pos)                   /*!< 0x01000000 */
+#define DMA_IFCR_CGIF7         DMA_IFCR_CGIF7_Msk                              /*!< Channel 7 Global interrupt clear */
+#define DMA_IFCR_CTCIF7_Pos    (25U)
+#define DMA_IFCR_CTCIF7_Msk    (0x1UL << DMA_IFCR_CTCIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_IFCR_CTCIF7        DMA_IFCR_CTCIF7_Msk                             /*!< Channel 7 Transfer Complete clear */
+#define DMA_IFCR_CHTIF7_Pos    (26U)
+#define DMA_IFCR_CHTIF7_Msk    (0x1UL << DMA_IFCR_CHTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_IFCR_CHTIF7        DMA_IFCR_CHTIF7_Msk                             /*!< Channel 7 Half Transfer clear */
+#define DMA_IFCR_CTEIF7_Pos    (27U)
+#define DMA_IFCR_CTEIF7_Msk    (0x1UL << DMA_IFCR_CTEIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_IFCR_CTEIF7        DMA_IFCR_CTEIF7_Msk                             /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define DMA_CCR_EN_Pos         (0U)
+#define DMA_CCR_EN_Msk         (0x1UL << DMA_CCR_EN_Pos)                       /*!< 0x00000001 */
+#define DMA_CCR_EN             DMA_CCR_EN_Msk                                  /*!< Channel enable                      */
+#define DMA_CCR_TCIE_Pos       (1U)
+#define DMA_CCR_TCIE_Msk       (0x1UL << DMA_CCR_TCIE_Pos)                     /*!< 0x00000002 */
+#define DMA_CCR_TCIE           DMA_CCR_TCIE_Msk                                /*!< Transfer complete interrupt enable  */
+#define DMA_CCR_HTIE_Pos       (2U)
+#define DMA_CCR_HTIE_Msk       (0x1UL << DMA_CCR_HTIE_Pos)                     /*!< 0x00000004 */
+#define DMA_CCR_HTIE           DMA_CCR_HTIE_Msk                                /*!< Half Transfer interrupt enable      */
+#define DMA_CCR_TEIE_Pos       (3U)
+#define DMA_CCR_TEIE_Msk       (0x1UL << DMA_CCR_TEIE_Pos)                     /*!< 0x00000008 */
+#define DMA_CCR_TEIE           DMA_CCR_TEIE_Msk                                /*!< Transfer error interrupt enable     */
+#define DMA_CCR_DIR_Pos        (4U)
+#define DMA_CCR_DIR_Msk        (0x1UL << DMA_CCR_DIR_Pos)                      /*!< 0x00000010 */
+#define DMA_CCR_DIR            DMA_CCR_DIR_Msk                                 /*!< Data transfer direction             */
+#define DMA_CCR_CIRC_Pos       (5U)
+#define DMA_CCR_CIRC_Msk       (0x1UL << DMA_CCR_CIRC_Pos)                     /*!< 0x00000020 */
+#define DMA_CCR_CIRC           DMA_CCR_CIRC_Msk                                /*!< Circular mode                       */
+#define DMA_CCR_PINC_Pos       (6U)
+#define DMA_CCR_PINC_Msk       (0x1UL << DMA_CCR_PINC_Pos)                     /*!< 0x00000040 */
+#define DMA_CCR_PINC           DMA_CCR_PINC_Msk                                /*!< Peripheral increment mode           */
+#define DMA_CCR_MINC_Pos       (7U)
+#define DMA_CCR_MINC_Msk       (0x1UL << DMA_CCR_MINC_Pos)                     /*!< 0x00000080 */
+#define DMA_CCR_MINC           DMA_CCR_MINC_Msk                                /*!< Memory increment mode               */
+
+#define DMA_CCR_PSIZE_Pos      (8U)
+#define DMA_CCR_PSIZE_Msk      (0x3UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000300 */
+#define DMA_CCR_PSIZE          DMA_CCR_PSIZE_Msk                               /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define DMA_CCR_PSIZE_0        (0x1U << DMA_CCR_PSIZE_Pos)                     /*!< 0x00000100 */
+#define DMA_CCR_PSIZE_1        (0x2U << DMA_CCR_PSIZE_Pos)                     /*!< 0x00000200 */
+
+#define DMA_CCR_MSIZE_Pos      (10U)
+#define DMA_CCR_MSIZE_Msk      (0x3UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000C00 */
+#define DMA_CCR_MSIZE          DMA_CCR_MSIZE_Msk                               /*!< MSIZE[1:0] bits (Memory size)       */
+#define DMA_CCR_MSIZE_0        (0x1U << DMA_CCR_MSIZE_Pos)                     /*!< 0x00000400 */
+#define DMA_CCR_MSIZE_1        (0x2U << DMA_CCR_MSIZE_Pos)                     /*!< 0x00000800 */
+
+#define DMA_CCR_PL_Pos         (12U)
+#define DMA_CCR_PL_Msk         (0x3UL << DMA_CCR_PL_Pos)                       /*!< 0x00003000 */
+#define DMA_CCR_PL             DMA_CCR_PL_Msk                                  /*!< PL[1:0] bits(Channel Priority level)*/
+#define DMA_CCR_PL_0           (0x1U << DMA_CCR_PL_Pos)                        /*!< 0x00001000 */
+#define DMA_CCR_PL_1           (0x2U << DMA_CCR_PL_Pos)                        /*!< 0x00002000 */
+
+#define DMA_CCR_MEM2MEM_Pos    (14U)
+#define DMA_CCR_MEM2MEM_Msk    (0x1UL << DMA_CCR_MEM2MEM_Pos)                  /*!< 0x00004000 */
+#define DMA_CCR_MEM2MEM        DMA_CCR_MEM2MEM_Msk                             /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define DMA_CNDTR_NDT_Pos      (0U)
+#define DMA_CNDTR_NDT_Msk      (0xFFFFUL << DMA_CNDTR_NDT_Pos)                 /*!< 0x0000FFFF */
+#define DMA_CNDTR_NDT          DMA_CNDTR_NDT_Msk                               /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define DMA_CPAR_PA_Pos        (0U)
+#define DMA_CPAR_PA_Msk        (0xFFFFFFFFUL << DMA_CPAR_PA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CPAR_PA            DMA_CPAR_PA_Msk                                 /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define DMA_CMAR_MA_Pos        (0U)
+#define DMA_CMAR_MA_Msk        (0xFFFFFFFFUL << DMA_CMAR_MA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CMAR_MA            DMA_CMAR_MA_Msk                                 /*!< Memory Address                      */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMAMUX Controller                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMAMUX_CxCR register  **************/
+#define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
+#define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk       /*!< DMA Request ID                       */
+#define DMAMUX_CxCR_DMAREQ_ID_0                (0x01U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_CxCR_DMAREQ_ID_1                (0x02U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_CxCR_DMAREQ_ID_2                (0x04U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_CxCR_DMAREQ_ID_3                (0x08U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_CxCR_DMAREQ_ID_4                (0x10U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_CxCR_DMAREQ_ID_5                (0x20U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
+#define DMAMUX_CxCR_SOIE_Pos                   (8U)
+#define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos) /*!< 0x00000100 */
+#define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk            /*!< Synchro overrun interrupt enable     */
+#define DMAMUX_CxCR_EGE_Pos                    (9U)
+#define DMAMUX_CxCR_EGE_Msk                    (0x1UL << DMAMUX_CxCR_EGE_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CxCR_EGE                        DMAMUX_CxCR_EGE_Msk             /*!< Event generation interrupt enable    */
+#define DMAMUX_CxCR_SE_Pos                     (16U)
+#define DMAMUX_CxCR_SE_Msk                     (0x1UL << DMAMUX_CxCR_SE_Pos)   /*!< 0x00010000 */
+#define DMAMUX_CxCR_SE                         DMAMUX_CxCR_SE_Msk              /*!< Synchronization enable               */
+#define DMAMUX_CxCR_SPOL_Pos                   (17U)
+#define DMAMUX_CxCR_SPOL_Msk                   (0x3UL << DMAMUX_CxCR_SPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_CxCR_SPOL                       DMAMUX_CxCR_SPOL_Msk            /*!< Synchronization polarity             */
+#define DMAMUX_CxCR_SPOL_0                     (0x1U << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00020000 */
+#define DMAMUX_CxCR_SPOL_1                     (0x2U << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00040000 */
+#define DMAMUX_CxCR_NBREQ_Pos                  (19U)
+#define DMAMUX_CxCR_NBREQ_Msk                  (0x1FUL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_CxCR_NBREQ                      DMAMUX_CxCR_NBREQ_Msk           /*!< Number of request                    */
+#define DMAMUX_CxCR_NBREQ_0                    (0x01U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_CxCR_NBREQ_1                    (0x02U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_CxCR_NBREQ_2                    (0x04U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_CxCR_NBREQ_3                    (0x08U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_CxCR_NBREQ_4                    (0x10U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00800000 */
+#define DMAMUX_CxCR_SYNC_ID_Pos                (24U)
+#define DMAMUX_CxCR_SYNC_ID_Msk                (0x1FUL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x1F000000 */
+#define DMAMUX_CxCR_SYNC_ID                    DMAMUX_CxCR_SYNC_ID_Msk         /*!< Synchronization ID                   */
+#define DMAMUX_CxCR_SYNC_ID_0                  (0x01U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x01000000 */
+#define DMAMUX_CxCR_SYNC_ID_1                  (0x02U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x02000000 */
+#define DMAMUX_CxCR_SYNC_ID_2                  (0x04U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x04000000 */
+#define DMAMUX_CxCR_SYNC_ID_3                  (0x08U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x08000000 */
+#define DMAMUX_CxCR_SYNC_ID_4                  (0x10U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x10000000 */
+
+/*******************  Bits definition for DMAMUX_CSR register  **************/
+#define DMAMUX_CSR_SOF0_Pos                    (0U)
+#define DMAMUX_CSR_SOF0_Msk                    (0x1UL << DMAMUX_CSR_SOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CSR_SOF0                        DMAMUX_CSR_SOF0_Msk             /*!< Synchronization Overrun Flag 0       */
+#define DMAMUX_CSR_SOF1_Pos                    (1U)
+#define DMAMUX_CSR_SOF1_Msk                    (0x1UL << DMAMUX_CSR_SOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CSR_SOF1                        DMAMUX_CSR_SOF1_Msk             /*!< Synchronization Overrun Flag 1       */
+#define DMAMUX_CSR_SOF2_Pos                    (2U)
+#define DMAMUX_CSR_SOF2_Msk                    (0x1UL << DMAMUX_CSR_SOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CSR_SOF2                        DMAMUX_CSR_SOF2_Msk             /*!< Synchronization Overrun Flag 2       */
+#define DMAMUX_CSR_SOF3_Pos                    (3U)
+#define DMAMUX_CSR_SOF3_Msk                    (0x1UL << DMAMUX_CSR_SOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CSR_SOF3                        DMAMUX_CSR_SOF3_Msk             /*!< Synchronization Overrun Flag 3       */
+#define DMAMUX_CSR_SOF4_Pos                    (4U)
+#define DMAMUX_CSR_SOF4_Msk                    (0x1UL << DMAMUX_CSR_SOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CSR_SOF4                        DMAMUX_CSR_SOF4_Msk             /*!< Synchronization Overrun Flag 4       */
+#define DMAMUX_CSR_SOF5_Pos                    (5U)
+#define DMAMUX_CSR_SOF5_Msk                    (0x1UL << DMAMUX_CSR_SOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CSR_SOF5                        DMAMUX_CSR_SOF5_Msk             /*!< Synchronization Overrun Flag 5       */
+#define DMAMUX_CSR_SOF6_Pos                    (6U)
+#define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+
+/********************  Bits definition for DMAMUX_CFR register  **************/
+#define DMAMUX_CFR_CSOF0_Pos                   (0U)
+#define DMAMUX_CFR_CSOF0_Msk                   (0x1UL << DMAMUX_CFR_CSOF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_CFR_CSOF0                       DMAMUX_CFR_CSOF0_Msk            /*!< Clear Overrun Flag 0                 */
+#define DMAMUX_CFR_CSOF1_Pos                   (1U)
+#define DMAMUX_CFR_CSOF1_Msk                   (0x1UL << DMAMUX_CFR_CSOF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_CFR_CSOF1                       DMAMUX_CFR_CSOF1_Msk            /*!< Clear Overrun Flag 1                 */
+#define DMAMUX_CFR_CSOF2_Pos                   (2U)
+#define DMAMUX_CFR_CSOF2_Msk                   (0x1UL << DMAMUX_CFR_CSOF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_CFR_CSOF2                       DMAMUX_CFR_CSOF2_Msk            /*!< Clear Overrun Flag 2                 */
+#define DMAMUX_CFR_CSOF3_Pos                   (3U)
+#define DMAMUX_CFR_CSOF3_Msk                   (0x1UL << DMAMUX_CFR_CSOF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_CFR_CSOF3                       DMAMUX_CFR_CSOF3_Msk            /*!< Clear Overrun Flag 3                 */
+#define DMAMUX_CFR_CSOF4_Pos                   (4U)
+#define DMAMUX_CFR_CSOF4_Msk                   (0x1UL << DMAMUX_CFR_CSOF4_Pos) /*!< 0x00000010 */
+#define DMAMUX_CFR_CSOF4                       DMAMUX_CFR_CSOF4_Msk            /*!< Clear Overrun Flag 4                 */
+#define DMAMUX_CFR_CSOF5_Pos                   (5U)
+#define DMAMUX_CFR_CSOF5_Msk                   (0x1UL << DMAMUX_CFR_CSOF5_Pos) /*!< 0x00000020 */
+#define DMAMUX_CFR_CSOF5                       DMAMUX_CFR_CSOF5_Msk            /*!< Clear Overrun Flag 5                 */
+#define DMAMUX_CFR_CSOF6_Pos                   (6U)
+#define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos) /*!< 0x00000040 */
+#define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk            /*!< Clear Overrun Flag 6                 */
+
+/********************  Bits definition for DMAMUX_RGxCR register  ************/
+#define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
+#define DMAMUX_RGxCR_SIG_ID_Msk                (0x1FUL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x0000001F */
+#define DMAMUX_RGxCR_SIG_ID                    DMAMUX_RGxCR_SIG_ID_Msk         /*!< Signal ID                            */
+#define DMAMUX_RGxCR_SIG_ID_0                  (0x01U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGxCR_SIG_ID_1                  (0x02U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGxCR_SIG_ID_2                  (0x04U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGxCR_SIG_ID_3                  (0x08U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGxCR_SIG_ID_4                  (0x10U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_RGxCR_OIE_Pos                   (8U)
+#define DMAMUX_RGxCR_OIE_Msk                   (0x1UL << DMAMUX_RGxCR_OIE_Pos) /*!< 0x00000100 */
+#define DMAMUX_RGxCR_OIE                       DMAMUX_RGxCR_OIE_Msk            /*!< Overrun interrupt enable             */
+#define DMAMUX_RGxCR_GE_Pos                    (16U)
+#define DMAMUX_RGxCR_GE_Msk                    (0x1UL << DMAMUX_RGxCR_GE_Pos)  /*!< 0x00010000 */
+#define DMAMUX_RGxCR_GE                        DMAMUX_RGxCR_GE_Msk             /*!< Generation enable                    */
+#define DMAMUX_RGxCR_GPOL_Pos                  (17U)
+#define DMAMUX_RGxCR_GPOL_Msk                  (0x3UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_RGxCR_GPOL                      DMAMUX_RGxCR_GPOL_Msk           /*!< Generation polarity                  */
+#define DMAMUX_RGxCR_GPOL_0                    (0x1U << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00020000 */
+#define DMAMUX_RGxCR_GPOL_1                    (0x2U << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00040000 */
+#define DMAMUX_RGxCR_GNBREQ_Pos                (19U)
+#define DMAMUX_RGxCR_GNBREQ_Msk                (0x1FUL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_RGxCR_GNBREQ                    DMAMUX_RGxCR_GNBREQ_Msk          /*!< Number of request                    */
+#define DMAMUX_RGxCR_GNBREQ_0                  (0x01U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_RGxCR_GNBREQ_1                  (0x02U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_RGxCR_GNBREQ_2                  (0x04U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_RGxCR_GNBREQ_3                  (0x08U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_RGxCR_GNBREQ_4                  (0x10U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00800000 */
+
+/********************  Bits definition for DMAMUX_RGSR register  **************/
+#define DMAMUX_RGSR_OF0_Pos                    (0U)
+#define DMAMUX_RGSR_OF0_Msk                    (0x1UL << DMAMUX_RGSR_OF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_RGSR_OF0                        DMAMUX_RGSR_OF0_Msk             /*!< Overrun flag 0                       */
+#define DMAMUX_RGSR_OF1_Pos                    (1U)
+#define DMAMUX_RGSR_OF1_Msk                    (0x1UL << DMAMUX_RGSR_OF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_RGSR_OF1                        DMAMUX_RGSR_OF1_Msk             /*!< Overrun flag 1                       */
+#define DMAMUX_RGSR_OF2_Pos                    (2U)
+#define DMAMUX_RGSR_OF2_Msk                    (0x1UL << DMAMUX_RGSR_OF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_RGSR_OF2                        DMAMUX_RGSR_OF2_Msk             /*!< Overrun flag 2                       */
+#define DMAMUX_RGSR_OF3_Pos                    (3U)
+#define DMAMUX_RGSR_OF3_Msk                    (0x1UL << DMAMUX_RGSR_OF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_RGSR_OF3                        DMAMUX_RGSR_OF3_Msk             /*!< Overrun flag 3                       */
+
+/********************  Bits definition for DMAMUX_RGCFR register  **************/
+#define DMAMUX_RGCFR_COF0_Pos                  (0U)
+#define DMAMUX_RGCFR_COF0_Msk                  (0x1UL << DMAMUX_RGCFR_COF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGCFR_COF0                      DMAMUX_RGCFR_COF0_Msk           /*!< Clear Overrun flag 0                 */
+#define DMAMUX_RGCFR_COF1_Pos                  (1U)
+#define DMAMUX_RGCFR_COF1_Msk                  (0x1UL << DMAMUX_RGCFR_COF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGCFR_COF1                      DMAMUX_RGCFR_COF1_Msk           /*!< Clear Overrun flag 1                 */
+#define DMAMUX_RGCFR_COF2_Pos                  (2U)
+#define DMAMUX_RGCFR_COF2_Msk                  (0x1UL << DMAMUX_RGCFR_COF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGCFR_COF2                      DMAMUX_RGCFR_COF2_Msk           /*!< Clear Overrun flag 2                 */
+#define DMAMUX_RGCFR_COF3_Pos                  (3U)
+#define DMAMUX_RGCFR_COF3_Msk                  (0x1UL << DMAMUX_RGCFR_COF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGCFR_COF3                      DMAMUX_RGCFR_COF3_Msk           /*!< Clear Overrun flag 3                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+
+/******************  Bit definition for EXTI_RTSR1 register  ******************/
+#define EXTI_RTSR1_RT_Pos        (0U)
+#define EXTI_RTSR1_RT_Msk        (0x803FFFFFUL << EXTI_RTSR1_RT_Pos)           /*!< 0x803FFFFF */
+#define EXTI_RTSR1_RT            EXTI_RTSR1_RT_Msk                             /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR1_RT0_Pos       (0U)
+#define EXTI_RTSR1_RT0_Msk       (0x1UL << EXTI_RTSR1_RT0_Pos)                 /*!< 0x00000001 */
+#define EXTI_RTSR1_RT0           EXTI_RTSR1_RT0_Msk                            /*!< Rising trigger event configuration bit of line 0 */
+#define EXTI_RTSR1_RT1_Pos       (1U)
+#define EXTI_RTSR1_RT1_Msk       (0x1UL << EXTI_RTSR1_RT1_Pos)                 /*!< 0x00000002 */
+#define EXTI_RTSR1_RT1           EXTI_RTSR1_RT1_Msk                            /*!< Rising trigger event configuration bit of line 1 */
+#define EXTI_RTSR1_RT2_Pos       (2U)
+#define EXTI_RTSR1_RT2_Msk       (0x1UL << EXTI_RTSR1_RT2_Pos)                 /*!< 0x00000004 */
+#define EXTI_RTSR1_RT2           EXTI_RTSR1_RT2_Msk                            /*!< Rising trigger event configuration bit of line 2 */
+#define EXTI_RTSR1_RT3_Pos       (3U)
+#define EXTI_RTSR1_RT3_Msk       (0x1UL << EXTI_RTSR1_RT3_Pos)                 /*!< 0x00000008 */
+#define EXTI_RTSR1_RT3           EXTI_RTSR1_RT3_Msk                            /*!< Rising trigger event configuration bit of line 3 */
+#define EXTI_RTSR1_RT4_Pos       (4U)
+#define EXTI_RTSR1_RT4_Msk       (0x1UL << EXTI_RTSR1_RT4_Pos)                 /*!< 0x00000010 */
+#define EXTI_RTSR1_RT4           EXTI_RTSR1_RT4_Msk                            /*!< Rising trigger event configuration bit of line 4 */
+#define EXTI_RTSR1_RT5_Pos       (5U)
+#define EXTI_RTSR1_RT5_Msk       (0x1UL << EXTI_RTSR1_RT5_Pos)                 /*!< 0x00000020 */
+#define EXTI_RTSR1_RT5           EXTI_RTSR1_RT5_Msk                            /*!< Rising trigger event configuration bit of line 5 */
+#define EXTI_RTSR1_RT6_Pos       (6U)
+#define EXTI_RTSR1_RT6_Msk       (0x1UL << EXTI_RTSR1_RT6_Pos)                 /*!< 0x00000040 */
+#define EXTI_RTSR1_RT6           EXTI_RTSR1_RT6_Msk                            /*!< Rising trigger event configuration bit of line 6 */
+#define EXTI_RTSR1_RT7_Pos       (7U)
+#define EXTI_RTSR1_RT7_Msk       (0x1UL << EXTI_RTSR1_RT7_Pos)                 /*!< 0x00000080 */
+#define EXTI_RTSR1_RT7           EXTI_RTSR1_RT7_Msk                            /*!< Rising trigger event configuration bit of line 7 */
+#define EXTI_RTSR1_RT8_Pos       (8U)
+#define EXTI_RTSR1_RT8_Msk       (0x1UL << EXTI_RTSR1_RT8_Pos)                 /*!< 0x00000100 */
+#define EXTI_RTSR1_RT8           EXTI_RTSR1_RT8_Msk                            /*!< Rising trigger event configuration bit of line 8 */
+#define EXTI_RTSR1_RT9_Pos       (9U)
+#define EXTI_RTSR1_RT9_Msk       (0x1UL << EXTI_RTSR1_RT9_Pos)                 /*!< 0x00000200 */
+#define EXTI_RTSR1_RT9           EXTI_RTSR1_RT9_Msk                            /*!< Rising trigger event configuration bit of line 9 */
+#define EXTI_RTSR1_RT10_Pos      (10U)
+#define EXTI_RTSR1_RT10_Msk      (0x1UL << EXTI_RTSR1_RT10_Pos)                /*!< 0x00000400 */
+#define EXTI_RTSR1_RT10          EXTI_RTSR1_RT10_Msk                           /*!< Rising trigger event configuration bit of line 10 */
+#define EXTI_RTSR1_RT11_Pos      (11U)
+#define EXTI_RTSR1_RT11_Msk      (0x1UL << EXTI_RTSR1_RT11_Pos)                /*!< 0x00000800 */
+#define EXTI_RTSR1_RT11          EXTI_RTSR1_RT11_Msk                           /*!< Rising trigger event configuration bit of line 11 */
+#define EXTI_RTSR1_RT12_Pos      (12U)
+#define EXTI_RTSR1_RT12_Msk      (0x1UL << EXTI_RTSR1_RT12_Pos)                /*!< 0x00001000 */
+#define EXTI_RTSR1_RT12          EXTI_RTSR1_RT12_Msk                           /*!< Rising trigger event configuration bit of line 12 */
+#define EXTI_RTSR1_RT13_Pos      (13U)
+#define EXTI_RTSR1_RT13_Msk      (0x1UL << EXTI_RTSR1_RT13_Pos)                /*!< 0x00002000 */
+#define EXTI_RTSR1_RT13          EXTI_RTSR1_RT13_Msk                           /*!< Rising trigger event configuration bit of line 13 */
+#define EXTI_RTSR1_RT14_Pos      (14U)
+#define EXTI_RTSR1_RT14_Msk      (0x1UL << EXTI_RTSR1_RT14_Pos)                /*!< 0x00004000 */
+#define EXTI_RTSR1_RT14          EXTI_RTSR1_RT14_Msk                           /*!< Rising trigger event configuration bit of line 14 */
+#define EXTI_RTSR1_RT15_Pos      (15U)
+#define EXTI_RTSR1_RT15_Msk      (0x1UL << EXTI_RTSR1_RT15_Pos)                /*!< 0x00008000 */
+#define EXTI_RTSR1_RT15          EXTI_RTSR1_RT15_Msk                           /*!< Rising trigger event configuration bit of line 15 */
+#define EXTI_RTSR1_RT16_Pos      (16U)
+#define EXTI_RTSR1_RT16_Msk      (0x1UL << EXTI_RTSR1_RT16_Pos)                /*!< 0x00010000 */
+#define EXTI_RTSR1_RT16          EXTI_RTSR1_RT16_Msk                           /*!< Rising trigger event configuration bit of line 16 */
+#define EXTI_RTSR1_RT17_Pos      (17U)
+#define EXTI_RTSR1_RT17_Msk      (0x1UL << EXTI_RTSR1_RT17_Pos)                /*!< 0x00020000 */
+#define EXTI_RTSR1_RT17          EXTI_RTSR1_RT17_Msk                           /*!< Rising trigger event configuration bit of line 17 */
+#define EXTI_RTSR1_RT18_Pos      (18U)
+#define EXTI_RTSR1_RT18_Msk      (0x1UL << EXTI_RTSR1_RT18_Pos)                /*!< 0x00040000 */
+#define EXTI_RTSR1_RT18          EXTI_RTSR1_RT18_Msk                           /*!< Rising trigger event configuration bit of line 18 */
+#define EXTI_RTSR1_RT19_Pos      (19U)
+#define EXTI_RTSR1_RT19_Msk      (0x1UL << EXTI_RTSR1_RT19_Pos)                /*!< 0x00080000 */
+#define EXTI_RTSR1_RT19          EXTI_RTSR1_RT19_Msk                           /*!< Rising trigger event configuration bit of line 19 */
+#define EXTI_RTSR1_RT20_Pos      (20U)
+#define EXTI_RTSR1_RT20_Msk      (0x1UL << EXTI_RTSR1_RT20_Pos)                /*!< 0x00100000 */
+#define EXTI_RTSR1_RT20          EXTI_RTSR1_RT20_Msk                           /*!< Rising trigger event configuration bit of line 20 */
+#define EXTI_RTSR1_RT31_Pos      (31U)
+#define EXTI_RTSR1_RT31_Msk      (0x1UL << EXTI_RTSR1_RT31_Pos)                /*!< 0x80000000 */
+#define EXTI_RTSR1_RT31          EXTI_RTSR1_RT31_Msk                           /*!< Rising trigger event configuration bit of line 31 */
+
+/******************  Bit definition for EXTI_FTSR1 register  ******************/
+#define EXTI_FTSR1_FT_Pos        (0U)
+#define EXTI_FTSR1_FT_Msk        (0x803FFFFFUL << EXTI_FTSR1_FT_Pos)           /*!< 0x803FFFFF */
+#define EXTI_FTSR1_FT            EXTI_FTSR1_FT_Msk                             /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR1_FT0_Pos       (0U)
+#define EXTI_FTSR1_FT0_Msk       (0x1UL << EXTI_FTSR1_FT0_Pos)                 /*!< 0x00000001 */
+#define EXTI_FTSR1_FT0           EXTI_FTSR1_FT0_Msk                            /*!< Falling trigger event configuration bit of line 0 */
+#define EXTI_FTSR1_FT1_Pos       (1U)
+#define EXTI_FTSR1_FT1_Msk       (0x1UL << EXTI_FTSR1_FT1_Pos)                 /*!< 0x00000002 */
+#define EXTI_FTSR1_FT1           EXTI_FTSR1_FT1_Msk                            /*!< Falling trigger event configuration bit of line 1 */
+#define EXTI_FTSR1_FT2_Pos       (2U)
+#define EXTI_FTSR1_FT2_Msk       (0x1UL << EXTI_FTSR1_FT2_Pos)                 /*!< 0x00000004 */
+#define EXTI_FTSR1_FT2           EXTI_FTSR1_FT2_Msk                            /*!< Falling trigger event configuration bit of line 2 */
+#define EXTI_FTSR1_FT3_Pos       (3U)
+#define EXTI_FTSR1_FT3_Msk       (0x1UL << EXTI_FTSR1_FT3_Pos)                 /*!< 0x00000008 */
+#define EXTI_FTSR1_FT3           EXTI_FTSR1_FT3_Msk                            /*!< Falling trigger event configuration bit of line 3 */
+#define EXTI_FTSR1_FT4_Pos       (4U)
+#define EXTI_FTSR1_FT4_Msk       (0x1UL << EXTI_FTSR1_FT4_Pos)                 /*!< 0x00000010 */
+#define EXTI_FTSR1_FT4           EXTI_FTSR1_FT4_Msk                            /*!< Falling trigger event configuration bit of line 4 */
+#define EXTI_FTSR1_FT5_Pos       (5U)
+#define EXTI_FTSR1_FT5_Msk       (0x1UL << EXTI_FTSR1_FT5_Pos)                 /*!< 0x00000020 */
+#define EXTI_FTSR1_FT5           EXTI_FTSR1_FT5_Msk                            /*!< Falling trigger event configuration bit of line 5 */
+#define EXTI_FTSR1_FT6_Pos       (6U)
+#define EXTI_FTSR1_FT6_Msk       (0x1UL << EXTI_FTSR1_FT6_Pos)                 /*!< 0x00000040 */
+#define EXTI_FTSR1_FT6           EXTI_FTSR1_FT6_Msk                            /*!< Falling trigger event configuration bit of line 6 */
+#define EXTI_FTSR1_FT7_Pos       (7U)
+#define EXTI_FTSR1_FT7_Msk       (0x1UL << EXTI_FTSR1_FT7_Pos)                 /*!< 0x00000080 */
+#define EXTI_FTSR1_FT7           EXTI_FTSR1_FT7_Msk                            /*!< Falling trigger event configuration bit of line 7 */
+#define EXTI_FTSR1_FT8_Pos       (8U)
+#define EXTI_FTSR1_FT8_Msk       (0x1UL << EXTI_FTSR1_FT8_Pos)                 /*!< 0x00000100 */
+#define EXTI_FTSR1_FT8           EXTI_FTSR1_FT8_Msk                            /*!< Falling trigger event configuration bit of line 8 */
+#define EXTI_FTSR1_FT9_Pos       (9U)
+#define EXTI_FTSR1_FT9_Msk       (0x1UL << EXTI_FTSR1_FT9_Pos)                 /*!< 0x00000200 */
+#define EXTI_FTSR1_FT9           EXTI_FTSR1_FT9_Msk                            /*!< Falling trigger event configuration bit of line 9 */
+#define EXTI_FTSR1_FT10_Pos      (10U)
+#define EXTI_FTSR1_FT10_Msk      (0x1UL << EXTI_FTSR1_FT10_Pos)                /*!< 0x00000400 */
+#define EXTI_FTSR1_FT10          EXTI_FTSR1_FT10_Msk                           /*!< Falling trigger event configuration bit of line 10 */
+#define EXTI_FTSR1_FT11_Pos      (11U)
+#define EXTI_FTSR1_FT11_Msk      (0x1UL << EXTI_FTSR1_FT11_Pos)                /*!< 0x00000800 */
+#define EXTI_FTSR1_FT11          EXTI_FTSR1_FT11_Msk                           /*!< Falling trigger event configuration bit of line 11 */
+#define EXTI_FTSR1_FT12_Pos      (12U)
+#define EXTI_FTSR1_FT12_Msk      (0x1UL << EXTI_FTSR1_FT12_Pos)                /*!< 0x00001000 */
+#define EXTI_FTSR1_FT12          EXTI_FTSR1_FT12_Msk                           /*!< Falling trigger event configuration bit of line 12 */
+#define EXTI_FTSR1_FT13_Pos      (13U)
+#define EXTI_FTSR1_FT13_Msk      (0x1UL << EXTI_FTSR1_FT13_Pos)                /*!< 0x00002000 */
+#define EXTI_FTSR1_FT13          EXTI_FTSR1_FT13_Msk                           /*!< Falling trigger event configuration bit of line 13 */
+#define EXTI_FTSR1_FT14_Pos      (14U)
+#define EXTI_FTSR1_FT14_Msk      (0x1UL << EXTI_FTSR1_FT14_Pos)                /*!< 0x00004000 */
+#define EXTI_FTSR1_FT14          EXTI_FTSR1_FT14_Msk                           /*!< Falling trigger event configuration bit of line 14 */
+#define EXTI_FTSR1_FT15_Pos      (15U)
+#define EXTI_FTSR1_FT15_Msk      (0x1UL << EXTI_FTSR1_FT15_Pos)                /*!< 0x00008000 */
+#define EXTI_FTSR1_FT15          EXTI_FTSR1_FT15_Msk                           /*!< Falling trigger event configuration bit of line 15 */
+#define EXTI_FTSR1_FT16_Pos      (16U)
+#define EXTI_FTSR1_FT16_Msk      (0x1UL << EXTI_FTSR1_FT16_Pos)                /*!< 0x00010000 */
+#define EXTI_FTSR1_FT16          EXTI_FTSR1_FT16_Msk                           /*!< Falling trigger event configuration bit of line 16 */
+#define EXTI_FTSR1_FT17_Pos      (17U)
+#define EXTI_FTSR1_FT17_Msk      (0x1UL << EXTI_FTSR1_FT17_Pos)                /*!< 0x00020000 */
+#define EXTI_FTSR1_FT17          EXTI_FTSR1_FT17_Msk                           /*!< Falling trigger event configuration bit of line 17 */
+#define EXTI_FTSR1_FT18_Pos      (18U)
+#define EXTI_FTSR1_FT18_Msk      (0x1UL << EXTI_FTSR1_FT18_Pos)                /*!< 0x00040000 */
+#define EXTI_FTSR1_FT18          EXTI_FTSR1_FT18_Msk                           /*!< Falling trigger event configuration bit of line 18 */
+#define EXTI_FTSR1_FT19_Pos      (19U)
+#define EXTI_FTSR1_FT19_Msk      (0x1UL << EXTI_FTSR1_FT19_Pos)                /*!< 0x00080000 */
+#define EXTI_FTSR1_FT19          EXTI_FTSR1_FT19_Msk                           /*!< Falling trigger event configuration bit of line 19 */
+#define EXTI_FTSR1_FT20_Pos      (20U)
+#define EXTI_FTSR1_FT20_Msk      (0x1UL << EXTI_FTSR1_FT20_Pos)                /*!< 0x00100000 */
+#define EXTI_FTSR1_FT20          EXTI_FTSR1_FT20_Msk                           /*!< Falling trigger event configuration bit of line 20 */
+#define EXTI_FTSR1_FT31_Pos      (31U)
+#define EXTI_FTSR1_FT31_Msk      (0x1UL << EXTI_FTSR1_FT31_Pos)                /*!< 0x80000000 */
+#define EXTI_FTSR1_FT31          EXTI_FTSR1_FT31_Msk                           /*!< Falling trigger event configuration bit of line 31 */
+
+/******************  Bit definition for EXTI_SWIER1 register  *****************/
+#define EXTI_SWIER1_SWI_Pos      (0U)
+#define EXTI_SWIER1_SWI_Msk      (0x803FFFFFUL << EXTI_SWIER1_SWI_Pos)         /*!< 0x803FFFFF */
+#define EXTI_SWIER1_SWI          EXTI_SWIER1_SWI_Msk                           /*!< Software interrupt */
+#define EXTI_SWIER1_SWI0_Pos     (0U)
+#define EXTI_SWIER1_SWI0_Msk     (0x1UL << EXTI_SWIER1_SWI0_Pos)               /*!< 0x00000001 */
+#define EXTI_SWIER1_SWI0         EXTI_SWIER1_SWI0_Msk                          /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER1_SWI1_Pos     (1U)
+#define EXTI_SWIER1_SWI1_Msk     (0x1UL << EXTI_SWIER1_SWI1_Pos)               /*!< 0x00000002 */
+#define EXTI_SWIER1_SWI1         EXTI_SWIER1_SWI1_Msk                          /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER1_SWI2_Pos     (2U)
+#define EXTI_SWIER1_SWI2_Msk     (0x1UL << EXTI_SWIER1_SWI2_Pos)               /*!< 0x00000004 */
+#define EXTI_SWIER1_SWI2         EXTI_SWIER1_SWI2_Msk                          /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER1_SWI3_Pos     (3U)
+#define EXTI_SWIER1_SWI3_Msk     (0x1UL << EXTI_SWIER1_SWI3_Pos)               /*!< 0x00000008 */
+#define EXTI_SWIER1_SWI3         EXTI_SWIER1_SWI3_Msk                          /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER1_SWI4_Pos     (4U)
+#define EXTI_SWIER1_SWI4_Msk     (0x1UL << EXTI_SWIER1_SWI4_Pos)               /*!< 0x00000010 */
+#define EXTI_SWIER1_SWI4         EXTI_SWIER1_SWI4_Msk                          /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER1_SWI5_Pos     (5U)
+#define EXTI_SWIER1_SWI5_Msk     (0x1UL << EXTI_SWIER1_SWI5_Pos)               /*!< 0x00000020 */
+#define EXTI_SWIER1_SWI5         EXTI_SWIER1_SWI5_Msk                          /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER1_SWI6_Pos     (6U)
+#define EXTI_SWIER1_SWI6_Msk     (0x1UL << EXTI_SWIER1_SWI6_Pos)               /*!< 0x00000040 */
+#define EXTI_SWIER1_SWI6         EXTI_SWIER1_SWI6_Msk                          /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER1_SWI7_Pos     (7U)
+#define EXTI_SWIER1_SWI7_Msk     (0x1UL << EXTI_SWIER1_SWI7_Pos)               /*!< 0x00000080 */
+#define EXTI_SWIER1_SWI7         EXTI_SWIER1_SWI7_Msk                          /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER1_SWI8_Pos     (8U)
+#define EXTI_SWIER1_SWI8_Msk     (0x1UL << EXTI_SWIER1_SWI8_Pos)               /*!< 0x00000100 */
+#define EXTI_SWIER1_SWI8         EXTI_SWIER1_SWI8_Msk                          /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER1_SWI9_Pos     (9U)
+#define EXTI_SWIER1_SWI9_Msk     (0x1UL << EXTI_SWIER1_SWI9_Pos)               /*!< 0x00000200 */
+#define EXTI_SWIER1_SWI9         EXTI_SWIER1_SWI9_Msk                          /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER1_SWI10_Pos    (10U)
+#define EXTI_SWIER1_SWI10_Msk    (0x1UL << EXTI_SWIER1_SWI10_Pos)              /*!< 0x00000400 */
+#define EXTI_SWIER1_SWI10        EXTI_SWIER1_SWI10_Msk                         /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER1_SWI11_Pos    (11U)
+#define EXTI_SWIER1_SWI11_Msk    (0x1UL << EXTI_SWIER1_SWI11_Pos)              /*!< 0x00000800 */
+#define EXTI_SWIER1_SWI11        EXTI_SWIER1_SWI11_Msk                         /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER1_SWI12_Pos    (12U)
+#define EXTI_SWIER1_SWI12_Msk    (0x1UL << EXTI_SWIER1_SWI12_Pos)              /*!< 0x00001000 */
+#define EXTI_SWIER1_SWI12        EXTI_SWIER1_SWI12_Msk                         /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER1_SWI13_Pos    (13U)
+#define EXTI_SWIER1_SWI13_Msk    (0x1UL << EXTI_SWIER1_SWI13_Pos)              /*!< 0x00002000 */
+#define EXTI_SWIER1_SWI13        EXTI_SWIER1_SWI13_Msk                         /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER1_SWI14_Pos    (14U)
+#define EXTI_SWIER1_SWI14_Msk    (0x1UL << EXTI_SWIER1_SWI14_Pos)              /*!< 0x00004000 */
+#define EXTI_SWIER1_SWI14        EXTI_SWIER1_SWI14_Msk                         /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER1_SWI15_Pos    (15U)
+#define EXTI_SWIER1_SWI15_Msk    (0x1UL << EXTI_SWIER1_SWI15_Pos)              /*!< 0x00008000 */
+#define EXTI_SWIER1_SWI15        EXTI_SWIER1_SWI15_Msk                         /*!< Software Interrupt on line 15 */
+#define EXTI_SWIER1_SWI16_Pos    (16U)
+#define EXTI_SWIER1_SWI16_Msk    (0x1UL << EXTI_SWIER1_SWI16_Pos)              /*!< 0x00010000 */
+#define EXTI_SWIER1_SWI16        EXTI_SWIER1_SWI16_Msk                         /*!< Software Interrupt on line 16 */
+#define EXTI_SWIER1_SWI17_Pos    (17U)
+#define EXTI_SWIER1_SWI17_Msk    (0x1UL << EXTI_SWIER1_SWI17_Pos)              /*!< 0x00020000 */
+#define EXTI_SWIER1_SWI17        EXTI_SWIER1_SWI17_Msk                         /*!< Software Interrupt on line 17 */
+#define EXTI_SWIER1_SWI18_Pos    (18U)
+#define EXTI_SWIER1_SWI18_Msk    (0x1UL << EXTI_SWIER1_SWI18_Pos)              /*!< 0x00040000 */
+#define EXTI_SWIER1_SWI18        EXTI_SWIER1_SWI18_Msk                         /*!< Software Interrupt on line 18 */
+#define EXTI_SWIER1_SWI19_Pos    (19U)
+#define EXTI_SWIER1_SWI19_Msk    (0x1UL << EXTI_SWIER1_SWI19_Pos)              /*!< 0x00080000 */
+#define EXTI_SWIER1_SWI19        EXTI_SWIER1_SWI19_Msk                         /*!< Software Interrupt on line 19 */
+#define EXTI_SWIER1_SWI20_Pos    (20U)
+#define EXTI_SWIER1_SWI20_Msk    (0x1UL << EXTI_SWIER1_SWI20_Pos)              /*!< 0x00100000 */
+#define EXTI_SWIER1_SWI20        EXTI_SWIER1_SWI20_Msk                         /*!< Software Interrupt on line 20 */
+#define EXTI_SWIER1_SWI31_Pos    (31U)
+#define EXTI_SWIER1_SWI31_Msk    (0x1UL << EXTI_SWIER1_SWI31_Pos)              /*!< 0x80000000 */
+#define EXTI_SWIER1_SWI31         EXTI_SWIER1_SWI31_Msk                        /*!< Software Interrupt on line 31 */
+
+/*******************  Bit definition for EXTI_PR1 register  *******************/
+#define EXTI_PR1_PIF_Pos         (0U)
+#define EXTI_PR1_PIF_Msk         (0x803FFFFFUL << EXTI_PR1_PIF_Pos)            /*!< 0x803FFFFF */
+#define EXTI_PR1_PIF             EXTI_PR1_PIF_Msk                              /*!< Pending bit */
+#define EXTI_PR1_PIF0_Pos        (0U)
+#define EXTI_PR1_PIF0_Msk        (0x1UL << EXTI_PR1_PIF0_Pos)                  /*!< 0x00000001 */
+#define EXTI_PR1_PIF0            EXTI_PR1_PIF0_Msk                             /*!< Pending bit for line 0 */
+#define EXTI_PR1_PIF1_Pos        (1U)
+#define EXTI_PR1_PIF1_Msk        (0x1UL << EXTI_PR1_PIF1_Pos)                  /*!< 0x00000002 */
+#define EXTI_PR1_PIF1            EXTI_PR1_PIF1_Msk                             /*!< Pending bit for line 1 */
+#define EXTI_PR1_PIF2_Pos        (2U)
+#define EXTI_PR1_PIF2_Msk        (0x1UL << EXTI_PR1_PIF2_Pos)                  /*!< 0x00000004 */
+#define EXTI_PR1_PIF2            EXTI_PR1_PIF2_Msk                             /*!< Pending bit for line 2 */
+#define EXTI_PR1_PIF3_Pos        (3U)
+#define EXTI_PR1_PIF3_Msk        (0x1UL << EXTI_PR1_PIF3_Pos)                  /*!< 0x00000008 */
+#define EXTI_PR1_PIF3            EXTI_PR1_PIF3_Msk                             /*!< Pending bit for line 3 */
+#define EXTI_PR1_PIF4_Pos        (4U)
+#define EXTI_PR1_PIF4_Msk        (0x1UL << EXTI_PR1_PIF4_Pos)                  /*!< 0x00000010 */
+#define EXTI_PR1_PIF4            EXTI_PR1_PIF4_Msk                             /*!< Pending bit for line 4 */
+#define EXTI_PR1_PIF5_Pos        (5U)
+#define EXTI_PR1_PIF5_Msk        (0x1UL << EXTI_PR1_PIF5_Pos)                  /*!< 0x00000020 */
+#define EXTI_PR1_PIF5            EXTI_PR1_PIF5_Msk                             /*!< Pending bit for line 5 */
+#define EXTI_PR1_PIF6_Pos        (6U)
+#define EXTI_PR1_PIF6_Msk        (0x1UL << EXTI_PR1_PIF6_Pos)                  /*!< 0x00000040 */
+#define EXTI_PR1_PIF6            EXTI_PR1_PIF6_Msk                             /*!< Pending bit for line 6 */
+#define EXTI_PR1_PIF7_Pos        (7U)
+#define EXTI_PR1_PIF7_Msk        (0x1UL << EXTI_PR1_PIF7_Pos)                  /*!< 0x00000080 */
+#define EXTI_PR1_PIF7            EXTI_PR1_PIF7_Msk                             /*!< Pending bit for line 7 */
+#define EXTI_PR1_PIF8_Pos        (8U)
+#define EXTI_PR1_PIF8_Msk        (0x1UL << EXTI_PR1_PIF8_Pos)                  /*!< 0x00000100 */
+#define EXTI_PR1_PIF8            EXTI_PR1_PIF8_Msk                             /*!< Pending bit for line 8 */
+#define EXTI_PR1_PIF9_Pos        (9U)
+#define EXTI_PR1_PIF9_Msk        (0x1UL << EXTI_PR1_PIF9_Pos)                  /*!< 0x00000200 */
+#define EXTI_PR1_PIF9            EXTI_PR1_PIF9_Msk                             /*!< Pending bit for line 9 */
+#define EXTI_PR1_PIF10_Pos       (10U)
+#define EXTI_PR1_PIF10_Msk       (0x1UL << EXTI_PR1_PIF10_Pos)                 /*!< 0x00000400 */
+#define EXTI_PR1_PIF10           EXTI_PR1_PIF10_Msk                            /*!< Pending bit for line 10 */
+#define EXTI_PR1_PIF11_Pos       (11U)
+#define EXTI_PR1_PIF11_Msk       (0x1UL << EXTI_PR1_PIF11_Pos)                 /*!< 0x00000800 */
+#define EXTI_PR1_PIF11           EXTI_PR1_PIF11_Msk                            /*!< Pending bit for line 11 */
+#define EXTI_PR1_PIF12_Pos       (12U)
+#define EXTI_PR1_PIF12_Msk       (0x1UL << EXTI_PR1_PIF12_Pos)                 /*!< 0x00001000 */
+#define EXTI_PR1_PIF12           EXTI_PR1_PIF12_Msk                            /*!< Pending bit for line 12 */
+#define EXTI_PR1_PIF13_Pos       (13U)
+#define EXTI_PR1_PIF13_Msk       (0x1UL << EXTI_PR1_PIF13_Pos)                 /*!< 0x00002000 */
+#define EXTI_PR1_PIF13           EXTI_PR1_PIF13_Msk                            /*!< Pending bit for line 13 */
+#define EXTI_PR1_PIF14_Pos       (14U)
+#define EXTI_PR1_PIF14_Msk       (0x1UL << EXTI_PR1_PIF14_Pos)                 /*!< 0x00004000 */
+#define EXTI_PR1_PIF14           EXTI_PR1_PIF14_Msk                            /*!< Pending bit for line 14 */
+#define EXTI_PR1_PIF15_Pos       (15U)
+#define EXTI_PR1_PIF15_Msk       (0x1UL << EXTI_PR1_PIF15_Pos)                 /*!< 0x00008000 */
+#define EXTI_PR1_PIF15           EXTI_PR1_PIF15_Msk                            /*!< Pending bit for line 15 */
+#define EXTI_PR1_PIF16_Pos       (16U)
+#define EXTI_PR1_PIF16_Msk       (0x1UL << EXTI_PR1_PIF16_Pos)                 /*!< 0x00010000 */
+#define EXTI_PR1_PIF16           EXTI_PR1_PIF16_Msk                            /*!< Pending bit for line 16 */
+#define EXTI_PR1_PIF17_Pos       (17U)
+#define EXTI_PR1_PIF17_Msk       (0x1UL << EXTI_PR1_PIF17_Pos)                 /*!< 0x00020000 */
+#define EXTI_PR1_PIF17           EXTI_PR1_PIF17_Msk                            /*!< Pending bit for line 17 */
+#define EXTI_PR1_PIF18_Pos       (18U)
+#define EXTI_PR1_PIF18_Msk       (0x1UL << EXTI_PR1_PIF18_Pos)                 /*!< 0x00040000 */
+#define EXTI_PR1_PIF18           EXTI_PR1_PIF18_Msk                            /*!< Pending bit for line 18 */
+#define EXTI_PR1_PIF19_Pos       (19U)
+#define EXTI_PR1_PIF19_Msk       (0x1UL << EXTI_PR1_PIF19_Pos)                 /*!< 0x00080000 */
+#define EXTI_PR1_PIF19           EXTI_PR1_PIF19_Msk                            /*!< Pending bit for line 19 */
+#define EXTI_PR1_PIF20_Pos       (20U)
+#define EXTI_PR1_PIF20_Msk       (0x1UL << EXTI_PR1_PIF20_Pos)                 /*!< 0x00100000 */
+#define EXTI_PR1_PIF20           EXTI_PR1_PIF20_Msk                            /*!< Pending bit for line 20 */
+#define EXTI_PR1_PIF31_Pos       (31U)
+#define EXTI_PR1_PIF31_Msk       (0x1UL << EXTI_PR1_PIF31_Pos)                 /*!< 0x80000000 */
+#define EXTI_PR1_PIF31           EXTI_PR1_PIF31_Msk                            /*!< Pending bit for line 31 */
+
+/******************  Bit definition for EXTI_RTSR2 register  ******************/
+#define EXTI_RTSR2_RT_Pos        (0U)
+#define EXTI_RTSR2_RT_Msk        (0x302UL << EXTI_RTSR2_RT_Pos)                /*!< 0x00000302 */
+#define EXTI_RTSR2_RT            EXTI_RTSR2_RT_Msk                             /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR2_RT33_Pos      (1U)
+#define EXTI_RTSR2_RT33_Msk      (0x1UL << EXTI_RTSR2_RT33_Pos)                /*!< 0x00000002 */
+#define EXTI_RTSR2_RT33          EXTI_RTSR2_RT33_Msk                           /*!< Rising trigger event configuration bit of line 33 */
+#define EXTI_RTSR2_RT40_Pos      (8U)
+#define EXTI_RTSR2_RT40_Msk      (0x1UL << EXTI_RTSR2_RT40_Pos)                /*!< 0x00000100 */
+#define EXTI_RTSR2_RT40          EXTI_RTSR2_RT40_Msk                           /*!< Rising trigger event configuration bit of line 40 */
+#define EXTI_RTSR2_RT41_Pos      (9U)
+#define EXTI_RTSR2_RT41_Msk      (0x1UL << EXTI_RTSR2_RT41_Pos)                /*!< 0x00000200 */
+#define EXTI_RTSR2_RT41          EXTI_RTSR2_RT41_Msk                           /*!< Rising trigger event configuration bit of line 41 */
+
+/******************  Bit definition for EXTI_FTSR2 register  ******************/
+#define EXTI_FTSR2_FT_Pos        (0U)
+#define EXTI_FTSR2_FT_Msk        (0x302UL << EXTI_FTSR2_FT_Pos)                /*!< 0x00000302 */
+#define EXTI_FTSR2_FT            EXTI_FTSR2_FT_Msk                             /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR2_FT33_Pos      (1U)
+#define EXTI_FTSR2_FT33_Msk      (0x1UL << EXTI_FTSR2_FT33_Pos)                /*!< 0x00000002 */
+#define EXTI_FTSR2_FT33          EXTI_FTSR2_FT33_Msk                           /*!< Falling trigger event configuration bit of line 33 */
+#define EXTI_FTSR2_FT40_Pos      (8U)
+#define EXTI_FTSR2_FT40_Msk      (0x1UL << EXTI_FTSR2_FT40_Pos)                /*!< 0x00000100 */
+#define EXTI_FTSR2_FT40          EXTI_FTSR2_FT40_Msk                           /*!< Falling trigger event configuration bit of line 40 */
+#define EXTI_FTSR2_FT41_Pos      (9U)
+#define EXTI_FTSR2_FT41_Msk      (0x1UL << EXTI_FTSR2_FT41_Pos)                /*!< 0x00000200 */
+#define EXTI_FTSR2_FT41          EXTI_FTSR2_FT41_Msk                           /*!< Falling trigger event configuration bit of line 41 */
+
+/******************  Bit definition for EXTI_SWIER2 register  *****************/
+#define EXTI_SWIER2_SWI_Pos      (0U)
+#define EXTI_SWIER2_SWI_Msk      (0x302UL << EXTI_SWIER2_SWI_Pos)              /*!< 0x00000302 */
+#define EXTI_SWIER2_SWI          EXTI_SWIER2_SWI_Msk                           /*!< Falling trigger event configuration bit */
+#define EXTI_SWIER2_SWI33_Pos    (1U)
+#define EXTI_SWIER2_SWI33_Msk    (0x1UL << EXTI_SWIER2_SWI33_Pos)                /*!< 0x00000002 */
+#define EXTI_SWIER2_SWI33        EXTI_SWIER2_SWI33_Msk                           /*!< Software Interrupt on line 33 */
+#define EXTI_SWIER2_SWI40_Pos    (8U)
+#define EXTI_SWIER2_SWI40_Msk    (0x1UL << EXTI_SWIER2_SWI40_Pos)                /*!< 0x00000100 */
+#define EXTI_SWIER2_SWI40        EXTI_SWIER2_SWI40_Msk                           /*!< Software Interrupt on line 40 */
+#define EXTI_SWIER2_SWI41_Pos    (9U)
+#define EXTI_SWIER2_SWI41_Msk    (0x1UL << EXTI_SWIER2_SWI41_Pos)                /*!< 0x00000200 */
+#define EXTI_SWIER2_SWI41        EXTI_SWIER2_SWI41_Msk                           /*!< Software Interrupt on line 41 */
+
+/*******************  Bit definition for EXTI_PR2 register  *******************/
+#define EXTI_PR2_PIF_Pos         (0U)
+#define EXTI_PR2_PIF_Msk         (0x302UL << EXTI_PR2_PIF_Pos)                 /*!< 0x00000302 */
+#define EXTI_PR2_PIF             EXTI_PR2_PIF_Msk                              /*!< Pending bit */
+#define EXTI_PR2_PIF33_Pos       (1U)
+#define EXTI_PR2_PIF33_Msk       (0x1UL << EXTI_PR2_PIF33_Pos)                 /*!< 0x00000002 */
+#define EXTI_PR2_PIF33           EXTI_PR2_PIF33_Msk                            /*!< Pending bit for line 33 */
+#define EXTI_PR2_PIF40_Pos       (8U)
+#define EXTI_PR2_PIF40_Msk       (0x1UL << EXTI_PR2_PIF40_Pos)                 /*!< 0x00000100 */
+#define EXTI_PR2_PIF40           EXTI_PR2_PIF40_Msk                            /*!< Pending bit for line 40 */
+#define EXTI_PR2_PIF41_Pos       (9U)
+#define EXTI_PR2_PIF41_Msk       (0x1UL << EXTI_PR2_PIF41_Pos)                 /*!< 0x00000200 */
+#define EXTI_PR2_PIF41           EXTI_PR2_PIF41_Msk                            /*!< Pending bit for line 41 */
+
+/********************  Bits definition for EXTI_IMR1 register  ****************/
+#define EXTI_IMR1_Pos            (0U)
+#define EXTI_IMR1_Msk            (0xFFFFFFFFUL << EXTI_IMR1_Pos)               /*!< 0xFFFFFFFF */
+#define EXTI_IMR1_IM             EXTI_IMR1_Msk                                 /*!< CPU1 wakeup with interrupt Mask on Event */
+#define EXTI_IMR1_IM0_Pos        (0U)
+#define EXTI_IMR1_IM0_Msk        (0x1UL << EXTI_IMR1_IM0_Pos)                  /*!< 0x00000001 */
+#define EXTI_IMR1_IM0            EXTI_IMR1_IM0_Msk                             /*!< CPU1 Interrupt Mask on line 0 */
+#define EXTI_IMR1_IM1_Pos        (1U)
+#define EXTI_IMR1_IM1_Msk        (0x1UL << EXTI_IMR1_IM1_Pos)                  /*!< 0x00000002 */
+#define EXTI_IMR1_IM1            EXTI_IMR1_IM1_Msk                             /*!< CPU1 Interrupt Mask on line 1 */
+#define EXTI_IMR1_IM2_Pos        (2U)
+#define EXTI_IMR1_IM2_Msk        (0x1UL << EXTI_IMR1_IM2_Pos)                  /*!< 0x00000004 */
+#define EXTI_IMR1_IM2            EXTI_IMR1_IM2_Msk                             /*!< CPU1 Interrupt Mask on line 2 */
+#define EXTI_IMR1_IM3_Pos        (3U)
+#define EXTI_IMR1_IM3_Msk        (0x1UL << EXTI_IMR1_IM3_Pos)                  /*!< 0x00000008 */
+#define EXTI_IMR1_IM3            EXTI_IMR1_IM3_Msk                             /*!< CPU1 Interrupt Mask on line 3 */
+#define EXTI_IMR1_IM4_Pos        (4U)
+#define EXTI_IMR1_IM4_Msk        (0x1UL << EXTI_IMR1_IM4_Pos)                  /*!< 0x00000010 */
+#define EXTI_IMR1_IM4            EXTI_IMR1_IM4_Msk                             /*!< CPU1 Interrupt Mask on line 4 */
+#define EXTI_IMR1_IM5_Pos        (5U)
+#define EXTI_IMR1_IM5_Msk        (0x1UL << EXTI_IMR1_IM5_Pos)                  /*!< 0x00000020 */
+#define EXTI_IMR1_IM5            EXTI_IMR1_IM5_Msk                             /*!< CPU1 Interrupt Mask on line 5 */
+#define EXTI_IMR1_IM6_Pos        (6U)
+#define EXTI_IMR1_IM6_Msk        (0x1UL << EXTI_IMR1_IM6_Pos)                  /*!< 0x00000040 */
+#define EXTI_IMR1_IM6            EXTI_IMR1_IM6_Msk                             /*!< CPU1 Interrupt Mask on line 6 */
+#define EXTI_IMR1_IM7_Pos        (7U)
+#define EXTI_IMR1_IM7_Msk        (0x1UL << EXTI_IMR1_IM7_Pos)                  /*!< 0x00000080 */
+#define EXTI_IMR1_IM7            EXTI_IMR1_IM7_Msk                             /*!< CPU1 Interrupt Mask on line 7 */
+#define EXTI_IMR1_IM8_Pos        (8U)
+#define EXTI_IMR1_IM8_Msk        (0x1UL << EXTI_IMR1_IM8_Pos)                  /*!< 0x00000100 */
+#define EXTI_IMR1_IM8            EXTI_IMR1_IM8_Msk                             /*!< CPU1 Interrupt Mask on line 8 */
+#define EXTI_IMR1_IM9_Pos        (9U)
+#define EXTI_IMR1_IM9_Msk        (0x1UL << EXTI_IMR1_IM9_Pos)                  /*!< 0x00000200 */
+#define EXTI_IMR1_IM9            EXTI_IMR1_IM9_Msk                             /*!< CPU1 Interrupt Mask on line 9 */
+#define EXTI_IMR1_IM10_Pos       (10U)
+#define EXTI_IMR1_IM10_Msk       (0x1UL << EXTI_IMR1_IM10_Pos)                 /*!< 0x00000400 */
+#define EXTI_IMR1_IM10           EXTI_IMR1_IM10_Msk                            /*!< CPU1 Interrupt Mask on line 10 */
+#define EXTI_IMR1_IM11_Pos       (11U)
+#define EXTI_IMR1_IM11_Msk       (0x1UL << EXTI_IMR1_IM11_Pos)                 /*!< 0x00000800 */
+#define EXTI_IMR1_IM11           EXTI_IMR1_IM11_Msk                            /*!< CPU1 Interrupt Mask on line 11 */
+#define EXTI_IMR1_IM12_Pos       (12U)
+#define EXTI_IMR1_IM12_Msk       (0x1UL << EXTI_IMR1_IM12_Pos)                 /*!< 0x00001000 */
+#define EXTI_IMR1_IM12           EXTI_IMR1_IM12_Msk                            /*!< CPU1 Interrupt Mask on line 12 */
+#define EXTI_IMR1_IM13_Pos       (13U)
+#define EXTI_IMR1_IM13_Msk       (0x1UL << EXTI_IMR1_IM13_Pos)                 /*!< 0x00002000 */
+#define EXTI_IMR1_IM13           EXTI_IMR1_IM13_Msk                            /*!< CPU1 Interrupt Mask on line 13 */
+#define EXTI_IMR1_IM14_Pos       (14U)
+#define EXTI_IMR1_IM14_Msk       (0x1UL << EXTI_IMR1_IM14_Pos)                 /*!< 0x00004000 */
+#define EXTI_IMR1_IM14           EXTI_IMR1_IM14_Msk                            /*!< CPU1 Interrupt Mask on line 14 */
+#define EXTI_IMR1_IM15_Pos       (15U)
+#define EXTI_IMR1_IM15_Msk       (0x1UL << EXTI_IMR1_IM15_Pos)                 /*!< 0x00008000 */
+#define EXTI_IMR1_IM15           EXTI_IMR1_IM15_Msk                            /*!< CPU1 Interrupt Mask on line 15 */
+#define EXTI_IMR1_IM16_Pos       (16U)
+#define EXTI_IMR1_IM16_Msk       (0x1UL << EXTI_IMR1_IM16_Pos)                 /*!< 0x00010000 */
+#define EXTI_IMR1_IM16           EXTI_IMR1_IM16_Msk                            /*!< CPU1 Interrupt Mask on line 16 */
+#define EXTI_IMR1_IM17_Pos       (17U)
+#define EXTI_IMR1_IM17_Msk       (0x1UL << EXTI_IMR1_IM17_Pos)                 /*!< 0x00020000 */
+#define EXTI_IMR1_IM17           EXTI_IMR1_IM17_Msk                            /*!< CPU1 Interrupt Mask on line 17 */
+#define EXTI_IMR1_IM18_Pos       (18U)
+#define EXTI_IMR1_IM18_Msk       (0x1UL << EXTI_IMR1_IM18_Pos)                 /*!< 0x00040000 */
+#define EXTI_IMR1_IM18           EXTI_IMR1_IM18_Msk                            /*!< CPU1 Interrupt Mask on line 18 */
+#define EXTI_IMR1_IM19_Pos       (19U)
+#define EXTI_IMR1_IM19_Msk       (0x1UL << EXTI_IMR1_IM19_Pos)                 /*!< 0x00080000 */
+#define EXTI_IMR1_IM19           EXTI_IMR1_IM19_Msk                            /*!< CPU1 Interrupt Mask on line 19 */
+#define EXTI_IMR1_IM20_Pos       (20U)
+#define EXTI_IMR1_IM20_Msk       (0x1UL << EXTI_IMR1_IM20_Pos)                 /*!< 0x00100000 */
+#define EXTI_IMR1_IM20           EXTI_IMR1_IM20_Msk                            /*!< CPU1 Interrupt Mask on line 20 */
+#define EXTI_IMR1_IM22_Pos       (22U)
+#define EXTI_IMR1_IM22_Msk       (0x1UL << EXTI_IMR1_IM22_Pos)                 /*!< 0x00400000 */
+#define EXTI_IMR1_IM22           EXTI_IMR1_IM22_Msk                            /*!< CPU1 Interrupt Mask on line 22 */
+#define EXTI_IMR1_IM24_Pos       (24U)
+#define EXTI_IMR1_IM24_Msk       (0x1UL << EXTI_IMR1_IM24_Pos)                 /*!< 0x01000000 */
+#define EXTI_IMR1_IM24           EXTI_IMR1_IM24_Msk                            /*!< CPU1 Interrupt Mask on line 24 */
+#define EXTI_IMR1_IM25_Pos       (25U)
+#define EXTI_IMR1_IM25_Msk       (0x1UL << EXTI_IMR1_IM25_Pos)                 /*!< 0x02000000 */
+#define EXTI_IMR1_IM25           EXTI_IMR1_IM25_Msk                            /*!< CPU1 Interrupt Mask on line 25 */
+#define EXTI_IMR1_IM29_Pos       (29U)
+#define EXTI_IMR1_IM29_Msk       (0x1UL << EXTI_IMR1_IM29_Pos)                 /*!< 0x20000000 */
+#define EXTI_IMR1_IM29           EXTI_IMR1_IM29_Msk                            /*!< CPU1 Interrupt Mask on line 29 */
+#define EXTI_IMR1_IM30_Pos       (30U)
+#define EXTI_IMR1_IM30_Msk       (0x1UL << EXTI_IMR1_IM30_Pos)                 /*!< 0x40000000 */
+#define EXTI_IMR1_IM30           EXTI_IMR1_IM30_Msk                            /*!< CPU1 Interrupt Mask on line 30 */
+#define EXTI_IMR1_IM31_Pos       (31U)
+#define EXTI_IMR1_IM31_Msk       (0x1UL << EXTI_IMR1_IM31_Pos)                 /*!< 0x80000000 */
+#define EXTI_IMR1_IM31           EXTI_IMR1_IM31_Msk                            /*!< CPU1 Interrupt Mask on line 31 */
+
+/********************  Bits definition for EXTI_EMR1 register  ****************/
+#define EXTI_EMR1_Pos            (0U)
+#define EXTI_EMR1_Msk            (0x003EFFFFUL << EXTI_EMR1_Pos)               /*!< 0xFFFFFFFF */
+#define EXTI_EMR1_EM             EXTI_EMR1_Msk                                 /*!< CPU1 Event Mask */
+#define EXTI_EMR1_EM0_Pos        (0U)
+#define EXTI_EMR1_EM0_Msk        (0x1UL << EXTI_EMR1_EM0_Pos)                  /*!< 0x00000001 */
+#define EXTI_EMR1_EM0            EXTI_EMR1_EM0_Msk                             /*!< CPU1 Event Mask on line 0 */
+#define EXTI_EMR1_EM1_Pos        (1U)
+#define EXTI_EMR1_EM1_Msk        (0x1UL << EXTI_EMR1_EM1_Pos)                  /*!< 0x00000002 */
+#define EXTI_EMR1_EM1            EXTI_EMR1_EM1_Msk                             /*!< CPU1 Event Mask on line 1 */
+#define EXTI_EMR1_EM2_Pos        (2U)
+#define EXTI_EMR1_EM2_Msk        (0x1UL << EXTI_EMR1_EM2_Pos)                  /*!< 0x00000004 */
+#define EXTI_EMR1_EM2            EXTI_EMR1_EM2_Msk                             /*!< CPU1 Event Mask on line 2 */
+#define EXTI_EMR1_EM3_Pos        (3U)
+#define EXTI_EMR1_EM3_Msk        (0x1UL << EXTI_EMR1_EM3_Pos)                  /*!< 0x00000008 */
+#define EXTI_EMR1_EM3            EXTI_EMR1_EM3_Msk                             /*!< CPU1 Event Mask on line 3 */
+#define EXTI_EMR1_EM4_Pos        (4U)
+#define EXTI_EMR1_EM4_Msk        (0x1UL << EXTI_EMR1_EM4_Pos)                  /*!< 0x00000010 */
+#define EXTI_EMR1_EM4            EXTI_EMR1_EM4_Msk                             /*!< CPU1 Event Mask on line 4 */
+#define EXTI_EMR1_EM5_Pos        (5U)
+#define EXTI_EMR1_EM5_Msk        (0x1UL << EXTI_EMR1_EM5_Pos)                  /*!< 0x00000020 */
+#define EXTI_EMR1_EM5            EXTI_EMR1_EM5_Msk                             /*!< CPU1 Event Mask on line 5 */
+#define EXTI_EMR1_EM6_Pos        (6U)
+#define EXTI_EMR1_EM6_Msk        (0x1UL << EXTI_EMR1_EM6_Pos)                  /*!< 0x00000040 */
+#define EXTI_EMR1_EM6            EXTI_EMR1_EM6_Msk                             /*!< CPU1 Event Mask on line 6 */
+#define EXTI_EMR1_EM7_Pos        (7U)
+#define EXTI_EMR1_EM7_Msk        (0x1UL << EXTI_EMR1_EM7_Pos)                  /*!< 0x00000080 */
+#define EXTI_EMR1_EM7            EXTI_EMR1_EM7_Msk                             /*!< CPU1 Event Mask on line 7 */
+#define EXTI_EMR1_EM8_Pos        (8U)
+#define EXTI_EMR1_EM8_Msk        (0x1UL << EXTI_EMR1_EM8_Pos)                  /*!< 0x00000100 */
+#define EXTI_EMR1_EM8            EXTI_EMR1_EM8_Msk                             /*!< CPU1 Event Mask on line 8 */
+#define EXTI_EMR1_EM9_Pos        (9U)
+#define EXTI_EMR1_EM9_Msk        (0x1UL << EXTI_EMR1_EM9_Pos)                  /*!< 0x00000200 */
+#define EXTI_EMR1_EM9            EXTI_EMR1_EM9_Msk                             /*!< CPU1 Event Mask on line 9 */
+#define EXTI_EMR1_EM10_Pos       (10U)
+#define EXTI_EMR1_EM10_Msk       (0x1UL << EXTI_EMR1_EM10_Pos)                 /*!< 0x00000400 */
+#define EXTI_EMR1_EM10           EXTI_EMR1_EM10_Msk                            /*!< CPU1 Event Mask on line 10 */
+#define EXTI_EMR1_EM11_Pos       (11U)
+#define EXTI_EMR1_EM11_Msk       (0x1UL << EXTI_EMR1_EM11_Pos)                 /*!< 0x00000800 */
+#define EXTI_EMR1_EM11           EXTI_EMR1_EM11_Msk                            /*!< CPU1 Event Mask on line 11 */
+#define EXTI_EMR1_EM12_Pos       (12U)
+#define EXTI_EMR1_EM12_Msk       (0x1UL << EXTI_EMR1_EM12_Pos)                 /*!< 0x00001000 */
+#define EXTI_EMR1_EM12           EXTI_EMR1_EM12_Msk                            /*!< CPU1 Event Mask on line 12 */
+#define EXTI_EMR1_EM13_Pos       (13U)
+#define EXTI_EMR1_EM13_Msk       (0x1UL << EXTI_EMR1_EM13_Pos)                 /*!< 0x00002000 */
+#define EXTI_EMR1_EM13           EXTI_EMR1_EM13_Msk                            /*!< CPU1 Event Mask on line 13 */
+#define EXTI_EMR1_EM14_Pos       (14U)
+#define EXTI_EMR1_EM14_Msk       (0x1UL << EXTI_EMR1_EM14_Pos)                 /*!< 0x00004000 */
+#define EXTI_EMR1_EM14           EXTI_EMR1_EM14_Msk                            /*!< CPU1 Event Mask on line 14 */
+#define EXTI_EMR1_EM15_Pos       (15U)
+#define EXTI_EMR1_EM15_Msk       (0x1UL << EXTI_EMR1_EM15_Pos)                 /*!< 0x00008000 */
+#define EXTI_EMR1_EM15           EXTI_EMR1_EM15_Msk                            /*!< CPU1 Event Mask on line 15 */
+#define EXTI_EMR1_EM17_Pos       (17U)
+#define EXTI_EMR1_EM17_Msk       (0x1UL << EXTI_EMR1_EM17_Pos)                 /*!< 0x00020000 */
+#define EXTI_EMR1_EM17           EXTI_EMR1_EM17_Msk                            /*!< CPU1 Event Mask on line 17 */
+#define EXTI_EMR1_EM18_Pos       (18U)
+#define EXTI_EMR1_EM18_Msk       (0x1UL << EXTI_EMR1_EM18_Pos)                 /*!< 0x00040000 */
+#define EXTI_EMR1_EM18           EXTI_EMR1_EM18_Msk                            /*!< CPU1 Event Mask on line 18 */
+#define EXTI_EMR1_EM19_Pos       (19U)
+#define EXTI_EMR1_EM19_Msk       (0x1UL << EXTI_EMR1_EM19_Pos)                 /*!< 0x00080000 */
+#define EXTI_EMR1_EM19           EXTI_EMR1_EM19_Msk                            /*!< CPU1 Event Mask on line 19 */
+#define EXTI_EMR1_EM20_Pos       (20U)
+#define EXTI_EMR1_EM20_Msk       (0x1UL << EXTI_EMR1_EM20_Pos)                 /*!< 0x00100000 */
+#define EXTI_EMR1_EM20           EXTI_EMR1_EM20_Msk                            /*!< CPU1 Event Mask on line 20 */
+
+/********************  Bits definition for EXTI_IMR2 register  ****************/
+#define EXTI_IMR2_Pos            (0U)
+#define EXTI_IMR2_Msk            (0x0001FFFFUL << EXTI_IMR2_Pos)               /*!< 0x0001FFFF */
+#define EXTI_IMR2_IM             EXTI_IMR2_Msk                                 /*!< CPU1 Interrupt Mask  */
+#define EXTI_IMR2_IM33_Pos       (1U)
+#define EXTI_IMR2_IM33_Msk       (0x1UL << EXTI_IMR2_IM33_Pos)                 /*!< 0x00000002 */
+#define EXTI_IMR2_IM33           EXTI_IMR2_IM33_Msk                            /*!< CPU1 Interrupt Mask on line 33 */
+#define EXTI_IMR2_IM36_Pos       (4U)
+#define EXTI_IMR2_IM36_Msk       (0x1UL << EXTI_IMR2_IM36_Pos)                 /*!< 0x00000010 */
+#define EXTI_IMR2_IM36           EXTI_IMR2_IM36_Msk                            /*!< CPU1 Interrupt Mask on line 36 */
+#define EXTI_IMR2_IM37_Pos       (5U)
+#define EXTI_IMR2_IM37_Msk       (0x1UL << EXTI_IMR2_IM37_Pos)                 /*!< 0x00000020 */
+#define EXTI_IMR2_IM37           EXTI_IMR2_IM37_Msk                            /*!< CPU1 Interrupt Mask on line 37 */
+#define EXTI_IMR2_IM38_Pos       (6U)
+#define EXTI_IMR2_IM38_Msk       (0x1UL << EXTI_IMR2_IM38_Pos)                 /*!< 0x00000040 */
+#define EXTI_IMR2_IM38           EXTI_IMR2_IM38_Msk                            /*!< CPU1 Interrupt Mask on line 38 */
+#define EXTI_IMR2_IM39_Pos       (7U)
+#define EXTI_IMR2_IM39_Msk       (0x1UL << EXTI_IMR2_IM39_Pos)                 /*!< 0x00000080 */
+#define EXTI_IMR2_IM39           EXTI_IMR2_IM39_Msk                            /*!< CPU1 Interrupt Mask on line 39 */
+#define EXTI_IMR2_IM40_Pos       (8U)
+#define EXTI_IMR2_IM40_Msk       (0x1UL << EXTI_IMR2_IM40_Pos)                 /*!< 0x00000100 */
+#define EXTI_IMR2_IM40           EXTI_IMR2_IM40_Msk                            /*!< CPU1 Interrupt Mask on line 40 */
+#define EXTI_IMR2_IM41_Pos       (9U)
+#define EXTI_IMR2_IM41_Msk       (0x1UL << EXTI_IMR2_IM41_Pos)                 /*!< 0x00000200 */
+#define EXTI_IMR2_IM41           EXTI_IMR2_IM41_Msk                            /*!< CPU1 Interrupt Mask on line 41 */
+#define EXTI_IMR2_IM42_Pos       (10U)
+#define EXTI_IMR2_IM42_Msk       (0x1UL << EXTI_IMR2_IM42_Pos)                 /*!< 0x00000400 */
+#define EXTI_IMR2_IM42           EXTI_IMR2_IM42_Msk                            /*!< CPU1 Interrupt Mask on line 42 */
+#define EXTI_IMR2_IM44_Pos       (12U)
+#define EXTI_IMR2_IM44_Msk       (0x1UL << EXTI_IMR2_IM44_Pos)                 /*!< 0x00001000 */
+#define EXTI_IMR2_IM44           EXTI_IMR2_IM44_Msk                            /*!< CPU1 Interrupt Mask on line 44 */
+#define EXTI_IMR2_IM45_Pos       (13U)
+#define EXTI_IMR2_IM45_Msk       (0x1UL << EXTI_IMR2_IM45_Pos)                 /*!< 0x00002000 */
+#define EXTI_IMR2_IM45           EXTI_IMR2_IM45_Msk                            /*!< CPU1 Interrupt Mask on line 45 */
+#define EXTI_IMR2_IM48_Pos       (16U)
+#define EXTI_IMR2_IM48_Msk       (0x1UL << EXTI_IMR2_IM48_Pos)                 /*!< 0x00010000 */
+#define EXTI_IMR2_IM48           EXTI_IMR2_IM48_Msk                            /*!< CPU1 Interrupt Mask on line 48 */
+
+/********************  Bits definition for EXTI_EMR2 register  ****************/
+#define EXTI_EMR2_Pos            (0U)
+#define EXTI_EMR2_Msk            (0x00000300UL << EXTI_EMR2_Pos)               /*!< 0x000003000 */
+#define EXTI_EMR2_EM             EXTI_EMR2_Msk                                 /*!< CPU1 Interrupt Mask  */
+#define EXTI_EMR2_EM40_Pos       (8U)
+#define EXTI_EMR2_EM40_Msk       (0x1UL << EXTI_EMR2_EM40_Pos)                 /*!< 0x00000100 */
+#define EXTI_EMR2_EM40           EXTI_EMR2_EM40_Msk                            /*!< CPU1 Event Mask on line 40 */
+#define EXTI_EMR2_EM41_Pos       (9U)
+#define EXTI_EMR2_EM41_Msk       (0x1UL << EXTI_EMR2_EM41_Pos)                 /*!< 0x00000200 */
+#define EXTI_EMR2_EM41           EXTI_EMR2_EM41_Msk                            /*!< CPU1 Event Mask on line 41 */
+
+/********************  Bits definition for EXTI_C2IMR1 register  **************/
+#define EXTI_C2IMR1_Pos          (0U)
+#define EXTI_C2IMR1_Msk          (0xFFFFFFFFUL << EXTI_C2IMR1_Pos)             /*!< 0xFFFFFFFF */
+#define EXTI_C2IMR1_IM           EXTI_C2IMR1_Msk                               /*!< CPU2 wakeup with interrupt Mask on Event */
+#define EXTI_C2IMR1_IM0_Pos      (0U)
+#define EXTI_C2IMR1_IM0_Msk      (0x1UL << EXTI_C2IMR1_IM0_Pos)                /*!< 0x00000001 */
+#define EXTI_C2IMR1_IM0          EXTI_C2IMR1_IM0_Msk                           /*!< CPU2 Interrupt Mask on line 0 */
+#define EXTI_C2IMR1_IM1_Pos      (1U)
+#define EXTI_C2IMR1_IM1_Msk      (0x1UL << EXTI_C2IMR1_IM1_Pos)                /*!< 0x00000002 */
+#define EXTI_C2IMR1_IM1          EXTI_C2IMR1_IM1_Msk                           /*!< CPU2 Interrupt Mask on line 1 */
+#define EXTI_C2IMR1_IM2_Pos      (2U)
+#define EXTI_C2IMR1_IM2_Msk      (0x1UL << EXTI_C2IMR1_IM2_Pos)                /*!< 0x00000004 */
+#define EXTI_C2IMR1_IM2          EXTI_C2IMR1_IM2_Msk                           /*!< CPU2 Interrupt Mask on line 2 */
+#define EXTI_C2IMR1_IM3_Pos      (3U)
+#define EXTI_C2IMR1_IM3_Msk      (0x1UL << EXTI_C2IMR1_IM3_Pos)                /*!< 0x00000008 */
+#define EXTI_C2IMR1_IM3          EXTI_C2IMR1_IM3_Msk                           /*!< CPU2 Interrupt Mask on line 3 */
+#define EXTI_C2IMR1_IM4_Pos      (4U)
+#define EXTI_C2IMR1_IM4_Msk      (0x1UL << EXTI_C2IMR1_IM4_Pos)                /*!< 0x00000010 */
+#define EXTI_C2IMR1_IM4          EXTI_C2IMR1_IM4_Msk                           /*!< CPU2 Interrupt Mask on line 4 */
+#define EXTI_C2IMR1_IM5_Pos      (5U)
+#define EXTI_C2IMR1_IM5_Msk      (0x1UL << EXTI_C2IMR1_IM5_Pos)                /*!< 0x00000020 */
+#define EXTI_C2IMR1_IM5          EXTI_C2IMR1_IM5_Msk                           /*!< CPU2 Interrupt Mask on line 5 */
+#define EXTI_C2IMR1_IM6_Pos      (6U)
+#define EXTI_C2IMR1_IM6_Msk      (0x1UL << EXTI_C2IMR1_IM6_Pos)                /*!< 0x00000040 */
+#define EXTI_C2IMR1_IM6          EXTI_C2IMR1_IM6_Msk                           /*!< CPU2 Interrupt Mask on line 6 */
+#define EXTI_C2IMR1_IM7_Pos      (7U)
+#define EXTI_C2IMR1_IM7_Msk      (0x1UL << EXTI_C2IMR1_IM7_Pos)                /*!< 0x00000080 */
+#define EXTI_C2IMR1_IM7          EXTI_C2IMR1_IM7_Msk                           /*!< CPU2 Interrupt Mask on line 7 */
+#define EXTI_C2IMR1_IM8_Pos      (8U)
+#define EXTI_C2IMR1_IM8_Msk      (0x1UL << EXTI_C2IMR1_IM8_Pos)                /*!< 0x00000100 */
+#define EXTI_C2IMR1_IM8          EXTI_C2IMR1_IM8_Msk                           /*!< CPU2 Interrupt Mask on line 8 */
+#define EXTI_C2IMR1_IM9_Pos      (9U)
+#define EXTI_C2IMR1_IM9_Msk      (0x1UL << EXTI_C2IMR1_IM9_Pos)                /*!< 0x00000200 */
+#define EXTI_C2IMR1_IM9          EXTI_C2IMR1_IM9_Msk                           /*!< CPU2 Interrupt Mask on line 9 */
+#define EXTI_C2IMR1_IM10_Pos     (10U)
+#define EXTI_C2IMR1_IM10_Msk     (0x1UL << EXTI_C2IMR1_IM10_Pos)               /*!< 0x00000400 */
+#define EXTI_C2IMR1_IM10         EXTI_C2IMR1_IM10_Msk                          /*!< CPU2 Interrupt Mask on line 10 */
+#define EXTI_C2IMR1_IM11_Pos     (11U)
+#define EXTI_C2IMR1_IM11_Msk     (0x1UL << EXTI_C2IMR1_IM11_Pos)               /*!< 0x00000800 */
+#define EXTI_C2IMR1_IM11         EXTI_C2IMR1_IM11_Msk                          /*!< CPU2 Interrupt Mask on line 11 */
+#define EXTI_C2IMR1_IM12_Pos     (12U)
+#define EXTI_C2IMR1_IM12_Msk     (0x1UL << EXTI_C2IMR1_IM12_Pos)               /*!< 0x00001000 */
+#define EXTI_C2IMR1_IM12         EXTI_C2IMR1_IM12_Msk                          /*!< CPU2 Interrupt Mask on line 12 */
+#define EXTI_C2IMR1_IM13_Pos     (13U)
+#define EXTI_C2IMR1_IM13_Msk     (0x1UL << EXTI_C2IMR1_IM13_Pos)               /*!< 0x00002000 */
+#define EXTI_C2IMR1_IM13         EXTI_C2IMR1_IM13_Msk                          /*!< CPU2 Interrupt Mask on line 13 */
+#define EXTI_C2IMR1_IM14_Pos     (14U)
+#define EXTI_C2IMR1_IM14_Msk     (0x1UL << EXTI_C2IMR1_IM14_Pos)               /*!< 0x00004000 */
+#define EXTI_C2IMR1_IM14         EXTI_C2IMR1_IM14_Msk                          /*!< CPU2 Interrupt Mask on line 14 */
+#define EXTI_C2IMR1_IM15_Pos     (15U)
+#define EXTI_C2IMR1_IM15_Msk     (0x1UL << EXTI_C2IMR1_IM15_Pos)               /*!< 0x00008000 */
+#define EXTI_C2IMR1_IM15         EXTI_C2IMR1_IM15_Msk                          /*!< CPU2 Interrupt Mask on line 15 */
+#define EXTI_C2IMR1_IM16_Pos     (16U)
+#define EXTI_C2IMR1_IM16_Msk     (0x1UL << EXTI_C2IMR1_IM16_Pos)               /*!< 0x00010000 */
+#define EXTI_C2IMR1_IM16         EXTI_C2IMR1_IM16_Msk                          /*!< CPU2 Interrupt Mask on line 16 */
+#define EXTI_C2IMR1_IM17_Pos     (17U)
+#define EXTI_C2IMR1_IM17_Msk     (0x1UL << EXTI_C2IMR1_IM17_Pos)               /*!< 0x00020000 */
+#define EXTI_C2IMR1_IM17         EXTI_C2IMR1_IM17_Msk                          /*!< CPU2 Interrupt Mask on line 17 */
+#define EXTI_C2IMR1_IM18_Pos     (18U)
+#define EXTI_C2IMR1_IM18_Msk     (0x1UL << EXTI_C2IMR1_IM18_Pos)               /*!< 0x00040000 */
+#define EXTI_C2IMR1_IM18         EXTI_C2IMR1_IM18_Msk                          /*!< CPU2 Interrupt Mask on line 18 */
+#define EXTI_C2IMR1_IM19_Pos     (19U)
+#define EXTI_C2IMR1_IM19_Msk     (0x1UL << EXTI_C2IMR1_IM19_Pos)               /*!< 0x00080000 */
+#define EXTI_C2IMR1_IM19         EXTI_C2IMR1_IM19_Msk                          /*!< CPU2 Interrupt Mask on line 19 */
+#define EXTI_C2IMR1_IM20_Pos     (20U)
+#define EXTI_C2IMR1_IM20_Msk     (0x1UL << EXTI_C2IMR1_IM20_Pos)               /*!< 0x00100000 */
+#define EXTI_C2IMR1_IM20         EXTI_C2IMR1_IM20_Msk                          /*!< CPU2 Interrupt Mask on line 20 */
+#define EXTI_C2IMR1_IM22_Pos     (22U)
+#define EXTI_C2IMR1_IM22_Msk     (0x1UL << EXTI_C2IMR1_IM22_Pos)               /*!< 0x00400000 */
+#define EXTI_C2IMR1_IM22         EXTI_C2IMR1_IM22_Msk                          /*!< CPU2 Interrupt Mask on line 22 */
+#define EXTI_C2IMR1_IM24_Pos     (24U)
+#define EXTI_C2IMR1_IM24_Msk     (0x1UL << EXTI_C2IMR1_IM24_Pos)               /*!< 0x01000000 */
+#define EXTI_C2IMR1_IM24         EXTI_C2IMR1_IM24_Msk                          /*!< CPU2 Interrupt Mask on line 24 */
+#define EXTI_C2IMR1_IM25_Pos     (25U)
+#define EXTI_C2IMR1_IM25_Msk     (0x1UL << EXTI_C2IMR1_IM25_Pos)               /*!< 0x02000000 */
+#define EXTI_C2IMR1_IM25         EXTI_C2IMR1_IM25_Msk                          /*!< CPU2 Interrupt Mask on line 25 */
+#define EXTI_C2IMR1_IM29_Pos     (29U)
+#define EXTI_C2IMR1_IM29_Msk     (0x1UL << EXTI_C2IMR1_IM29_Pos)               /*!< 0x20000000 */
+#define EXTI_C2IMR1_IM29         EXTI_C2IMR1_IM29_Msk                          /*!< CPU2 Interrupt Mask on line 29 */
+#define EXTI_C2IMR1_IM30_Pos     (30U)
+#define EXTI_C2IMR1_IM30_Msk     (0x1UL << EXTI_C2IMR1_IM30_Pos)               /*!< 0x40000000 */
+#define EXTI_C2IMR1_IM30         EXTI_C2IMR1_IM30_Msk                          /*!< CPU2 Interrupt Mask on line 30 */
+#define EXTI_C2IMR1_IM31_Pos     (31U)
+#define EXTI_C2IMR1_IM31_Msk     (0x1UL << EXTI_C2IMR1_IM31_Pos)               /*!< 0x80000000 */
+#define EXTI_C2IMR1_IM31         EXTI_C2IMR1_IM31_Msk                          /*!< CPU2 Interrupt Mask on line 31 */
+
+/********************  Bits definition for EXTI_C2EMR1 register  **************/
+#define EXTI_C2EMR1_Pos          (0U)
+#define EXTI_C2EMR1_Msk          (0x003EFFFFUL << EXTI_C2EMR1_Pos)             /*!< 0xFFFFFFFF */
+#define EXTI_C2EMR1_EM           EXTI_C2EMR1_Msk                               /*!< CPU2 Event Mask */
+#define EXTI_C2EMR1_EM0_Pos      (0U)
+#define EXTI_C2EMR1_EM0_Msk      (0x1UL << EXTI_C2EMR1_EM0_Pos)                /*!< 0x00000001 */
+#define EXTI_C2EMR1_EM0          EXTI_C2EMR1_EM0_Msk                           /*!< CPU2 Event Mask on line 0 */
+#define EXTI_C2EMR1_EM1_Pos      (1U)
+#define EXTI_C2EMR1_EM1_Msk      (0x1UL << EXTI_C2EMR1_EM1_Pos)                /*!< 0x00000002 */
+#define EXTI_C2EMR1_EM1          EXTI_C2EMR1_EM1_Msk                           /*!< CPU2 Event Mask on line 1 */
+#define EXTI_C2EMR1_EM2_Pos      (2U)
+#define EXTI_C2EMR1_EM2_Msk      (0x1UL << EXTI_C2EMR1_EM2_Pos)                /*!< 0x00000004 */
+#define EXTI_C2EMR1_EM2          EXTI_C2EMR1_EM2_Msk                           /*!< CPU2 Event Mask on line 2 */
+#define EXTI_C2EMR1_EM3_Pos      (3U)
+#define EXTI_C2EMR1_EM3_Msk      (0x1UL << EXTI_C2EMR1_EM3_Pos)                /*!< 0x00000008 */
+#define EXTI_C2EMR1_EM3          EXTI_C2EMR1_EM3_Msk                           /*!< CPU2 Event Mask on line 3 */
+#define EXTI_C2EMR1_EM4_Pos      (4U)
+#define EXTI_C2EMR1_EM4_Msk      (0x1UL << EXTI_C2EMR1_EM4_Pos)                /*!< 0x00000010 */
+#define EXTI_C2EMR1_EM4          EXTI_C2EMR1_EM4_Msk                           /*!< CPU2 Event Mask on line 4 */
+#define EXTI_C2EMR1_EM5_Pos      (5U)
+#define EXTI_C2EMR1_EM5_Msk      (0x1UL << EXTI_C2EMR1_EM5_Pos)                /*!< 0x00000020 */
+#define EXTI_C2EMR1_EM5          EXTI_C2EMR1_EM5_Msk                           /*!< CPU2 Event Mask on line 5 */
+#define EXTI_C2EMR1_EM6_Pos      (6U)
+#define EXTI_C2EMR1_EM6_Msk      (0x1UL << EXTI_C2EMR1_EM6_Pos)                /*!< 0x00000040 */
+#define EXTI_C2EMR1_EM6          EXTI_C2EMR1_EM6_Msk                           /*!< CPU2 Event Mask on line 6 */
+#define EXTI_C2EMR1_EM7_Pos      (7U)
+#define EXTI_C2EMR1_EM7_Msk      (0x1UL << EXTI_C2EMR1_EM7_Pos)                /*!< 0x00000080 */
+#define EXTI_C2EMR1_EM7          EXTI_C2EMR1_EM7_Msk                           /*!< CPU2 Event Mask on line 7 */
+#define EXTI_C2EMR1_EM8_Pos      (8U)
+#define EXTI_C2EMR1_EM8_Msk      (0x1UL << EXTI_C2EMR1_EM8_Pos)                /*!< 0x00000100 */
+#define EXTI_C2EMR1_EM8          EXTI_C2EMR1_EM8_Msk                           /*!< CPU2 Event Mask on line 8 */
+#define EXTI_C2EMR1_EM9_Pos      (9U)
+#define EXTI_C2EMR1_EM9_Msk      (0x1UL << EXTI_C2EMR1_EM9_Pos)                /*!< 0x00000200 */
+#define EXTI_C2EMR1_EM9          EXTI_C2EMR1_EM9_Msk                           /*!< CPU2 Event Mask on line 9 */
+#define EXTI_C2EMR1_EM10_Pos     (10U)
+#define EXTI_C2EMR1_EM10_Msk     (0x1UL << EXTI_C2EMR1_EM10_Pos)               /*!< 0x00000400 */
+#define EXTI_C2EMR1_EM10         EXTI_C2EMR1_EM10_Msk                          /*!< CPU2 Event Mask on line 10 */
+#define EXTI_C2EMR1_EM11_Pos     (11U)
+#define EXTI_C2EMR1_EM11_Msk     (0x1UL << EXTI_C2EMR1_EM11_Pos)               /*!< 0x00000800 */
+#define EXTI_C2EMR1_EM11         EXTI_C2EMR1_EM11_Msk                          /*!< CPU2 Event Mask on line 11 */
+#define EXTI_C2EMR1_EM12_Pos     (12U)
+#define EXTI_C2EMR1_EM12_Msk     (0x1UL << EXTI_C2EMR1_EM12_Pos)               /*!< 0x00001000 */
+#define EXTI_C2EMR1_EM12         EXTI_C2EMR1_EM12_Msk                          /*!< CPU2 Event Mask on line 12 */
+#define EXTI_C2EMR1_EM13_Pos     (13U)
+#define EXTI_C2EMR1_EM13_Msk     (0x1UL << EXTI_C2EMR1_EM13_Pos)               /*!< 0x00002000 */
+#define EXTI_C2EMR1_EM13         EXTI_C2EMR1_EM13_Msk                          /*!< CPU2 Event Mask on line 13 */
+#define EXTI_C2EMR1_EM14_Pos     (14U)
+#define EXTI_C2EMR1_EM14_Msk     (0x1UL << EXTI_C2EMR1_EM14_Pos)               /*!< 0x00004000 */
+#define EXTI_C2EMR1_EM14         EXTI_C2EMR1_EM14_Msk                          /*!< CPU2 Event Mask on line 14 */
+#define EXTI_C2EMR1_EM15_Pos     (15U)
+#define EXTI_C2EMR1_EM15_Msk     (0x1UL << EXTI_C2EMR1_EM15_Pos)               /*!< 0x00008000 */
+#define EXTI_C2EMR1_EM15         EXTI_C2EMR1_EM15_Msk                          /*!< CPU2 Event Mask on line 15 */
+#define EXTI_C2EMR1_EM17_Pos     (17U)
+#define EXTI_C2EMR1_EM17_Msk     (0x1UL << EXTI_C2EMR1_EM17_Pos)               /*!< 0x00020000 */
+#define EXTI_C2EMR1_EM17         EXTI_C2EMR1_EM17_Msk                          /*!< CPU2 Event Mask on line 17 */
+#define EXTI_C2EMR1_EM18_Pos     (18U)
+#define EXTI_C2EMR1_EM18_Msk     (0x1UL << EXTI_C2EMR1_EM18_Pos)               /*!< 0x00040000 */
+#define EXTI_C2EMR1_EM18         EXTI_C2EMR1_EM18_Msk                          /*!< CPU2 Event Mask on line 18 */
+#define EXTI_C2EMR1_EM19_Pos     (19U)
+#define EXTI_C2EMR1_EM19_Msk     (0x1UL << EXTI_C2EMR1_EM19_Pos)               /*!< 0x00080000 */
+#define EXTI_C2EMR1_EM19         EXTI_C2EMR1_EM19_Msk                          /*!< CPU2 Event Mask on line 19 */
+#define EXTI_C2EMR1_EM20_Pos     (20U)
+#define EXTI_C2EMR1_EM20_Msk     (0x1UL << EXTI_C2EMR1_EM20_Pos)               /*!< 0x00100000 */
+#define EXTI_C2EMR1_EM20         EXTI_C2EMR1_EM20_Msk                          /*!< CPU2 Event Mask on line 20 */
+
+/********************  Bits definition for EXTI_C2IMR2 register  **************/
+#define EXTI_C2IMR2_Pos          (0U)
+#define EXTI_C2IMR2_Msk          (0x0001FFFFUL << EXTI_C2IMR2_Pos)             /*!< 0x0001FFFF */
+#define EXTI_C2IMR2_IM           EXTI_C2IMR2_Msk                               /*!< CPU2 Interrupt Mask  */
+#define EXTI_C2IMR2_IM33_Pos     (1U)
+#define EXTI_C2IMR2_IM33_Msk     (0x1UL << EXTI_C2IMR2_IM33_Pos)               /*!< 0x00000002 */
+#define EXTI_C2IMR2_IM33         EXTI_C2IMR2_IM33_Msk                          /*!< CPU2 Interrupt Mask on line 33 */
+#define EXTI_C2IMR2_IM36_Pos     (4U)
+#define EXTI_C2IMR2_IM36_Msk     (0x1UL << EXTI_C2IMR2_IM36_Pos)               /*!< 0x00000010 */
+#define EXTI_C2IMR2_IM36         EXTI_C2IMR2_IM36_Msk                          /*!< CPU2 Interrupt Mask on line 36 */
+#define EXTI_C2IMR2_IM37_Pos     (5U)
+#define EXTI_C2IMR2_IM37_Msk     (0x1UL << EXTI_C2IMR2_IM37_Pos)               /*!< 0x00000020 */
+#define EXTI_C2IMR2_IM37         EXTI_C2IMR2_IM37_Msk                          /*!< CPU2 Interrupt Mask on line 37 */
+#define EXTI_C2IMR2_IM38_Pos     (6U)
+#define EXTI_C2IMR2_IM38_Msk     (0x1UL << EXTI_C2IMR2_IM38_Pos)               /*!< 0x00000040 */
+#define EXTI_C2IMR2_IM38         EXTI_C2IMR2_IM38_Msk                          /*!< CPU2 Interrupt Mask on line 38 */
+#define EXTI_C2IMR2_IM39_Pos     (7U)
+#define EXTI_C2IMR2_IM39_Msk     (0x1UL << EXTI_C2IMR2_IM39_Pos)               /*!< 0x00000080 */
+#define EXTI_C2IMR2_IM39         EXTI_C2IMR2_IM39_Msk                          /*!< CPU2 Interrupt Mask on line 39 */
+#define EXTI_C2IMR2_IM40_Pos     (8U)
+#define EXTI_C2IMR2_IM40_Msk     (0x1UL << EXTI_C2IMR2_IM40_Pos)               /*!< 0x00000100 */
+#define EXTI_C2IMR2_IM40         EXTI_C2IMR2_IM40_Msk                          /*!< CPU2 Interrupt Mask on line 40 */
+#define EXTI_C2IMR2_IM41_Pos     (9U)
+#define EXTI_C2IMR2_IM41_Msk     (0x1UL << EXTI_C2IMR2_IM41_Pos)               /*!< 0x00000200 */
+#define EXTI_C2IMR2_IM41         EXTI_C2IMR2_IM41_Msk                          /*!< CPU2 Interrupt Mask on line 41 */
+#define EXTI_C2IMR2_IM42_Pos     (10U)
+#define EXTI_C2IMR2_IM42_Msk     (0x1UL << EXTI_C2IMR2_IM42_Pos)               /*!< 0x00000400 */
+#define EXTI_C2IMR2_IM42         EXTI_C2IMR2_IM42_Msk                          /*!< CPU2 Interrupt Mask on line 42 */
+#define EXTI_C2IMR2_IM44_Pos     (12U)
+#define EXTI_C2IMR2_IM44_Msk     (0x1UL << EXTI_C2IMR2_IM44_Pos)               /*!< 0x00001000 */
+#define EXTI_C2IMR2_IM44         EXTI_C2IMR2_IM44_Msk                          /*!< CPU2 Interrupt Mask on line 44 */
+#define EXTI_C2IMR2_IM45_Pos     (13U)
+#define EXTI_C2IMR2_IM45_Msk     (0x1UL << EXTI_C2IMR2_IM45_Pos)               /*!< 0x00002000 */
+#define EXTI_C2IMR2_IM45         EXTI_C2IMR2_IM45_Msk                          /*!< CPU2 Interrupt Mask on line 45 */
+#define EXTI_C2IMR2_IM48_Pos     (16U)
+#define EXTI_C2IMR2_IM48_Msk     (0x1UL << EXTI_C2IMR2_IM48_Pos)               /*!< 0x00010000 */
+#define EXTI_C2IMR2_IM48         EXTI_C2IMR2_IM48_Msk                          /*!< CPU2 Interrupt Mask on line 48 */
+
+/********************  Bits definition for EXTI_C2EMR2 register  **************/
+#define EXTI_C2EMR2_Pos          (8U)
+#define EXTI_C2EMR2_Msk          (0x00000300UL << EXTI_C2EMR2_Pos)             /*!< 0x000003000 */
+#define EXTI_C2EMR2_EM           EXTI_C2EMR2_Msk                               /*!< CPU2 Interrupt Mask  */
+#define EXTI_C2EMR2_EM40_Pos     (8U)
+#define EXTI_C2EMR2_EM40_Msk     (0x1UL << EXTI_C2EMR2_EM40_Pos)               /*!< 0x00000100 */
+#define EXTI_C2EMR2_EM40         EXTI_C2EMR2_EM40_Msk                          /*!< CPU2 Event Mask on line 40 */
+#define EXTI_C2EMR2_EM41_Pos     (9U)
+#define EXTI_C2EMR2_EM41_Msk     (0x1UL << EXTI_C2EMR2_EM41_Pos)               /*!< 0x00000200 */
+#define EXTI_C2EMR2_EM41         EXTI_C2EMR2_EM41_Msk                          /*!< CPU2 Event Mask on line 41 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Public Key Accelerator (PKA)                         */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bits definition for PKA_CR register  **************/
+#define PKA_CR_EN_Pos              (0U)
+#define PKA_CR_EN_Msk              (0x1UL << PKA_CR_EN_Pos)                /*!< 0x00000001 */
+#define PKA_CR_EN                  PKA_CR_EN_Msk                           /*!< PKA enable */
+#define PKA_CR_START_Pos           (1U)
+#define PKA_CR_START_Msk           (0x1UL << PKA_CR_START_Pos)             /*!< 0x00000002 */
+#define PKA_CR_START               PKA_CR_START_Msk                        /*!< Start operation */
+#define PKA_CR_MODE_Pos            (8U)
+#define PKA_CR_MODE_Msk            (0x3FUL << PKA_CR_MODE_Pos)             /*!< 0x00003F00 */
+#define PKA_CR_MODE                PKA_CR_MODE_Msk                         /*!< MODE[5:0] PKA operation code */
+#define PKA_CR_MODE_0              (0x01U << PKA_CR_MODE_Pos)              /*!< 0x00000100 */
+#define PKA_CR_MODE_1              (0x02U << PKA_CR_MODE_Pos)              /*!< 0x00000200 */
+#define PKA_CR_MODE_2              (0x04U << PKA_CR_MODE_Pos)              /*!< 0x00000400 */
+#define PKA_CR_MODE_3              (0x08U << PKA_CR_MODE_Pos)              /*!< 0x00000800 */
+#define PKA_CR_MODE_4              (0x10U << PKA_CR_MODE_Pos)              /*!< 0x00001000 */
+#define PKA_CR_MODE_5              (0x20U << PKA_CR_MODE_Pos)              /*!< 0x00002000 */
+#define PKA_CR_PROCENDIE_Pos       (17U)
+#define PKA_CR_PROCENDIE_Msk       (0x1UL << PKA_CR_PROCENDIE_Pos)         /*!< 0x00020000 */
+#define PKA_CR_PROCENDIE           PKA_CR_PROCENDIE_Msk                    /*!< End of operation interrupt enable */
+#define PKA_CR_RAMERRIE_Pos        (19U)
+#define PKA_CR_RAMERRIE_Msk        (0x1UL << PKA_CR_RAMERRIE_Pos)          /*!< 0x00080000 */
+#define PKA_CR_RAMERRIE            PKA_CR_RAMERRIE_Msk                     /*!< RAM error interrupt enable */
+#define PKA_CR_ADDRERRIE_Pos       (20U)
+#define PKA_CR_ADDRERRIE_Msk       (0x1UL << PKA_CR_ADDRERRIE_Pos)         /*!< 0x00100000 */
+#define PKA_CR_ADDRERRIE           PKA_CR_ADDRERRIE_Msk                    /*!< RAM error interrupt enable */
+
+/*******************  Bits definition for PKA_SR register  **************/
+#define PKA_SR_BUSY_Pos            (16U)
+#define PKA_SR_BUSY_Msk            (0x1UL << PKA_SR_BUSY_Pos)              /*!< 0x00010000 */
+#define PKA_SR_BUSY                PKA_SR_BUSY_Msk                         /*!< PKA operation is in progress */
+#define PKA_SR_PROCENDF_Pos        (17U)
+#define PKA_SR_PROCENDF_Msk        (0x1UL << PKA_SR_PROCENDF_Pos)          /*!< 0x00020000 */
+#define PKA_SR_PROCENDF            PKA_SR_PROCENDF_Msk                     /*!< PKA end of operation flag */
+#define PKA_SR_RAMERRF_Pos         (19U)
+#define PKA_SR_RAMERRF_Msk         (0x1UL << PKA_SR_RAMERRF_Pos)           /*!< 0x00080000 */
+#define PKA_SR_RAMERRF             PKA_SR_RAMERRF_Msk                      /*!< PKA RAM error flag */
+#define PKA_SR_ADDRERRF_Pos        (20U)
+#define PKA_SR_ADDRERRF_Msk        (0x1UL << PKA_SR_ADDRERRF_Pos)          /*!< 0x00100000 */
+#define PKA_SR_ADDRERRF            PKA_SR_ADDRERRF_Msk                     /*!< Address error flag */
+
+/*******************  Bits definition for PKA_CLRFR register  **************/
+#define PKA_CLRFR_PROCENDFC_Pos    (17U)
+#define PKA_CLRFR_PROCENDFC_Msk    (0x1UL << PKA_CLRFR_PROCENDFC_Pos)      /*!< 0x00020000 */
+#define PKA_CLRFR_PROCENDFC        PKA_CLRFR_PROCENDFC_Msk                 /*!< Clear PKA end of operation flag */
+#define PKA_CLRFR_RAMERRFC_Pos     (19U)
+#define PKA_CLRFR_RAMERRFC_Msk     (0x1UL << PKA_CLRFR_RAMERRFC_Pos)       /*!< 0x00080000 */
+#define PKA_CLRFR_RAMERRFC         PKA_CLRFR_RAMERRFC_Msk                  /*!< Clear PKA RAM error flag */
+#define PKA_CLRFR_ADDRERRFC_Pos    (20U)
+#define PKA_CLRFR_ADDRERRFC_Msk    (0x1UL << PKA_CLRFR_ADDRERRFC_Pos)      /*!< 0x00100000 */
+#define PKA_CLRFR_ADDRERRFC        PKA_CLRFR_ADDRERRFC_Msk                 /*!< Clear address error flag */
+
+/*******************  Bits definition for PKA RAM  *************************/
+#define PKA_RAM_OFFSET                            0x400U                           /*!< PKA RAM address offset */
+
+/* Compute Montgomery parameter input data */
+#define PKA_MONTGOMERY_PARAM_IN_MOD_NB_BITS       ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_MONTGOMERY_PARAM_IN_MODULUS           ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Compute Montgomery parameter output data */
+#define PKA_MONTGOMERY_PARAM_OUT_PARAMETER        ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Output Montgomery parameter */
+
+/* Compute modular exponentiation input data */
+#define PKA_MODULAR_EXP_IN_EXP_NB_BITS            ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent number of bits */
+#define PKA_MODULAR_EXP_IN_OP_NB_BITS             ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM       ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Input storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_IN_EXPONENT_BASE          ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input base of the exponentiation */
+#define PKA_MODULAR_EXP_IN_EXPONENT               ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent to process */
+#define PKA_MODULAR_EXP_IN_MODULUS                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Compute modular exponentiation output data */
+#define PKA_MODULAR_EXP_OUT_MONTGOMERY_PARAM      ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Output storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC1          ((0x724U - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 1 */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC2          ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 2 */
+#define PKA_MODULAR_EXP_OUT_EXPONENT_BASE         ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Output base of the exponentiation */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC3          ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 3 */
+
+/* Compute ECC scalar multiplication input data */
+#define PKA_ECC_SCALAR_MUL_IN_EXP_NB_BITS         ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_OP_NB_BITS          ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF_SIGN        ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF             ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_MOD_GF              ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECC_SCALAR_MUL_IN_MONTGOMERY_PARAM    ((0x4B4U - PKA_RAM_OFFSET)>>2)   /*!< Input storage area for Montgomery parameter */
+#define PKA_ECC_SCALAR_MUL_IN_K                   ((0x508U - PKA_RAM_OFFSET)>>2)   /*!< Input 'k' of KP */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X     ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y     ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+
+/* Compute ECC scalar multiplication output data */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_X           ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Output result X coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_Y           ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Output result Y coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_X1     ((0xDE8U - PKA_RAM_OFFSET)>>2)   /*!< Output last double X1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_Y1     ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Output last double Y1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_Z1     ((0xE90U - PKA_RAM_OFFSET)>>2)   /*!< Output last double Z1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_X2     ((0xEE4U - PKA_RAM_OFFSET)>>2)   /*!< Output check point X2 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_Y2     ((0xF38U - PKA_RAM_OFFSET)>>2)   /*!< Output check point Y2 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_Z2     ((0xF8CU - PKA_RAM_OFFSET)>>2)   /*!< Output check point Z2 coordinate */
+
+/* Point check input data */
+#define PKA_POINT_CHECK_IN_MOD_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_POINT_CHECK_IN_A_COEFF_SIGN           ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_POINT_CHECK_IN_A_COEFF                ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_POINT_CHECK_IN_B_COEFF                ((0x7FCU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'b' coefficient */
+#define PKA_POINT_CHECK_IN_MOD_GF                 ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_X        ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_Y        ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+
+/* Point check output data */
+#define PKA_POINT_CHECK_OUT_ERROR                 ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Output error */
+
+/* ECDSA signature input data */
+#define PKA_ECDSA_SIGN_IN_ORDER_NB_BITS           ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input order number of bits */
+#define PKA_ECDSA_SIGN_IN_MOD_NB_BITS             ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_ECDSA_SIGN_IN_A_COEFF_SIGN            ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_A_COEFF                 ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_MOD_GF                  ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECDSA_SIGN_IN_K                       ((0x508U - PKA_RAM_OFFSET)>>2)   /*!< Input k value of the ECDSA */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_X         ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_Y         ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_SIGN_IN_HASH_E                  ((0xDE8U - PKA_RAM_OFFSET)>>2)   /*!< Input e, hash of the message */
+#define PKA_ECDSA_SIGN_IN_PRIVATE_KEY_D           ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Input d, private key */
+#define PKA_ECDSA_SIGN_IN_ORDER_N                 ((0xE94U - PKA_RAM_OFFSET)>>2)   /*!< Input n, order of the curve */
+
+/* ECDSA signature output data */
+#define PKA_ECDSA_SIGN_OUT_ERROR                  ((0xEE8U - PKA_RAM_OFFSET)>>2)   /*!< Output error */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_R            ((0x700U - PKA_RAM_OFFSET)>>2)   /*!< Output signature r */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_S            ((0x754U - PKA_RAM_OFFSET)>>2)   /*!< Output signature s */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_X          ((0x103CU - PKA_RAM_OFFSET)>>2)  /*!< Output final point kP X coordinate */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_Y          ((0x1090U - PKA_RAM_OFFSET)>>2)  /*!< Output final point kP Y coordinate */
+
+/* ECDSA verification input data */
+#define PKA_ECDSA_VERIF_IN_ORDER_NB_BITS          ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input order number of bits */
+#define PKA_ECDSA_VERIF_IN_MOD_NB_BITS            ((0x4B4U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_ECDSA_VERIF_IN_A_COEFF_SIGN           ((0x45CU - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_A_COEFF                ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_MOD_GF                 ((0x4B8U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_X        ((0x5E8U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_Y        ((0x63CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X     ((0xF40U - PKA_RAM_OFFSET)>>2)   /*!< Input public key point X coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y     ((0xF94U - PKA_RAM_OFFSET)>>2)   /*!< Input public key point Y coordinate */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_R            ((0x1098U - PKA_RAM_OFFSET)>>2)  /*!< Input r, part of the signature */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_S            ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input s, part of the signature */
+#define PKA_ECDSA_VERIF_IN_HASH_E                 ((0xFE8U - PKA_RAM_OFFSET)>>2)   /*!< Input e, hash of the message */
+#define PKA_ECDSA_VERIF_IN_ORDER_N                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input n, order of the curve */
+
+/* ECDSA verification output data */
+#define PKA_ECDSA_VERIF_OUT_RESULT                ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* RSA CRT exponentiation input data */
+#define PKA_RSA_CRT_EXP_IN_MOD_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operands number of bits */
+#define PKA_RSA_CRT_EXP_IN_DP_CRT                 ((0x65CU - PKA_RAM_OFFSET)>>2)   /*!< Input Dp CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_DQ_CRT                 ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Input Dq CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_QINV_CRT               ((0x7ECU - PKA_RAM_OFFSET)>>2)   /*!< Input qInv CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_PRIME_P                ((0x97CU - PKA_RAM_OFFSET)>>2)   /*!< Input Prime p */
+#define PKA_RSA_CRT_EXP_IN_PRIME_Q                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input Prime q */
+#define PKA_RSA_CRT_EXP_IN_EXPONENT_BASE          ((0xEECU - PKA_RAM_OFFSET)>>2)   /*!< Input base of the exponentiation */
+
+/* RSA CRT exponentiation output data */
+#define PKA_RSA_CRT_EXP_OUT_RESULT                ((0x724U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular reduction input data */
+#define PKA_MODULAR_REDUC_IN_OP_LENGTH            ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input operand length */
+#define PKA_MODULAR_REDUC_IN_OPERAND              ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand */
+#define PKA_MODULAR_REDUC_IN_MOD_LENGTH           ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus length */
+#define PKA_MODULAR_REDUC_IN_MODULUS              ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Modular reduction output data */
+#define PKA_MODULAR_REDUC_OUT_RESULT              ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic addition input data */
+#define PKA_ARITHMETIC_ADD_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ADD_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ADD_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic addition output data */
+#define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic subtraction input data */
+#define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic subtraction output data */
+#define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic multiplication input data */
+#define PKA_ARITHMETIC_MUL_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_MUL_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_MUL_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic multiplication output data */
+#define PKA_ARITHMETIC_MUL_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Comparison input data */
+#define PKA_COMPARISON_NB_BITS                    ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_COMPARISON_IN_OP1                     ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_COMPARISON_IN_OP2                     ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Comparison output data */
+#define PKA_COMPARISON_OUT_RESULT                 ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular addition input data */
+#define PKA_MODULAR_ADD_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_ADD_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_ADD_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MODULAR_ADD_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 (modulus) */
+
+/* Modular addition output data */
+#define PKA_MODULAR_ADD_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular inversion input data */
+#define PKA_MODULAR_INV_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_INV_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_INV_IN_OP2_MOD                ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 (modulus) */
+
+/* Modular inversion output data */
+#define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular subtraction input data */
+#define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
+
+/* Modular subtraction output data */
+#define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Montgomery multiplication input data */
+#define PKA_MONTGOMERY_MUL_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MONTGOMERY_MUL_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MONTGOMERY_MUL_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MONTGOMERY_MUL_IN_OP3_MOD             ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Montgomery multiplication output data */
+#define PKA_MONTGOMERY_MUL_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Generic Arithmetic input data */
+#define PKA_ARITHMETIC_ALL_OPS_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP1             ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP2             ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP3             ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Generic Arithmetic output data */
+#define PKA_ARITHMETIC_ALL_OPS_OUT_RESULT         ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos               (0U)
+#define FLASH_ACR_LATENCY_Msk               (0x7UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY                   FLASH_ACR_LATENCY_Msk              /*!< Latency                                             */
+#define FLASH_ACR_LATENCY_0                 (0x1UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000001 */
+#define FLASH_ACR_LATENCY_1                 (0x2UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000002 */
+#define FLASH_ACR_LATENCY_2                 (0x4UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000004 */
+#define FLASH_ACR_PRFTEN_Pos                (8U)
+#define FLASH_ACR_PRFTEN_Msk                (0x1UL << FLASH_ACR_PRFTEN_Pos)    /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN                    FLASH_ACR_PRFTEN_Msk               /*!< Prefetch enable                                     */
+#define FLASH_ACR_ICEN_Pos                  (9U)
+#define FLASH_ACR_ICEN_Msk                  (0x1UL << FLASH_ACR_ICEN_Pos)      /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                      FLASH_ACR_ICEN_Msk                 /*!< Instruction cache enable                            */
+#define FLASH_ACR_DCEN_Pos                  (10U)
+#define FLASH_ACR_DCEN_Msk                  (0x1UL << FLASH_ACR_DCEN_Pos)      /*!< 0x00000400 */
+#define FLASH_ACR_DCEN                      FLASH_ACR_DCEN_Msk                 /*!< Data cache enable                                   */
+#define FLASH_ACR_ICRST_Pos                 (11U)
+#define FLASH_ACR_ICRST_Msk                 (0x1UL << FLASH_ACR_ICRST_Pos)     /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                     FLASH_ACR_ICRST_Msk                /*!< Instruction cache reset                             */
+#define FLASH_ACR_DCRST_Pos                 (12U)
+#define FLASH_ACR_DCRST_Msk                 (0x1UL << FLASH_ACR_DCRST_Pos)     /*!< 0x00001000 */
+#define FLASH_ACR_DCRST                     FLASH_ACR_DCRST_Msk                /*!< Data cache reset                                    */
+#define FLASH_ACR_PES_Pos                   (15U)
+#define FLASH_ACR_PES_Msk                   (0x1UL << FLASH_ACR_PES_Pos)       /*!< 0x00008000 */
+#define FLASH_ACR_PES                       FLASH_ACR_PES_Msk                  /*!< Program/erase suspend request                       */
+#define FLASH_ACR_EMPTY_Pos                 (16U)
+#define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
+#define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
+
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos                    (0U)
+#define FLASH_SR_EOP_Msk                    (0x1UL << FLASH_SR_EOP_Pos)        /*!< 0x00000001 */
+#define FLASH_SR_EOP                        FLASH_SR_EOP_Msk                   /*!< End of Operation                                    */
+#define FLASH_SR_OPERR_Pos                  (1U)
+#define FLASH_SR_OPERR_Msk                  (0x1UL << FLASH_SR_OPERR_Pos)      /*!< 0x00000002 */
+#define FLASH_SR_OPERR                      FLASH_SR_OPERR_Msk                 /*!< Operation error                                     */
+#define FLASH_SR_PROGERR_Pos                (3U)
+#define FLASH_SR_PROGERR_Msk                (0x1UL << FLASH_SR_PROGERR_Pos)    /*!< 0x00000008 */
+#define FLASH_SR_PROGERR                    FLASH_SR_PROGERR_Msk               /*!< Programming error                                   */
+#define FLASH_SR_WRPERR_Pos                 (4U)
+#define FLASH_SR_WRPERR_Msk                 (0x1UL << FLASH_SR_WRPERR_Pos)     /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                     FLASH_SR_WRPERR_Msk                /*!< Write protection error                              */
+#define FLASH_SR_PGAERR_Pos                 (5U)
+#define FLASH_SR_PGAERR_Msk                 (0x1UL << FLASH_SR_PGAERR_Pos)     /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                     FLASH_SR_PGAERR_Msk                /*!< Programming alignment error                         */
+#define FLASH_SR_SIZERR_Pos                 (6U)
+#define FLASH_SR_SIZERR_Msk                 (0x1UL << FLASH_SR_SIZERR_Pos)     /*!< 0x00000040 */
+#define FLASH_SR_SIZERR                     FLASH_SR_SIZERR_Msk                /*!< Size error                                          */
+#define FLASH_SR_PGSERR_Pos                 (7U)
+#define FLASH_SR_PGSERR_Msk                 (0x1UL << FLASH_SR_PGSERR_Pos)     /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                     FLASH_SR_PGSERR_Msk                /*!< Programming sequence error                          */
+#define FLASH_SR_MISERR_Pos                 (8U)
+#define FLASH_SR_MISERR_Msk                 (0x1UL << FLASH_SR_MISERR_Pos)     /*!< 0x00000100 */
+#define FLASH_SR_MISERR                     FLASH_SR_MISERR_Msk                /*!< Fast programming data miss error                    */
+#define FLASH_SR_FASTERR_Pos                (9U)
+#define FLASH_SR_FASTERR_Msk                (0x1UL << FLASH_SR_FASTERR_Pos)    /*!< 0x00000200 */
+#define FLASH_SR_FASTERR                    FLASH_SR_FASTERR_Msk               /*!< Fast programming error                              */
+#define FLASH_SR_OPTNV_Pos                  (13U)
+#define FLASH_SR_OPTNV_Msk                  (0x1UL << FLASH_SR_OPTNV_Pos)     /*!< 0x00002000 */
+#define FLASH_SR_OPTNV                      FLASH_SR_OPTNV_Msk                /*!< User option OPTVAL indication                       */
+#define FLASH_SR_RDERR_Pos                  (14U)
+#define FLASH_SR_RDERR_Msk                  (0x1UL << FLASH_SR_RDERR_Pos)      /*!< 0x00004000 */
+#define FLASH_SR_RDERR                      FLASH_SR_RDERR_Msk                 /*!< PCROP read error                                    */
+#define FLASH_SR_OPTVERR_Pos                (15U)
+#define FLASH_SR_OPTVERR_Msk                (0x1UL << FLASH_SR_OPTVERR_Pos)    /*!< 0x00008000 */
+#define FLASH_SR_OPTVERR                    FLASH_SR_OPTVERR_Msk               /*!< Option validity error                               */
+#define FLASH_SR_BSY_Pos                    (16U)
+#define FLASH_SR_BSY_Msk                    (0x1UL << FLASH_SR_BSY_Pos)        /*!< 0x00010000 */
+#define FLASH_SR_BSY                        FLASH_SR_BSY_Msk                   /*!< Flash Busy                                          */
+#define FLASH_SR_CFGBSY_Pos                 (18U)
+#define FLASH_SR_CFGBSY_Msk                 (0x1UL << FLASH_SR_CFGBSY_Pos)     /*!< 0x00040000 */
+#define FLASH_SR_CFGBSY                     FLASH_SR_CFGBSY_Msk                /*!< Programming or erase configuration busy             */
+#define FLASH_SR_PESD_Pos                   (19U)
+#define FLASH_SR_PESD_Msk                   (0x1UL << FLASH_SR_PESD_Pos)       /*!< 0x00080000 */
+#define FLASH_SR_PESD                       FLASH_SR_PESD_Msk                  /*!< Programming/erase operation suspended               */
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                     (0U)
+#define FLASH_CR_PG_Msk                     (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
+#define FLASH_CR_PG                         FLASH_CR_PG_Msk                    /*!< Flash programming                                   */
+#define FLASH_CR_PER_Pos                    (1U)
+#define FLASH_CR_PER_Msk                    (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
+#define FLASH_CR_PER                        FLASH_CR_PER_Msk                   /*!< Page erase                                          */
+#define FLASH_CR_MER_Pos                    (2U)
+#define FLASH_CR_MER_Msk                    (0x1UL << FLASH_CR_MER_Pos)        /*!< 0x00000004 */
+#define FLASH_CR_MER                        FLASH_CR_MER_Msk                   /*!< Mass erase                                          */
+#define FLASH_CR_PNB_Pos                    (3U)
+#define FLASH_CR_PNB_Msk                    (0xFFUL << FLASH_CR_PNB_Pos)       /*!< 0x000007F8 */
+#define FLASH_CR_PNB                        FLASH_CR_PNB_Msk                   /*!< Page number selection mask                          */
+#define FLASH_CR_STRT_Pos                   (16U)
+#define FLASH_CR_STRT_Msk                   (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
+#define FLASH_CR_STRT                       FLASH_CR_STRT_Msk                  /*!< Start an erase operation                            */
+#define FLASH_CR_OPTSTRT_Pos                (17U)
+#define FLASH_CR_OPTSTRT_Msk                (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT                    FLASH_CR_OPTSTRT_Msk               /*!< Options modification start                          */
+#define FLASH_CR_FSTPG_Pos                  (18U)
+#define FLASH_CR_FSTPG_Msk                  (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
+#define FLASH_CR_FSTPG                      FLASH_CR_FSTPG_Msk                 /*!< Fast programming                                    */
+#define FLASH_CR_EOPIE_Pos                  (24U)
+#define FLASH_CR_EOPIE_Msk                  (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                      FLASH_CR_EOPIE_Msk                 /*!< End of operation interrupt enable                   */
+#define FLASH_CR_ERRIE_Pos                  (25U)
+#define FLASH_CR_ERRIE_Msk                  (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
+#define FLASH_CR_ERRIE                      FLASH_CR_ERRIE_Msk                 /*!< Error interrupt enable                              */
+#define FLASH_CR_RDERRIE_Pos                (26U)
+#define FLASH_CR_RDERRIE_Msk                (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE                    FLASH_CR_RDERRIE_Msk               /*!< PCROP read error interrupt enable                   */
+#define FLASH_CR_OBL_LAUNCH_Pos             (27U)
+#define FLASH_CR_OBL_LAUNCH_Msk             (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
+#define FLASH_CR_OBL_LAUNCH                 FLASH_CR_OBL_LAUNCH_Msk            /*!< Force the option byte loading                       */
+#define FLASH_CR_OPTLOCK_Pos                (30U)
+#define FLASH_CR_OPTLOCK_Msk                (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK                    FLASH_CR_OPTLOCK_Msk               /*!< Options lock                                        */
+#define FLASH_CR_LOCK_Pos                   (31U)
+#define FLASH_CR_LOCK_Msk                   (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
+#define FLASH_CR_LOCK                       FLASH_CR_LOCK_Msk                  /*!< Flash control register lock                         */
+
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos             (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk             (0x1FFFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x0001FFFF */
+#define FLASH_ECCR_ADDR_ECC                 FLASH_ECCR_ADDR_ECC_Msk            /*!< double-word address ECC fail                        */
+#define FLASH_ECCR_SYSF_ECC_Pos             (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk             (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                 FLASH_ECCR_SYSF_ECC_Msk            /*!< System flash ECC fail                               */
+#define FLASH_ECCR_ECCCIE_Pos               (24U)
+#define FLASH_ECCR_ECCCIE_Msk               (0x1UL << FLASH_ECCR_ECCCIE_Pos)   /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                   FLASH_ECCR_ECCCIE_Msk              /*!< ECC correction interrupt enable                     */
+#define FLASH_ECCR_CPUID_Pos                (26U)
+#define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
+#define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
+#define FLASH_ECCR_ECCC_Pos                 (30U)
+#define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
+#define FLASH_ECCR_ECCD_Pos                 (31U)
+#define FLASH_ECCR_ECCD_Msk                 (0x1UL << FLASH_ECCR_ECCD_Pos)     /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                     FLASH_ECCR_ECCD_Msk                /*!< ECC detection                                       */
+
+/*******************  Bits definition for FLASH_OPTR register  ****************/
+#define FLASH_OPTR_RDP_Pos                  (0U)
+#define FLASH_OPTR_RDP_Msk                  (0xFFUL << FLASH_OPTR_RDP_Pos)     /*!< 0x000000FF */
+#define FLASH_OPTR_RDP                      FLASH_OPTR_RDP_Msk                 /*!< Read protection level                               */
+#define FLASH_OPTR_ESE_Pos                  (8U)
+#define FLASH_OPTR_ESE_Msk                  (0x1UL << FLASH_OPTR_ESE_Pos)      /*!< 0x00000100 */
+#define FLASH_OPTR_ESE                      FLASH_OPTR_ESE_Msk                 /*!< Security enable                                     */
+#define FLASH_OPTR_BOR_LEV_Pos              (9U)
+#define FLASH_OPTR_BOR_LEV_Msk              (0x7UL << FLASH_OPTR_BOR_LEV_Pos)  /*!< 0x00000E00 */
+#define FLASH_OPTR_BOR_LEV                  FLASH_OPTR_BOR_LEV_Msk             /*!< BOR reset level mask                                */
+#define FLASH_OPTR_BOR_LEV_0                (0x1U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000200 */
+#define FLASH_OPTR_BOR_LEV_1                (0x2U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000400 */
+#define FLASH_OPTR_BOR_LEV_2                (0x4U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000800 */
+#define FLASH_OPTR_nRST_STOP_Pos            (12U)
+#define FLASH_OPTR_nRST_STOP_Msk            (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_nRST_STOP                FLASH_OPTR_nRST_STOP_Msk           /*!< Reset option in Stop mode                           */
+#define FLASH_OPTR_nRST_STDBY_Pos           (13U)
+#define FLASH_OPTR_nRST_STDBY_Msk           (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STDBY               FLASH_OPTR_nRST_STDBY_Msk          /*!< Reset option in Standby mode                        */
+#define FLASH_OPTR_nRST_SHDW_Pos            (14U)
+#define FLASH_OPTR_nRST_SHDW_Msk            (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_SHDW                FLASH_OPTR_nRST_SHDW_Msk           /*!< Reset option in Shutdown mode                       */
+#define FLASH_OPTR_IRHEN_Pos                (15U)
+#define FLASH_OPTR_IRHEN_Msk                (0x1UL << FLASH_OPTR_IRHEN_Pos)    /*!< 0x00008000 */
+#define FLASH_OPTR_IRHEN                    FLASH_OPTR_IRHEN_Msk               /*!< Internal reset holder enable bit                    */
+#define FLASH_OPTR_IWDG_SW_Pos              (16U)
+#define FLASH_OPTR_IWDG_SW_Msk              (0x1UL << FLASH_OPTR_IWDG_SW_Pos)  /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW                  FLASH_OPTR_IWDG_SW_Msk             /*!< Independent watchdog selection                      */
+#define FLASH_OPTR_IWDG_STOP_Pos            (17U)
+#define FLASH_OPTR_IWDG_STOP_Msk            (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP                FLASH_OPTR_IWDG_STOP_Msk           /*!< Independent watchdog counter option in Stop mode    */
+#define FLASH_OPTR_IWDG_STDBY_Pos           (18U)
+#define FLASH_OPTR_IWDG_STDBY_Msk           (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY               FLASH_OPTR_IWDG_STDBY_Msk          /*!< Independent watchdog counter option in Standby mode */
+#define FLASH_OPTR_WWDG_SW_Pos              (19U)
+#define FLASH_OPTR_WWDG_SW_Msk              (0x1UL << FLASH_OPTR_WWDG_SW_Pos)  /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW                  FLASH_OPTR_WWDG_SW_Msk             /*!< Window watchdog selection                           */
+#define FLASH_OPTR_nRST_MODE_1_Pos          (22U)
+#define FLASH_OPTR_nRST_MODE_1_Msk          (0x1UL << FLASH_OPTR_nRST_MODE_1_Pos)  /*!< 0x04000000 */
+#define FLASH_OPTR_nRST_MODE_1              FLASH_OPTR_nRST_MODE_1_Msk         /*!< PB11 GPIO normal mode                               */
+#define FLASH_OPTR_nBOOT1_Pos               (23U)
+#define FLASH_OPTR_nBOOT1_Msk               (0x1UL << FLASH_OPTR_nBOOT1_Pos)   /*!< 0x00800000 */
+#define FLASH_OPTR_nBOOT1                   FLASH_OPTR_nBOOT1_Msk              /*!< Boot Configuration                                  */
+#define FLASH_OPTR_SRAM2PE_Pos              (24U)
+#define FLASH_OPTR_SRAM2PE_Msk              (0x1UL << FLASH_OPTR_SRAM2PE_Pos)  /*!< 0x01000000 */
+#define FLASH_OPTR_SRAM2PE                  FLASH_OPTR_SRAM2PE_Msk             /*!< SRAM2 parity check enable                           */
+#define FLASH_OPTR_SRAM2RST_Pos             (25U)
+#define FLASH_OPTR_SRAM2RST_Msk             (0x1UL << FLASH_OPTR_SRAM2RST_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_SRAM2RST                 FLASH_OPTR_SRAM2RST_Msk            /*!< SRAM2 erase option when system reset                */
+#define FLASH_OPTR_nSWBOOT0_Pos             (26U)
+#define FLASH_OPTR_nSWBOOT0_Msk             (0x1UL << FLASH_OPTR_nSWBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nSWBOOT0                 FLASH_OPTR_nSWBOOT0_Msk            /*!< Software BOOT0                                      */
+#define FLASH_OPTR_nBOOT0_Pos               (27U)
+#define FLASH_OPTR_nBOOT0_Msk               (0x1UL << FLASH_OPTR_nBOOT0_Pos)   /*!< 0x08000000 */
+#define FLASH_OPTR_nBOOT0                   FLASH_OPTR_nBOOT0_Msk              /*!< BOOT0 option bit                                    */
+#define FLASH_OPTR_nRST_MODE_0_Pos          (28U)
+#define FLASH_OPTR_nRST_MODE_0_Msk          (0x1UL << FLASH_OPTR_nRST_MODE_0_Pos)  /*!< 0x10000000 */
+#define FLASH_OPTR_nRST_MODE_0              FLASH_OPTR_nRST_MODE_0_Msk         /*!< PB11 reset input mode                               */
+#define FLASH_OPTR_nRST_MODE_Pos            (22U)
+#define FLASH_OPTR_nRST_MODE_Msk            (0x41UL << FLASH_OPTR_nRST_MODE_Pos)  /*!< 0x10400000 */
+#define FLASH_OPTR_nRST_MODE                FLASH_OPTR_nRST_MODE_Msk
+#define FLASH_OPTR_AGC_TRIM_Pos             (29U)
+#define FLASH_OPTR_AGC_TRIM_Msk             (0x7UL << FLASH_OPTR_AGC_TRIM_Pos)  /*!< 0xE0000000 */
+#define FLASH_OPTR_AGC_TRIM                 FLASH_OPTR_AGC_TRIM_Msk             /*!< Automatic Gain Control trimming mask               */
+#define FLASH_OPTR_AGC_TRIM_0               (0x1U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x20000000 */
+#define FLASH_OPTR_AGC_TRIM_1               (0x2U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x40000000 */
+#define FLASH_OPTR_AGC_TRIM_2               (0x4U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x80000000 */
+
+/******************  Bits definition for FLASH_PCROP1ASR register  ************/
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Pos    (0U)
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk    (0x1FFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT        FLASH_PCROP1ASR_PCROP1A_STRT_Msk   /*!< PCROP area A start offset                           */
+
+/******************  Bits definition for FLASH_PCROP1AER register  ************/
+#define FLASH_PCROP1AER_PCROP1A_END_Pos     (0U)
+#define FLASH_PCROP1AER_PCROP1A_END_Msk     (0x1FFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1AER_PCROP1A_END         FLASH_PCROP1AER_PCROP1A_END_Msk    /*!< PCROP area A end offset                             */
+#define FLASH_PCROP1AER_PCROP_RDP_Pos       (31U)
+#define FLASH_PCROP1AER_PCROP_RDP_Msk       (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP           FLASH_PCROP1AER_PCROP_RDP_Msk      /*!< PCROP area   preserved when RDP level decreased     */
+
+/******************  Bits definition for FLASH_WRP1AR register  ***************/
+#define FLASH_WRP1AR_WRP1A_STRT_Pos         (0U)
+#define FLASH_WRP1AR_WRP1A_STRT_Msk         (0xFFUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_WRP1AR_WRP1A_STRT             FLASH_WRP1AR_WRP1A_STRT_Msk        /*!< WRP area A start offset                             */
+#define FLASH_WRP1AR_WRP1A_END_Pos          (16U)
+#define FLASH_WRP1AR_WRP1A_END_Msk          (0xFFUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x00FF0000 */
+#define FLASH_WRP1AR_WRP1A_END              FLASH_WRP1AR_WRP1A_END_Msk         /*!< WRP area A end offset                               */
+
+/******************  Bits definition for FLASH_WRP1BR register  ***************/
+#define FLASH_WRP1BR_WRP1B_STRT_Pos         (0U)
+#define FLASH_WRP1BR_WRP1B_STRT_Msk         (0xFFUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_WRP1BR_WRP1B_STRT             FLASH_WRP1BR_WRP1B_STRT_Msk        /*!< WRP area B start offset                             */
+#define FLASH_WRP1BR_WRP1B_END_Pos          (16U)
+#define FLASH_WRP1BR_WRP1B_END_Msk          (0xFFUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x00FF0000 */
+#define FLASH_WRP1BR_WRP1B_END              FLASH_WRP1BR_WRP1B_END_Msk         /*!< WRP area B end offset                               */
+
+/******************  Bits definition for FLASH_PCROP1BSR register  ************/
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Pos    (0U)
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk    (0x1FFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT        FLASH_PCROP1BSR_PCROP1B_STRT_Msk   /*!< PCROP area B start offset                           */
+
+/******************  Bits definition for FLASH_PCROP1BER register  ************/
+#define FLASH_PCROP1BER_PCROP1B_END_Pos     (0U)
+#define FLASH_PCROP1BER_PCROP1B_END_Msk     (0x1FFUL << FLASH_PCROP1BER_PCROP1B_END_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1BER_PCROP1B_END         FLASH_PCROP1BER_PCROP1B_END_Msk    /*!< PCROP area B end offset                             */
+
+/******************  Bits definition for FLASH_IPCCBR register  ************/
+#define FLASH_IPCCBR_IPCCDBA_Pos            (0U)
+#define FLASH_IPCCBR_IPCCDBA_Msk            (0x3FFFUL << FLASH_IPCCBR_IPCCDBA_Pos) /*!< 0x00003FFF */
+#define FLASH_IPCCBR_IPCCDBA                FLASH_IPCCBR_IPCCDBA_Msk           /*!< IPCC data buffer base address                       */
+
+/******************  Bits definition for FLASH_SFR register  ************/
+#define FLASH_SFR_SFSA_Pos                  (0U)
+#define FLASH_SFR_SFSA_Msk                  (0xFFUL << FLASH_SFR_SFSA_Pos)     /*!< 0x000000FF */
+#define FLASH_SFR_SFSA                      FLASH_SFR_SFSA_Msk                 /* Secure flash start address                             */
+#define FLASH_SFR_FSD_Pos                   (8U)
+#define FLASH_SFR_FSD_Msk                   (0x1UL << FLASH_SFR_FSD_Pos)       /*!< 0x00000100 */
+#define FLASH_SFR_FSD                       FLASH_SFR_FSD_Msk                  /* Flash mode secure                                      */
+#define FLASH_SFR_DDS_Pos                   (12U)
+#define FLASH_SFR_DDS_Msk                   (0x1UL << FLASH_SFR_DDS_Pos)       /*!< 0x00001000 */
+#define FLASH_SFR_DDS                       FLASH_SFR_DDS_Msk                  /* Enabling and disabling CPU2 Debug access               */
+
+/******************  Bits definition for FLASH_SRRVR register  ************/
+#define FLASH_SRRVR_SBRV_Pos                (0U)
+#define FLASH_SRRVR_SBRV_Msk                (0x1FFFFUL << FLASH_SRRVR_SBRV_Pos) /*!< 0x0001FFFF */
+#define FLASH_SRRVR_SBRV                    FLASH_SRRVR_SBRV_Msk                /* CPU2 boot reset vector memory offset                  */
+
+#define FLASH_SRRVR_SBRSA_A_Pos             (18U)
+#define FLASH_SRRVR_SBRSA_A_Msk             (0x1FUL << FLASH_SRRVR_SBRSA_A_Pos) /*!< 0x007C0000 */
+#define FLASH_SRRVR_SBRSA_A                 FLASH_SRRVR_SBRSA_A_Msk             /* Secure backup SRAM2a start address                    */
+#define FLASH_SRRVR_BRSD_A_Pos              (23U)
+#define FLASH_SRRVR_BRSD_A_Msk              (0x1UL << FLASH_SRRVR_BRSD_A_Pos)   /*!< 0x00800000 */
+#define FLASH_SRRVR_BRSD_A                  FLASH_SRRVR_BRSD_A_Msk              /* Backup SRAM2A secure mode                             */
+
+#define FLASH_SRRVR_SBRSA_B_Pos             (25U)
+#define FLASH_SRRVR_SBRSA_B_Msk             (0x3UL << FLASH_SRRVR_SBRSA_B_Pos)  /*!< 0x06000000 */
+#define FLASH_SRRVR_SBRSA_B                 FLASH_SRRVR_SBRSA_B_Msk             /* Secure backup SRAM2b start address                    */
+#define FLASH_SRRVR_BRSD_B_Pos              (30U)
+#define FLASH_SRRVR_BRSD_B_Msk              (0x1UL << FLASH_SRRVR_BRSD_B_Pos)   /*!< 0x40000000 */
+#define FLASH_SRRVR_BRSD_B                  FLASH_SRRVR_BRSD_B_Msk              /* Backup SRAM2B secure mode                             */
+#define FLASH_SRRVR_C2OPT_Pos               (31U)
+#define FLASH_SRRVR_C2OPT_Msk               (0x1UL << FLASH_SRRVR_C2OPT_Pos)    /*!< 0x80000000 */
+#define FLASH_SRRVR_C2OPT                   FLASH_SRRVR_C2OPT_Msk               /* CPU2 boot reset vector memory selection                */
+
+/******************  Bits definition for FLASH_C2ACR register  ************/
+#define FLASH_C2ACR_PRFTEN_Pos              (8U)
+#define FLASH_C2ACR_PRFTEN_Msk              (0x1UL << FLASH_C2ACR_PRFTEN_Pos) /*!< 0x00000100 */
+#define FLASH_C2ACR_PRFTEN                  FLASH_C2ACR_PRFTEN_Msk            /*!< CPU2 Prefetch enable                                */
+#define FLASH_C2ACR_ICEN_Pos                (9U)
+#define FLASH_C2ACR_ICEN_Msk                (0x1UL << FLASH_C2ACR_ICEN_Pos)   /*!< 0x00000200 */
+#define FLASH_C2ACR_ICEN                    FLASH_C2ACR_ICEN_Msk              /*!< CPU2 Instruction cache enable                       */
+#define FLASH_C2ACR_ICRST_Pos               (11U)
+#define FLASH_C2ACR_ICRST_Msk               (0x1UL << FLASH_C2ACR_ICRST_Pos)  /*!< 0x00000800 */
+#define FLASH_C2ACR_ICRST                   FLASH_C2ACR_ICRST_Msk             /*!< CPU2 Instruction cache reset                        */
+#define FLASH_C2ACR_PES_Pos                 (15U)
+#define FLASH_C2ACR_PES_Msk                 (0x1UL << FLASH_C2ACR_PES_Pos)    /*!< 0x00008000 */
+#define FLASH_C2ACR_PES                     FLASH_C2ACR_PES_Msk               /*!< CPU2 Program/erase suspend request                  */
+
+/******************  Bits definition for FLASH_C2SR register  ************/
+#define FLASH_C2SR_EOP_Pos                  (0U)
+#define FLASH_C2SR_EOP_Msk                  (0x1UL << FLASH_C2SR_EOP_Pos)     /*!< 0x00000001 */
+#define FLASH_C2SR_EOP                      FLASH_C2SR_EOP_Msk                /*!< CPU2 End of operation                            */
+#define FLASH_C2SR_OPERR_Pos                (1U)
+#define FLASH_C2SR_OPERR_Msk                (0x1UL << FLASH_C2SR_OPERR_Pos)   /*!< 0x00000002 */
+#define FLASH_C2SR_OPERR                    FLASH_C2SR_OPERR_Msk              /*!< CPU2 Operation error                             */
+#define FLASH_C2SR_PROGERR_Pos              (3U)
+#define FLASH_C2SR_PROGERR_Msk              (0x1UL << FLASH_C2SR_PROGERR_Pos) /*!< 0x00000008 */
+#define FLASH_C2SR_PROGERR                  FLASH_C2SR_PROGERR_Msk            /*!< CPU2 Programming error                           */
+#define FLASH_C2SR_WRPERR_Pos               (4U)
+#define FLASH_C2SR_WRPERR_Msk               (0x1UL << FLASH_C2SR_WRPERR_Pos)  /*!< 0x00000010 */
+#define FLASH_C2SR_WRPERR                   FLASH_C2SR_WRPERR_Msk             /*!< CPU2 Write protection error                      */
+#define FLASH_C2SR_PGAERR_Pos               (5U)
+#define FLASH_C2SR_PGAERR_Msk               (0x1UL << FLASH_C2SR_PGAERR_Pos)  /*!< 0x00000020 */
+#define FLASH_C2SR_PGAERR                   FLASH_C2SR_PGAERR_Msk             /*!< CPU2 Programming alignment error                 */
+#define FLASH_C2SR_SIZERR_Pos               (6U)
+#define FLASH_C2SR_SIZERR_Msk               (0x1UL << FLASH_C2SR_SIZERR_Pos)  /*!< 0x00000040 */
+#define FLASH_C2SR_SIZERR                   FLASH_C2SR_SIZERR_Msk             /*!< CPU2 Size error                                  */
+#define FLASH_C2SR_PGSERR_Pos               (7U)
+#define FLASH_C2SR_PGSERR_Msk               (0x1UL << FLASH_C2SR_PGSERR_Pos)  /*!< 0x00000080 */
+#define FLASH_C2SR_PGSERR                   FLASH_C2SR_PGSERR_Msk             /*!< CPU2 Programming sequence error                  */
+#define FLASH_C2SR_MISERR_Pos               (8U)
+#define FLASH_C2SR_MISERR_Msk               (0x1UL << FLASH_C2SR_MISERR_Pos)  /*!< 0x00000100 */
+#define FLASH_C2SR_MISERR                   FLASH_C2SR_MISERR_Msk             /*!< CPU2 Fast programming data miss error            */
+#define FLASH_C2SR_FASTERR_Pos              (9U)
+#define FLASH_C2SR_FASTERR_Msk              (0x1UL << FLASH_C2SR_FASTERR_Pos) /*!< 0x00000200 */
+#define FLASH_C2SR_FASTERR                  FLASH_C2SR_FASTERR_Msk            /*!< CPU2 Fast programming error                      */
+#define FLASH_C2SR_RDERR_Pos                (14U)
+#define FLASH_C2SR_RDERR_Msk                (0x1UL << FLASH_C2SR_RDERR_Pos)   /*!< 0x00004000 */
+#define FLASH_C2SR_RDERR                    FLASH_C2SR_RDERR_Msk              /*!< CPU2 PCROP read error                            */
+#define FLASH_C2SR_BSY_Pos                  (16U)
+#define FLASH_C2SR_BSY_Msk                  (0x1UL << FLASH_C2SR_BSY_Pos)     /*!< 0x00010000 */
+#define FLASH_C2SR_BSY                      FLASH_C2SR_BSY_Msk                /*!< CPU2 Flash busy                                  */
+#define FLASH_C2SR_CFGBSY_Pos               (18U)
+#define FLASH_C2SR_CFGBSY_Msk               (0x1UL << FLASH_C2SR_CFGBSY_Pos)  /*!< 0x00040000 */
+#define FLASH_C2SR_CFGBSY                   FLASH_C2SR_CFGBSY_Msk             /*!< CPU2 Programming or erase configuration busy     */
+#define FLASH_C2SR_PESD_Pos                 (19U)
+#define FLASH_C2SR_PESD_Msk                 (0x1UL << FLASH_C2SR_PESD_Pos)   /*!< 0x00080000 */
+#define FLASH_C2SR_PESD                     FLASH_C2SR_PESD_Msk              /*!< CPU2 Programming/erase operation suspended       */
+
+/******************  Bits definition for FLASH_C2CR register  ************/
+#define FLASH_C2CR_PG_Pos                   (0U)
+#define FLASH_C2CR_PG_Msk                   (0x1UL << FLASH_C2CR_PG_Pos)      /*!< 0x00000001 */
+#define FLASH_C2CR_PG                       FLASH_C2CR_PG_Msk                 /*!< CPU2 Flash programming                                   */
+#define FLASH_C2CR_PER_Pos                  (1U)
+#define FLASH_C2CR_PER_Msk                  (0x1UL << FLASH_C2CR_PER_Pos)     /*!< 0x00000002 */
+#define FLASH_C2CR_PER                      FLASH_C2CR_PER_Msk                /*!< CPU2 Page erase                                          */
+#define FLASH_C2CR_MER_Pos                  (2U)
+#define FLASH_C2CR_MER_Msk                  (0x1UL << FLASH_C2CR_MER_Pos)     /*!< 0x00000004 */
+#define FLASH_C2CR_MER                      FLASH_C2CR_MER_Msk                /*!< CPU2 Mass erase                                          */
+#define FLASH_C2CR_PNB_Pos                  (3U)
+#define FLASH_C2CR_PNB_Msk                  (0xFFUL << FLASH_C2CR_PNB_Pos)    /*!< 0x000007F8 */
+#define FLASH_C2CR_PNB                      FLASH_C2CR_PNB_Msk                /*!< CPU2 Page number selection mask                          */
+#define FLASH_C2CR_STRT_Pos                 (16U)
+#define FLASH_C2CR_STRT_Msk                 (0x1UL << FLASH_C2CR_STRT_Pos)    /*!< 0x00010000 */
+#define FLASH_C2CR_STRT                     FLASH_C2CR_STRT_Msk               /*!< CPU2 Start an erase operation                            */
+#define FLASH_C2CR_FSTPG_Pos                (18U)
+#define FLASH_C2CR_FSTPG_Msk                (0x1UL << FLASH_C2CR_FSTPG_Pos)   /*!< 0x00040000 */
+#define FLASH_C2CR_FSTPG                    FLASH_C2CR_FSTPG_Msk              /*!< CPU2 Fast programming                                    */
+#define FLASH_C2CR_EOPIE_Pos                (24U)
+#define FLASH_C2CR_EOPIE_Msk                (0x1UL << FLASH_C2CR_EOPIE_Pos)   /*!< 0x01000000 */
+#define FLASH_C2CR_EOPIE                    FLASH_C2CR_EOPIE_Msk              /*!< CPU2 End of operation interrupt enable                   */
+#define FLASH_C2CR_ERRIE_Pos                (25U)
+#define FLASH_C2CR_ERRIE_Msk                (0x1UL << FLASH_C2CR_ERRIE_Pos)   /*!< 0x02000000 */
+#define FLASH_C2CR_ERRIE                    FLASH_C2CR_ERRIE_Msk              /*!< CPU2 Error interrupt enable                              */
+#define FLASH_C2CR_RDERRIE_Pos              (26U)
+#define FLASH_C2CR_RDERRIE_Msk              (0x1UL << FLASH_C2CR_RDERRIE_Pos) /*!< 0x04000000 */
+#define FLASH_C2CR_RDERRIE                  FLASH_C2CR_RDERRIE_Msk            /*!< CPU2 PCROP read error interrupt enable                   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0_Pos           (0U)
+#define GPIO_MODER_MODE0_Msk           (0x3UL << GPIO_MODER_MODE0_Pos)         /*!< 0x00000003 */
+#define GPIO_MODER_MODE0               GPIO_MODER_MODE0_Msk
+#define GPIO_MODER_MODE0_0             (0x1U << GPIO_MODER_MODE0_Pos)          /*!< 0x00000001 */
+#define GPIO_MODER_MODE0_1             (0x2U << GPIO_MODER_MODE0_Pos)          /*!< 0x00000002 */
+#define GPIO_MODER_MODE1_Pos           (2U)
+#define GPIO_MODER_MODE1_Msk           (0x3UL << GPIO_MODER_MODE1_Pos)         /*!< 0x0000000C */
+#define GPIO_MODER_MODE1               GPIO_MODER_MODE1_Msk
+#define GPIO_MODER_MODE1_0             (0x1U << GPIO_MODER_MODE1_Pos)          /*!< 0x00000004 */
+#define GPIO_MODER_MODE1_1             (0x2U << GPIO_MODER_MODE1_Pos)          /*!< 0x00000008 */
+#define GPIO_MODER_MODE2_Pos           (4U)
+#define GPIO_MODER_MODE2_Msk           (0x3UL << GPIO_MODER_MODE2_Pos)         /*!< 0x00000030 */
+#define GPIO_MODER_MODE2               GPIO_MODER_MODE2_Msk
+#define GPIO_MODER_MODE2_0             (0x1U << GPIO_MODER_MODE2_Pos)          /*!< 0x00000010 */
+#define GPIO_MODER_MODE2_1             (0x2U << GPIO_MODER_MODE2_Pos)          /*!< 0x00000020 */
+#define GPIO_MODER_MODE3_Pos           (6U)
+#define GPIO_MODER_MODE3_Msk           (0x3UL << GPIO_MODER_MODE3_Pos)         /*!< 0x000000C0 */
+#define GPIO_MODER_MODE3               GPIO_MODER_MODE3_Msk
+#define GPIO_MODER_MODE3_0             (0x1U << GPIO_MODER_MODE3_Pos)          /*!< 0x00000040 */
+#define GPIO_MODER_MODE3_1             (0x2U << GPIO_MODER_MODE3_Pos)          /*!< 0x00000080 */
+#define GPIO_MODER_MODE4_Pos           (8U)
+#define GPIO_MODER_MODE4_Msk           (0x3UL << GPIO_MODER_MODE4_Pos)         /*!< 0x00000300 */
+#define GPIO_MODER_MODE4               GPIO_MODER_MODE4_Msk
+#define GPIO_MODER_MODE4_0             (0x1U << GPIO_MODER_MODE4_Pos)          /*!< 0x00000100 */
+#define GPIO_MODER_MODE4_1             (0x2U << GPIO_MODER_MODE4_Pos)          /*!< 0x00000200 */
+#define GPIO_MODER_MODE5_Pos           (10U)
+#define GPIO_MODER_MODE5_Msk           (0x3UL << GPIO_MODER_MODE5_Pos)         /*!< 0x00000C00 */
+#define GPIO_MODER_MODE5               GPIO_MODER_MODE5_Msk
+#define GPIO_MODER_MODE5_0             (0x1U << GPIO_MODER_MODE5_Pos)          /*!< 0x00000400 */
+#define GPIO_MODER_MODE5_1             (0x2U << GPIO_MODER_MODE5_Pos)          /*!< 0x00000800 */
+#define GPIO_MODER_MODE6_Pos           (12U)
+#define GPIO_MODER_MODE6_Msk           (0x3UL << GPIO_MODER_MODE6_Pos)         /*!< 0x00003000 */
+#define GPIO_MODER_MODE6               GPIO_MODER_MODE6_Msk
+#define GPIO_MODER_MODE6_0             (0x1U << GPIO_MODER_MODE6_Pos)          /*!< 0x00001000 */
+#define GPIO_MODER_MODE6_1             (0x2U << GPIO_MODER_MODE6_Pos)          /*!< 0x00002000 */
+#define GPIO_MODER_MODE7_Pos           (14U)
+#define GPIO_MODER_MODE7_Msk           (0x3UL << GPIO_MODER_MODE7_Pos)         /*!< 0x0000C000 */
+#define GPIO_MODER_MODE7               GPIO_MODER_MODE7_Msk
+#define GPIO_MODER_MODE7_0             (0x1U << GPIO_MODER_MODE7_Pos)          /*!< 0x00004000 */
+#define GPIO_MODER_MODE7_1             (0x2U << GPIO_MODER_MODE7_Pos)          /*!< 0x00008000 */
+#define GPIO_MODER_MODE8_Pos           (16U)
+#define GPIO_MODER_MODE8_Msk           (0x3UL << GPIO_MODER_MODE8_Pos)         /*!< 0x00030000 */
+#define GPIO_MODER_MODE8               GPIO_MODER_MODE8_Msk
+#define GPIO_MODER_MODE8_0             (0x1U << GPIO_MODER_MODE8_Pos)          /*!< 0x00010000 */
+#define GPIO_MODER_MODE8_1             (0x2U << GPIO_MODER_MODE8_Pos)          /*!< 0x00020000 */
+#define GPIO_MODER_MODE9_Pos           (18U)
+#define GPIO_MODER_MODE9_Msk           (0x3UL << GPIO_MODER_MODE9_Pos)         /*!< 0x000C0000 */
+#define GPIO_MODER_MODE9               GPIO_MODER_MODE9_Msk
+#define GPIO_MODER_MODE9_0             (0x1U << GPIO_MODER_MODE9_Pos)          /*!< 0x00040000 */
+#define GPIO_MODER_MODE9_1             (0x2U << GPIO_MODER_MODE9_Pos)          /*!< 0x00080000 */
+#define GPIO_MODER_MODE10_Pos          (20U)
+#define GPIO_MODER_MODE10_Msk          (0x3UL << GPIO_MODER_MODE10_Pos)        /*!< 0x00300000 */
+#define GPIO_MODER_MODE10              GPIO_MODER_MODE10_Msk
+#define GPIO_MODER_MODE10_0            (0x1U << GPIO_MODER_MODE10_Pos)         /*!< 0x00100000 */
+#define GPIO_MODER_MODE10_1            (0x2U << GPIO_MODER_MODE10_Pos)         /*!< 0x00200000 */
+#define GPIO_MODER_MODE11_Pos          (22U)
+#define GPIO_MODER_MODE11_Msk          (0x3UL << GPIO_MODER_MODE11_Pos)        /*!< 0x00C00000 */
+#define GPIO_MODER_MODE11              GPIO_MODER_MODE11_Msk
+#define GPIO_MODER_MODE11_0            (0x1U << GPIO_MODER_MODE11_Pos)         /*!< 0x00400000 */
+#define GPIO_MODER_MODE11_1            (0x2U << GPIO_MODER_MODE11_Pos)         /*!< 0x00800000 */
+#define GPIO_MODER_MODE12_Pos          (24U)
+#define GPIO_MODER_MODE12_Msk          (0x3UL << GPIO_MODER_MODE12_Pos)        /*!< 0x03000000 */
+#define GPIO_MODER_MODE12              GPIO_MODER_MODE12_Msk
+#define GPIO_MODER_MODE12_0            (0x1U << GPIO_MODER_MODE12_Pos)         /*!< 0x01000000 */
+#define GPIO_MODER_MODE12_1            (0x2U << GPIO_MODER_MODE12_Pos)         /*!< 0x02000000 */
+#define GPIO_MODER_MODE13_Pos          (26U)
+#define GPIO_MODER_MODE13_Msk          (0x3UL << GPIO_MODER_MODE13_Pos)        /*!< 0x0C000000 */
+#define GPIO_MODER_MODE13              GPIO_MODER_MODE13_Msk
+#define GPIO_MODER_MODE13_0            (0x1U << GPIO_MODER_MODE13_Pos)         /*!< 0x04000000 */
+#define GPIO_MODER_MODE13_1            (0x2U << GPIO_MODER_MODE13_Pos)         /*!< 0x08000000 */
+#define GPIO_MODER_MODE14_Pos          (28U)
+#define GPIO_MODER_MODE14_Msk          (0x3UL << GPIO_MODER_MODE14_Pos)        /*!< 0x30000000 */
+#define GPIO_MODER_MODE14              GPIO_MODER_MODE14_Msk
+#define GPIO_MODER_MODE14_0            (0x1U << GPIO_MODER_MODE14_Pos)         /*!< 0x10000000 */
+#define GPIO_MODER_MODE14_1            (0x2U << GPIO_MODER_MODE14_Pos)         /*!< 0x20000000 */
+#define GPIO_MODER_MODE15_Pos          (30U)
+#define GPIO_MODER_MODE15_Msk          (0x3UL << GPIO_MODER_MODE15_Pos)        /*!< 0xC0000000 */
+#define GPIO_MODER_MODE15              GPIO_MODER_MODE15_Msk
+#define GPIO_MODER_MODE15_0            (0x1U << GPIO_MODER_MODE15_Pos)         /*!< 0x40000000 */
+#define GPIO_MODER_MODE15_1            (0x2U << GPIO_MODER_MODE15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos            (0U)
+#define GPIO_OTYPER_OT0_Msk            (0x1UL << GPIO_OTYPER_OT0_Pos)          /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                GPIO_OTYPER_OT0_Msk
+#define GPIO_OTYPER_OT1_Pos            (1U)
+#define GPIO_OTYPER_OT1_Msk            (0x1UL << GPIO_OTYPER_OT1_Pos)          /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                GPIO_OTYPER_OT1_Msk
+#define GPIO_OTYPER_OT2_Pos            (2U)
+#define GPIO_OTYPER_OT2_Msk            (0x1UL << GPIO_OTYPER_OT2_Pos)          /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                GPIO_OTYPER_OT2_Msk
+#define GPIO_OTYPER_OT3_Pos            (3U)
+#define GPIO_OTYPER_OT3_Msk            (0x1UL << GPIO_OTYPER_OT3_Pos)          /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                GPIO_OTYPER_OT3_Msk
+#define GPIO_OTYPER_OT4_Pos            (4U)
+#define GPIO_OTYPER_OT4_Msk            (0x1UL << GPIO_OTYPER_OT4_Pos)          /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                GPIO_OTYPER_OT4_Msk
+#define GPIO_OTYPER_OT5_Pos            (5U)
+#define GPIO_OTYPER_OT5_Msk            (0x1UL << GPIO_OTYPER_OT5_Pos)          /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                GPIO_OTYPER_OT5_Msk
+#define GPIO_OTYPER_OT6_Pos            (6U)
+#define GPIO_OTYPER_OT6_Msk            (0x1UL << GPIO_OTYPER_OT6_Pos)          /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                GPIO_OTYPER_OT6_Msk
+#define GPIO_OTYPER_OT7_Pos            (7U)
+#define GPIO_OTYPER_OT7_Msk            (0x1UL << GPIO_OTYPER_OT7_Pos)          /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                GPIO_OTYPER_OT7_Msk
+#define GPIO_OTYPER_OT8_Pos            (8U)
+#define GPIO_OTYPER_OT8_Msk            (0x1UL << GPIO_OTYPER_OT8_Pos)          /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                GPIO_OTYPER_OT8_Msk
+#define GPIO_OTYPER_OT9_Pos            (9U)
+#define GPIO_OTYPER_OT9_Msk            (0x1UL << GPIO_OTYPER_OT9_Pos)          /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                GPIO_OTYPER_OT9_Msk
+#define GPIO_OTYPER_OT10_Pos           (10U)
+#define GPIO_OTYPER_OT10_Msk           (0x1UL << GPIO_OTYPER_OT10_Pos)         /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10               GPIO_OTYPER_OT10_Msk
+#define GPIO_OTYPER_OT11_Pos           (11U)
+#define GPIO_OTYPER_OT11_Msk           (0x1UL << GPIO_OTYPER_OT11_Pos)         /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11               GPIO_OTYPER_OT11_Msk
+#define GPIO_OTYPER_OT12_Pos           (12U)
+#define GPIO_OTYPER_OT12_Msk           (0x1UL << GPIO_OTYPER_OT12_Pos)         /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12               GPIO_OTYPER_OT12_Msk
+#define GPIO_OTYPER_OT13_Pos           (13U)
+#define GPIO_OTYPER_OT13_Msk           (0x1UL << GPIO_OTYPER_OT13_Pos)         /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13               GPIO_OTYPER_OT13_Msk
+#define GPIO_OTYPER_OT14_Pos           (14U)
+#define GPIO_OTYPER_OT14_Msk           (0x1UL << GPIO_OTYPER_OT14_Pos)         /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14               GPIO_OTYPER_OT14_Msk
+#define GPIO_OTYPER_OT15_Pos           (15U)
+#define GPIO_OTYPER_OT15_Msk           (0x1UL << GPIO_OTYPER_OT15_Pos)         /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15               GPIO_OTYPER_OT15_Msk
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos       (0U)
+#define GPIO_OSPEEDR_OSPEED0_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)     /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0           GPIO_OSPEEDR_OSPEED0_Msk
+#define GPIO_OSPEEDR_OSPEED0_0         (0x1U << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1         (0x2U << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos       (2U)
+#define GPIO_OSPEEDR_OSPEED1_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)     /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1           GPIO_OSPEEDR_OSPEED1_Msk
+#define GPIO_OSPEEDR_OSPEED1_0         (0x1U << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1         (0x2U << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos       (4U)
+#define GPIO_OSPEEDR_OSPEED2_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)     /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2           GPIO_OSPEEDR_OSPEED2_Msk
+#define GPIO_OSPEEDR_OSPEED2_0         (0x1U << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1         (0x2U << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos       (6U)
+#define GPIO_OSPEEDR_OSPEED3_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)     /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3           GPIO_OSPEEDR_OSPEED3_Msk
+#define GPIO_OSPEEDR_OSPEED3_0         (0x1U << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1         (0x2U << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos       (8U)
+#define GPIO_OSPEEDR_OSPEED4_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)     /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4           GPIO_OSPEEDR_OSPEED4_Msk
+#define GPIO_OSPEEDR_OSPEED4_0         (0x1U << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1         (0x2U << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos       (10U)
+#define GPIO_OSPEEDR_OSPEED5_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)     /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5           GPIO_OSPEEDR_OSPEED5_Msk
+#define GPIO_OSPEEDR_OSPEED5_0         (0x1U << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1         (0x2U << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos       (12U)
+#define GPIO_OSPEEDR_OSPEED6_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)     /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6           GPIO_OSPEEDR_OSPEED6_Msk
+#define GPIO_OSPEEDR_OSPEED6_0         (0x1U << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1         (0x2U << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos       (14U)
+#define GPIO_OSPEEDR_OSPEED7_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)     /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7           GPIO_OSPEEDR_OSPEED7_Msk
+#define GPIO_OSPEEDR_OSPEED7_0         (0x1U << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1         (0x2U << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos       (16U)
+#define GPIO_OSPEEDR_OSPEED8_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)     /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8           GPIO_OSPEEDR_OSPEED8_Msk
+#define GPIO_OSPEEDR_OSPEED8_0         (0x1U << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1         (0x2U << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos       (18U)
+#define GPIO_OSPEEDR_OSPEED9_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)     /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9           GPIO_OSPEEDR_OSPEED9_Msk
+#define GPIO_OSPEEDR_OSPEED9_0         (0x1U << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1         (0x2U << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos      (20U)
+#define GPIO_OSPEEDR_OSPEED10_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)    /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10          GPIO_OSPEEDR_OSPEED10_Msk
+#define GPIO_OSPEEDR_OSPEED10_0        (0x1U << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1        (0x2U << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos      (22U)
+#define GPIO_OSPEEDR_OSPEED11_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)    /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11          GPIO_OSPEEDR_OSPEED11_Msk
+#define GPIO_OSPEEDR_OSPEED11_0        (0x1U << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1        (0x2U << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos      (24U)
+#define GPIO_OSPEEDR_OSPEED12_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)    /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12          GPIO_OSPEEDR_OSPEED12_Msk
+#define GPIO_OSPEEDR_OSPEED12_0        (0x1U << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1        (0x2U << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos      (26U)
+#define GPIO_OSPEEDR_OSPEED13_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)    /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13          GPIO_OSPEEDR_OSPEED13_Msk
+#define GPIO_OSPEEDR_OSPEED13_0        (0x1U << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1        (0x2U << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos      (28U)
+#define GPIO_OSPEEDR_OSPEED14_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)    /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14          GPIO_OSPEEDR_OSPEED14_Msk
+#define GPIO_OSPEEDR_OSPEED14_0        (0x1U << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1        (0x2U << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos      (30U)
+#define GPIO_OSPEEDR_OSPEED15_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)    /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15          GPIO_OSPEEDR_OSPEED15_Msk
+#define GPIO_OSPEEDR_OSPEED15_0        (0x1U << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1        (0x2U << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos           (0U)
+#define GPIO_PUPDR_PUPD0_Msk           (0x3UL << GPIO_PUPDR_PUPD0_Pos)         /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0               GPIO_PUPDR_PUPD0_Msk
+#define GPIO_PUPDR_PUPD0_0             (0x1U << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1             (0x2U << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos           (2U)
+#define GPIO_PUPDR_PUPD1_Msk           (0x3UL << GPIO_PUPDR_PUPD1_Pos)         /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1               GPIO_PUPDR_PUPD1_Msk
+#define GPIO_PUPDR_PUPD1_0             (0x1U << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1             (0x2U << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos           (4U)
+#define GPIO_PUPDR_PUPD2_Msk           (0x3UL << GPIO_PUPDR_PUPD2_Pos)         /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2               GPIO_PUPDR_PUPD2_Msk
+#define GPIO_PUPDR_PUPD2_0             (0x1U << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1             (0x2U << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos           (6U)
+#define GPIO_PUPDR_PUPD3_Msk           (0x3UL << GPIO_PUPDR_PUPD3_Pos)         /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3               GPIO_PUPDR_PUPD3_Msk
+#define GPIO_PUPDR_PUPD3_0             (0x1U << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1             (0x2U << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos           (8U)
+#define GPIO_PUPDR_PUPD4_Msk           (0x3UL << GPIO_PUPDR_PUPD4_Pos)         /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4               GPIO_PUPDR_PUPD4_Msk
+#define GPIO_PUPDR_PUPD4_0             (0x1U << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1             (0x2U << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos           (10U)
+#define GPIO_PUPDR_PUPD5_Msk           (0x3UL << GPIO_PUPDR_PUPD5_Pos)         /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5               GPIO_PUPDR_PUPD5_Msk
+#define GPIO_PUPDR_PUPD5_0             (0x1U << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1             (0x2U << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos           (12U)
+#define GPIO_PUPDR_PUPD6_Msk           (0x3UL << GPIO_PUPDR_PUPD6_Pos)         /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6               GPIO_PUPDR_PUPD6_Msk
+#define GPIO_PUPDR_PUPD6_0             (0x1U << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1             (0x2U << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos           (14U)
+#define GPIO_PUPDR_PUPD7_Msk           (0x3UL << GPIO_PUPDR_PUPD7_Pos)         /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7               GPIO_PUPDR_PUPD7_Msk
+#define GPIO_PUPDR_PUPD7_0             (0x1U << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1             (0x2U << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos           (16U)
+#define GPIO_PUPDR_PUPD8_Msk           (0x3UL << GPIO_PUPDR_PUPD8_Pos)         /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8               GPIO_PUPDR_PUPD8_Msk
+#define GPIO_PUPDR_PUPD8_0             (0x1U << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1             (0x2U << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos           (18U)
+#define GPIO_PUPDR_PUPD9_Msk           (0x3UL << GPIO_PUPDR_PUPD9_Pos)         /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9               GPIO_PUPDR_PUPD9_Msk
+#define GPIO_PUPDR_PUPD9_0             (0x1U << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1             (0x2U << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos          (20U)
+#define GPIO_PUPDR_PUPD10_Msk          (0x3UL << GPIO_PUPDR_PUPD10_Pos)        /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10              GPIO_PUPDR_PUPD10_Msk
+#define GPIO_PUPDR_PUPD10_0            (0x1U << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1            (0x2U << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos          (22U)
+#define GPIO_PUPDR_PUPD11_Msk          (0x3UL << GPIO_PUPDR_PUPD11_Pos)        /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11              GPIO_PUPDR_PUPD11_Msk
+#define GPIO_PUPDR_PUPD11_0            (0x1U << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1            (0x2U << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos          (24U)
+#define GPIO_PUPDR_PUPD12_Msk          (0x3UL << GPIO_PUPDR_PUPD12_Pos)        /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12              GPIO_PUPDR_PUPD12_Msk
+#define GPIO_PUPDR_PUPD12_0            (0x1U << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1            (0x2U << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos          (26U)
+#define GPIO_PUPDR_PUPD13_Msk          (0x3UL << GPIO_PUPDR_PUPD13_Pos)        /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13              GPIO_PUPDR_PUPD13_Msk
+#define GPIO_PUPDR_PUPD13_0            (0x1U << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1            (0x2U << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos          (28U)
+#define GPIO_PUPDR_PUPD14_Msk          (0x3UL << GPIO_PUPDR_PUPD14_Pos)        /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14              GPIO_PUPDR_PUPD14_Msk
+#define GPIO_PUPDR_PUPD14_0            (0x1U << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1            (0x2U << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos          (30U)
+#define GPIO_PUPDR_PUPD15_Msk          (0x3UL << GPIO_PUPDR_PUPD15_Pos)        /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15              GPIO_PUPDR_PUPD15_Msk
+#define GPIO_PUPDR_PUPD15_0            (0x1U << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1            (0x2U << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos               (0U)
+#define GPIO_IDR_ID0_Msk               (0x1UL << GPIO_IDR_ID0_Pos)             /*!< 0x00000001 */
+#define GPIO_IDR_ID0                   GPIO_IDR_ID0_Msk
+#define GPIO_IDR_ID1_Pos               (1U)
+#define GPIO_IDR_ID1_Msk               (0x1UL << GPIO_IDR_ID1_Pos)             /*!< 0x00000002 */
+#define GPIO_IDR_ID1                   GPIO_IDR_ID1_Msk
+#define GPIO_IDR_ID2_Pos               (2U)
+#define GPIO_IDR_ID2_Msk               (0x1UL << GPIO_IDR_ID2_Pos)             /*!< 0x00000004 */
+#define GPIO_IDR_ID2                   GPIO_IDR_ID2_Msk
+#define GPIO_IDR_ID3_Pos               (3U)
+#define GPIO_IDR_ID3_Msk               (0x1UL << GPIO_IDR_ID3_Pos)             /*!< 0x00000008 */
+#define GPIO_IDR_ID3                   GPIO_IDR_ID3_Msk
+#define GPIO_IDR_ID4_Pos               (4U)
+#define GPIO_IDR_ID4_Msk               (0x1UL << GPIO_IDR_ID4_Pos)             /*!< 0x00000010 */
+#define GPIO_IDR_ID4                   GPIO_IDR_ID4_Msk
+#define GPIO_IDR_ID5_Pos               (5U)
+#define GPIO_IDR_ID5_Msk               (0x1UL << GPIO_IDR_ID5_Pos)             /*!< 0x00000020 */
+#define GPIO_IDR_ID5                   GPIO_IDR_ID5_Msk
+#define GPIO_IDR_ID6_Pos               (6U)
+#define GPIO_IDR_ID6_Msk               (0x1UL << GPIO_IDR_ID6_Pos)             /*!< 0x00000040 */
+#define GPIO_IDR_ID6                   GPIO_IDR_ID6_Msk
+#define GPIO_IDR_ID7_Pos               (7U)
+#define GPIO_IDR_ID7_Msk               (0x1UL << GPIO_IDR_ID7_Pos)             /*!< 0x00000080 */
+#define GPIO_IDR_ID7                   GPIO_IDR_ID7_Msk
+#define GPIO_IDR_ID8_Pos               (8U)
+#define GPIO_IDR_ID8_Msk               (0x1UL << GPIO_IDR_ID8_Pos)             /*!< 0x00000100 */
+#define GPIO_IDR_ID8                   GPIO_IDR_ID8_Msk
+#define GPIO_IDR_ID9_Pos               (9U)
+#define GPIO_IDR_ID9_Msk               (0x1UL << GPIO_IDR_ID9_Pos)             /*!< 0x00000200 */
+#define GPIO_IDR_ID9                   GPIO_IDR_ID9_Msk
+#define GPIO_IDR_ID10_Pos              (10U)
+#define GPIO_IDR_ID10_Msk              (0x1UL << GPIO_IDR_ID10_Pos)            /*!< 0x00000400 */
+#define GPIO_IDR_ID10                  GPIO_IDR_ID10_Msk
+#define GPIO_IDR_ID11_Pos              (11U)
+#define GPIO_IDR_ID11_Msk              (0x1UL << GPIO_IDR_ID11_Pos)            /*!< 0x00000800 */
+#define GPIO_IDR_ID11                  GPIO_IDR_ID11_Msk
+#define GPIO_IDR_ID12_Pos              (12U)
+#define GPIO_IDR_ID12_Msk              (0x1UL << GPIO_IDR_ID12_Pos)            /*!< 0x00001000 */
+#define GPIO_IDR_ID12                  GPIO_IDR_ID12_Msk
+#define GPIO_IDR_ID13_Pos              (13U)
+#define GPIO_IDR_ID13_Msk              (0x1UL << GPIO_IDR_ID13_Pos)            /*!< 0x00002000 */
+#define GPIO_IDR_ID13                  GPIO_IDR_ID13_Msk
+#define GPIO_IDR_ID14_Pos              (14U)
+#define GPIO_IDR_ID14_Msk              (0x1UL << GPIO_IDR_ID14_Pos)            /*!< 0x00004000 */
+#define GPIO_IDR_ID14                  GPIO_IDR_ID14_Msk
+#define GPIO_IDR_ID15_Pos              (15U)
+#define GPIO_IDR_ID15_Msk              (0x1UL << GPIO_IDR_ID15_Pos)            /*!< 0x00008000 */
+#define GPIO_IDR_ID15                  GPIO_IDR_ID15_Msk
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos               (0U)
+#define GPIO_ODR_OD0_Msk               (0x1UL << GPIO_ODR_OD0_Pos)             /*!< 0x00000001 */
+#define GPIO_ODR_OD0                   GPIO_ODR_OD0_Msk
+#define GPIO_ODR_OD1_Pos               (1U)
+#define GPIO_ODR_OD1_Msk               (0x1UL << GPIO_ODR_OD1_Pos)             /*!< 0x00000002 */
+#define GPIO_ODR_OD1                   GPIO_ODR_OD1_Msk
+#define GPIO_ODR_OD2_Pos               (2U)
+#define GPIO_ODR_OD2_Msk               (0x1UL << GPIO_ODR_OD2_Pos)             /*!< 0x00000004 */
+#define GPIO_ODR_OD2                   GPIO_ODR_OD2_Msk
+#define GPIO_ODR_OD3_Pos               (3U)
+#define GPIO_ODR_OD3_Msk               (0x1UL << GPIO_ODR_OD3_Pos)             /*!< 0x00000008 */
+#define GPIO_ODR_OD3                   GPIO_ODR_OD3_Msk
+#define GPIO_ODR_OD4_Pos               (4U)
+#define GPIO_ODR_OD4_Msk               (0x1UL << GPIO_ODR_OD4_Pos)             /*!< 0x00000010 */
+#define GPIO_ODR_OD4                   GPIO_ODR_OD4_Msk
+#define GPIO_ODR_OD5_Pos               (5U)
+#define GPIO_ODR_OD5_Msk               (0x1UL << GPIO_ODR_OD5_Pos)             /*!< 0x00000020 */
+#define GPIO_ODR_OD5                   GPIO_ODR_OD5_Msk
+#define GPIO_ODR_OD6_Pos               (6U)
+#define GPIO_ODR_OD6_Msk               (0x1UL << GPIO_ODR_OD6_Pos)             /*!< 0x00000040 */
+#define GPIO_ODR_OD6                   GPIO_ODR_OD6_Msk
+#define GPIO_ODR_OD7_Pos               (7U)
+#define GPIO_ODR_OD7_Msk               (0x1UL << GPIO_ODR_OD7_Pos)             /*!< 0x00000080 */
+#define GPIO_ODR_OD7                   GPIO_ODR_OD7_Msk
+#define GPIO_ODR_OD8_Pos               (8U)
+#define GPIO_ODR_OD8_Msk               (0x1UL << GPIO_ODR_OD8_Pos)             /*!< 0x00000100 */
+#define GPIO_ODR_OD8                   GPIO_ODR_OD8_Msk
+#define GPIO_ODR_OD9_Pos               (9U)
+#define GPIO_ODR_OD9_Msk               (0x1UL << GPIO_ODR_OD9_Pos)             /*!< 0x00000200 */
+#define GPIO_ODR_OD9                   GPIO_ODR_OD9_Msk
+#define GPIO_ODR_OD10_Pos              (10U)
+#define GPIO_ODR_OD10_Msk              (0x1UL << GPIO_ODR_OD10_Pos)            /*!< 0x00000400 */
+#define GPIO_ODR_OD10                  GPIO_ODR_OD10_Msk
+#define GPIO_ODR_OD11_Pos              (11U)
+#define GPIO_ODR_OD11_Msk              (0x1UL << GPIO_ODR_OD11_Pos)            /*!< 0x00000800 */
+#define GPIO_ODR_OD11                  GPIO_ODR_OD11_Msk
+#define GPIO_ODR_OD12_Pos              (12U)
+#define GPIO_ODR_OD12_Msk              (0x1UL << GPIO_ODR_OD12_Pos)            /*!< 0x00001000 */
+#define GPIO_ODR_OD12                  GPIO_ODR_OD12_Msk
+#define GPIO_ODR_OD13_Pos              (13U)
+#define GPIO_ODR_OD13_Msk              (0x1UL << GPIO_ODR_OD13_Pos)            /*!< 0x00002000 */
+#define GPIO_ODR_OD13                  GPIO_ODR_OD13_Msk
+#define GPIO_ODR_OD14_Pos              (14U)
+#define GPIO_ODR_OD14_Msk              (0x1UL << GPIO_ODR_OD14_Pos)            /*!< 0x00004000 */
+#define GPIO_ODR_OD14                  GPIO_ODR_OD14_Msk
+#define GPIO_ODR_OD15_Pos              (15U)
+#define GPIO_ODR_OD15_Msk              (0x1UL << GPIO_ODR_OD15_Pos)            /*!< 0x00008000 */
+#define GPIO_ODR_OD15                  GPIO_ODR_OD15_Msk
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos              (0U)
+#define GPIO_BSRR_BS0_Msk              (0x1UL << GPIO_BSRR_BS0_Pos)            /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                  GPIO_BSRR_BS0_Msk
+#define GPIO_BSRR_BS1_Pos              (1U)
+#define GPIO_BSRR_BS1_Msk              (0x1UL << GPIO_BSRR_BS1_Pos)            /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                  GPIO_BSRR_BS1_Msk
+#define GPIO_BSRR_BS2_Pos              (2U)
+#define GPIO_BSRR_BS2_Msk              (0x1UL << GPIO_BSRR_BS2_Pos)            /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                  GPIO_BSRR_BS2_Msk
+#define GPIO_BSRR_BS3_Pos              (3U)
+#define GPIO_BSRR_BS3_Msk              (0x1UL << GPIO_BSRR_BS3_Pos)            /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                  GPIO_BSRR_BS3_Msk
+#define GPIO_BSRR_BS4_Pos              (4U)
+#define GPIO_BSRR_BS4_Msk              (0x1UL << GPIO_BSRR_BS4_Pos)            /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                  GPIO_BSRR_BS4_Msk
+#define GPIO_BSRR_BS5_Pos              (5U)
+#define GPIO_BSRR_BS5_Msk              (0x1UL << GPIO_BSRR_BS5_Pos)            /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                  GPIO_BSRR_BS5_Msk
+#define GPIO_BSRR_BS6_Pos              (6U)
+#define GPIO_BSRR_BS6_Msk              (0x1UL << GPIO_BSRR_BS6_Pos)            /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                  GPIO_BSRR_BS6_Msk
+#define GPIO_BSRR_BS7_Pos              (7U)
+#define GPIO_BSRR_BS7_Msk              (0x1UL << GPIO_BSRR_BS7_Pos)            /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                  GPIO_BSRR_BS7_Msk
+#define GPIO_BSRR_BS8_Pos              (8U)
+#define GPIO_BSRR_BS8_Msk              (0x1UL << GPIO_BSRR_BS8_Pos)            /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                  GPIO_BSRR_BS8_Msk
+#define GPIO_BSRR_BS9_Pos              (9U)
+#define GPIO_BSRR_BS9_Msk              (0x1UL << GPIO_BSRR_BS9_Pos)            /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                  GPIO_BSRR_BS9_Msk
+#define GPIO_BSRR_BS10_Pos             (10U)
+#define GPIO_BSRR_BS10_Msk             (0x1UL << GPIO_BSRR_BS10_Pos)           /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                 GPIO_BSRR_BS10_Msk
+#define GPIO_BSRR_BS11_Pos             (11U)
+#define GPIO_BSRR_BS11_Msk             (0x1UL << GPIO_BSRR_BS11_Pos)           /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                 GPIO_BSRR_BS11_Msk
+#define GPIO_BSRR_BS12_Pos             (12U)
+#define GPIO_BSRR_BS12_Msk             (0x1UL << GPIO_BSRR_BS12_Pos)           /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                 GPIO_BSRR_BS12_Msk
+#define GPIO_BSRR_BS13_Pos             (13U)
+#define GPIO_BSRR_BS13_Msk             (0x1UL << GPIO_BSRR_BS13_Pos)           /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                 GPIO_BSRR_BS13_Msk
+#define GPIO_BSRR_BS14_Pos             (14U)
+#define GPIO_BSRR_BS14_Msk             (0x1UL << GPIO_BSRR_BS14_Pos)           /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                 GPIO_BSRR_BS14_Msk
+#define GPIO_BSRR_BS15_Pos             (15U)
+#define GPIO_BSRR_BS15_Msk             (0x1UL << GPIO_BSRR_BS15_Pos)           /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                 GPIO_BSRR_BS15_Msk
+#define GPIO_BSRR_BR0_Pos              (16U)
+#define GPIO_BSRR_BR0_Msk              (0x1UL << GPIO_BSRR_BR0_Pos)            /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                  GPIO_BSRR_BR0_Msk
+#define GPIO_BSRR_BR1_Pos              (17U)
+#define GPIO_BSRR_BR1_Msk              (0x1UL << GPIO_BSRR_BR1_Pos)            /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                  GPIO_BSRR_BR1_Msk
+#define GPIO_BSRR_BR2_Pos              (18U)
+#define GPIO_BSRR_BR2_Msk              (0x1UL << GPIO_BSRR_BR2_Pos)            /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                  GPIO_BSRR_BR2_Msk
+#define GPIO_BSRR_BR3_Pos              (19U)
+#define GPIO_BSRR_BR3_Msk              (0x1UL << GPIO_BSRR_BR3_Pos)            /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                  GPIO_BSRR_BR3_Msk
+#define GPIO_BSRR_BR4_Pos              (20U)
+#define GPIO_BSRR_BR4_Msk              (0x1UL << GPIO_BSRR_BR4_Pos)            /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                  GPIO_BSRR_BR4_Msk
+#define GPIO_BSRR_BR5_Pos              (21U)
+#define GPIO_BSRR_BR5_Msk              (0x1UL << GPIO_BSRR_BR5_Pos)            /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                  GPIO_BSRR_BR5_Msk
+#define GPIO_BSRR_BR6_Pos              (22U)
+#define GPIO_BSRR_BR6_Msk              (0x1UL << GPIO_BSRR_BR6_Pos)            /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                  GPIO_BSRR_BR6_Msk
+#define GPIO_BSRR_BR7_Pos              (23U)
+#define GPIO_BSRR_BR7_Msk              (0x1UL << GPIO_BSRR_BR7_Pos)            /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                  GPIO_BSRR_BR7_Msk
+#define GPIO_BSRR_BR8_Pos              (24U)
+#define GPIO_BSRR_BR8_Msk              (0x1UL << GPIO_BSRR_BR8_Pos)            /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                  GPIO_BSRR_BR8_Msk
+#define GPIO_BSRR_BR9_Pos              (25U)
+#define GPIO_BSRR_BR9_Msk              (0x1UL << GPIO_BSRR_BR9_Pos)            /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                  GPIO_BSRR_BR9_Msk
+#define GPIO_BSRR_BR10_Pos             (26U)
+#define GPIO_BSRR_BR10_Msk             (0x1UL << GPIO_BSRR_BR10_Pos)           /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                 GPIO_BSRR_BR10_Msk
+#define GPIO_BSRR_BR11_Pos             (27U)
+#define GPIO_BSRR_BR11_Msk             (0x1UL << GPIO_BSRR_BR11_Pos)           /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                 GPIO_BSRR_BR11_Msk
+#define GPIO_BSRR_BR12_Pos             (28U)
+#define GPIO_BSRR_BR12_Msk             (0x1UL << GPIO_BSRR_BR12_Pos)           /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                 GPIO_BSRR_BR12_Msk
+#define GPIO_BSRR_BR13_Pos             (29U)
+#define GPIO_BSRR_BR13_Msk             (0x1UL << GPIO_BSRR_BR13_Pos)           /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                 GPIO_BSRR_BR13_Msk
+#define GPIO_BSRR_BR14_Pos             (30U)
+#define GPIO_BSRR_BR14_Msk             (0x1UL << GPIO_BSRR_BR14_Pos)           /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                 GPIO_BSRR_BR14_Msk
+#define GPIO_BSRR_BR15_Pos             (31U)
+#define GPIO_BSRR_BR15_Msk             (0x1UL << GPIO_BSRR_BR15_Pos)           /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                 GPIO_BSRR_BR15_Msk
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos             (0U)
+#define GPIO_LCKR_LCK0_Msk             (0x1UL << GPIO_LCKR_LCK0_Pos)           /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                 GPIO_LCKR_LCK0_Msk
+#define GPIO_LCKR_LCK1_Pos             (1U)
+#define GPIO_LCKR_LCK1_Msk             (0x1UL << GPIO_LCKR_LCK1_Pos)           /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                 GPIO_LCKR_LCK1_Msk
+#define GPIO_LCKR_LCK2_Pos             (2U)
+#define GPIO_LCKR_LCK2_Msk             (0x1UL << GPIO_LCKR_LCK2_Pos)           /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                 GPIO_LCKR_LCK2_Msk
+#define GPIO_LCKR_LCK3_Pos             (3U)
+#define GPIO_LCKR_LCK3_Msk             (0x1UL << GPIO_LCKR_LCK3_Pos)           /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                 GPIO_LCKR_LCK3_Msk
+#define GPIO_LCKR_LCK4_Pos             (4U)
+#define GPIO_LCKR_LCK4_Msk             (0x1UL << GPIO_LCKR_LCK4_Pos)           /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                 GPIO_LCKR_LCK4_Msk
+#define GPIO_LCKR_LCK5_Pos             (5U)
+#define GPIO_LCKR_LCK5_Msk             (0x1UL << GPIO_LCKR_LCK5_Pos)           /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                 GPIO_LCKR_LCK5_Msk
+#define GPIO_LCKR_LCK6_Pos             (6U)
+#define GPIO_LCKR_LCK6_Msk             (0x1UL << GPIO_LCKR_LCK6_Pos)           /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                 GPIO_LCKR_LCK6_Msk
+#define GPIO_LCKR_LCK7_Pos             (7U)
+#define GPIO_LCKR_LCK7_Msk             (0x1UL << GPIO_LCKR_LCK7_Pos)           /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                 GPIO_LCKR_LCK7_Msk
+#define GPIO_LCKR_LCK8_Pos             (8U)
+#define GPIO_LCKR_LCK8_Msk             (0x1UL << GPIO_LCKR_LCK8_Pos)           /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                 GPIO_LCKR_LCK8_Msk
+#define GPIO_LCKR_LCK9_Pos             (9U)
+#define GPIO_LCKR_LCK9_Msk             (0x1UL << GPIO_LCKR_LCK9_Pos)           /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                 GPIO_LCKR_LCK9_Msk
+#define GPIO_LCKR_LCK10_Pos            (10U)
+#define GPIO_LCKR_LCK10_Msk            (0x1UL << GPIO_LCKR_LCK10_Pos)          /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                GPIO_LCKR_LCK10_Msk
+#define GPIO_LCKR_LCK11_Pos            (11U)
+#define GPIO_LCKR_LCK11_Msk            (0x1UL << GPIO_LCKR_LCK11_Pos)          /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                GPIO_LCKR_LCK11_Msk
+#define GPIO_LCKR_LCK12_Pos            (12U)
+#define GPIO_LCKR_LCK12_Msk            (0x1UL << GPIO_LCKR_LCK12_Pos)          /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                GPIO_LCKR_LCK12_Msk
+#define GPIO_LCKR_LCK13_Pos            (13U)
+#define GPIO_LCKR_LCK13_Msk            (0x1UL << GPIO_LCKR_LCK13_Pos)          /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                GPIO_LCKR_LCK13_Msk
+#define GPIO_LCKR_LCK14_Pos            (14U)
+#define GPIO_LCKR_LCK14_Msk            (0x1UL << GPIO_LCKR_LCK14_Pos)          /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                GPIO_LCKR_LCK14_Msk
+#define GPIO_LCKR_LCK15_Pos            (15U)
+#define GPIO_LCKR_LCK15_Msk            (0x1UL << GPIO_LCKR_LCK15_Pos)          /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                GPIO_LCKR_LCK15_Msk
+#define GPIO_LCKR_LCKK_Pos             (16U)
+#define GPIO_LCKR_LCKK_Msk             (0x1UL << GPIO_LCKR_LCKK_Pos)           /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                 GPIO_LCKR_LCKK_Msk
+
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos           (0U)
+#define GPIO_AFRL_AFSEL0_Msk           (0xFUL << GPIO_AFRL_AFSEL0_Pos)         /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0               GPIO_AFRL_AFSEL0_Msk
+#define GPIO_AFRL_AFSEL0_0             (0x1U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1             (0x2U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2             (0x4U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3             (0x8U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos           (4U)
+#define GPIO_AFRL_AFSEL1_Msk           (0xFUL << GPIO_AFRL_AFSEL1_Pos)         /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1               GPIO_AFRL_AFSEL1_Msk
+#define GPIO_AFRL_AFSEL1_0             (0x1U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1             (0x2U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2             (0x4U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3             (0x8U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos           (8U)
+#define GPIO_AFRL_AFSEL2_Msk           (0xFUL << GPIO_AFRL_AFSEL2_Pos)         /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2               GPIO_AFRL_AFSEL2_Msk
+#define GPIO_AFRL_AFSEL2_0             (0x1U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1             (0x2U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2             (0x4U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3             (0x8U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos           (12U)
+#define GPIO_AFRL_AFSEL3_Msk           (0xFUL << GPIO_AFRL_AFSEL3_Pos)         /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3               GPIO_AFRL_AFSEL3_Msk
+#define GPIO_AFRL_AFSEL3_0             (0x1U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1             (0x2U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2             (0x4U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3             (0x8U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos           (16U)
+#define GPIO_AFRL_AFSEL4_Msk           (0xFUL << GPIO_AFRL_AFSEL4_Pos)         /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4               GPIO_AFRL_AFSEL4_Msk
+#define GPIO_AFRL_AFSEL4_0             (0x1U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1             (0x2U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2             (0x4U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3             (0x8U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos           (20U)
+#define GPIO_AFRL_AFSEL5_Msk           (0xFUL << GPIO_AFRL_AFSEL5_Pos)         /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5               GPIO_AFRL_AFSEL5_Msk
+#define GPIO_AFRL_AFSEL5_0             (0x1U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1             (0x2U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2             (0x4U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3             (0x8U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos           (24U)
+#define GPIO_AFRL_AFSEL6_Msk           (0xFUL << GPIO_AFRL_AFSEL6_Pos)         /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6               GPIO_AFRL_AFSEL6_Msk
+#define GPIO_AFRL_AFSEL6_0             (0x1U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1             (0x2U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2             (0x4U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3             (0x8U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos           (28U)
+#define GPIO_AFRL_AFSEL7_Msk           (0xFUL << GPIO_AFRL_AFSEL7_Pos)         /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7               GPIO_AFRL_AFSEL7_Msk
+#define GPIO_AFRL_AFSEL7_0             (0x1U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1             (0x2U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2             (0x4U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3             (0x8U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x80000000 */
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos           (0U)
+#define GPIO_AFRH_AFSEL8_Msk           (0xFUL << GPIO_AFRH_AFSEL8_Pos)         /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8               GPIO_AFRH_AFSEL8_Msk
+#define GPIO_AFRH_AFSEL8_0             (0x1U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1             (0x2U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2             (0x4U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3             (0x8U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos           (4U)
+#define GPIO_AFRH_AFSEL9_Msk           (0xFUL << GPIO_AFRH_AFSEL9_Pos)         /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9               GPIO_AFRH_AFSEL9_Msk
+#define GPIO_AFRH_AFSEL9_0             (0x1U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1             (0x2U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2             (0x4U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3             (0x8U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos          (8U)
+#define GPIO_AFRH_AFSEL10_Msk          (0xFUL << GPIO_AFRH_AFSEL10_Pos)        /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10              GPIO_AFRH_AFSEL10_Msk
+#define GPIO_AFRH_AFSEL10_0            (0x1U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1            (0x2U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2            (0x4U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3            (0x8U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos          (12U)
+#define GPIO_AFRH_AFSEL11_Msk          (0xFUL << GPIO_AFRH_AFSEL11_Pos)        /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11              GPIO_AFRH_AFSEL11_Msk
+#define GPIO_AFRH_AFSEL11_0            (0x1U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1            (0x2U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2            (0x4U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3            (0x8U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos          (16U)
+#define GPIO_AFRH_AFSEL12_Msk          (0xFUL << GPIO_AFRH_AFSEL12_Pos)        /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12              GPIO_AFRH_AFSEL12_Msk
+#define GPIO_AFRH_AFSEL12_0            (0x1U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1            (0x2U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2            (0x4U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3            (0x8U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos          (20U)
+#define GPIO_AFRH_AFSEL13_Msk          (0xFUL << GPIO_AFRH_AFSEL13_Pos)        /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13              GPIO_AFRH_AFSEL13_Msk
+#define GPIO_AFRH_AFSEL13_0            (0x1U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1            (0x2U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2            (0x4U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3            (0x8U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos          (24U)
+#define GPIO_AFRH_AFSEL14_Msk          (0xFUL << GPIO_AFRH_AFSEL14_Pos)        /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14              GPIO_AFRH_AFSEL14_Msk
+#define GPIO_AFRH_AFSEL14_0            (0x1U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1            (0x2U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2            (0x4U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3            (0x8U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos          (28U)
+#define GPIO_AFRH_AFSEL15_Msk          (0xFUL << GPIO_AFRH_AFSEL15_Pos)        /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15              GPIO_AFRH_AFSEL15_Msk
+#define GPIO_AFRH_AFSEL15_0            (0x1U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1            (0x2U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2            (0x4U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3            (0x8U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_BRR register  ******************/
+#define GPIO_BRR_BR0_Pos               (0U)
+#define GPIO_BRR_BR0_Msk               (0x1UL << GPIO_BRR_BR0_Pos)             /*!< 0x00000001 */
+#define GPIO_BRR_BR0                   GPIO_BRR_BR0_Msk
+#define GPIO_BRR_BR1_Pos               (1U)
+#define GPIO_BRR_BR1_Msk               (0x1UL << GPIO_BRR_BR1_Pos)             /*!< 0x00000002 */
+#define GPIO_BRR_BR1                   GPIO_BRR_BR1_Msk
+#define GPIO_BRR_BR2_Pos               (2U)
+#define GPIO_BRR_BR2_Msk               (0x1UL << GPIO_BRR_BR2_Pos)             /*!< 0x00000004 */
+#define GPIO_BRR_BR2                   GPIO_BRR_BR2_Msk
+#define GPIO_BRR_BR3_Pos               (3U)
+#define GPIO_BRR_BR3_Msk               (0x1UL << GPIO_BRR_BR3_Pos)             /*!< 0x00000008 */
+#define GPIO_BRR_BR3                   GPIO_BRR_BR3_Msk
+#define GPIO_BRR_BR4_Pos               (4U)
+#define GPIO_BRR_BR4_Msk               (0x1UL << GPIO_BRR_BR4_Pos)             /*!< 0x00000010 */
+#define GPIO_BRR_BR4                   GPIO_BRR_BR4_Msk
+#define GPIO_BRR_BR5_Pos               (5U)
+#define GPIO_BRR_BR5_Msk               (0x1UL << GPIO_BRR_BR5_Pos)             /*!< 0x00000020 */
+#define GPIO_BRR_BR5                   GPIO_BRR_BR5_Msk
+#define GPIO_BRR_BR6_Pos               (6U)
+#define GPIO_BRR_BR6_Msk               (0x1UL << GPIO_BRR_BR6_Pos)             /*!< 0x00000040 */
+#define GPIO_BRR_BR6                   GPIO_BRR_BR6_Msk
+#define GPIO_BRR_BR7_Pos               (7U)
+#define GPIO_BRR_BR7_Msk               (0x1UL << GPIO_BRR_BR7_Pos)             /*!< 0x00000080 */
+#define GPIO_BRR_BR7                   GPIO_BRR_BR7_Msk
+#define GPIO_BRR_BR8_Pos               (8U)
+#define GPIO_BRR_BR8_Msk               (0x1UL << GPIO_BRR_BR8_Pos)             /*!< 0x00000100 */
+#define GPIO_BRR_BR8                   GPIO_BRR_BR8_Msk
+#define GPIO_BRR_BR9_Pos               (9U)
+#define GPIO_BRR_BR9_Msk               (0x1UL << GPIO_BRR_BR9_Pos)             /*!< 0x00000200 */
+#define GPIO_BRR_BR9                   GPIO_BRR_BR9_Msk
+#define GPIO_BRR_BR10_Pos              (10U)
+#define GPIO_BRR_BR10_Msk              (0x1UL << GPIO_BRR_BR10_Pos)            /*!< 0x00000400 */
+#define GPIO_BRR_BR10                  GPIO_BRR_BR10_Msk
+#define GPIO_BRR_BR11_Pos              (11U)
+#define GPIO_BRR_BR11_Msk              (0x1UL << GPIO_BRR_BR11_Pos)            /*!< 0x00000800 */
+#define GPIO_BRR_BR11                  GPIO_BRR_BR11_Msk
+#define GPIO_BRR_BR12_Pos              (12U)
+#define GPIO_BRR_BR12_Msk              (0x1UL << GPIO_BRR_BR12_Pos)            /*!< 0x00001000 */
+#define GPIO_BRR_BR12                  GPIO_BRR_BR12_Msk
+#define GPIO_BRR_BR13_Pos              (13U)
+#define GPIO_BRR_BR13_Msk              (0x1UL << GPIO_BRR_BR13_Pos)            /*!< 0x00002000 */
+#define GPIO_BRR_BR13                  GPIO_BRR_BR13_Msk
+#define GPIO_BRR_BR14_Pos              (14U)
+#define GPIO_BRR_BR14_Msk              (0x1UL << GPIO_BRR_BR14_Pos)            /*!< 0x00004000 */
+#define GPIO_BRR_BR14                  GPIO_BRR_BR14_Msk
+#define GPIO_BRR_BR15_Pos              (15U)
+#define GPIO_BRR_BR15_Msk              (0x1UL << GPIO_BRR_BR15_Pos)            /*!< 0x00008000 */
+#define GPIO_BRR_BR15                  GPIO_BRR_BR15_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                        HSEM HW Semaphore                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for HSEM_R register  ********************/
+#define HSEM_R_PROCID_Pos        (0U)
+#define HSEM_R_PROCID_Msk        (0xFFUL << HSEM_R_PROCID_Pos)                 /*!< 0x000000FF */
+#define HSEM_R_PROCID            HSEM_R_PROCID_Msk                             /*!<Semaphore ProcessID */
+#define HSEM_R_COREID_Pos        (8U)
+#define HSEM_R_COREID_Msk        (0xFUL << HSEM_R_COREID_Pos)                  /*!< 0x00000F00 */
+#define HSEM_R_COREID            HSEM_R_COREID_Msk                             /*!<Semaphore CoreID. */
+#define HSEM_R_LOCK_Pos          (31U)
+#define HSEM_R_LOCK_Msk          (0x1UL << HSEM_R_LOCK_Pos)                    /*!< 0x80000000 */
+#define HSEM_R_LOCK              HSEM_R_LOCK_Msk                               /*!<Lock indication. */
+
+/********************  Bit definition for HSEM_RLR register  ******************/
+#define HSEM_RLR_PROCID_Pos      (0U)
+#define HSEM_RLR_PROCID_Msk      (0xFFUL << HSEM_RLR_PROCID_Pos)               /*!< 0x000000FF */
+#define HSEM_RLR_PROCID          HSEM_RLR_PROCID_Msk                           /*!<Semaphore ProcessID */
+#define HSEM_RLR_COREID_Pos      (8U)
+#define HSEM_RLR_COREID_Msk      (0xFUL << HSEM_RLR_COREID_Pos)                /*!< 0x00000F00 */
+#define HSEM_RLR_COREID          HSEM_RLR_COREID_Msk                           /*!<Semaphore CoreID. */
+#define HSEM_RLR_LOCK_Pos        (31U)
+#define HSEM_RLR_LOCK_Msk        (0x1UL << HSEM_RLR_LOCK_Pos)                  /*!< 0x80000000 */
+#define HSEM_RLR_LOCK            HSEM_RLR_LOCK_Msk                             /*!<Lock indication. */
+
+/********************  Bit definition for HSEM_C1IER register  ****************/
+#define HSEM_C1IER_ISE0_Pos      (0U)
+#define HSEM_C1IER_ISE0_Msk      (0x1UL << HSEM_C1IER_ISE0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1IER_ISE0          HSEM_C1IER_ISE0_Msk                           /*!<semaphore 0 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE1_Pos      (1U)
+#define HSEM_C1IER_ISE1_Msk      (0x1UL << HSEM_C1IER_ISE1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1IER_ISE1          HSEM_C1IER_ISE1_Msk                           /*!<semaphore 1 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE2_Pos      (2U)
+#define HSEM_C1IER_ISE2_Msk      (0x1UL << HSEM_C1IER_ISE2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1IER_ISE2          HSEM_C1IER_ISE2_Msk                           /*!<semaphore 2 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE3_Pos      (3U)
+#define HSEM_C1IER_ISE3_Msk      (0x1UL << HSEM_C1IER_ISE3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1IER_ISE3          HSEM_C1IER_ISE3_Msk                           /*!<semaphore 3 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE4_Pos      (4U)
+#define HSEM_C1IER_ISE4_Msk      (0x1UL << HSEM_C1IER_ISE4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1IER_ISE4          HSEM_C1IER_ISE4_Msk                           /*!<semaphore 4 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE5_Pos      (5U)
+#define HSEM_C1IER_ISE5_Msk      (0x1UL << HSEM_C1IER_ISE5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1IER_ISE5          HSEM_C1IER_ISE5_Msk                           /*!<semaphore 5 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE6_Pos      (6U)
+#define HSEM_C1IER_ISE6_Msk      (0x1UL << HSEM_C1IER_ISE6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1IER_ISE6          HSEM_C1IER_ISE6_Msk                           /*!<semaphore 6 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE7_Pos      (7U)
+#define HSEM_C1IER_ISE7_Msk      (0x1UL << HSEM_C1IER_ISE7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1IER_ISE7          HSEM_C1IER_ISE7_Msk                           /*!<semaphore 7 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE8_Pos      (8U)
+#define HSEM_C1IER_ISE8_Msk      (0x1UL << HSEM_C1IER_ISE8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1IER_ISE8          HSEM_C1IER_ISE8_Msk                           /*!<semaphore 8 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE9_Pos      (9U)
+#define HSEM_C1IER_ISE9_Msk      (0x1UL << HSEM_C1IER_ISE9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1IER_ISE9          HSEM_C1IER_ISE9_Msk                           /*!<semaphore 9 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE10_Pos     (10U)
+#define HSEM_C1IER_ISE10_Msk     (0x1UL << HSEM_C1IER_ISE10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1IER_ISE10         HSEM_C1IER_ISE10_Msk                          /*!<semaphore 10 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE11_Pos     (11U)
+#define HSEM_C1IER_ISE11_Msk     (0x1UL << HSEM_C1IER_ISE11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1IER_ISE11         HSEM_C1IER_ISE11_Msk                          /*!<semaphore 11 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE12_Pos     (12U)
+#define HSEM_C1IER_ISE12_Msk     (0x1UL << HSEM_C1IER_ISE12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1IER_ISE12         HSEM_C1IER_ISE12_Msk                          /*!<semaphore 12 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE13_Pos     (13U)
+#define HSEM_C1IER_ISE13_Msk     (0x1UL << HSEM_C1IER_ISE13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1IER_ISE13         HSEM_C1IER_ISE13_Msk                          /*!<semaphore 13 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE14_Pos     (14U)
+#define HSEM_C1IER_ISE14_Msk     (0x1UL << HSEM_C1IER_ISE14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1IER_ISE14         HSEM_C1IER_ISE14_Msk                          /*!<semaphore 14 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE15_Pos     (15U)
+#define HSEM_C1IER_ISE15_Msk     (0x1UL << HSEM_C1IER_ISE15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1IER_ISE15         HSEM_C1IER_ISE15_Msk                          /*!<semaphore 15 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE16_Pos     (16U)
+#define HSEM_C1IER_ISE16_Msk     (0x1UL << HSEM_C1IER_ISE16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1IER_ISE16         HSEM_C1IER_ISE16_Msk                          /*!<semaphore 16 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE17_Pos     (17U)
+#define HSEM_C1IER_ISE17_Msk     (0x1UL << HSEM_C1IER_ISE17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1IER_ISE17         HSEM_C1IER_ISE17_Msk                          /*!<semaphore 17 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE18_Pos     (18U)
+#define HSEM_C1IER_ISE18_Msk     (0x1UL << HSEM_C1IER_ISE18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1IER_ISE18         HSEM_C1IER_ISE18_Msk                          /*!<semaphore 18 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE19_Pos     (19U)
+#define HSEM_C1IER_ISE19_Msk     (0x1UL << HSEM_C1IER_ISE19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1IER_ISE19         HSEM_C1IER_ISE19_Msk                          /*!<semaphore 19 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE20_Pos     (20U)
+#define HSEM_C1IER_ISE20_Msk     (0x1UL << HSEM_C1IER_ISE20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1IER_ISE20         HSEM_C1IER_ISE20_Msk                          /*!<semaphore 20 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE21_Pos     (21U)
+#define HSEM_C1IER_ISE21_Msk     (0x1UL << HSEM_C1IER_ISE21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1IER_ISE21         HSEM_C1IER_ISE21_Msk                          /*!<semaphore 21 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE22_Pos     (22U)
+#define HSEM_C1IER_ISE22_Msk     (0x1UL << HSEM_C1IER_ISE22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1IER_ISE22         HSEM_C1IER_ISE22_Msk                          /*!<semaphore 22 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE23_Pos     (23U)
+#define HSEM_C1IER_ISE23_Msk     (0x1UL << HSEM_C1IER_ISE23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1IER_ISE23         HSEM_C1IER_ISE23_Msk                          /*!<semaphore 23 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE24_Pos     (24U)
+#define HSEM_C1IER_ISE24_Msk     (0x1UL << HSEM_C1IER_ISE24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1IER_ISE24         HSEM_C1IER_ISE24_Msk                          /*!<semaphore 24 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE25_Pos     (25U)
+#define HSEM_C1IER_ISE25_Msk     (0x1UL << HSEM_C1IER_ISE25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1IER_ISE25         HSEM_C1IER_ISE25_Msk                          /*!<semaphore 25 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE26_Pos     (26U)
+#define HSEM_C1IER_ISE26_Msk     (0x1UL << HSEM_C1IER_ISE26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1IER_ISE26         HSEM_C1IER_ISE26_Msk                          /*!<semaphore 26 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE27_Pos     (27U)
+#define HSEM_C1IER_ISE27_Msk     (0x1UL << HSEM_C1IER_ISE27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1IER_ISE27         HSEM_C1IER_ISE27_Msk                          /*!<semaphore 27 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE28_Pos     (28U)
+#define HSEM_C1IER_ISE28_Msk     (0x1UL << HSEM_C1IER_ISE28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1IER_ISE28         HSEM_C1IER_ISE28_Msk                          /*!<semaphore 28 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE29_Pos     (29U)
+#define HSEM_C1IER_ISE29_Msk     (0x1UL << HSEM_C1IER_ISE29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1IER_ISE29         HSEM_C1IER_ISE29_Msk                          /*!<semaphore 29 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE30_Pos     (30U)
+#define HSEM_C1IER_ISE30_Msk     (0x1UL << HSEM_C1IER_ISE30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1IER_ISE30         HSEM_C1IER_ISE30_Msk                          /*!<semaphore 30 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE31_Pos     (31U)
+#define HSEM_C1IER_ISE31_Msk     (0x1UL << HSEM_C1IER_ISE31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1IER_ISE31         HSEM_C1IER_ISE31_Msk                          /*!<semaphore 31 CPU1 interrupt enable bit. */
+
+/********************  Bit definition for HSEM_C1ICR register  *****************/
+#define HSEM_C1ICR_ISC0_Pos      (0U)
+#define HSEM_C1ICR_ISC0_Msk      (0x1UL << HSEM_C1ICR_ISC0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1ICR_ISC0          HSEM_C1ICR_ISC0_Msk                           /*!<semaphore 0 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC1_Pos      (1U)
+#define HSEM_C1ICR_ISC1_Msk      (0x1UL << HSEM_C1ICR_ISC1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1ICR_ISC1          HSEM_C1ICR_ISC1_Msk                           /*!<semaphore 1 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC2_Pos      (2U)
+#define HSEM_C1ICR_ISC2_Msk      (0x1UL << HSEM_C1ICR_ISC2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1ICR_ISC2          HSEM_C1ICR_ISC2_Msk                           /*!<semaphore 2 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC3_Pos      (3U)
+#define HSEM_C1ICR_ISC3_Msk      (0x1UL << HSEM_C1ICR_ISC3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1ICR_ISC3          HSEM_C1ICR_ISC3_Msk                           /*!<semaphore 3 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC4_Pos      (4U)
+#define HSEM_C1ICR_ISC4_Msk      (0x1UL << HSEM_C1ICR_ISC4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1ICR_ISC4          HSEM_C1ICR_ISC4_Msk                           /*!<semaphore 4 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC5_Pos      (5U)
+#define HSEM_C1ICR_ISC5_Msk      (0x1UL << HSEM_C1ICR_ISC5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1ICR_ISC5          HSEM_C1ICR_ISC5_Msk                           /*!<semaphore 5 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC6_Pos      (6U)
+#define HSEM_C1ICR_ISC6_Msk      (0x1UL << HSEM_C1ICR_ISC6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1ICR_ISC6          HSEM_C1ICR_ISC6_Msk                           /*!<semaphore 6 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC7_Pos      (7U)
+#define HSEM_C1ICR_ISC7_Msk      (0x1UL << HSEM_C1ICR_ISC7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1ICR_ISC7          HSEM_C1ICR_ISC7_Msk                           /*!<semaphore 7 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC8_Pos      (8U)
+#define HSEM_C1ICR_ISC8_Msk      (0x1UL << HSEM_C1ICR_ISC8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1ICR_ISC8          HSEM_C1ICR_ISC8_Msk                           /*!<semaphore 8 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC9_Pos      (9U)
+#define HSEM_C1ICR_ISC9_Msk      (0x1UL << HSEM_C1ICR_ISC9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1ICR_ISC9          HSEM_C1ICR_ISC9_Msk                           /*!<semaphore 9 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC10_Pos     (10U)
+#define HSEM_C1ICR_ISC10_Msk     (0x1UL << HSEM_C1ICR_ISC10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1ICR_ISC10         HSEM_C1ICR_ISC10_Msk                          /*!<semaphore 10 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC11_Pos     (11U)
+#define HSEM_C1ICR_ISC11_Msk     (0x1UL << HSEM_C1ICR_ISC11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1ICR_ISC11         HSEM_C1ICR_ISC11_Msk                          /*!<semaphore 11 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC12_Pos     (12U)
+#define HSEM_C1ICR_ISC12_Msk     (0x1UL << HSEM_C1ICR_ISC12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1ICR_ISC12         HSEM_C1ICR_ISC12_Msk                          /*!<semaphore 12 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC13_Pos     (13U)
+#define HSEM_C1ICR_ISC13_Msk     (0x1UL << HSEM_C1ICR_ISC13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1ICR_ISC13         HSEM_C1ICR_ISC13_Msk                          /*!<semaphore 13 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC14_Pos     (14U)
+#define HSEM_C1ICR_ISC14_Msk     (0x1UL << HSEM_C1ICR_ISC14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1ICR_ISC14         HSEM_C1ICR_ISC14_Msk                          /*!<semaphore 14 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC15_Pos     (15U)
+#define HSEM_C1ICR_ISC15_Msk     (0x1UL << HSEM_C1ICR_ISC15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1ICR_ISC15         HSEM_C1ICR_ISC15_Msk                          /*!<semaphore 15 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC16_Pos     (16U)
+#define HSEM_C1ICR_ISC16_Msk     (0x1UL << HSEM_C1ICR_ISC16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1ICR_ISC16         HSEM_C1ICR_ISC16_Msk                          /*!<semaphore 16 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC17_Pos     (17U)
+#define HSEM_C1ICR_ISC17_Msk     (0x1UL << HSEM_C1ICR_ISC17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1ICR_ISC17         HSEM_C1ICR_ISC17_Msk                          /*!<semaphore 17 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC18_Pos     (18U)
+#define HSEM_C1ICR_ISC18_Msk     (0x1UL << HSEM_C1ICR_ISC18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1ICR_ISC18         HSEM_C1ICR_ISC18_Msk                          /*!<semaphore 18 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC19_Pos     (19U)
+#define HSEM_C1ICR_ISC19_Msk     (0x1UL << HSEM_C1ICR_ISC19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1ICR_ISC19         HSEM_C1ICR_ISC19_Msk                          /*!<semaphore 19 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC20_Pos     (20U)
+#define HSEM_C1ICR_ISC20_Msk     (0x1UL << HSEM_C1ICR_ISC20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1ICR_ISC20         HSEM_C1ICR_ISC20_Msk                          /*!<semaphore 20 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC21_Pos     (21U)
+#define HSEM_C1ICR_ISC21_Msk     (0x1UL << HSEM_C1ICR_ISC21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1ICR_ISC21         HSEM_C1ICR_ISC21_Msk                          /*!<semaphore 21 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC22_Pos     (22U)
+#define HSEM_C1ICR_ISC22_Msk     (0x1UL << HSEM_C1ICR_ISC22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1ICR_ISC22         HSEM_C1ICR_ISC22_Msk                          /*!<semaphore 22 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC23_Pos     (23U)
+#define HSEM_C1ICR_ISC23_Msk     (0x1UL << HSEM_C1ICR_ISC23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1ICR_ISC23         HSEM_C1ICR_ISC23_Msk                          /*!<semaphore 23 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC24_Pos     (24U)
+#define HSEM_C1ICR_ISC24_Msk     (0x1UL << HSEM_C1ICR_ISC24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1ICR_ISC24         HSEM_C1ICR_ISC24_Msk                          /*!<semaphore 24 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC25_Pos     (25U)
+#define HSEM_C1ICR_ISC25_Msk     (0x1UL << HSEM_C1ICR_ISC25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1ICR_ISC25         HSEM_C1ICR_ISC25_Msk                          /*!<semaphore 25 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC26_Pos     (26U)
+#define HSEM_C1ICR_ISC26_Msk     (0x1UL << HSEM_C1ICR_ISC26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1ICR_ISC26         HSEM_C1ICR_ISC26_Msk                          /*!<semaphore 26 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC27_Pos     (27U)
+#define HSEM_C1ICR_ISC27_Msk     (0x1UL << HSEM_C1ICR_ISC27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1ICR_ISC27         HSEM_C1ICR_ISC27_Msk                          /*!<semaphore 27 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC28_Pos     (28U)
+#define HSEM_C1ICR_ISC28_Msk     (0x1UL << HSEM_C1ICR_ISC28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1ICR_ISC28         HSEM_C1ICR_ISC28_Msk                          /*!<semaphore 28 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC29_Pos     (29U)
+#define HSEM_C1ICR_ISC29_Msk     (0x1UL << HSEM_C1ICR_ISC29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1ICR_ISC29         HSEM_C1ICR_ISC29_Msk                          /*!<semaphore 29 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC30_Pos     (30U)
+#define HSEM_C1ICR_ISC30_Msk     (0x1UL << HSEM_C1ICR_ISC30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1ICR_ISC30         HSEM_C1ICR_ISC30_Msk                          /*!<semaphore 30 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC31_Pos     (31U)
+#define HSEM_C1ICR_ISC31_Msk     (0x1UL << HSEM_C1ICR_ISC31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1ICR_ISC31         HSEM_C1ICR_ISC31_Msk                          /*!<semaphore 31 CPU1 interrupt clear bit. */
+
+/********************  Bit definition for HSEM_C1ISR register  *****************/
+#define HSEM_C1ISR_ISF0_Pos      (0U)
+#define HSEM_C1ISR_ISF0_Msk      (0x1UL << HSEM_C1ISR_ISF0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1ISR_ISF0          HSEM_C1ISR_ISF0_Msk                           /*!<semaphore 0 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF1_Pos      (1U)
+#define HSEM_C1ISR_ISF1_Msk      (0x1UL << HSEM_C1ISR_ISF1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1ISR_ISF1          HSEM_C1ISR_ISF1_Msk                           /*!<semaphore 1 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF2_Pos      (2U)
+#define HSEM_C1ISR_ISF2_Msk      (0x1UL << HSEM_C1ISR_ISF2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1ISR_ISF2          HSEM_C1ISR_ISF2_Msk                           /*!<semaphore 2 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF3_Pos      (3U)
+#define HSEM_C1ISR_ISF3_Msk      (0x1UL << HSEM_C1ISR_ISF3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1ISR_ISF3          HSEM_C1ISR_ISF3_Msk                           /*!<semaphore 3 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF4_Pos      (4U)
+#define HSEM_C1ISR_ISF4_Msk      (0x1UL << HSEM_C1ISR_ISF4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1ISR_ISF4          HSEM_C1ISR_ISF4_Msk                           /*!<semaphore 4 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF5_Pos      (5U)
+#define HSEM_C1ISR_ISF5_Msk      (0x1UL << HSEM_C1ISR_ISF5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1ISR_ISF5          HSEM_C1ISR_ISF5_Msk                           /*!<semaphore 5 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF6_Pos      (6U)
+#define HSEM_C1ISR_ISF6_Msk      (0x1UL << HSEM_C1ISR_ISF6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1ISR_ISF6          HSEM_C1ISR_ISF6_Msk                           /*!<semaphore 6 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF7_Pos      (7U)
+#define HSEM_C1ISR_ISF7_Msk      (0x1UL << HSEM_C1ISR_ISF7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1ISR_ISF7          HSEM_C1ISR_ISF7_Msk                           /*!<semaphore 7 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF8_Pos      (8U)
+#define HSEM_C1ISR_ISF8_Msk      (0x1UL << HSEM_C1ISR_ISF8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1ISR_ISF8          HSEM_C1ISR_ISF8_Msk                           /*!<semaphore 8 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF9_Pos      (9U)
+#define HSEM_C1ISR_ISF9_Msk      (0x1UL << HSEM_C1ISR_ISF9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1ISR_ISF9          HSEM_C1ISR_ISF9_Msk                           /*!<semaphore 9 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF10_Pos     (10U)
+#define HSEM_C1ISR_ISF10_Msk     (0x1UL << HSEM_C1ISR_ISF10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1ISR_ISF10         HSEM_C1ISR_ISF10_Msk                          /*!<semaphore 10 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF11_Pos     (11U)
+#define HSEM_C1ISR_ISF11_Msk     (0x1UL << HSEM_C1ISR_ISF11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1ISR_ISF11         HSEM_C1ISR_ISF11_Msk                          /*!<semaphore 11 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF12_Pos     (12U)
+#define HSEM_C1ISR_ISF12_Msk     (0x1UL << HSEM_C1ISR_ISF12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1ISR_ISF12         HSEM_C1ISR_ISF12_Msk                          /*!<semaphore 12 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF13_Pos     (13U)
+#define HSEM_C1ISR_ISF13_Msk     (0x1UL << HSEM_C1ISR_ISF13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1ISR_ISF13         HSEM_C1ISR_ISF13_Msk                          /*!<semaphore 13 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF14_Pos     (14U)
+#define HSEM_C1ISR_ISF14_Msk     (0x1UL << HSEM_C1ISR_ISF14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1ISR_ISF14         HSEM_C1ISR_ISF14_Msk                          /*!<semaphore 14 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF15_Pos     (15U)
+#define HSEM_C1ISR_ISF15_Msk     (0x1UL << HSEM_C1ISR_ISF15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1ISR_ISF15         HSEM_C1ISR_ISF15_Msk                          /*!<semaphore 15 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF16_Pos     (16U)
+#define HSEM_C1ISR_ISF16_Msk     (0x1UL << HSEM_C1ISR_ISF16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1ISR_ISF16         HSEM_C1ISR_ISF16_Msk                          /*!<semaphore 16 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF17_Pos     (17U)
+#define HSEM_C1ISR_ISF17_Msk     (0x1UL << HSEM_C1ISR_ISF17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1ISR_ISF17         HSEM_C1ISR_ISF17_Msk                          /*!<semaphore 17 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF18_Pos     (18U)
+#define HSEM_C1ISR_ISF18_Msk     (0x1UL << HSEM_C1ISR_ISF18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1ISR_ISF18         HSEM_C1ISR_ISF18_Msk                          /*!<semaphore 18 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF19_Pos     (19U)
+#define HSEM_C1ISR_ISF19_Msk     (0x1UL << HSEM_C1ISR_ISF19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1ISR_ISF19         HSEM_C1ISR_ISF19_Msk                          /*!<semaphore 19 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF20_Pos     (20U)
+#define HSEM_C1ISR_ISF20_Msk     (0x1UL << HSEM_C1ISR_ISF20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1ISR_ISF20         HSEM_C1ISR_ISF20_Msk                          /*!<semaphore 20 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF21_Pos     (21U)
+#define HSEM_C1ISR_ISF21_Msk     (0x1UL << HSEM_C1ISR_ISF21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1ISR_ISF21         HSEM_C1ISR_ISF21_Msk                          /*!<semaphore 21 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF22_Pos     (22U)
+#define HSEM_C1ISR_ISF22_Msk     (0x1UL << HSEM_C1ISR_ISF22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1ISR_ISF22         HSEM_C1ISR_ISF22_Msk                          /*!<semaphore 22 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF23_Pos     (23U)
+#define HSEM_C1ISR_ISF23_Msk     (0x1UL << HSEM_C1ISR_ISF23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1ISR_ISF23         HSEM_C1ISR_ISF23_Msk                          /*!<semaphore 23 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF24_Pos     (24U)
+#define HSEM_C1ISR_ISF24_Msk     (0x1UL << HSEM_C1ISR_ISF24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1ISR_ISF24         HSEM_C1ISR_ISF24_Msk                          /*!<semaphore 24 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF25_Pos     (25U)
+#define HSEM_C1ISR_ISF25_Msk     (0x1UL << HSEM_C1ISR_ISF25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1ISR_ISF25         HSEM_C1ISR_ISF25_Msk                          /*!<semaphore 25 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF26_Pos     (26U)
+#define HSEM_C1ISR_ISF26_Msk     (0x1UL << HSEM_C1ISR_ISF26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1ISR_ISF26         HSEM_C1ISR_ISF26_Msk                          /*!<semaphore 26 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF27_Pos     (27U)
+#define HSEM_C1ISR_ISF27_Msk     (0x1UL << HSEM_C1ISR_ISF27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1ISR_ISF27         HSEM_C1ISR_ISF27_Msk                          /*!<semaphore 27 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF28_Pos     (28U)
+#define HSEM_C1ISR_ISF28_Msk     (0x1UL << HSEM_C1ISR_ISF28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1ISR_ISF28         HSEM_C1ISR_ISF28_Msk                          /*!<semaphore 28 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF29_Pos     (29U)
+#define HSEM_C1ISR_ISF29_Msk     (0x1UL << HSEM_C1ISR_ISF29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1ISR_ISF29         HSEM_C1ISR_ISF29_Msk                          /*!<semaphore 29 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF30_Pos     (30U)
+#define HSEM_C1ISR_ISF30_Msk     (0x1UL << HSEM_C1ISR_ISF30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1ISR_ISF30         HSEM_C1ISR_ISF30_Msk                          /*!<semaphore 30 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF31_Pos     (31U)
+#define HSEM_C1ISR_ISF31_Msk     (0x1UL << HSEM_C1ISR_ISF31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1ISR_ISF31         HSEM_C1ISR_ISF31_Msk                          /*!<semaphore 31 CPU1 interrupt status bit. */
+
+/********************  Bit definition for HSEM_C1MISR register  *****************/
+#define HSEM_C1MISR_MISF0_Pos     (0U)
+#define HSEM_C1MISR_MISF0_Msk     (0x1UL << HSEM_C1MISR_MISF0_Pos)               /*!< 0x00000001 */
+#define HSEM_C1MISR_MISF0         HSEM_C1MISR_MISF0_Msk                          /*!<semaphore 0 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF1_Pos     (1U)
+#define HSEM_C1MISR_MISF1_Msk     (0x1UL << HSEM_C1MISR_MISF1_Pos)               /*!< 0x00000002 */
+#define HSEM_C1MISR_MISF1         HSEM_C1MISR_MISF1_Msk                          /*!<semaphore 1 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF2_Pos     (2U)
+#define HSEM_C1MISR_MISF2_Msk     (0x1UL << HSEM_C1MISR_MISF2_Pos)               /*!< 0x00000004 */
+#define HSEM_C1MISR_MISF2         HSEM_C1MISR_MISF2_Msk                          /*!<semaphore 2 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF3_Pos     (3U)
+#define HSEM_C1MISR_MISF3_Msk     (0x1UL << HSEM_C1MISR_MISF3_Pos)               /*!< 0x00000008 */
+#define HSEM_C1MISR_MISF3         HSEM_C1MISR_MISF3_Msk                          /*!<semaphore 3 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF4_Pos     (4U)
+#define HSEM_C1MISR_MISF4_Msk     (0x1UL << HSEM_C1MISR_MISF4_Pos)               /*!< 0x00000010 */
+#define HSEM_C1MISR_MISF4         HSEM_C1MISR_MISF4_Msk                          /*!<semaphore 4 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF5_Pos     (5U)
+#define HSEM_C1MISR_MISF5_Msk     (0x1UL << HSEM_C1MISR_MISF5_Pos)               /*!< 0x00000020 */
+#define HSEM_C1MISR_MISF5         HSEM_C1MISR_MISF5_Msk                          /*!<semaphore 5 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF6_Pos     (6U)
+#define HSEM_C1MISR_MISF6_Msk     (0x1UL << HSEM_C1MISR_MISF6_Pos)               /*!< 0x00000040 */
+#define HSEM_C1MISR_MISF6         HSEM_C1MISR_MISF6_Msk                          /*!<semaphore 6 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF7_Pos     (7U)
+#define HSEM_C1MISR_MISF7_Msk     (0x1UL << HSEM_C1MISR_MISF7_Pos)               /*!< 0x00000080 */
+#define HSEM_C1MISR_MISF7         HSEM_C1MISR_MISF7_Msk                          /*!<semaphore 7 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF8_Pos     (8U)
+#define HSEM_C1MISR_MISF8_Msk     (0x1UL << HSEM_C1MISR_MISF8_Pos)               /*!< 0x00000100 */
+#define HSEM_C1MISR_MISF8         HSEM_C1MISR_MISF8_Msk                          /*!<semaphore 8 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF9_Pos     (9U)
+#define HSEM_C1MISR_MISF9_Msk     (0x1UL << HSEM_C1MISR_MISF9_Pos)               /*!< 0x00000200 */
+#define HSEM_C1MISR_MISF9         HSEM_C1MISR_MISF9_Msk                          /*!<semaphore 9 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF10_Pos    (10U)
+#define HSEM_C1MISR_MISF10_Msk    (0x1UL << HSEM_C1MISR_MISF10_Pos)              /*!< 0x00000400 */
+#define HSEM_C1MISR_MISF10        HSEM_C1MISR_MISF10_Msk                         /*!<semaphore 10 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF11_Pos    (11U)
+#define HSEM_C1MISR_MISF11_Msk    (0x1UL << HSEM_C1MISR_MISF11_Pos)              /*!< 0x00000800 */
+#define HSEM_C1MISR_MISF11        HSEM_C1MISR_MISF11_Msk                         /*!<semaphore 11 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF12_Pos    (12U)
+#define HSEM_C1MISR_MISF12_Msk    (0x1UL << HSEM_C1MISR_MISF12_Pos)              /*!< 0x00001000 */
+#define HSEM_C1MISR_MISF12        HSEM_C1MISR_MISF12_Msk                         /*!<semaphore 12 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF13_Pos    (13U)
+#define HSEM_C1MISR_MISF13_Msk    (0x1UL << HSEM_C1MISR_MISF13_Pos)              /*!< 0x00002000 */
+#define HSEM_C1MISR_MISF13        HSEM_C1MISR_MISF13_Msk                         /*!<semaphore 13 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF14_Pos    (14U)
+#define HSEM_C1MISR_MISF14_Msk    (0x1UL << HSEM_C1MISR_MISF14_Pos)              /*!< 0x00004000 */
+#define HSEM_C1MISR_MISF14        HSEM_C1MISR_MISF14_Msk                         /*!<semaphore 14 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF15_Pos    (15U)
+#define HSEM_C1MISR_MISF15_Msk    (0x1UL << HSEM_C1MISR_MISF15_Pos)              /*!< 0x00008000 */
+#define HSEM_C1MISR_MISF15        HSEM_C1MISR_MISF15_Msk                         /*!<semaphore 15 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF16_Pos    (16U)
+#define HSEM_C1MISR_MISF16_Msk    (0x1UL << HSEM_C1MISR_MISF16_Pos)              /*!< 0x00010000 */
+#define HSEM_C1MISR_MISF16        HSEM_C1MISR_MISF16_Msk                         /*!<semaphore 16 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF17_Pos    (17U)
+#define HSEM_C1MISR_MISF17_Msk    (0x1UL << HSEM_C1MISR_MISF17_Pos)              /*!< 0x00020000 */
+#define HSEM_C1MISR_MISF17        HSEM_C1MISR_MISF17_Msk                         /*!<semaphore 17 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF18_Pos    (18U)
+#define HSEM_C1MISR_MISF18_Msk    (0x1UL << HSEM_C1MISR_MISF18_Pos)              /*!< 0x00040000 */
+#define HSEM_C1MISR_MISF18        HSEM_C1MISR_MISF18_Msk                         /*!<semaphore 18 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF19_Pos    (19U)
+#define HSEM_C1MISR_MISF19_Msk    (0x1UL << HSEM_C1MISR_MISF19_Pos)              /*!< 0x00080000 */
+#define HSEM_C1MISR_MISF19        HSEM_C1MISR_MISF19_Msk                         /*!<semaphore 19 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF20_Pos    (20U)
+#define HSEM_C1MISR_MISF20_Msk    (0x1UL << HSEM_C1MISR_MISF20_Pos)              /*!< 0x00100000 */
+#define HSEM_C1MISR_MISF20        HSEM_C1MISR_MISF20_Msk                         /*!<semaphore 20 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF21_Pos    (21U)
+#define HSEM_C1MISR_MISF21_Msk    (0x1UL << HSEM_C1MISR_MISF21_Pos)              /*!< 0x00200000 */
+#define HSEM_C1MISR_MISF21        HSEM_C1MISR_MISF21_Msk                         /*!<semaphore 21 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF22_Pos    (22U)
+#define HSEM_C1MISR_MISF22_Msk    (0x1UL << HSEM_C1MISR_MISF22_Pos)              /*!< 0x00400000 */
+#define HSEM_C1MISR_MISF22        HSEM_C1MISR_MISF22_Msk                         /*!<semaphore 22 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF23_Pos    (23U)
+#define HSEM_C1MISR_MISF23_Msk    (0x1UL << HSEM_C1MISR_MISF23_Pos)              /*!< 0x00800000 */
+#define HSEM_C1MISR_MISF23        HSEM_C1MISR_MISF23_Msk                         /*!<semaphore 23 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF24_Pos    (24U)
+#define HSEM_C1MISR_MISF24_Msk    (0x1UL << HSEM_C1MISR_MISF24_Pos)              /*!< 0x01000000 */
+#define HSEM_C1MISR_MISF24        HSEM_C1MISR_MISF24_Msk                         /*!<semaphore 24 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF25_Pos    (25U)
+#define HSEM_C1MISR_MISF25_Msk    (0x1UL << HSEM_C1MISR_MISF25_Pos)              /*!< 0x02000000 */
+#define HSEM_C1MISR_MISF25        HSEM_C1MISR_MISF25_Msk                         /*!<semaphore 25 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF26_Pos    (26U)
+#define HSEM_C1MISR_MISF26_Msk    (0x1UL << HSEM_C1MISR_MISF26_Pos)              /*!< 0x04000000 */
+#define HSEM_C1MISR_MISF26        HSEM_C1MISR_MISF26_Msk                         /*!<semaphore 26 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF27_Pos    (27U)
+#define HSEM_C1MISR_MISF27_Msk    (0x1UL << HSEM_C1MISR_MISF27_Pos)              /*!< 0x08000000 */
+#define HSEM_C1MISR_MISF27        HSEM_C1MISR_MISF27_Msk                         /*!<semaphore 27 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF28_Pos    (28U)
+#define HSEM_C1MISR_MISF28_Msk    (0x1UL << HSEM_C1MISR_MISF28_Pos)              /*!< 0x10000000 */
+#define HSEM_C1MISR_MISF28        HSEM_C1MISR_MISF28_Msk                         /*!<semaphore 28 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF29_Pos    (29U)
+#define HSEM_C1MISR_MISF29_Msk    (0x1UL << HSEM_C1MISR_MISF29_Pos)              /*!< 0x20000000 */
+#define HSEM_C1MISR_MISF29        HSEM_C1MISR_MISF29_Msk                         /*!<semaphore 29 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF30_Pos    (30U)
+#define HSEM_C1MISR_MISF30_Msk    (0x1UL << HSEM_C1MISR_MISF30_Pos)              /*!< 0x40000000 */
+#define HSEM_C1MISR_MISF30        HSEM_C1MISR_MISF30_Msk                         /*!<semaphore 30 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF31_Pos    (31U)
+#define HSEM_C1MISR_MISF31_Msk    (0x1UL << HSEM_C1MISR_MISF31_Pos)              /*!< 0x80000000 */
+#define HSEM_C1MISR_MISF31        HSEM_C1MISR_MISF31_Msk                         /*!<semaphore 31 CPU1 interrupt masked status bit. */
+
+/********************  Bit definition for HSEM_C2IER register  *****************/
+#define HSEM_C2IER_ISE0_Pos      (0U)
+#define HSEM_C2IER_ISE0_Msk      (0x1UL << HSEM_C2IER_ISE0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2IER_ISE0          HSEM_C2IER_ISE0_Msk                           /*!<semaphore 0 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE1_Pos      (1U)
+#define HSEM_C2IER_ISE1_Msk      (0x1UL << HSEM_C2IER_ISE1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2IER_ISE1          HSEM_C2IER_ISE1_Msk                           /*!<semaphore 1 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE2_Pos      (2U)
+#define HSEM_C2IER_ISE2_Msk      (0x1UL << HSEM_C2IER_ISE2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2IER_ISE2          HSEM_C2IER_ISE2_Msk                           /*!<semaphore 2 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE3_Pos      (3U)
+#define HSEM_C2IER_ISE3_Msk      (0x1UL << HSEM_C2IER_ISE3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2IER_ISE3          HSEM_C2IER_ISE3_Msk                           /*!<semaphore 3 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE4_Pos      (4U)
+#define HSEM_C2IER_ISE4_Msk      (0x1UL << HSEM_C2IER_ISE4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2IER_ISE4          HSEM_C2IER_ISE4_Msk                           /*!<semaphore 4 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE5_Pos      (5U)
+#define HSEM_C2IER_ISE5_Msk      (0x1UL << HSEM_C2IER_ISE5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2IER_ISE5          HSEM_C2IER_ISE5_Msk                           /*!<semaphore 5 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE6_Pos      (6U)
+#define HSEM_C2IER_ISE6_Msk      (0x1UL << HSEM_C2IER_ISE6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2IER_ISE6          HSEM_C2IER_ISE6_Msk                           /*!<semaphore 6 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE7_Pos      (7U)
+#define HSEM_C2IER_ISE7_Msk      (0x1UL << HSEM_C2IER_ISE7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2IER_ISE7          HSEM_C2IER_ISE7_Msk                           /*!<semaphore 7 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE8_Pos      (8U)
+#define HSEM_C2IER_ISE8_Msk      (0x1UL << HSEM_C2IER_ISE8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2IER_ISE8          HSEM_C2IER_ISE8_Msk                           /*!<semaphore 8 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE9_Pos      (9U)
+#define HSEM_C2IER_ISE9_Msk      (0x1UL << HSEM_C2IER_ISE9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2IER_ISE9          HSEM_C2IER_ISE9_Msk                           /*!<semaphore 9 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE10_Pos     (10U)
+#define HSEM_C2IER_ISE10_Msk     (0x1UL << HSEM_C2IER_ISE10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2IER_ISE10         HSEM_C2IER_ISE10_Msk                          /*!<semaphore 10 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE11_Pos     (11U)
+#define HSEM_C2IER_ISE11_Msk     (0x1UL << HSEM_C2IER_ISE11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2IER_ISE11         HSEM_C2IER_ISE11_Msk                          /*!<semaphore 11 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE12_Pos     (12U)
+#define HSEM_C2IER_ISE12_Msk     (0x1UL << HSEM_C2IER_ISE12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2IER_ISE12         HSEM_C2IER_ISE12_Msk                          /*!<semaphore 12 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE13_Pos     (13U)
+#define HSEM_C2IER_ISE13_Msk     (0x1UL << HSEM_C2IER_ISE13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2IER_ISE13         HSEM_C2IER_ISE13_Msk                          /*!<semaphore 13 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE14_Pos     (14U)
+#define HSEM_C2IER_ISE14_Msk     (0x1UL << HSEM_C2IER_ISE14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2IER_ISE14         HSEM_C2IER_ISE14_Msk                          /*!<semaphore 14 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE15_Pos     (15U)
+#define HSEM_C2IER_ISE15_Msk     (0x1UL << HSEM_C2IER_ISE15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2IER_ISE15         HSEM_C2IER_ISE15_Msk                          /*!<semaphore 15 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE16_Pos     (16U)
+#define HSEM_C2IER_ISE16_Msk     (0x1UL << HSEM_C2IER_ISE16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2IER_ISE16         HSEM_C2IER_ISE16_Msk                          /*!<semaphore 16 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE17_Pos     (17U)
+#define HSEM_C2IER_ISE17_Msk     (0x1UL << HSEM_C2IER_ISE17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2IER_ISE17         HSEM_C2IER_ISE17_Msk                          /*!<semaphore 17 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE18_Pos     (18U)
+#define HSEM_C2IER_ISE18_Msk     (0x1UL << HSEM_C2IER_ISE18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2IER_ISE18         HSEM_C2IER_ISE18_Msk                          /*!<semaphore 18 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE19_Pos     (19U)
+#define HSEM_C2IER_ISE19_Msk     (0x1UL << HSEM_C2IER_ISE19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2IER_ISE19         HSEM_C2IER_ISE19_Msk                          /*!<semaphore 19 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE20_Pos     (20U)
+#define HSEM_C2IER_ISE20_Msk     (0x1UL << HSEM_C2IER_ISE20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2IER_ISE20         HSEM_C2IER_ISE20_Msk                          /*!<semaphore 20 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE21_Pos     (21U)
+#define HSEM_C2IER_ISE21_Msk     (0x1UL << HSEM_C2IER_ISE21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2IER_ISE21         HSEM_C2IER_ISE21_Msk                          /*!<semaphore 21 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE22_Pos     (22U)
+#define HSEM_C2IER_ISE22_Msk     (0x1UL << HSEM_C2IER_ISE22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2IER_ISE22         HSEM_C2IER_ISE22_Msk                          /*!<semaphore 22 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE23_Pos     (23U)
+#define HSEM_C2IER_ISE23_Msk     (0x1UL << HSEM_C2IER_ISE23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2IER_ISE23         HSEM_C2IER_ISE23_Msk                          /*!<semaphore 23 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE24_Pos     (24U)
+#define HSEM_C2IER_ISE24_Msk     (0x1UL << HSEM_C2IER_ISE24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2IER_ISE24         HSEM_C2IER_ISE24_Msk                          /*!<semaphore 24 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE25_Pos     (25U)
+#define HSEM_C2IER_ISE25_Msk     (0x1UL << HSEM_C2IER_ISE25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2IER_ISE25         HSEM_C2IER_ISE25_Msk                          /*!<semaphore 25 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE26_Pos     (26U)
+#define HSEM_C2IER_ISE26_Msk     (0x1UL << HSEM_C2IER_ISE26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2IER_ISE26         HSEM_C2IER_ISE26_Msk                          /*!<semaphore 26 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE27_Pos     (27U)
+#define HSEM_C2IER_ISE27_Msk     (0x1UL << HSEM_C2IER_ISE27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2IER_ISE27         HSEM_C2IER_ISE27_Msk                          /*!<semaphore 27 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE28_Pos     (28U)
+#define HSEM_C2IER_ISE28_Msk     (0x1UL << HSEM_C2IER_ISE28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2IER_ISE28         HSEM_C2IER_ISE28_Msk                          /*!<semaphore 28 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE29_Pos     (29U)
+#define HSEM_C2IER_ISE29_Msk     (0x1UL << HSEM_C2IER_ISE29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2IER_ISE29         HSEM_C2IER_ISE29_Msk                          /*!<semaphore 29 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE30_Pos     (30U)
+#define HSEM_C2IER_ISE30_Msk     (0x1UL << HSEM_C2IER_ISE30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2IER_ISE30         HSEM_C2IER_ISE30_Msk                          /*!<semaphore 30 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE31_Pos     (31U)
+#define HSEM_C2IER_ISE31_Msk     (0x1UL << HSEM_C2IER_ISE31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2IER_ISE31         HSEM_C2IER_ISE31_Msk                          /*!<semaphore 31 CPU2 interrupt enable bit. */
+
+/********************  Bit definition for HSEM_C2ICR register  *****************/
+#define HSEM_C2ICR_ISC0_Pos      (0U)
+#define HSEM_C2ICR_ISC0_Msk      (0x1UL << HSEM_C2ICR_ISC0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2ICR_ISC0          HSEM_C2ICR_ISC0_Msk                           /*!<semaphore 0 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC1_Pos      (1U)
+#define HSEM_C2ICR_ISC1_Msk      (0x1UL << HSEM_C2ICR_ISC1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2ICR_ISC1          HSEM_C2ICR_ISC1_Msk                           /*!<semaphore 1 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC2_Pos      (2U)
+#define HSEM_C2ICR_ISC2_Msk      (0x1UL << HSEM_C2ICR_ISC2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2ICR_ISC2          HSEM_C2ICR_ISC2_Msk                           /*!<semaphore 2 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC3_Pos      (3U)
+#define HSEM_C2ICR_ISC3_Msk      (0x1UL << HSEM_C2ICR_ISC3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2ICR_ISC3          HSEM_C2ICR_ISC3_Msk                           /*!<semaphore 3 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC4_Pos      (4U)
+#define HSEM_C2ICR_ISC4_Msk      (0x1UL << HSEM_C2ICR_ISC4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2ICR_ISC4          HSEM_C2ICR_ISC4_Msk                           /*!<semaphore 4 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC5_Pos      (5U)
+#define HSEM_C2ICR_ISC5_Msk      (0x1UL << HSEM_C2ICR_ISC5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2ICR_ISC5          HSEM_C2ICR_ISC5_Msk                           /*!<semaphore 5 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC6_Pos      (6U)
+#define HSEM_C2ICR_ISC6_Msk      (0x1UL << HSEM_C2ICR_ISC6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2ICR_ISC6          HSEM_C2ICR_ISC6_Msk                           /*!<semaphore 6 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC7_Pos      (7U)
+#define HSEM_C2ICR_ISC7_Msk      (0x1UL << HSEM_C2ICR_ISC7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2ICR_ISC7          HSEM_C2ICR_ISC7_Msk                           /*!<semaphore 7 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC8_Pos      (8U)
+#define HSEM_C2ICR_ISC8_Msk      (0x1UL << HSEM_C2ICR_ISC8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2ICR_ISC8          HSEM_C2ICR_ISC8_Msk                           /*!<semaphore 8 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC9_Pos      (9U)
+#define HSEM_C2ICR_ISC9_Msk      (0x1UL << HSEM_C2ICR_ISC9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2ICR_ISC9          HSEM_C2ICR_ISC9_Msk                           /*!<semaphore 9 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC10_Pos     (10U)
+#define HSEM_C2ICR_ISC10_Msk     (0x1UL << HSEM_C2ICR_ISC10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2ICR_ISC10         HSEM_C2ICR_ISC10_Msk                          /*!<semaphore 10 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC11_Pos     (11U)
+#define HSEM_C2ICR_ISC11_Msk     (0x1UL << HSEM_C2ICR_ISC11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2ICR_ISC11         HSEM_C2ICR_ISC11_Msk                          /*!<semaphore 11 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC12_Pos     (12U)
+#define HSEM_C2ICR_ISC12_Msk     (0x1UL << HSEM_C2ICR_ISC12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2ICR_ISC12         HSEM_C2ICR_ISC12_Msk                          /*!<semaphore 12 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC13_Pos     (13U)
+#define HSEM_C2ICR_ISC13_Msk     (0x1UL << HSEM_C2ICR_ISC13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2ICR_ISC13         HSEM_C2ICR_ISC13_Msk                          /*!<semaphore 13 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC14_Pos     (14U)
+#define HSEM_C2ICR_ISC14_Msk     (0x1UL << HSEM_C2ICR_ISC14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2ICR_ISC14         HSEM_C2ICR_ISC14_Msk                          /*!<semaphore 14 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC15_Pos     (15U)
+#define HSEM_C2ICR_ISC15_Msk     (0x1UL << HSEM_C2ICR_ISC15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2ICR_ISC15         HSEM_C2ICR_ISC15_Msk                          /*!<semaphore 15 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC16_Pos     (16U)
+#define HSEM_C2ICR_ISC16_Msk     (0x1UL << HSEM_C2ICR_ISC16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2ICR_ISC16         HSEM_C2ICR_ISC16_Msk                          /*!<semaphore 16 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC17_Pos     (17U)
+#define HSEM_C2ICR_ISC17_Msk     (0x1UL << HSEM_C2ICR_ISC17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2ICR_ISC17         HSEM_C2ICR_ISC17_Msk                          /*!<semaphore 17 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC18_Pos     (18U)
+#define HSEM_C2ICR_ISC18_Msk     (0x1UL << HSEM_C2ICR_ISC18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2ICR_ISC18         HSEM_C2ICR_ISC18_Msk                          /*!<semaphore 18 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC19_Pos     (19U)
+#define HSEM_C2ICR_ISC19_Msk     (0x1UL << HSEM_C2ICR_ISC19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2ICR_ISC19         HSEM_C2ICR_ISC19_Msk                          /*!<semaphore 19 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC20_Pos     (20U)
+#define HSEM_C2ICR_ISC20_Msk     (0x1UL << HSEM_C2ICR_ISC20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2ICR_ISC20         HSEM_C2ICR_ISC20_Msk                          /*!<semaphore 20 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC21_Pos     (21U)
+#define HSEM_C2ICR_ISC21_Msk     (0x1UL << HSEM_C2ICR_ISC21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2ICR_ISC21         HSEM_C2ICR_ISC21_Msk                          /*!<semaphore 21 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC22_Pos     (22U)
+#define HSEM_C2ICR_ISC22_Msk     (0x1UL << HSEM_C2ICR_ISC22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2ICR_ISC22         HSEM_C2ICR_ISC22_Msk                          /*!<semaphore 22 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC23_Pos     (23U)
+#define HSEM_C2ICR_ISC23_Msk     (0x1UL << HSEM_C2ICR_ISC23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2ICR_ISC23         HSEM_C2ICR_ISC23_Msk                          /*!<semaphore 23 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC24_Pos     (24U)
+#define HSEM_C2ICR_ISC24_Msk     (0x1UL << HSEM_C2ICR_ISC24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2ICR_ISC24         HSEM_C2ICR_ISC24_Msk                          /*!<semaphore 24 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC25_Pos     (25U)
+#define HSEM_C2ICR_ISC25_Msk     (0x1UL << HSEM_C2ICR_ISC25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2ICR_ISC25         HSEM_C2ICR_ISC25_Msk                          /*!<semaphore 25 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC26_Pos     (26U)
+#define HSEM_C2ICR_ISC26_Msk     (0x1UL << HSEM_C2ICR_ISC26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2ICR_ISC26         HSEM_C2ICR_ISC26_Msk                          /*!<semaphore 26 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC27_Pos     (27U)
+#define HSEM_C2ICR_ISC27_Msk     (0x1UL << HSEM_C2ICR_ISC27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2ICR_ISC27         HSEM_C2ICR_ISC27_Msk                          /*!<semaphore 27 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC28_Pos     (28U)
+#define HSEM_C2ICR_ISC28_Msk     (0x1UL << HSEM_C2ICR_ISC28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2ICR_ISC28         HSEM_C2ICR_ISC28_Msk                          /*!<semaphore 28 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC29_Pos     (29U)
+#define HSEM_C2ICR_ISC29_Msk     (0x1UL << HSEM_C2ICR_ISC29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2ICR_ISC29         HSEM_C2ICR_ISC29_Msk                          /*!<semaphore 29 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC30_Pos     (30U)
+#define HSEM_C2ICR_ISC30_Msk     (0x1UL << HSEM_C2ICR_ISC30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2ICR_ISC30         HSEM_C2ICR_ISC30_Msk                          /*!<semaphore 30 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC31_Pos     (31U)
+#define HSEM_C2ICR_ISC31_Msk     (0x1UL << HSEM_C2ICR_ISC31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2ICR_ISC31         HSEM_C2ICR_ISC31_Msk                          /*!<semaphore 31 CPU2 interrupt clear bit. */
+
+/********************  Bit definition for HSEM_C2ISR register  *****************/
+#define HSEM_C2ISR_ISF0_Pos      (0U)
+#define HSEM_C2ISR_ISF0_Msk      (0x1UL << HSEM_C2ISR_ISF0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2ISR_ISF0          HSEM_C2ISR_ISF0_Msk                           /*!<semaphore 0 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF1_Pos      (1U)
+#define HSEM_C2ISR_ISF1_Msk      (0x1UL << HSEM_C2ISR_ISF1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2ISR_ISF1          HSEM_C2ISR_ISF1_Msk                           /*!<semaphore 1 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF2_Pos      (2U)
+#define HSEM_C2ISR_ISF2_Msk      (0x1UL << HSEM_C2ISR_ISF2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2ISR_ISF2          HSEM_C2ISR_ISF2_Msk                           /*!<semaphore 2 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF3_Pos      (3U)
+#define HSEM_C2ISR_ISF3_Msk      (0x1UL << HSEM_C2ISR_ISF3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2ISR_ISF3          HSEM_C2ISR_ISF3_Msk                           /*!<semaphore 3 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF4_Pos      (4U)
+#define HSEM_C2ISR_ISF4_Msk      (0x1UL << HSEM_C2ISR_ISF4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2ISR_ISF4          HSEM_C2ISR_ISF4_Msk                           /*!<semaphore 4 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF5_Pos      (5U)
+#define HSEM_C2ISR_ISF5_Msk      (0x1UL << HSEM_C2ISR_ISF5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2ISR_ISF5          HSEM_C2ISR_ISF5_Msk                           /*!<semaphore 5 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF6_Pos      (6U)
+#define HSEM_C2ISR_ISF6_Msk      (0x1UL << HSEM_C2ISR_ISF6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2ISR_ISF6          HSEM_C2ISR_ISF6_Msk                           /*!<semaphore 6 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF7_Pos      (7U)
+#define HSEM_C2ISR_ISF7_Msk      (0x1UL << HSEM_C2ISR_ISF7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2ISR_ISF7          HSEM_C2ISR_ISF7_Msk                           /*!<semaphore 7 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF8_Pos      (8U)
+#define HSEM_C2ISR_ISF8_Msk      (0x1UL << HSEM_C2ISR_ISF8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2ISR_ISF8          HSEM_C2ISR_ISF8_Msk                           /*!<semaphore 8 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF9_Pos      (9U)
+#define HSEM_C2ISR_ISF9_Msk      (0x1UL << HSEM_C2ISR_ISF9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2ISR_ISF9          HSEM_C2ISR_ISF9_Msk                           /*!<semaphore 9 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF10_Pos     (10U)
+#define HSEM_C2ISR_ISF10_Msk     (0x1UL << HSEM_C2ISR_ISF10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2ISR_ISF10         HSEM_C2ISR_ISF10_Msk                          /*!<semaphore 10 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF11_Pos     (11U)
+#define HSEM_C2ISR_ISF11_Msk     (0x1UL << HSEM_C2ISR_ISF11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2ISR_ISF11         HSEM_C2ISR_ISF11_Msk                          /*!<semaphore 11 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF12_Pos     (12U)
+#define HSEM_C2ISR_ISF12_Msk     (0x1UL << HSEM_C2ISR_ISF12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2ISR_ISF12         HSEM_C2ISR_ISF12_Msk                          /*!<semaphore 12 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF13_Pos     (13U)
+#define HSEM_C2ISR_ISF13_Msk     (0x1UL << HSEM_C2ISR_ISF13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2ISR_ISF13         HSEM_C2ISR_ISF13_Msk                          /*!<semaphore 13 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF14_Pos     (14U)
+#define HSEM_C2ISR_ISF14_Msk     (0x1UL << HSEM_C2ISR_ISF14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2ISR_ISF14         HSEM_C2ISR_ISF14_Msk                          /*!<semaphore 14 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF15_Pos     (15U)
+#define HSEM_C2ISR_ISF15_Msk     (0x1UL << HSEM_C2ISR_ISF15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2ISR_ISF15         HSEM_C2ISR_ISF15_Msk                          /*!<semaphore 15 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF16_Pos     (16U)
+#define HSEM_C2ISR_ISF16_Msk     (0x1UL << HSEM_C2ISR_ISF16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2ISR_ISF16         HSEM_C2ISR_ISF16_Msk                          /*!<semaphore 16 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF17_Pos     (17U)
+#define HSEM_C2ISR_ISF17_Msk     (0x1UL << HSEM_C2ISR_ISF17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2ISR_ISF17         HSEM_C2ISR_ISF17_Msk                          /*!<semaphore 17 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF18_Pos     (18U)
+#define HSEM_C2ISR_ISF18_Msk     (0x1UL << HSEM_C2ISR_ISF18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2ISR_ISF18         HSEM_C2ISR_ISF18_Msk                          /*!<semaphore 18 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF19_Pos     (19U)
+#define HSEM_C2ISR_ISF19_Msk     (0x1UL << HSEM_C2ISR_ISF19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2ISR_ISF19         HSEM_C2ISR_ISF19_Msk                          /*!<semaphore 19 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF20_Pos     (20U)
+#define HSEM_C2ISR_ISF20_Msk     (0x1UL << HSEM_C2ISR_ISF20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2ISR_ISF20         HSEM_C2ISR_ISF20_Msk                          /*!<semaphore 20 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF21_Pos     (21U)
+#define HSEM_C2ISR_ISF21_Msk     (0x1UL << HSEM_C2ISR_ISF21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2ISR_ISF21         HSEM_C2ISR_ISF21_Msk                          /*!<semaphore 21 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF22_Pos     (22U)
+#define HSEM_C2ISR_ISF22_Msk     (0x1UL << HSEM_C2ISR_ISF22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2ISR_ISF22         HSEM_C2ISR_ISF22_Msk                          /*!<semaphore 22 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF23_Pos     (23U)
+#define HSEM_C2ISR_ISF23_Msk     (0x1UL << HSEM_C2ISR_ISF23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2ISR_ISF23         HSEM_C2ISR_ISF23_Msk                          /*!<semaphore 23 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF24_Pos     (24U)
+#define HSEM_C2ISR_ISF24_Msk     (0x1UL << HSEM_C2ISR_ISF24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2ISR_ISF24         HSEM_C2ISR_ISF24_Msk                          /*!<semaphore 24 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF25_Pos     (25U)
+#define HSEM_C2ISR_ISF25_Msk     (0x1UL << HSEM_C2ISR_ISF25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2ISR_ISF25         HSEM_C2ISR_ISF25_Msk                          /*!<semaphore 25 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF26_Pos     (26U)
+#define HSEM_C2ISR_ISF26_Msk     (0x1UL << HSEM_C2ISR_ISF26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2ISR_ISF26         HSEM_C2ISR_ISF26_Msk                          /*!<semaphore 26 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF27_Pos     (27U)
+#define HSEM_C2ISR_ISF27_Msk     (0x1UL << HSEM_C2ISR_ISF27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2ISR_ISF27         HSEM_C2ISR_ISF27_Msk                          /*!<semaphore 27 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF28_Pos     (28U)
+#define HSEM_C2ISR_ISF28_Msk     (0x1UL << HSEM_C2ISR_ISF28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2ISR_ISF28         HSEM_C2ISR_ISF28_Msk                          /*!<semaphore 28 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF29_Pos     (29U)
+#define HSEM_C2ISR_ISF29_Msk     (0x1UL << HSEM_C2ISR_ISF29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2ISR_ISF29         HSEM_C2ISR_ISF29_Msk                          /*!<semaphore 29 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF30_Pos     (30U)
+#define HSEM_C2ISR_ISF30_Msk     (0x1UL << HSEM_C2ISR_ISF30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2ISR_ISF30         HSEM_C2ISR_ISF30_Msk                          /*!<semaphore 30 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF31_Pos     (31U)
+#define HSEM_C2ISR_ISF31_Msk     (0x1UL << HSEM_C2ISR_ISF31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2ISR_ISF31         HSEM_C2ISR_ISF31_Msk                          /*!<semaphore 31 CPU2 interrupt status bit. */
+
+/********************  Bit definition for HSEM_C2MISR register  *****************/
+#define HSEM_C2MISR_MISF0_Pos     (0U)
+#define HSEM_C2MISR_MISF0_Msk     (0x1UL << HSEM_C2MISR_MISF0_Pos)               /*!< 0x00000001 */
+#define HSEM_C2MISR_MISF0         HSEM_C2MISR_MISF0_Msk                          /*!<semaphore 0 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF1_Pos     (1U)
+#define HSEM_C2MISR_MISF1_Msk     (0x1UL << HSEM_C2MISR_MISF1_Pos)               /*!< 0x00000002 */
+#define HSEM_C2MISR_MISF1         HSEM_C2MISR_MISF1_Msk                          /*!<semaphore 1 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF2_Pos     (2U)
+#define HSEM_C2MISR_MISF2_Msk     (0x1UL << HSEM_C2MISR_MISF2_Pos)               /*!< 0x00000004 */
+#define HSEM_C2MISR_MISF2         HSEM_C2MISR_MISF2_Msk                          /*!<semaphore 2 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF3_Pos     (3U)
+#define HSEM_C2MISR_MISF3_Msk     (0x1UL << HSEM_C2MISR_MISF3_Pos)               /*!< 0x00000008 */
+#define HSEM_C2MISR_MISF3         HSEM_C2MISR_MISF3_Msk                          /*!<semaphore 3 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF4_Pos     (4U)
+#define HSEM_C2MISR_MISF4_Msk     (0x1UL << HSEM_C2MISR_MISF4_Pos)               /*!< 0x00000010 */
+#define HSEM_C2MISR_MISF4         HSEM_C2MISR_MISF4_Msk                          /*!<semaphore 4 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF5_Pos     (5U)
+#define HSEM_C2MISR_MISF5_Msk     (0x1UL << HSEM_C2MISR_MISF5_Pos)               /*!< 0x00000020 */
+#define HSEM_C2MISR_MISF5         HSEM_C2MISR_MISF5_Msk                          /*!<semaphore 5 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF6_Pos     (6U)
+#define HSEM_C2MISR_MISF6_Msk     (0x1UL << HSEM_C2MISR_MISF6_Pos)               /*!< 0x00000040 */
+#define HSEM_C2MISR_MISF6         HSEM_C2MISR_MISF6_Msk                          /*!<semaphore 6 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF7_Pos     (7U)
+#define HSEM_C2MISR_MISF7_Msk     (0x1UL << HSEM_C2MISR_MISF7_Pos)               /*!< 0x00000080 */
+#define HSEM_C2MISR_MISF7         HSEM_C2MISR_MISF7_Msk                          /*!<semaphore 7 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF8_Pos     (8U)
+#define HSEM_C2MISR_MISF8_Msk     (0x1UL << HSEM_C2MISR_MISF8_Pos)               /*!< 0x00000100 */
+#define HSEM_C2MISR_MISF8         HSEM_C2MISR_MISF8_Msk                          /*!<semaphore 8 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF9_Pos     (9U)
+#define HSEM_C2MISR_MISF9_Msk     (0x1UL << HSEM_C2MISR_MISF9_Pos)               /*!< 0x00000200 */
+#define HSEM_C2MISR_MISF9         HSEM_C2MISR_MISF9_Msk                          /*!<semaphore 9 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF10_Pos    (10U)
+#define HSEM_C2MISR_MISF10_Msk    (0x1UL << HSEM_C2MISR_MISF10_Pos)              /*!< 0x00000400 */
+#define HSEM_C2MISR_MISF10        HSEM_C2MISR_MISF10_Msk                         /*!<semaphore 10 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF11_Pos    (11U)
+#define HSEM_C2MISR_MISF11_Msk    (0x1UL << HSEM_C2MISR_MISF11_Pos)              /*!< 0x00000800 */
+#define HSEM_C2MISR_MISF11        HSEM_C2MISR_MISF11_Msk                         /*!<semaphore 11 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF12_Pos    (12U)
+#define HSEM_C2MISR_MISF12_Msk    (0x1UL << HSEM_C2MISR_MISF12_Pos)              /*!< 0x00001000 */
+#define HSEM_C2MISR_MISF12        HSEM_C2MISR_MISF12_Msk                         /*!<semaphore 12 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF13_Pos    (13U)
+#define HSEM_C2MISR_MISF13_Msk    (0x1UL << HSEM_C2MISR_MISF13_Pos)              /*!< 0x00002000 */
+#define HSEM_C2MISR_MISF13        HSEM_C2MISR_MISF13_Msk                         /*!<semaphore 13 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF14_Pos    (14U)
+#define HSEM_C2MISR_MISF14_Msk    (0x1UL << HSEM_C2MISR_MISF14_Pos)              /*!< 0x00004000 */
+#define HSEM_C2MISR_MISF14        HSEM_C2MISR_MISF14_Msk                         /*!<semaphore 14 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF15_Pos    (15U)
+#define HSEM_C2MISR_MISF15_Msk    (0x1UL << HSEM_C2MISR_MISF15_Pos)              /*!< 0x00008000 */
+#define HSEM_C2MISR_MISF15        HSEM_C2MISR_MISF15_Msk                         /*!<semaphore 15 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF16_Pos    (16U)
+#define HSEM_C2MISR_MISF16_Msk    (0x1UL << HSEM_C2MISR_MISF16_Pos)              /*!< 0x00010000 */
+#define HSEM_C2MISR_MISF16        HSEM_C2MISR_MISF16_Msk                         /*!<semaphore 16 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF17_Pos    (17U)
+#define HSEM_C2MISR_MISF17_Msk    (0x1UL << HSEM_C2MISR_MISF17_Pos)              /*!< 0x00020000 */
+#define HSEM_C2MISR_MISF17        HSEM_C2MISR_MISF17_Msk                         /*!<semaphore 17 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF18_Pos    (18U)
+#define HSEM_C2MISR_MISF18_Msk    (0x1UL << HSEM_C2MISR_MISF18_Pos)              /*!< 0x00040000 */
+#define HSEM_C2MISR_MISF18        HSEM_C2MISR_MISF18_Msk                         /*!<semaphore 18 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF19_Pos    (19U)
+#define HSEM_C2MISR_MISF19_Msk    (0x1UL << HSEM_C2MISR_MISF19_Pos)              /*!< 0x00080000 */
+#define HSEM_C2MISR_MISF19        HSEM_C2MISR_MISF19_Msk                         /*!<semaphore 19 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF20_Pos    (20U)
+#define HSEM_C2MISR_MISF20_Msk    (0x1UL << HSEM_C2MISR_MISF20_Pos)              /*!< 0x00100000 */
+#define HSEM_C2MISR_MISF20        HSEM_C2MISR_MISF20_Msk                         /*!<semaphore 20 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF21_Pos    (21U)
+#define HSEM_C2MISR_MISF21_Msk    (0x1UL << HSEM_C2MISR_MISF21_Pos)              /*!< 0x00200000 */
+#define HSEM_C2MISR_MISF21        HSEM_C2MISR_MISF21_Msk                         /*!<semaphore 21 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF22_Pos    (22U)
+#define HSEM_C2MISR_MISF22_Msk    (0x1UL << HSEM_C2MISR_MISF22_Pos)              /*!< 0x00400000 */
+#define HSEM_C2MISR_MISF22        HSEM_C2MISR_MISF22_Msk                         /*!<semaphore 22 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF23_Pos    (23U)
+#define HSEM_C2MISR_MISF23_Msk    (0x1UL << HSEM_C2MISR_MISF23_Pos)              /*!< 0x00800000 */
+#define HSEM_C2MISR_MISF23        HSEM_C2MISR_MISF23_Msk                         /*!<semaphore 23 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF24_Pos    (24U)
+#define HSEM_C2MISR_MISF24_Msk    (0x1UL << HSEM_C2MISR_MISF24_Pos)              /*!< 0x01000000 */
+#define HSEM_C2MISR_MISF24        HSEM_C2MISR_MISF24_Msk                         /*!<semaphore 24 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF25_Pos    (25U)
+#define HSEM_C2MISR_MISF25_Msk    (0x1UL << HSEM_C2MISR_MISF25_Pos)              /*!< 0x02000000 */
+#define HSEM_C2MISR_MISF25        HSEM_C2MISR_MISF25_Msk                         /*!<semaphore 25 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF26_Pos    (26U)
+#define HSEM_C2MISR_MISF26_Msk    (0x1UL << HSEM_C2MISR_MISF26_Pos)              /*!< 0x04000000 */
+#define HSEM_C2MISR_MISF26        HSEM_C2MISR_MISF26_Msk                         /*!<semaphore 26 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF27_Pos    (27U)
+#define HSEM_C2MISR_MISF27_Msk    (0x1UL << HSEM_C2MISR_MISF27_Pos)              /*!< 0x08000000 */
+#define HSEM_C2MISR_MISF27        HSEM_C2MISR_MISF27_Msk                         /*!<semaphore 27 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF28_Pos    (28U)
+#define HSEM_C2MISR_MISF28_Msk    (0x1UL << HSEM_C2MISR_MISF28_Pos)              /*!< 0x10000000 */
+#define HSEM_C2MISR_MISF28        HSEM_C2MISR_MISF28_Msk                         /*!<semaphore 28 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF29_Pos    (29U)
+#define HSEM_C2MISR_MISF29_Msk    (0x1UL << HSEM_C2MISR_MISF29_Pos)              /*!< 0x20000000 */
+#define HSEM_C2MISR_MISF29        HSEM_C2MISR_MISF29_Msk                         /*!<semaphore 29 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF30_Pos    (30U)
+#define HSEM_C2MISR_MISF30_Msk    (0x1UL << HSEM_C2MISR_MISF30_Pos)              /*!< 0x40000000 */
+#define HSEM_C2MISR_MISF30        HSEM_C2MISR_MISF30_Msk                         /*!<semaphore 30 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF31_Pos    (31U)
+#define HSEM_C2MISR_MISF31_Msk    (0x1UL << HSEM_C2MISR_MISF31_Pos)              /*!< 0x80000000 */
+#define HSEM_C2MISR_MISF31        HSEM_C2MISR_MISF31_Msk                         /*!<semaphore 31 CPU2 interrupt masked status bit. */
+
+/********************  Bit definition for HSEM_CR register  *****************/
+#define HSEM_CR_COREID_Pos       (8U)
+#define HSEM_CR_COREID_Msk       (0xFUL << HSEM_CR_COREID_Pos)                 /*!< 0x00000F00 */
+#define HSEM_CR_COREID           HSEM_CR_COREID_Msk                            /*!<CoreID of semaphores to be cleared. */
+#define HSEM_CR_COREID_CPU1      (0x4U << HSEM_CR_COREID_Pos)
+#define HSEM_CR_COREID_CPU2      (0x8U << HSEM_CR_COREID_Pos)
+#define HSEM_CR_COREID_CURRENT   HSEM_CR_COREID_CPU1
+#define HSEM_CR_KEY_Pos          (16U)
+#define HSEM_CR_KEY_Msk          (0xFFFFUL << HSEM_CR_KEY_Pos)                 /*!< 0xFFFF0000 */
+#define HSEM_CR_KEY              HSEM_CR_KEY_Msk                               /*!<semaphores clear key. */
+
+/********************  Bit definition for HSEM_KEYR register  *****************/
+#define HSEM_KEYR_KEY_Pos        (16U)
+#define HSEM_KEYR_KEY_Msk        (0xFFFFUL << HSEM_KEYR_KEY_Pos)               /*!< 0xFFFF0000 */
+#define HSEM_KEYR_KEY            HSEM_KEYR_KEY_Msk                             /*!<semaphores clear key. */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define I2C_CR1_PE_Pos               (0U)
+#define I2C_CR1_PE_Msk               (0x1UL << I2C_CR1_PE_Pos)                 /*!< 0x00000001 */
+#define I2C_CR1_PE                   I2C_CR1_PE_Msk                            /*!< Peripheral enable */
+#define I2C_CR1_TXIE_Pos             (1U)
+#define I2C_CR1_TXIE_Msk             (0x1UL << I2C_CR1_TXIE_Pos)               /*!< 0x00000002 */
+#define I2C_CR1_TXIE                 I2C_CR1_TXIE_Msk                          /*!< TX interrupt enable */
+#define I2C_CR1_RXIE_Pos             (2U)
+#define I2C_CR1_RXIE_Msk             (0x1UL << I2C_CR1_RXIE_Pos)               /*!< 0x00000004 */
+#define I2C_CR1_RXIE                 I2C_CR1_RXIE_Msk                          /*!< RX interrupt enable */
+#define I2C_CR1_ADDRIE_Pos           (3U)
+#define I2C_CR1_ADDRIE_Msk           (0x1UL << I2C_CR1_ADDRIE_Pos)             /*!< 0x00000008 */
+#define I2C_CR1_ADDRIE               I2C_CR1_ADDRIE_Msk                        /*!< Address match interrupt enable */
+#define I2C_CR1_NACKIE_Pos           (4U)
+#define I2C_CR1_NACKIE_Msk           (0x1UL << I2C_CR1_NACKIE_Pos)             /*!< 0x00000010 */
+#define I2C_CR1_NACKIE               I2C_CR1_NACKIE_Msk                        /*!< NACK received interrupt enable */
+#define I2C_CR1_STOPIE_Pos           (5U)
+#define I2C_CR1_STOPIE_Msk           (0x1UL << I2C_CR1_STOPIE_Pos)             /*!< 0x00000020 */
+#define I2C_CR1_STOPIE               I2C_CR1_STOPIE_Msk                        /*!< STOP detection interrupt enable */
+#define I2C_CR1_TCIE_Pos             (6U)
+#define I2C_CR1_TCIE_Msk             (0x1UL << I2C_CR1_TCIE_Pos)               /*!< 0x00000040 */
+#define I2C_CR1_TCIE                 I2C_CR1_TCIE_Msk                          /*!< Transfer complete interrupt enable */
+#define I2C_CR1_ERRIE_Pos            (7U)
+#define I2C_CR1_ERRIE_Msk            (0x1UL << I2C_CR1_ERRIE_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_ERRIE                I2C_CR1_ERRIE_Msk                         /*!< Errors interrupt enable */
+#define I2C_CR1_DNF_Pos              (8U)
+#define I2C_CR1_DNF_Msk              (0xFUL << I2C_CR1_DNF_Pos)                /*!< 0x00000F00 */
+#define I2C_CR1_DNF                  I2C_CR1_DNF_Msk                           /*!< Digital noise filter */
+#define I2C_CR1_ANFOFF_Pos           (12U)
+#define I2C_CR1_ANFOFF_Msk           (0x1UL << I2C_CR1_ANFOFF_Pos)             /*!< 0x00001000 */
+#define I2C_CR1_ANFOFF               I2C_CR1_ANFOFF_Msk                        /*!< Analog noise filter OFF */
+#define I2C_CR1_SWRST_Pos            (13U)
+#define I2C_CR1_SWRST_Msk            (0x1UL << I2C_CR1_SWRST_Pos)              /*!< 0x00002000 */
+#define I2C_CR1_SWRST                I2C_CR1_SWRST_Msk                         /*!< Software reset */
+#define I2C_CR1_TXDMAEN_Pos          (14U)
+#define I2C_CR1_TXDMAEN_Msk          (0x1UL << I2C_CR1_TXDMAEN_Pos)            /*!< 0x00004000 */
+#define I2C_CR1_TXDMAEN              I2C_CR1_TXDMAEN_Msk                       /*!< DMA transmission requests enable */
+#define I2C_CR1_RXDMAEN_Pos          (15U)
+#define I2C_CR1_RXDMAEN_Msk          (0x1UL << I2C_CR1_RXDMAEN_Pos)            /*!< 0x00008000 */
+#define I2C_CR1_RXDMAEN              I2C_CR1_RXDMAEN_Msk                       /*!< DMA reception requests enable */
+#define I2C_CR1_SBC_Pos              (16U)
+#define I2C_CR1_SBC_Msk              (0x1UL << I2C_CR1_SBC_Pos)                /*!< 0x00010000 */
+#define I2C_CR1_SBC                  I2C_CR1_SBC_Msk                           /*!< Slave byte control */
+#define I2C_CR1_NOSTRETCH_Pos        (17U)
+#define I2C_CR1_NOSTRETCH_Msk        (0x1UL << I2C_CR1_NOSTRETCH_Pos)          /*!< 0x00020000 */
+#define I2C_CR1_NOSTRETCH            I2C_CR1_NOSTRETCH_Msk                     /*!< Clock stretching disable */
+#define I2C_CR1_WUPEN_Pos            (18U)
+#define I2C_CR1_WUPEN_Msk            (0x1UL << I2C_CR1_WUPEN_Pos)              /*!< 0x00040000 */
+#define I2C_CR1_WUPEN                I2C_CR1_WUPEN_Msk                         /*!< Wakeup from STOP enable */
+#define I2C_CR1_GCEN_Pos             (19U)
+#define I2C_CR1_GCEN_Msk             (0x1UL << I2C_CR1_GCEN_Pos)               /*!< 0x00080000 */
+#define I2C_CR1_GCEN                 I2C_CR1_GCEN_Msk                          /*!< General call enable */
+#define I2C_CR1_SMBHEN_Pos           (20U)
+#define I2C_CR1_SMBHEN_Msk           (0x1UL << I2C_CR1_SMBHEN_Pos)             /*!< 0x00100000 */
+#define I2C_CR1_SMBHEN               I2C_CR1_SMBHEN_Msk                        /*!< SMBus host address enable */
+#define I2C_CR1_SMBDEN_Pos           (21U)
+#define I2C_CR1_SMBDEN_Msk           (0x1UL << I2C_CR1_SMBDEN_Pos)             /*!< 0x00200000 */
+#define I2C_CR1_SMBDEN               I2C_CR1_SMBDEN_Msk                        /*!< SMBus device default address enable */
+#define I2C_CR1_ALERTEN_Pos          (22U)
+#define I2C_CR1_ALERTEN_Msk          (0x1UL << I2C_CR1_ALERTEN_Pos)            /*!< 0x00400000 */
+#define I2C_CR1_ALERTEN              I2C_CR1_ALERTEN_Msk                       /*!< SMBus alert enable */
+#define I2C_CR1_PECEN_Pos            (23U)
+#define I2C_CR1_PECEN_Msk            (0x1UL << I2C_CR1_PECEN_Pos)              /*!< 0x00800000 */
+#define I2C_CR1_PECEN                I2C_CR1_PECEN_Msk                         /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_SADD_Pos             (0U)
+#define I2C_CR2_SADD_Msk             (0x3FFUL << I2C_CR2_SADD_Pos)             /*!< 0x000003FF */
+#define I2C_CR2_SADD                 I2C_CR2_SADD_Msk                          /*!< Slave address (master mode) */
+#define I2C_CR2_RD_WRN_Pos           (10U)
+#define I2C_CR2_RD_WRN_Msk           (0x1UL << I2C_CR2_RD_WRN_Pos)             /*!< 0x00000400 */
+#define I2C_CR2_RD_WRN               I2C_CR2_RD_WRN_Msk                        /*!< Transfer direction (master mode) */
+#define I2C_CR2_ADD10_Pos            (11U)
+#define I2C_CR2_ADD10_Msk            (0x1UL << I2C_CR2_ADD10_Pos)              /*!< 0x00000800 */
+#define I2C_CR2_ADD10                I2C_CR2_ADD10_Msk                         /*!< 10-bit addressing mode (master mode) */
+#define I2C_CR2_HEAD10R_Pos          (12U)
+#define I2C_CR2_HEAD10R_Msk          (0x1UL << I2C_CR2_HEAD10R_Pos)            /*!< 0x00001000 */
+#define I2C_CR2_HEAD10R              I2C_CR2_HEAD10R_Msk                       /*!< 10-bit address header only read direction (master mode) */
+#define I2C_CR2_START_Pos            (13U)
+#define I2C_CR2_START_Msk            (0x1UL << I2C_CR2_START_Pos)              /*!< 0x00002000 */
+#define I2C_CR2_START                I2C_CR2_START_Msk                         /*!< START generation */
+#define I2C_CR2_STOP_Pos             (14U)
+#define I2C_CR2_STOP_Msk             (0x1UL << I2C_CR2_STOP_Pos)               /*!< 0x00004000 */
+#define I2C_CR2_STOP                 I2C_CR2_STOP_Msk                          /*!< STOP generation (master mode) */
+#define I2C_CR2_NACK_Pos             (15U)
+#define I2C_CR2_NACK_Msk             (0x1UL << I2C_CR2_NACK_Pos)               /*!< 0x00008000 */
+#define I2C_CR2_NACK                 I2C_CR2_NACK_Msk                          /*!< NACK generation (slave mode) */
+#define I2C_CR2_NBYTES_Pos           (16U)
+#define I2C_CR2_NBYTES_Msk           (0xFFUL << I2C_CR2_NBYTES_Pos)            /*!< 0x00FF0000 */
+#define I2C_CR2_NBYTES               I2C_CR2_NBYTES_Msk                        /*!< Number of bytes */
+#define I2C_CR2_RELOAD_Pos           (24U)
+#define I2C_CR2_RELOAD_Msk           (0x1UL << I2C_CR2_RELOAD_Pos)             /*!< 0x01000000 */
+#define I2C_CR2_RELOAD               I2C_CR2_RELOAD_Msk                        /*!< NBYTES reload mode */
+#define I2C_CR2_AUTOEND_Pos          (25U)
+#define I2C_CR2_AUTOEND_Msk          (0x1UL << I2C_CR2_AUTOEND_Pos)            /*!< 0x02000000 */
+#define I2C_CR2_AUTOEND              I2C_CR2_AUTOEND_Msk                       /*!< Automatic end mode (master mode) */
+#define I2C_CR2_PECBYTE_Pos          (26U)
+#define I2C_CR2_PECBYTE_Msk          (0x1UL << I2C_CR2_PECBYTE_Pos)            /*!< 0x04000000 */
+#define I2C_CR2_PECBYTE              I2C_CR2_PECBYTE_Msk                       /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define I2C_OAR1_OA1_Pos             (0U)
+#define I2C_OAR1_OA1_Msk             (0x3FFUL << I2C_OAR1_OA1_Pos)             /*!< 0x000003FF */
+#define I2C_OAR1_OA1                 I2C_OAR1_OA1_Msk                          /*!< Interface own address 1 */
+#define I2C_OAR1_OA1MODE_Pos         (10U)
+#define I2C_OAR1_OA1MODE_Msk         (0x1UL << I2C_OAR1_OA1MODE_Pos)           /*!< 0x00000400 */
+#define I2C_OAR1_OA1MODE             I2C_OAR1_OA1MODE_Msk                      /*!< Own address 1 10-bit mode */
+#define I2C_OAR1_OA1EN_Pos           (15U)
+#define I2C_OAR1_OA1EN_Msk           (0x1UL << I2C_OAR1_OA1EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR1_OA1EN               I2C_OAR1_OA1EN_Msk                        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define I2C_OAR2_OA2_Pos             (1U)
+#define I2C_OAR2_OA2_Msk             (0x7FUL << I2C_OAR2_OA2_Pos)              /*!< 0x000000FE */
+#define I2C_OAR2_OA2                 I2C_OAR2_OA2_Msk                          /*!< Interface own address 2 */
+#define I2C_OAR2_OA2MSK_Pos          (8U)
+#define I2C_OAR2_OA2MSK_Msk          (0x7UL << I2C_OAR2_OA2MSK_Pos)            /*!< 0x00000700 */
+#define I2C_OAR2_OA2MSK              I2C_OAR2_OA2MSK_Msk                       /*!< Own address 2 masks */
+#define I2C_OAR2_OA2NOMASK           (0x00000000UL)                            /*!< No mask                                        */
+#define I2C_OAR2_OA2MASK01_Pos       (8U)
+#define I2C_OAR2_OA2MASK01_Msk       (0x1UL << I2C_OAR2_OA2MASK01_Pos)         /*!< 0x00000100 */
+#define I2C_OAR2_OA2MASK01           I2C_OAR2_OA2MASK01_Msk                    /*!< OA2[1] is masked, Only OA2[7:2] are compared   */
+#define I2C_OAR2_OA2MASK02_Pos       (9U)
+#define I2C_OAR2_OA2MASK02_Msk       (0x1UL << I2C_OAR2_OA2MASK02_Pos)         /*!< 0x00000200 */
+#define I2C_OAR2_OA2MASK02           I2C_OAR2_OA2MASK02_Msk                    /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define I2C_OAR2_OA2MASK03_Pos       (8U)
+#define I2C_OAR2_OA2MASK03_Msk       (0x3UL << I2C_OAR2_OA2MASK03_Pos)         /*!< 0x00000300 */
+#define I2C_OAR2_OA2MASK03           I2C_OAR2_OA2MASK03_Msk                    /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define I2C_OAR2_OA2MASK04_Pos       (10U)
+#define I2C_OAR2_OA2MASK04_Msk       (0x1UL << I2C_OAR2_OA2MASK04_Pos)         /*!< 0x00000400 */
+#define I2C_OAR2_OA2MASK04           I2C_OAR2_OA2MASK04_Msk                    /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define I2C_OAR2_OA2MASK05_Pos       (8U)
+#define I2C_OAR2_OA2MASK05_Msk       (0x5UL << I2C_OAR2_OA2MASK05_Pos)         /*!< 0x00000500 */
+#define I2C_OAR2_OA2MASK05           I2C_OAR2_OA2MASK05_Msk                    /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define I2C_OAR2_OA2MASK06_Pos       (9U)
+#define I2C_OAR2_OA2MASK06_Msk       (0x3UL << I2C_OAR2_OA2MASK06_Pos)         /*!< 0x00000600 */
+#define I2C_OAR2_OA2MASK06           I2C_OAR2_OA2MASK06_Msk                    /*!< OA2[6:1] is masked, Only OA2[7] are compared   */
+#define I2C_OAR2_OA2MASK07_Pos       (8U)
+#define I2C_OAR2_OA2MASK07_Msk       (0x7UL << I2C_OAR2_OA2MASK07_Pos)         /*!< 0x00000700 */
+#define I2C_OAR2_OA2MASK07           I2C_OAR2_OA2MASK07_Msk                    /*!< OA2[7:1] is masked, No comparison is done      */
+#define I2C_OAR2_OA2EN_Pos           (15U)
+#define I2C_OAR2_OA2EN_Msk           (0x1UL << I2C_OAR2_OA2EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR2_OA2EN               I2C_OAR2_OA2EN_Msk                        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define I2C_TIMINGR_SCLL_Pos         (0U)
+#define I2C_TIMINGR_SCLL_Msk         (0xFFUL << I2C_TIMINGR_SCLL_Pos)          /*!< 0x000000FF */
+#define I2C_TIMINGR_SCLL             I2C_TIMINGR_SCLL_Msk                      /*!< SCL low period (master mode) */
+#define I2C_TIMINGR_SCLH_Pos         (8U)
+#define I2C_TIMINGR_SCLH_Msk         (0xFFUL << I2C_TIMINGR_SCLH_Pos)          /*!< 0x0000FF00 */
+#define I2C_TIMINGR_SCLH             I2C_TIMINGR_SCLH_Msk                      /*!< SCL high period (master mode) */
+#define I2C_TIMINGR_SDADEL_Pos       (16U)
+#define I2C_TIMINGR_SDADEL_Msk       (0xFUL << I2C_TIMINGR_SDADEL_Pos)         /*!< 0x000F0000 */
+#define I2C_TIMINGR_SDADEL           I2C_TIMINGR_SDADEL_Msk                    /*!< Data hold time */
+#define I2C_TIMINGR_SCLDEL_Pos       (20U)
+#define I2C_TIMINGR_SCLDEL_Msk       (0xFUL << I2C_TIMINGR_SCLDEL_Pos)         /*!< 0x00F00000 */
+#define I2C_TIMINGR_SCLDEL           I2C_TIMINGR_SCLDEL_Msk                    /*!< Data setup time */
+#define I2C_TIMINGR_PRESC_Pos        (28U)
+#define I2C_TIMINGR_PRESC_Msk        (0xFUL << I2C_TIMINGR_PRESC_Pos)          /*!< 0xF0000000 */
+#define I2C_TIMINGR_PRESC            I2C_TIMINGR_PRESC_Msk                     /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define I2C_TIMEOUTR_TIMEOUTA_Pos    (0U)
+#define I2C_TIMEOUTR_TIMEOUTA_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTA_Pos)    /*!< 0x00000FFF */
+#define I2C_TIMEOUTR_TIMEOUTA        I2C_TIMEOUTR_TIMEOUTA_Msk                 /*!< Bus timeout A */
+#define I2C_TIMEOUTR_TIDLE_Pos       (12U)
+#define I2C_TIMEOUTR_TIDLE_Msk       (0x1UL << I2C_TIMEOUTR_TIDLE_Pos)         /*!< 0x00001000 */
+#define I2C_TIMEOUTR_TIDLE           I2C_TIMEOUTR_TIDLE_Msk                    /*!< Idle clock timeout detection */
+#define I2C_TIMEOUTR_TIMOUTEN_Pos    (15U)
+#define I2C_TIMEOUTR_TIMOUTEN_Msk    (0x1UL << I2C_TIMEOUTR_TIMOUTEN_Pos)      /*!< 0x00008000 */
+#define I2C_TIMEOUTR_TIMOUTEN        I2C_TIMEOUTR_TIMOUTEN_Msk                 /*!< Clock timeout enable */
+#define I2C_TIMEOUTR_TIMEOUTB_Pos    (16U)
+#define I2C_TIMEOUTR_TIMEOUTB_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTB_Pos)    /*!< 0x0FFF0000 */
+#define I2C_TIMEOUTR_TIMEOUTB        I2C_TIMEOUTR_TIMEOUTB_Msk                 /*!< Bus timeout B*/
+#define I2C_TIMEOUTR_TEXTEN_Pos      (31U)
+#define I2C_TIMEOUTR_TEXTEN_Msk      (0x1UL << I2C_TIMEOUTR_TEXTEN_Pos)        /*!< 0x80000000 */
+#define I2C_TIMEOUTR_TEXTEN          I2C_TIMEOUTR_TEXTEN_Msk                   /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define I2C_ISR_TXE_Pos              (0U)
+#define I2C_ISR_TXE_Msk              (0x1UL << I2C_ISR_TXE_Pos)                /*!< 0x00000001 */
+#define I2C_ISR_TXE                  I2C_ISR_TXE_Msk                           /*!< Transmit data register empty */
+#define I2C_ISR_TXIS_Pos             (1U)
+#define I2C_ISR_TXIS_Msk             (0x1UL << I2C_ISR_TXIS_Pos)               /*!< 0x00000002 */
+#define I2C_ISR_TXIS                 I2C_ISR_TXIS_Msk                          /*!< Transmit interrupt status */
+#define I2C_ISR_RXNE_Pos             (2U)
+#define I2C_ISR_RXNE_Msk             (0x1UL << I2C_ISR_RXNE_Pos)               /*!< 0x00000004 */
+#define I2C_ISR_RXNE                 I2C_ISR_RXNE_Msk                          /*!< Receive data register not empty */
+#define I2C_ISR_ADDR_Pos             (3U)
+#define I2C_ISR_ADDR_Msk             (0x1UL << I2C_ISR_ADDR_Pos)               /*!< 0x00000008 */
+#define I2C_ISR_ADDR                 I2C_ISR_ADDR_Msk                          /*!< Address matched (slave mode)*/
+#define I2C_ISR_NACKF_Pos            (4U)
+#define I2C_ISR_NACKF_Msk            (0x1UL << I2C_ISR_NACKF_Pos)              /*!< 0x00000010 */
+#define I2C_ISR_NACKF                I2C_ISR_NACKF_Msk                         /*!< NACK received flag */
+#define I2C_ISR_STOPF_Pos            (5U)
+#define I2C_ISR_STOPF_Msk            (0x1UL << I2C_ISR_STOPF_Pos)              /*!< 0x00000020 */
+#define I2C_ISR_STOPF                I2C_ISR_STOPF_Msk                         /*!< STOP detection flag */
+#define I2C_ISR_TC_Pos               (6U)
+#define I2C_ISR_TC_Msk               (0x1UL << I2C_ISR_TC_Pos)                 /*!< 0x00000040 */
+#define I2C_ISR_TC                   I2C_ISR_TC_Msk                            /*!< Transfer complete (master mode) */
+#define I2C_ISR_TCR_Pos              (7U)
+#define I2C_ISR_TCR_Msk              (0x1UL << I2C_ISR_TCR_Pos)                /*!< 0x00000080 */
+#define I2C_ISR_TCR                  I2C_ISR_TCR_Msk                           /*!< Transfer complete reload */
+#define I2C_ISR_BERR_Pos             (8U)
+#define I2C_ISR_BERR_Msk             (0x1UL << I2C_ISR_BERR_Pos)               /*!< 0x00000100 */
+#define I2C_ISR_BERR                 I2C_ISR_BERR_Msk                          /*!< Bus error */
+#define I2C_ISR_ARLO_Pos             (9U)
+#define I2C_ISR_ARLO_Msk             (0x1UL << I2C_ISR_ARLO_Pos)               /*!< 0x00000200 */
+#define I2C_ISR_ARLO                 I2C_ISR_ARLO_Msk                          /*!< Arbitration lost */
+#define I2C_ISR_OVR_Pos              (10U)
+#define I2C_ISR_OVR_Msk              (0x1UL << I2C_ISR_OVR_Pos)                /*!< 0x00000400 */
+#define I2C_ISR_OVR                  I2C_ISR_OVR_Msk                           /*!< Overrun/Underrun */
+#define I2C_ISR_PECERR_Pos           (11U)
+#define I2C_ISR_PECERR_Msk           (0x1UL << I2C_ISR_PECERR_Pos)             /*!< 0x00000800 */
+#define I2C_ISR_PECERR               I2C_ISR_PECERR_Msk                        /*!< PEC error in reception */
+#define I2C_ISR_TIMEOUT_Pos          (12U)
+#define I2C_ISR_TIMEOUT_Msk          (0x1UL << I2C_ISR_TIMEOUT_Pos)            /*!< 0x00001000 */
+#define I2C_ISR_TIMEOUT              I2C_ISR_TIMEOUT_Msk                       /*!< Timeout or Tlow detection flag */
+#define I2C_ISR_ALERT_Pos            (13U)
+#define I2C_ISR_ALERT_Msk            (0x1UL << I2C_ISR_ALERT_Pos)              /*!< 0x00002000 */
+#define I2C_ISR_ALERT                I2C_ISR_ALERT_Msk                         /*!< SMBus alert */
+#define I2C_ISR_BUSY_Pos             (15U)
+#define I2C_ISR_BUSY_Msk             (0x1UL << I2C_ISR_BUSY_Pos)               /*!< 0x00008000 */
+#define I2C_ISR_BUSY                 I2C_ISR_BUSY_Msk                          /*!< Bus busy */
+#define I2C_ISR_DIR_Pos              (16U)
+#define I2C_ISR_DIR_Msk              (0x1UL << I2C_ISR_DIR_Pos)                /*!< 0x00010000 */
+#define I2C_ISR_DIR                  I2C_ISR_DIR_Msk                           /*!< Transfer direction (slave mode) */
+#define I2C_ISR_ADDCODE_Pos          (17U)
+#define I2C_ISR_ADDCODE_Msk          (0x7FUL << I2C_ISR_ADDCODE_Pos)           /*!< 0x00FE0000 */
+#define I2C_ISR_ADDCODE              I2C_ISR_ADDCODE_Msk                       /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define I2C_ICR_ADDRCF_Pos           (3U)
+#define I2C_ICR_ADDRCF_Msk           (0x1UL << I2C_ICR_ADDRCF_Pos)             /*!< 0x00000008 */
+#define I2C_ICR_ADDRCF               I2C_ICR_ADDRCF_Msk                        /*!< Address matched clear flag */
+#define I2C_ICR_NACKCF_Pos           (4U)
+#define I2C_ICR_NACKCF_Msk           (0x1UL << I2C_ICR_NACKCF_Pos)             /*!< 0x00000010 */
+#define I2C_ICR_NACKCF               I2C_ICR_NACKCF_Msk                        /*!< NACK clear flag */
+#define I2C_ICR_STOPCF_Pos           (5U)
+#define I2C_ICR_STOPCF_Msk           (0x1UL << I2C_ICR_STOPCF_Pos)             /*!< 0x00000020 */
+#define I2C_ICR_STOPCF               I2C_ICR_STOPCF_Msk                        /*!< STOP detection clear flag */
+#define I2C_ICR_BERRCF_Pos           (8U)
+#define I2C_ICR_BERRCF_Msk           (0x1UL << I2C_ICR_BERRCF_Pos)             /*!< 0x00000100 */
+#define I2C_ICR_BERRCF               I2C_ICR_BERRCF_Msk                        /*!< Bus error clear flag */
+#define I2C_ICR_ARLOCF_Pos           (9U)
+#define I2C_ICR_ARLOCF_Msk           (0x1UL << I2C_ICR_ARLOCF_Pos)             /*!< 0x00000200 */
+#define I2C_ICR_ARLOCF               I2C_ICR_ARLOCF_Msk                        /*!< Arbitration lost clear flag */
+#define I2C_ICR_OVRCF_Pos            (10U)
+#define I2C_ICR_OVRCF_Msk            (0x1UL << I2C_ICR_OVRCF_Pos)              /*!< 0x00000400 */
+#define I2C_ICR_OVRCF                I2C_ICR_OVRCF_Msk                         /*!< Overrun/Underrun clear flag */
+#define I2C_ICR_PECCF_Pos            (11U)
+#define I2C_ICR_PECCF_Msk            (0x1UL << I2C_ICR_PECCF_Pos)              /*!< 0x00000800 */
+#define I2C_ICR_PECCF                I2C_ICR_PECCF_Msk                         /*!< PAC error clear flag */
+#define I2C_ICR_TIMOUTCF_Pos         (12U)
+#define I2C_ICR_TIMOUTCF_Msk         (0x1UL << I2C_ICR_TIMOUTCF_Pos)           /*!< 0x00001000 */
+#define I2C_ICR_TIMOUTCF             I2C_ICR_TIMOUTCF_Msk                      /*!< Timeout clear flag */
+#define I2C_ICR_ALERTCF_Pos          (13U)
+#define I2C_ICR_ALERTCF_Msk          (0x1UL << I2C_ICR_ALERTCF_Pos)            /*!< 0x00002000 */
+#define I2C_ICR_ALERTCF              I2C_ICR_ALERTCF_Msk                       /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define I2C_PECR_PEC_Pos             (0U)
+#define I2C_PECR_PEC_Msk             (0xFFUL << I2C_PECR_PEC_Pos)              /*!< 0x000000FF */
+#define I2C_PECR_PEC                 I2C_PECR_PEC_Msk                          /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define I2C_RXDR_RXDATA_Pos          (0U)
+#define I2C_RXDR_RXDATA_Msk          (0xFFUL << I2C_RXDR_RXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_RXDR_RXDATA              I2C_RXDR_RXDATA_Msk                       /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define I2C_TXDR_TXDATA_Pos          (0U)
+#define I2C_TXDR_TXDATA_Msk          (0xFFUL << I2C_TXDR_TXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_TXDR_TXDATA              I2C_TXDR_TXDATA_Msk                       /*!< 8-bit transmit data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos      (0U)
+#define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
+#define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos       (0U)
+#define IWDG_PR_PR_Msk       (0x7UL << IWDG_PR_PR_Pos)                         /*!< 0x00000007 */
+#define IWDG_PR_PR           IWDG_PR_PR_Msk                                    /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0         (0x1U << IWDG_PR_PR_Pos)                          /*!< 0x00000001 */
+#define IWDG_PR_PR_1         (0x2U << IWDG_PR_PR_Pos)                          /*!< 0x00000002 */
+#define IWDG_PR_PR_2         (0x4U << IWDG_PR_PR_Pos)                          /*!< 0x00000004 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos      (0U)
+#define IWDG_RLR_RL_Msk      (0xFFFUL << IWDG_RLR_RL_Pos)                      /*!< 0x00000FFF */
+#define IWDG_RLR_RL          IWDG_RLR_RL_Msk                                   /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos      (0U)
+#define IWDG_SR_PVU_Msk      (0x1UL << IWDG_SR_PVU_Pos)                        /*!< 0x00000001 */
+#define IWDG_SR_PVU          IWDG_SR_PVU_Msk                                   /*!< Watchdog prescaler value update */
+#define IWDG_SR_RVU_Pos      (1U)
+#define IWDG_SR_RVU_Msk      (0x1UL << IWDG_SR_RVU_Pos)                        /*!< 0x00000002 */
+#define IWDG_SR_RVU          IWDG_SR_RVU_Msk                                   /*!< Watchdog counter reload value update */
+#define IWDG_SR_WVU_Pos      (2U)
+#define IWDG_SR_WVU_Msk      (0x1UL << IWDG_SR_WVU_Pos)                        /*!< 0x00000004 */
+#define IWDG_SR_WVU          IWDG_SR_WVU_Msk                                   /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_WINR_WIN_Pos    (0U)
+#define IWDG_WINR_WIN_Msk    (0xFFFUL << IWDG_WINR_WIN_Pos)                    /*!< 0x00000FFF */
+#define IWDG_WINR_WIN        IWDG_WINR_WIN_Msk                                 /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                               Power Control                                */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define PWR_CR1_LPMS_Pos               (0U)
+#define PWR_CR1_LPMS_Msk               (0x7UL << PWR_CR1_LPMS_Pos)             /*!< 0x00000007 */
+#define PWR_CR1_LPMS                   PWR_CR1_LPMS_Msk                        /*!< Low Power Mode Selection for CPU1 */
+#define PWR_CR1_LPMS_0                 (0x1U << PWR_CR1_LPMS_Pos)              /*!< 0x00000001 */
+#define PWR_CR1_LPMS_1                 (0x2U << PWR_CR1_LPMS_Pos)              /*!< 0x00000002 */
+#define PWR_CR1_LPMS_2                 (0x4U << PWR_CR1_LPMS_Pos)              /*!< 0x00000004 */
+
+#define PWR_CR1_FPDR_Pos               (4U)
+#define PWR_CR1_FPDR_Msk               (0x1UL << PWR_CR1_FPDR_Pos)             /*!< 0x00000010 */
+#define PWR_CR1_FPDR                   PWR_CR1_FPDR_Msk                        /*!< Flash power down mode during LPrun for CPU1 */
+
+#define PWR_CR1_FPDS_Pos               (5U)
+#define PWR_CR1_FPDS_Msk               (0x1UL << PWR_CR1_FPDS_Pos)             /*!< 0x00000020 */
+#define PWR_CR1_FPDS                   PWR_CR1_FPDS_Msk                        /*!< Flash power down mode during LPsleep for CPU1 */
+
+#define PWR_CR1_DBP_Pos                (8U)
+#define PWR_CR1_DBP_Msk                (0x1UL << PWR_CR1_DBP_Pos)              /*!< 0x00000100 */
+#define PWR_CR1_DBP                    PWR_CR1_DBP_Msk                         /*!< Disable Backup Domain write protection */
+
+#define PWR_CR1_LPR_Pos                (14U)
+#define PWR_CR1_LPR_Msk                (0x1UL << PWR_CR1_LPR_Pos)              /*!< 0x00004000 */
+#define PWR_CR1_LPR                    PWR_CR1_LPR_Msk                         /*!< Regulator Low-Power Run mode */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define PWR_CR2_PVDE_Pos               (0U)
+#define PWR_CR2_PVDE_Msk               (0x1UL << PWR_CR2_PVDE_Pos)             /*!< 0x00000001 */
+#define PWR_CR2_PVDE                   PWR_CR2_PVDE_Msk                        /*!< Power voltage detector enable */
+
+#define PWR_CR2_PLS_Pos                (1U)
+#define PWR_CR2_PLS_Msk                (0x7UL << PWR_CR2_PLS_Pos)              /*!< 0x0000000E */
+#define PWR_CR2_PLS                    PWR_CR2_PLS_Msk                         /*!< Power voltage detector level selection */
+#define PWR_CR2_PLS_0                  (0x1U << PWR_CR2_PLS_Pos)               /*!< 0x00000002 */
+#define PWR_CR2_PLS_1                  (0x2U << PWR_CR2_PLS_Pos)               /*!< 0x00000004 */
+#define PWR_CR2_PLS_2                  (0x4U << PWR_CR2_PLS_Pos)               /*!< 0x00000008 */
+
+#define PWR_CR2_PVME_Pos               (4U)
+#define PWR_CR2_PVME_Msk               (0x4UL << PWR_CR2_PVME_Pos)             /*!< 0x00000040 */
+#define PWR_CR2_PVME                   PWR_CR2_PVME_Msk                        /*!< Peripherical Voltage Monitor Enable for all power domains */
+#define PWR_CR2_PVME3_Pos              (6U)
+#define PWR_CR2_PVME3_Msk              (0x1UL << PWR_CR2_PVME3_Pos)            /*!< 0x00000040 */
+#define PWR_CR2_PVME3                  PWR_CR2_PVME3_Msk                       /*!< Peripherical Voltage Monitor Vdda Enable */
+
+/********************  Bit definition for PWR_CR3 register  ********************/
+#define PWR_CR3_EWUP_Pos               (0U)
+#define PWR_CR3_EWUP_Msk               (0x09UL << PWR_CR3_EWUP_Pos)            /*!< 0x00000009 */
+#define PWR_CR3_EWUP                   PWR_CR3_EWUP_Msk                        /*!< Enable all external Wake-Up lines  */
+#define PWR_CR3_EWUP1_Pos              (0U)
+#define PWR_CR3_EWUP1_Msk              (0x1UL << PWR_CR3_EWUP1_Pos)            /*!< 0x00000001 */
+#define PWR_CR3_EWUP1                  PWR_CR3_EWUP1_Msk                       /*!< Enable external WKUP Pin 1 [line 0] */
+#define PWR_CR3_EWUP4_Pos              (3U)
+#define PWR_CR3_EWUP4_Msk              (0x1UL << PWR_CR3_EWUP4_Pos)            /*!< 0x00000008 */
+#define PWR_CR3_EWUP4                  PWR_CR3_EWUP4_Msk                       /*!< Enable external WKUP Pin 4 [line 3] */
+
+#define PWR_CR3_EBORHSMPSFB_Pos        (8U)
+#define PWR_CR3_EBORHSMPSFB_Msk        (0x1UL << PWR_CR3_EBORHSMPSFB_Pos)      /*!< 0x00000100 */
+#define PWR_CR3_EBORHSMPSFB            PWR_CR3_EBORHSMPSFB_Msk                 /*!< BORH and SMPS Step Down converter forced in Bypass interrupts for CPU1 */
+
+#define PWR_CR3_RRS_Pos                (9U)
+#define PWR_CR3_RRS_Msk                (0x1UL << PWR_CR3_RRS_Pos)              /*!< 0x00000200 */
+#define PWR_CR3_RRS                    PWR_CR3_RRS_Msk                         /*!< SRAM2 retention in STANDBY mode */
+
+#define PWR_CR3_APC_Pos                (10U)
+#define PWR_CR3_APC_Msk                (0x1UL << PWR_CR3_APC_Pos)              /*!< 0x00000400 */
+#define PWR_CR3_APC                    PWR_CR3_APC_Msk                         /*!< Apply pull-up and pull-down configuration for CPU1 */
+
+#define PWR_CR3_ECRPE_Pos              (11U)
+#define PWR_CR3_ECRPE_Msk              (0x1UL << PWR_CR3_ECRPE_Pos)            /*!< 0x00000800 */
+#define PWR_CR3_ECRPE                  PWR_CR3_ECRPE_Msk                       /*!< Critical radio phase end of activity interrupt for CPU1 */
+#define PWR_CR3_EBLEA_Pos              (12U)
+#define PWR_CR3_EBLEA_Msk              (0x1UL << PWR_CR3_EBLEA_Pos)            /*!< 0x00010000 */
+#define PWR_CR3_EBLEA                  PWR_CR3_EBLEA_Msk                       /*!< BLE end of activity interrupt for CPU1 */
+#define PWR_CR3_EC2H_Pos               (14U)
+#define PWR_CR3_EC2H_Msk               (0x1UL << PWR_CR3_EC2H_Pos)             /*!< 0x00040000 */
+#define PWR_CR3_EC2H                    PWR_CR3_EC2H_Msk                       /*!< CPU2 Hold interrupt for CPU1 */
+
+#define PWR_CR3_EIWUL_Pos              (15U)
+#define PWR_CR3_EIWUL_Msk              (0x1UL << PWR_CR3_EIWUL_Pos)            /*!< 0x00080000 */
+#define PWR_CR3_EIWUL                  PWR_CR3_EIWUL_Msk                       /*!< Internal Wake-Up line interrupt for CPU1 */
+
+/********************  Bit definition for PWR_CR4 register  ********************/
+#define PWR_CR4_WP_Pos                 (0U)
+#define PWR_CR4_WP_Msk                 (0x09UL << PWR_CR4_WP_Pos)              /*!< 0x00000009 */
+#define PWR_CR4_WP                     PWR_CR4_WP_Msk                          /*!< Wake-Up polarity for all pins */
+#define PWR_CR4_WP1_Pos                (0U)
+#define PWR_CR4_WP1_Msk                (0x1UL << PWR_CR4_WP1_Pos)              /*!< 0x00000001 */
+#define PWR_CR4_WP1                    PWR_CR4_WP1_Msk                         /*!< Wake-Up Pin 1 [line 0] polarity */
+#define PWR_CR4_WP4_Pos                (3U)
+#define PWR_CR4_WP4_Msk                (0x1UL << PWR_CR4_WP4_Pos)              /*!< 0x00000008 */
+#define PWR_CR4_WP4                    PWR_CR4_WP4_Msk                         /*!< Wake-Up Pin 4 [line 3] polarity */
+
+#define PWR_CR4_VBE_Pos                (8U)
+#define PWR_CR4_VBE_Msk                (0x1UL << PWR_CR4_VBE_Pos)              /*!< 0x00000100 */
+#define PWR_CR4_VBE                    PWR_CR4_VBE_Msk                         /*!< VBAT battery charging enable  */
+#define PWR_CR4_VBRS_Pos               (9U)
+#define PWR_CR4_VBRS_Msk               (0x1UL << PWR_CR4_VBRS_Pos)             /*!< 0x00000200 */
+#define PWR_CR4_VBRS                   PWR_CR4_VBRS_Msk                        /*!< VBAT battery charging resistor selection */
+
+#define PWR_CR4_C2BOOT_Pos             (15U)
+#define PWR_CR4_C2BOOT_Msk             (0x1UL << PWR_CR4_C2BOOT_Pos)           /*!< 0x00008000 */
+#define PWR_CR4_C2BOOT                 PWR_CR4_C2BOOT_Msk                      /*!< Boot CPU2 after reset or wakeup from Stop or Standby modes */
+
+/********************  Bit definition for PWR_SR1 register  ********************/
+#define PWR_SR1_WUF_Pos                (0U)
+#define PWR_SR1_WUF_Msk                (0x09UL << PWR_SR1_WUF_Pos)             /*!< 0x00000009 */
+#define PWR_SR1_WUF                    PWR_SR1_WUF_Msk                         /*!< Wakeup Flags of all pins */
+#define PWR_SR1_WUF1_Pos               (0U)
+#define PWR_SR1_WUF1_Msk               (0x1UL << PWR_SR1_WUF1_Pos)             /*!< 0x00000001 */
+#define PWR_SR1_WUF1                   PWR_SR1_WUF1_Msk                        /*!< Wakeup Pin 1 [Flag 0] */
+#define PWR_SR1_WUF4_Pos               (3U)
+#define PWR_SR1_WUF4_Msk               (0x1UL << PWR_SR1_WUF4_Pos)             /*!< 0x00000008 */
+#define PWR_SR1_WUF4                   PWR_SR1_WUF4_Msk                        /*!< Wakeup Pin 4 [Flag 3] */
+
+#define PWR_SR1_SMPSFBF_Pos            (7U)
+#define PWR_SR1_SMPSFBF_Msk            (0x1UL << PWR_SR1_SMPSFBF_Pos)          /*!< 0x00000100 */
+#define PWR_SR1_SMPSFBF                PWR_SR1_SMPSFBF_Msk                     /*!< SMPS Step Down converter forced in bypass mode interrupt flag */
+
+#define PWR_SR1_BORHF_Pos              (8U)
+#define PWR_SR1_BORHF_Msk              (0x1UL << PWR_SR1_BORHF_Pos)            /*!< 0x00000100 */
+#define PWR_SR1_BORHF                  PWR_SR1_BORHF_Msk                       /*!< BORH interrupt flag */
+
+#define PWR_SR1_BLEWUF_Pos             (9U)
+#define PWR_SR1_BLEWUF_Msk             (0x1UL << PWR_SR1_BLEWUF_Pos)           /*!< 0x00000200 */
+#define PWR_SR1_BLEWUF                 PWR_SR1_BLEWUF_Msk                      /*!< BLE wakeup interrupt flag */
+
+#define PWR_SR1_CRPEF_Pos              (11U)
+#define PWR_SR1_CRPEF_Msk              (0x1UL << PWR_SR1_CRPEF_Pos)            /*!< 0x00000800 */
+#define PWR_SR1_CRPEF                  PWR_SR1_CRPEF_Msk                       /*!< Critical radio phase end of activity interrupt flag */
+#define PWR_SR1_BLEAF_Pos              (12U)
+#define PWR_SR1_BLEAF_Msk              (0x1UL << PWR_SR1_BLEAF_Pos)            /*!< 0x00001000 */
+#define PWR_SR1_BLEAF                  PWR_SR1_BLEAF_Msk                       /*!< BLE end of activity interrupt flag */
+
+#define PWR_SR1_C2HF_Pos               (14U)
+#define PWR_SR1_C2HF_Msk               (0x1UL << PWR_SR1_C2HF_Pos)             /*!< 0x00004000 */
+#define PWR_SR1_C2HF                   PWR_SR1_C2HF_Msk                        /*!< CPU2 Hold interrupt flag */
+
+#define PWR_SR1_WUFI_Pos               (15U)
+#define PWR_SR1_WUFI_Msk               (0x1UL << PWR_SR1_WUFI_Pos)             /*!< 0x00008000 */
+#define PWR_SR1_WUFI                   PWR_SR1_WUFI_Msk                        /*!< Internal wakeup interrupt flag */
+
+/********************  Bit definition for PWR_SR2 register  ********************/
+#define PWR_SR2_SMPSBF_Pos             (0U)
+#define PWR_SR2_SMPSBF_Msk             (0x1UL << PWR_SR2_SMPSBF_Pos)           /*!< 0x00000001 */
+#define PWR_SR2_SMPSBF                 PWR_SR2_SMPSBF_Msk                      /*!< SMPS step down converter in operating mode bypass flag */
+#define PWR_SR2_SMPSF_Pos              (1U)
+#define PWR_SR2_SMPSF_Msk              (0x1UL << PWR_SR2_SMPSF_Pos)            /*!< 0x00000002 */
+#define PWR_SR2_SMPSF                  PWR_SR2_SMPSF_Msk                       /*!< SMPS step down converter in operating mode step down flag */
+
+#define PWR_SR2_REGLPS_Pos             (8U)
+#define PWR_SR2_REGLPS_Msk             (0x1UL << PWR_SR2_REGLPS_Pos)           /*!< 0x00000100 */
+#define PWR_SR2_REGLPS                 PWR_SR2_REGLPS_Msk                      /*!< Low-power regulator started */
+#define PWR_SR2_REGLPF_Pos             (9U)
+#define PWR_SR2_REGLPF_Msk             (0x1UL << PWR_SR2_REGLPF_Pos)           /*!< 0x00000200 */
+#define PWR_SR2_REGLPF                 PWR_SR2_REGLPF_Msk                      /*!< Low-power regulator flag */
+
+#define PWR_SR2_PVDO_Pos               (11U)
+#define PWR_SR2_PVDO_Msk               (0x1UL << PWR_SR2_PVDO_Pos)             /*!< 0x00000800 */
+#define PWR_SR2_PVDO                   PWR_SR2_PVDO_Msk                        /*!< Power voltage detector output */
+
+#define PWR_SR2_PVMO3_Pos              (14U)
+#define PWR_SR2_PVMO3_Msk              (0x1UL << PWR_SR2_PVMO3_Pos)            /*!< 0x00004000 */
+#define PWR_SR2_PVMO3                  PWR_SR2_PVMO3_Msk                       /*!< Peripheral voltage monitor output 3: VDDA vs. 1.62V */
+
+/********************  Bit definition for PWR_SCR register  ********************/
+#define PWR_SCR_CWUF_Pos               (0U)
+#define PWR_SCR_CWUF_Msk               (0x09UL << PWR_SCR_CWUF_Pos)            /*!< 0x00000009 */
+#define PWR_SCR_CWUF                   PWR_SCR_CWUF_Msk                        /*!< Clear Wake-up Flags for all pins */
+#define PWR_SCR_CWUF1_Pos              (0U)
+#define PWR_SCR_CWUF1_Msk              (0x1UL << PWR_SCR_CWUF1_Pos)            /*!< 0x00000001 */
+#define PWR_SCR_CWUF1                  PWR_SCR_CWUF1_Msk                       /*!< Clear Wake-up Pin 1 [Flag 0] */
+#define PWR_SCR_CWUF4_Pos              (3U)
+#define PWR_SCR_CWUF4_Msk              (0x1UL << PWR_SCR_CWUF4_Pos)            /*!< 0x00000008 */
+#define PWR_SCR_CWUF4                  PWR_SCR_CWUF4_Msk                       /*!< Clear Wake-up Pin 4 [Flag 3] */
+
+#define PWR_SCR_CSMPSFBF_Pos           (7U)
+#define PWR_SCR_CSMPSFBF_Msk           (0x1UL << PWR_SCR_CSMPSFBF_Pos)         /*!< 0x00000080 */
+#define PWR_SCR_CSMPSFBF               PWR_SCR_CSMPSFBF_Msk                    /*!< Clear SMPS Step Down converter forced in bypass mode interrupt flag  */
+
+#define PWR_SCR_CBORHF_Pos             (8U)
+#define PWR_SCR_CBORHF_Msk             (0x1UL << PWR_SCR_CBORHF_Pos)           /*!< 0x00000100 */
+#define PWR_SCR_CBORHF                 PWR_SCR_CBORHF_Msk                      /*!< Clear BORH interrupt flag  */
+
+#define PWR_SCR_CBLEWUF_Pos            (9U)
+#define PWR_SCR_CBLEWUF_Msk            (0x1UL << PWR_SCR_CBLEWUF_Pos)          /*!< 0x00000200 */
+#define PWR_SCR_CBLEWUF                PWR_SCR_CBLEWUF_Msk                     /*!< Clear BLE wakeup interrupt flag */
+
+#define PWR_SCR_CCRPEF_Pos             (11U)
+#define PWR_SCR_CCRPEF_Msk             (0x1UL << PWR_SCR_CCRPEF_Pos)           /*!< 0x00000800 */
+#define PWR_SCR_CCRPEF                 PWR_SCR_CCRPEF_Msk                      /*!< Clear Critical radio phase end of activity interrupt flag */
+#define PWR_SCR_CBLEAF_Pos             (12U)
+#define PWR_SCR_CBLEAF_Msk             (0x1UL << PWR_SCR_CBLEAF_Pos)           /*!< 0x00001000 */
+#define PWR_SCR_CBLEAF                 PWR_SCR_CBLEAF_Msk                      /*!< Clear BLE end of activity interrupt flag */
+
+#define PWR_SCR_CC2HF_Pos              (14U)
+#define PWR_SCR_CC2HF_Msk              (0x1UL << PWR_SCR_CC2HF_Pos)            /*!< 0x00004000 */
+#define PWR_SCR_CC2HF                  PWR_SCR_CC2HF_Msk                       /*!< Clear CPU2 Hold interrupt flag */
+
+/********************  Bit definition for PWR_CR5 register  ********************/
+#define PWR_CR5_SMPSVOS_Pos            (0U)
+#define PWR_CR5_SMPSVOS_Msk            (0xFUL << PWR_CR5_SMPSVOS_Pos)          /*!< 0x0000000F */
+#define PWR_CR5_SMPSVOS                PWR_CR5_SMPSVOS_Msk                     /*!< SMPS step down converter voltage output scaling voltage level */
+#define PWR_CR5_SMPSVOS_0              (0x01U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000001 */
+#define PWR_CR5_SMPSVOS_1              (0x02U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000002 */
+#define PWR_CR5_SMPSVOS_2              (0x04U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000004 */
+#define PWR_CR5_SMPSVOS_3              (0x08U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000008 */
+
+#define PWR_CR5_SMPSSC_Pos             (4U)
+#define PWR_CR5_SMPSSC_Msk             (0x7UL << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000070 */
+#define PWR_CR5_SMPSSC                 PWR_CR5_SMPSSC_Msk                      /*!< SMPS step down converter supply startup current selection */
+#define PWR_CR5_SMPSSC_0               (0x01U << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000010 */
+#define PWR_CR5_SMPSSC_1               (0x02U << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000020 */
+#define PWR_CR5_SMPSSC_2               (0x04U << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000040 */
+
+#define PWR_CR5_BORHC_Pos              (8U)
+#define PWR_CR5_BORHC_Msk              (0x1UL << PWR_CR5_BORHC_Pos)            /*!< 0x00000100 */
+#define PWR_CR5_BORHC                  PWR_CR5_BORHC_Msk                       /*!< BORH configuration selection */
+
+#define PWR_CR5_SMPSEN_Pos             (15U)
+#define PWR_CR5_SMPSEN_Msk             (0x1UL << PWR_CR5_SMPSEN_Pos)           /*!< 0x00008000 */
+#define PWR_CR5_SMPSEN                 PWR_CR5_SMPSEN_Msk                      /*!< Enable SMPS Step Down converter SMPS mode enable */
+
+/********************  Bit definition for PWR_PUCRA register  *****************/
+#define PWR_PUCRA_PA0_Pos              (0U)
+#define PWR_PUCRA_PA0_Msk              (0x1UL << PWR_PUCRA_PA0_Pos)            /*!< 0x00000001 */
+#define PWR_PUCRA_PA0                  PWR_PUCRA_PA0_Msk                       /*!< Pin PA0 Pull-Up set */
+#define PWR_PUCRA_PA1_Pos              (1U)
+#define PWR_PUCRA_PA1_Msk              (0x1UL << PWR_PUCRA_PA1_Pos)            /*!< 0x00000002 */
+#define PWR_PUCRA_PA1                  PWR_PUCRA_PA1_Msk                       /*!< Pin PA1 Pull-Up set */
+#define PWR_PUCRA_PA2_Pos              (2U)
+#define PWR_PUCRA_PA2_Msk              (0x1UL << PWR_PUCRA_PA2_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRA_PA2                  PWR_PUCRA_PA2_Msk                       /*!< Pin PA2 Pull-Up set */
+#define PWR_PUCRA_PA3_Pos              (3U)
+#define PWR_PUCRA_PA3_Msk              (0x1UL << PWR_PUCRA_PA3_Pos)            /*!< 0x00000008 */
+#define PWR_PUCRA_PA3                  PWR_PUCRA_PA3_Msk                       /*!< Pin PA3 Pull-Up set */
+#define PWR_PUCRA_PA4_Pos              (4U)
+#define PWR_PUCRA_PA4_Msk              (0x1UL << PWR_PUCRA_PA4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRA_PA4                  PWR_PUCRA_PA4_Msk                       /*!< Pin PA4 Pull-Up set */
+#define PWR_PUCRA_PA5_Pos              (5U)
+#define PWR_PUCRA_PA5_Msk              (0x1UL << PWR_PUCRA_PA5_Pos)            /*!< 0x00000020 */
+#define PWR_PUCRA_PA5                  PWR_PUCRA_PA5_Msk                       /*!< Pin PA5 Pull-Up set */
+#define PWR_PUCRA_PA6_Pos              (6U)
+#define PWR_PUCRA_PA6_Msk              (0x1UL << PWR_PUCRA_PA6_Pos)            /*!< 0x00000040 */
+#define PWR_PUCRA_PA6                  PWR_PUCRA_PA6_Msk                       /*!< Pin PA6 Pull-Up set */
+#define PWR_PUCRA_PA7_Pos              (7U)
+#define PWR_PUCRA_PA7_Msk              (0x1UL << PWR_PUCRA_PA7_Pos)            /*!< 0x00000080 */
+#define PWR_PUCRA_PA7                  PWR_PUCRA_PA7_Msk                       /*!< Pin PA7 Pull-Up set */
+#define PWR_PUCRA_PA8_Pos              (8U)
+#define PWR_PUCRA_PA8_Msk              (0x1UL << PWR_PUCRA_PA8_Pos)            /*!< 0x00000100 */
+#define PWR_PUCRA_PA8                  PWR_PUCRA_PA8_Msk                       /*!< Pin PA8 Pull-Up set */
+#define PWR_PUCRA_PA9_Pos              (9U)
+#define PWR_PUCRA_PA9_Msk              (0x1UL << PWR_PUCRA_PA9_Pos)            /*!< 0x00000200 */
+#define PWR_PUCRA_PA9                  PWR_PUCRA_PA9_Msk                       /*!< Pin PA9 Pull-Up set */
+#define PWR_PUCRA_PA10_Pos             (10U)
+#define PWR_PUCRA_PA10_Msk             (0x1UL << PWR_PUCRA_PA10_Pos)           /*!< 0x00000400 */
+#define PWR_PUCRA_PA10                 PWR_PUCRA_PA10_Msk                      /*!< Pin PA10 Pull-Up set */
+#define PWR_PUCRA_PA11_Pos             (11U)
+#define PWR_PUCRA_PA11_Msk             (0x1UL << PWR_PUCRA_PA11_Pos)           /*!< 0x00000800 */
+#define PWR_PUCRA_PA11                 PWR_PUCRA_PA11_Msk                      /*!< Pin PA11 Pull-Up set */
+#define PWR_PUCRA_PA12_Pos             (12U)
+#define PWR_PUCRA_PA12_Msk             (0x1UL << PWR_PUCRA_PA12_Pos)           /*!< 0x00001000 */
+#define PWR_PUCRA_PA12                 PWR_PUCRA_PA12_Msk                      /*!< Pin PA12 Pull-Up set */
+#define PWR_PUCRA_PA13_Pos             (13U)
+#define PWR_PUCRA_PA13_Msk             (0x1UL << PWR_PUCRA_PA13_Pos)           /*!< 0x00002000 */
+#define PWR_PUCRA_PA13                 PWR_PUCRA_PA13_Msk                      /*!< Pin PA13 Pull-Up set */
+#define PWR_PUCRA_PA15_Pos             (15U)
+#define PWR_PUCRA_PA15_Msk             (0x1UL << PWR_PUCRA_PA15_Pos)           /*!< 0x00008000 */
+#define PWR_PUCRA_PA15                 PWR_PUCRA_PA15_Msk                      /*!< Pin PA15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRA register  *****************/
+#define PWR_PDCRA_PA0_Pos              (0U)
+#define PWR_PDCRA_PA0_Msk              (0x1UL << PWR_PDCRA_PA0_Pos)            /*!< 0x00000001 */
+#define PWR_PDCRA_PA0                  PWR_PDCRA_PA0_Msk                       /*!< Pin PA0 Pull-Down set */
+#define PWR_PDCRA_PA1_Pos              (1U)
+#define PWR_PDCRA_PA1_Msk              (0x1UL << PWR_PDCRA_PA1_Pos)            /*!< 0x00000002 */
+#define PWR_PDCRA_PA1                  PWR_PDCRA_PA1_Msk                       /*!< Pin PA1 Pull-Down set */
+#define PWR_PDCRA_PA2_Pos              (2U)
+#define PWR_PDCRA_PA2_Msk              (0x1UL << PWR_PDCRA_PA2_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRA_PA2                  PWR_PDCRA_PA2_Msk                       /*!< Pin PA2 Pull-Down set */
+#define PWR_PDCRA_PA3_Pos              (3U)
+#define PWR_PDCRA_PA3_Msk              (0x1UL << PWR_PDCRA_PA3_Pos)            /*!< 0x00000008 */
+#define PWR_PDCRA_PA3                  PWR_PDCRA_PA3_Msk                       /*!< Pin PA3 Pull-Down set */
+#define PWR_PDCRA_PA4_Pos              (4U)
+#define PWR_PDCRA_PA4_Msk              (0x1UL << PWR_PDCRA_PA4_Pos)            /*!< 0x00000010 */
+#define PWR_PDCRA_PA4                  PWR_PDCRA_PA4_Msk                       /*!< Pin PA4 Pull-Down set */
+#define PWR_PDCRA_PA5_Pos              (5U)
+#define PWR_PDCRA_PA5_Msk              (0x1UL << PWR_PDCRA_PA5_Pos)            /*!< 0x00000020 */
+#define PWR_PDCRA_PA5                  PWR_PDCRA_PA5_Msk                       /*!< Pin PA5 Pull-Down set */
+#define PWR_PDCRA_PA6_Pos              (6U)
+#define PWR_PDCRA_PA6_Msk              (0x1UL << PWR_PDCRA_PA6_Pos)            /*!< 0x00000040 */
+#define PWR_PDCRA_PA6                  PWR_PDCRA_PA6_Msk                       /*!< Pin PA6 Pull-Down set */
+#define PWR_PDCRA_PA7_Pos              (7U)
+#define PWR_PDCRA_PA7_Msk              (0x1UL << PWR_PDCRA_PA7_Pos)            /*!< 0x00000080 */
+#define PWR_PDCRA_PA7                  PWR_PDCRA_PA7_Msk                       /*!< Pin PA7 Pull-Down set */
+#define PWR_PDCRA_PA8_Pos              (8U)
+#define PWR_PDCRA_PA8_Msk              (0x1UL << PWR_PDCRA_PA8_Pos)            /*!< 0x00000100 */
+#define PWR_PDCRA_PA8                  PWR_PDCRA_PA8_Msk                       /*!< Pin PA8 Pull-Down set */
+#define PWR_PDCRA_PA9_Pos              (9U)
+#define PWR_PDCRA_PA9_Msk              (0x1UL << PWR_PDCRA_PA9_Pos)            /*!< 0x00000200 */
+#define PWR_PDCRA_PA9                  PWR_PDCRA_PA9_Msk                       /*!< Pin PA9 Pull-Down set */
+#define PWR_PDCRA_PA10_Pos             (10U)
+#define PWR_PDCRA_PA10_Msk             (0x1UL << PWR_PDCRA_PA10_Pos)           /*!< 0x00000400 */
+#define PWR_PDCRA_PA10                 PWR_PDCRA_PA10_Msk                      /*!< Pin PA10 Pull-Down set */
+#define PWR_PDCRA_PA11_Pos             (11U)
+#define PWR_PDCRA_PA11_Msk             (0x1UL << PWR_PDCRA_PA11_Pos)           /*!< 0x00000800 */
+#define PWR_PDCRA_PA11                 PWR_PDCRA_PA11_Msk                      /*!< Pin PA11 Pull-Down set */
+#define PWR_PDCRA_PA12_Pos             (12U)
+#define PWR_PDCRA_PA12_Msk             (0x1UL << PWR_PDCRA_PA12_Pos)           /*!< 0x00001000 */
+#define PWR_PDCRA_PA12                 PWR_PDCRA_PA12_Msk                      /*!< Pin PA12 Pull-Down set */
+#define PWR_PDCRA_PA14_Pos             (14U)
+#define PWR_PDCRA_PA14_Msk             (0x1UL << PWR_PDCRA_PA14_Pos)           /*!< 0x00004000 */
+#define PWR_PDCRA_PA14                 PWR_PDCRA_PA14_Msk                      /*!< Pin PA14 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRB register  *****************/
+#define PWR_PUCRB_PB0_Pos              (0U)
+#define PWR_PUCRB_PB0_Msk              (0x1UL << PWR_PUCRB_PB0_Pos)            /*!< 0x00000001 */
+#define PWR_PUCRB_PB0                  PWR_PUCRB_PB0_Msk                       /*!< Pin PB0 Pull-Up set */
+#define PWR_PUCRB_PB1_Pos              (1U)
+#define PWR_PUCRB_PB1_Msk              (0x1UL << PWR_PUCRB_PB1_Pos)            /*!< 0x00000002 */
+#define PWR_PUCRB_PB1                  PWR_PUCRB_PB1_Msk                       /*!< Pin PB1 Pull-Up set */
+#define PWR_PUCRB_PB2_Pos              (2U)
+#define PWR_PUCRB_PB2_Msk              (0x1UL << PWR_PUCRB_PB2_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRB_PB2                  PWR_PUCRB_PB2_Msk                       /*!< Pin PB2 Pull-Up set */
+#define PWR_PUCRB_PB3_Pos              (3U)
+#define PWR_PUCRB_PB3_Msk              (0x1UL << PWR_PUCRB_PB3_Pos)            /*!< 0x00000008 */
+#define PWR_PUCRB_PB3                  PWR_PUCRB_PB3_Msk                       /*!< Pin PB3 Pull-Up set */
+#define PWR_PUCRB_PB4_Pos              (4U)
+#define PWR_PUCRB_PB4_Msk              (0x1UL << PWR_PUCRB_PB4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRB_PB4                  PWR_PUCRB_PB4_Msk                       /*!< Pin PB4 Pull-Up set */
+#define PWR_PUCRB_PB5_Pos              (5U)
+#define PWR_PUCRB_PB5_Msk              (0x1UL << PWR_PUCRB_PB5_Pos)            /*!< 0x00000020 */
+#define PWR_PUCRB_PB5                  PWR_PUCRB_PB5_Msk                       /*!< Pin PB5 Pull-Up set */
+#define PWR_PUCRB_PB6_Pos              (6U)
+#define PWR_PUCRB_PB6_Msk              (0x1UL << PWR_PUCRB_PB6_Pos)            /*!< 0x00000040 */
+#define PWR_PUCRB_PB6                  PWR_PUCRB_PB6_Msk                       /*!< Pin PB6 Pull-Up set */
+#define PWR_PUCRB_PB7_Pos              (7U)
+#define PWR_PUCRB_PB7_Msk              (0x1UL << PWR_PUCRB_PB7_Pos)            /*!< 0x00000080 */
+#define PWR_PUCRB_PB7                  PWR_PUCRB_PB7_Msk                       /*!< Pin PB7 Pull-Up set */
+#define PWR_PUCRB_PB8_Pos              (8U)
+#define PWR_PUCRB_PB8_Msk              (0x1UL << PWR_PUCRB_PB8_Pos)            /*!< 0x00000100 */
+#define PWR_PUCRB_PB8                  PWR_PUCRB_PB8_Msk                       /*!< Pin PB8 Pull-Up set */
+#define PWR_PUCRB_PB9_Pos              (9U)
+#define PWR_PUCRB_PB9_Msk              (0x1UL << PWR_PUCRB_PB9_Pos)            /*!< 0x00000200 */
+#define PWR_PUCRB_PB9                  PWR_PUCRB_PB9_Msk                       /*!< Pin PB9 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRB register  *****************/
+#define PWR_PDCRB_PB0_Pos              (0U)
+#define PWR_PDCRB_PB0_Msk              (0x1UL << PWR_PDCRB_PB0_Pos)            /*!< 0x00000001 */
+#define PWR_PDCRB_PB0                  PWR_PDCRB_PB0_Msk                       /*!< Pin PB0 Pull-Down set */
+#define PWR_PDCRB_PB1_Pos              (1U)
+#define PWR_PDCRB_PB1_Msk              (0x1UL << PWR_PDCRB_PB1_Pos)            /*!< 0x00000002 */
+#define PWR_PDCRB_PB1                  PWR_PDCRB_PB1_Msk                       /*!< Pin PB1 Pull-Down set */
+#define PWR_PDCRB_PB2_Pos              (2U)
+#define PWR_PDCRB_PB2_Msk              (0x1UL << PWR_PDCRB_PB2_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRB_PB2                  PWR_PDCRB_PB2_Msk                       /*!< Pin PB2 Pull-Down set */
+#define PWR_PDCRB_PB3_Pos              (3U)
+#define PWR_PDCRB_PB3_Msk              (0x1UL << PWR_PDCRB_PB3_Pos)            /*!< 0x00000008 */
+#define PWR_PDCRB_PB3                  PWR_PDCRB_PB3_Msk                       /*!< Pin PB3 Pull-Down set */
+#define PWR_PDCRB_PB5_Pos              (5U)
+#define PWR_PDCRB_PB5_Msk              (0x1UL << PWR_PDCRB_PB5_Pos)            /*!< 0x00000020 */
+#define PWR_PDCRB_PB5                  PWR_PDCRB_PB5_Msk                       /*!< Pin PB5 Pull-Down set */
+#define PWR_PDCRB_PB6_Pos              (6U)
+#define PWR_PDCRB_PB6_Msk              (0x1UL << PWR_PDCRB_PB6_Pos)            /*!< 0x00000040 */
+#define PWR_PDCRB_PB6                  PWR_PDCRB_PB6_Msk                       /*!< Pin PB6 Pull-Down set */
+#define PWR_PDCRB_PB7_Pos              (7U)
+#define PWR_PDCRB_PB7_Msk              (0x1UL << PWR_PDCRB_PB7_Pos)            /*!< 0x00000080 */
+#define PWR_PDCRB_PB7                  PWR_PDCRB_PB7_Msk                       /*!< Pin PB7 Pull-Down set */
+#define PWR_PDCRB_PB8_Pos              (8U)
+#define PWR_PDCRB_PB8_Msk              (0x1UL << PWR_PDCRB_PB8_Pos)            /*!< 0x00000100 */
+#define PWR_PDCRB_PB8                  PWR_PDCRB_PB8_Msk                       /*!< Pin PB8 Pull-Down set */
+#define PWR_PDCRB_PB9_Pos              (9U)
+#define PWR_PDCRB_PB9_Msk              (0x1UL << PWR_PDCRB_PB9_Pos)            /*!< 0x00000200 */
+#define PWR_PDCRB_PB9                  PWR_PDCRB_PB9_Msk                       /*!< Pin PB9 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRC register  *****************/
+#define PWR_PUCRC_PC14_Pos             (14U)
+#define PWR_PUCRC_PC14_Msk             (0x1UL << PWR_PUCRC_PC14_Pos)           /*!< 0x00004000 */
+#define PWR_PUCRC_PC14                 PWR_PUCRC_PC14_Msk                      /*!< Pin PC14 Pull-Up set */
+#define PWR_PUCRC_PC15_Pos             (15U)
+#define PWR_PUCRC_PC15_Msk             (0x1UL << PWR_PUCRC_PC15_Pos)           /*!< 0x00008000 */
+#define PWR_PUCRC_PC15                 PWR_PUCRC_PC15_Msk                      /*!< Pin PC15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRC register  *****************/
+#define PWR_PDCRC_PC14_Pos             (14U)
+#define PWR_PDCRC_PC14_Msk             (0x1UL << PWR_PDCRC_PC14_Pos)           /*!< 0x00004000 */
+#define PWR_PDCRC_PC14                 PWR_PDCRC_PC14_Msk                      /*!< Pin PC14 Pull-Down set */
+#define PWR_PDCRC_PC15_Pos             (15U)
+#define PWR_PDCRC_PC15_Msk             (0x1UL << PWR_PDCRC_PC15_Pos)           /*!< 0x00008000 */
+#define PWR_PDCRC_PC15                 PWR_PDCRC_PC15_Msk                      /*!< Pin PC15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRE register  *****************/
+#define PWR_PUCRE_PE4_Pos              (4U)
+#define PWR_PUCRE_PE4_Msk              (0x1UL << PWR_PUCRE_PE4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRE_PE4                  PWR_PUCRE_PE4_Msk                       /*!< Pin PE4 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRE register  *****************/
+#define PWR_PDCRE_PE4_Pos              (4U)
+#define PWR_PDCRE_PE4_Msk              (0x1UL << PWR_PDCRE_PE4_Pos)            /*!< 0x00000010 */
+#define PWR_PDCRE_PE4                  PWR_PDCRE_PE4_Msk                       /*!< Pin PE4 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRH register  *****************/
+#define PWR_PUCRH_PH3_Pos              (3U)
+#define PWR_PUCRH_PH3_Msk              (0x1UL << PWR_PUCRH_PH3_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRH_PH3                  PWR_PUCRH_PH3_Msk                       /*!< Pin PH3 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRH register  *****************/
+#define PWR_PDCRH_PH3_Pos              (3U)
+#define PWR_PDCRH_PH3_Msk              (0x1UL << PWR_PDCRH_PH3_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRH_PH3                  PWR_PDCRH_PH3_Msk                       /*!< Pin PH3 Pull-Down set */
+
+/********************  Bit definition for PWR_C2CR1 register  ********************/
+#define PWR_C2CR1_LPMS_Pos             (0U)
+#define PWR_C2CR1_LPMS_Msk             (0x7UL << PWR_C2CR1_LPMS_Pos)           /*!< 0x00000007 */
+#define PWR_C2CR1_LPMS                 PWR_C2CR1_LPMS_Msk                      /*!< Low Power Mode Selection for CPU2 */
+#define PWR_C2CR1_LPMS_0               (0x1U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000001 */
+#define PWR_C2CR1_LPMS_1               (0x2U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000002 */
+#define PWR_C2CR1_LPMS_2               (0x4U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000004 */
+
+#define PWR_C2CR1_FPDR_Pos             (4U)
+#define PWR_C2CR1_FPDR_Msk             (0x1UL << PWR_C2CR1_FPDR_Pos)           /*!< 0x00000010 */
+#define PWR_C2CR1_FPDR                 PWR_C2CR1_FPDR_Msk                      /*!< Flash power down mode during LPrun for CPU2 */
+
+#define PWR_C2CR1_FPDS_Pos             (5U)
+#define PWR_C2CR1_FPDS_Msk             (0x1UL << PWR_C2CR1_FPDS_Pos)           /*!< 0x00000020 */
+#define PWR_C2CR1_FPDS                 PWR_C2CR1_FPDS_Msk                      /*!< Flash power down mode during LPsleep for CPU2 */
+
+#define PWR_C2CR1_BLEEWKUP_Pos         (14U)
+#define PWR_C2CR1_BLEEWKUP_Msk         (0x1UL << PWR_C2CR1_BLEEWKUP_Pos)       /*!< 0x00008000 */
+#define PWR_C2CR1_BLEEWKUP             PWR_C2CR1_BLEEWKUP_Msk                  /*!< Radio BLE external wakeup signal */
+
+/********************  Bit definition for PWR_C2CR3 register  ********************/
+#define PWR_C2CR3_EWUP_Pos             (0U)
+#define PWR_C2CR3_EWUP_Msk             (0x09UL << PWR_C2CR3_EWUP_Pos)           /*!< 0x00000009 */
+#define PWR_C2CR3_EWUP                 PWR_C2CR3_EWUP_Msk                       /*!< Enable all external Wake-Up lines for CPU2 */
+#define PWR_C2CR3_EWUP1_Pos            (0U)
+#define PWR_C2CR3_EWUP1_Msk            (0x1UL << PWR_C2CR3_EWUP1_Pos)           /*!< 0x00000001 */
+#define PWR_C2CR3_EWUP1                PWR_C2CR3_EWUP1_Msk                      /*!< Enable external WKUP Pin 1 [line 0] for CPU2 */
+#define PWR_C2CR3_EWUP4_Pos            (3U)
+#define PWR_C2CR3_EWUP4_Msk            (0x1UL << PWR_C2CR3_EWUP4_Pos)           /*!< 0x00000008 */
+#define PWR_C2CR3_EWUP4                PWR_C2CR3_EWUP4_Msk                      /*!< Enable external WKUP Pin 4 [line 3] for CPU2 */
+
+#define PWR_C2CR3_EBLEWUP_Pos          (9U)
+#define PWR_C2CR3_EBLEWUP_Msk          (0x1UL << PWR_C2CR3_EBLEWUP_Pos)       /*!< 0x00000200 */
+#define PWR_C2CR3_EBLEWUP              PWR_C2CR3_EBLEWUP_Msk                 /*!< Enable BLE host wakeup interrupt for CPU2 */
+
+#define PWR_C2CR3_APC_Pos              (12U)
+#define PWR_C2CR3_APC_Msk              (0x1UL << PWR_C2CR3_APC_Pos)            /*!< 0x00001000 */
+#define PWR_C2CR3_APC                  PWR_C2CR3_APC_Msk                       /*!< Apply pull-up and pull-down configuration for CPU2 */
+
+#define PWR_C2CR3_EIWUL_Pos            (15U)
+#define PWR_C2CR3_EIWUL_Msk            (0x1UL << PWR_C2CR3_EIWUL_Pos)          /*!< 0x00008000 */
+#define PWR_C2CR3_EIWUL                PWR_C2CR3_EIWUL_Msk                     /*!< Internal Wake-Up line interrupt for CPU2 */
+
+/********************  Bit definition for PWR_EXTSCR register  ********************/
+#define PWR_EXTSCR_C1CSSF_Pos          (0U)
+#define PWR_EXTSCR_C1CSSF_Msk          (0x1UL << PWR_EXTSCR_C1CSSF_Pos)        /*!< 0x00000001 */
+#define PWR_EXTSCR_C1CSSF              PWR_EXTSCR_C1CSSF_Msk                   /*!< Clear standby and stop flags for CPU1 */
+#define PWR_EXTSCR_C2CSSF_Pos          (1U)
+#define PWR_EXTSCR_C2CSSF_Msk          (0x1UL << PWR_EXTSCR_C2CSSF_Pos)        /*!< 0x00000002 */
+#define PWR_EXTSCR_C2CSSF              PWR_EXTSCR_C2CSSF_Msk                   /*!< Clear standby and stop flags for CPU2 */
+#define PWR_EXTSCR_CCRPF_Pos           (2U)
+#define PWR_EXTSCR_CCRPF_Msk           (0x1UL << PWR_EXTSCR_CCRPF_Pos)         /*!< 0x00000004 */
+#define PWR_EXTSCR_CCRPF               PWR_EXTSCR_CCRPF_Msk                    /*!< Clear critical radio system phase flag */
+
+#define PWR_EXTSCR_C1SBF_Pos           (8U)
+#define PWR_EXTSCR_C1SBF_Msk           (0x1UL << PWR_EXTSCR_C1SBF_Pos)         /*!< 0x00000100 */
+#define PWR_EXTSCR_C1SBF               PWR_EXTSCR_C1SBF_Msk                    /*!< System standby flag for CPU1 */
+#define PWR_EXTSCR_C1STOPF_Pos         (9U)
+#define PWR_EXTSCR_C1STOPF_Msk         (0x1UL << PWR_EXTSCR_C1STOPF_Pos)       /*!< 0x00000200 */
+#define PWR_EXTSCR_C1STOPF             PWR_EXTSCR_C1STOPF_Msk                  /*!< System stop flag for CPU1 */
+#define PWR_EXTSCR_C2SBF_Pos           (10U)
+#define PWR_EXTSCR_C2SBF_Msk           (0x1UL << PWR_EXTSCR_C2SBF_Pos)         /*!< 0x00000400 */
+#define PWR_EXTSCR_C2SBF               PWR_EXTSCR_C2SBF_Msk                    /*!< System standby flag for CPU2 */
+#define PWR_EXTSCR_C2STOPF_Pos         (11U)
+#define PWR_EXTSCR_C2STOPF_Msk         (0x1UL << PWR_EXTSCR_C2STOPF_Pos)       /*!< 0x00000800 */
+#define PWR_EXTSCR_C2STOPF             PWR_EXTSCR_C2STOPF_Msk                  /*!< System stop flag for CPU2 */
+
+#define PWR_EXTSCR_CRPF_Pos            (13U)
+#define PWR_EXTSCR_CRPF_Msk            (0x1UL << PWR_EXTSCR_CRPF_Pos)          /*!< 0x00002000 */
+#define PWR_EXTSCR_CRPF                PWR_EXTSCR_CRPF_Msk                     /*!< Critical radio system phase flag */
+
+#define PWR_EXTSCR_C1DS_Pos            (14U)
+#define PWR_EXTSCR_C1DS_Msk            (0x1UL << PWR_EXTSCR_C1DS_Pos)          /*!< 0x00004000 */
+#define PWR_EXTSCR_C1DS                PWR_EXTSCR_C1DS_Msk                     /*!< CPU1 deepsleep mode flag */
+#define PWR_EXTSCR_C2DS_Pos            (15U)
+#define PWR_EXTSCR_C2DS_Msk            (0x1UL << PWR_EXTSCR_C2DS_Pos)          /*!< 0x00008000 */
+#define PWR_EXTSCR_C2DS                PWR_EXTSCR_C2DS_Msk                     /*!< CPU2 deepsleep mode flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+  * @brief Specific device feature definitions
+  */
+#define RCC_SMPS_SUPPORT
+
+/********************  Bit definition for RCC_CR register  *****************/
+#define RCC_CR_MSION_Pos                     (0U)
+#define RCC_CR_MSION_Msk                     (0x1UL << RCC_CR_MSION_Pos)       /*!< 0x00000001 */
+#define RCC_CR_MSION                         RCC_CR_MSION_Msk                  /*!< Internal Multi Speed oscillator (MSI) clock enable */
+#define RCC_CR_MSIRDY_Pos                    (1U)
+#define RCC_CR_MSIRDY_Msk                    (0x1UL << RCC_CR_MSIRDY_Pos)      /*!< 0x00000002 */
+#define RCC_CR_MSIRDY                        RCC_CR_MSIRDY_Msk                 /*!< Internal Multi Speed oscillator (MSI) clock ready flag */
+#define RCC_CR_MSIPLLEN_Pos                  (2U)
+#define RCC_CR_MSIPLLEN_Msk                  (0x1UL << RCC_CR_MSIPLLEN_Pos)    /*!< 0x00000004 */
+#define RCC_CR_MSIPLLEN                      RCC_CR_MSIPLLEN_Msk               /*!< Internal Multi Speed oscillator (MSI) PLL enable */
+
+/*!< MSIRANGE configuration : 12 frequency ranges available */
+#define RCC_CR_MSIRANGE_Pos                  (4U)
+#define RCC_CR_MSIRANGE_Msk                  (0xFUL << RCC_CR_MSIRANGE_Pos)    /*!< 0x000000F0 */
+#define RCC_CR_MSIRANGE                      RCC_CR_MSIRANGE_Msk               /*!< Internal Multi Speed oscillator (MSI) clock Range */
+#define RCC_CR_MSIRANGE_0                    (0x0U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000000 */
+#define RCC_CR_MSIRANGE_1                    (0x1U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000010 */
+#define RCC_CR_MSIRANGE_2                    (0x2U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000020 */
+#define RCC_CR_MSIRANGE_3                    (0x3U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000030 */
+#define RCC_CR_MSIRANGE_4                    (0x4U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000040 */
+#define RCC_CR_MSIRANGE_5                    (0x5U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000050 */
+#define RCC_CR_MSIRANGE_6                    (0x6U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000060 */
+#define RCC_CR_MSIRANGE_7                    (0x7U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000070 */
+#define RCC_CR_MSIRANGE_8                    (0x8U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000080 */
+#define RCC_CR_MSIRANGE_9                    (0x9U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000090 */
+#define RCC_CR_MSIRANGE_10                   (0xAU << RCC_CR_MSIRANGE_Pos)     /*!< 0x000000A0 */
+#define RCC_CR_MSIRANGE_11                   (0xBU << RCC_CR_MSIRANGE_Pos)     /*!< 0x000000B0 */
+
+#define RCC_CR_HSION_Pos                     (8U)
+#define RCC_CR_HSION_Msk                     (0x1UL << RCC_CR_HSION_Pos)       /*!< 0x00000100 */
+#define RCC_CR_HSION                         RCC_CR_HSION_Msk                  /*!< Internal High Speed oscillator (HSI16) clock enable */
+#define RCC_CR_HSIKERON_Pos                  (9U)
+#define RCC_CR_HSIKERON_Msk                  (0x1UL << RCC_CR_HSIKERON_Pos)    /*!< 0x00000200 */
+#define RCC_CR_HSIKERON                      RCC_CR_HSIKERON_Msk               /*!< Internal High Speed oscillator (HSI16) clock enable for some IPs Kernel */
+#define RCC_CR_HSIRDY_Pos                    (10U)
+#define RCC_CR_HSIRDY_Msk                    (0x1UL << RCC_CR_HSIRDY_Pos)      /*!< 0x00000400 */
+#define RCC_CR_HSIRDY                        RCC_CR_HSIRDY_Msk                 /*!< Internal High Speed oscillator (HSI16) clock ready flag */
+#define RCC_CR_HSIASFS_Pos                   (11U)
+#define RCC_CR_HSIASFS_Msk                   (0x1UL << RCC_CR_HSIASFS_Pos)     /*!< 0x00000800 */
+#define RCC_CR_HSIASFS                       RCC_CR_HSIASFS_Msk                /*!< HSI16 Automatic Start from Stop */
+#define RCC_CR_HSIKERDY_Pos                  (12U)
+#define RCC_CR_HSIKERDY_Msk                  (0x1UL << RCC_CR_HSIKERDY_Pos)     /*!< 0x00001000 */
+#define RCC_CR_HSIKERDY                       RCC_CR_HSIKERDY_Msk               /*!< Internal High Speed oscillator (HSI16) clock enable for some IPs Kernel ready flag*/
+
+#define RCC_CR_HSEON_Pos                     (16U)
+#define RCC_CR_HSEON_Msk                     (0x1UL << RCC_CR_HSEON_Pos)       /*!< 0x00010000 */
+#define RCC_CR_HSEON                         RCC_CR_HSEON_Msk                  /*!< External High Speed oscillator (HSE) clock enable */
+#define RCC_CR_HSERDY_Pos                    (17U)
+#define RCC_CR_HSERDY_Msk                    (0x1UL << RCC_CR_HSERDY_Pos)      /*!< 0x00020000 */
+#define RCC_CR_HSERDY                        RCC_CR_HSERDY_Msk                 /*!< External High Speed oscillator (HSE) clock ready */
+#define RCC_CR_CSSON_Pos                     (19U)
+#define RCC_CR_CSSON_Msk                     (0x1UL << RCC_CR_CSSON_Pos)       /*!< 0x00080000 */
+#define RCC_CR_CSSON                         RCC_CR_CSSON_Msk                  /*!< HSE Clock Security System enable */
+#define RCC_CR_HSEPRE_Pos                    (20U)
+#define RCC_CR_HSEPRE_Msk                    (0x1UL << RCC_CR_HSEPRE_Pos)       /*!< 0x00100000 */
+#define RCC_CR_HSEPRE                        RCC_CR_HSEPRE_Msk                  /*!< HSE sysclk prescaler */
+
+#define RCC_CR_PLLON_Pos                     (24U)
+#define RCC_CR_PLLON_Msk                     (0x1UL << RCC_CR_PLLON_Pos)       /*!< 0x01000000 */
+#define RCC_CR_PLLON                         RCC_CR_PLLON_Msk                  /*!< System PLL clock enable */
+#define RCC_CR_PLLRDY_Pos                    (25U)
+#define RCC_CR_PLLRDY_Msk                    (0x1UL << RCC_CR_PLLRDY_Pos)      /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                        RCC_CR_PLLRDY_Msk                 /*!< System PLL clock ready */
+
+/********************  Bit definition for RCC_ICSCR register  ***************/
+/*!< MSICAL configuration */
+#define RCC_ICSCR_MSICAL_Pos                 (0U)
+#define RCC_ICSCR_MSICAL_Msk                 (0xFFUL << RCC_ICSCR_MSICAL_Pos)  /*!< 0x000000FF */
+#define RCC_ICSCR_MSICAL                     RCC_ICSCR_MSICAL_Msk              /*!< MSICAL[7:0] bits */
+#define RCC_ICSCR_MSICAL_0                   (0x01U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000001 */
+#define RCC_ICSCR_MSICAL_1                   (0x02U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000002 */
+#define RCC_ICSCR_MSICAL_2                   (0x04U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000004 */
+#define RCC_ICSCR_MSICAL_3                   (0x08U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000008 */
+#define RCC_ICSCR_MSICAL_4                   (0x10U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000010 */
+#define RCC_ICSCR_MSICAL_5                   (0x20U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000020 */
+#define RCC_ICSCR_MSICAL_6                   (0x40U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000040 */
+#define RCC_ICSCR_MSICAL_7                   (0x80U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000080 */
+
+/*!< MSITRIM configuration */
+#define RCC_ICSCR_MSITRIM_Pos                (8U)
+#define RCC_ICSCR_MSITRIM_Msk                (0xFFUL << RCC_ICSCR_MSITRIM_Pos) /*!< 0x0000FF00 */
+#define RCC_ICSCR_MSITRIM                    RCC_ICSCR_MSITRIM_Msk             /*!< MSITRIM[7:0] bits */
+#define RCC_ICSCR_MSITRIM_0                  (0x01U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000100 */
+#define RCC_ICSCR_MSITRIM_1                  (0x02U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000200 */
+#define RCC_ICSCR_MSITRIM_2                  (0x04U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000400 */
+#define RCC_ICSCR_MSITRIM_3                  (0x08U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000800 */
+#define RCC_ICSCR_MSITRIM_4                  (0x10U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00001000 */
+#define RCC_ICSCR_MSITRIM_5                  (0x20U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00002000 */
+#define RCC_ICSCR_MSITRIM_6                  (0x40U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00004000 */
+#define RCC_ICSCR_MSITRIM_7                  (0x80U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00008000 */
+
+/*!< HSICAL configuration */
+#define RCC_ICSCR_HSICAL_Pos                 (16U)
+#define RCC_ICSCR_HSICAL_Msk                 (0xFFUL << RCC_ICSCR_HSICAL_Pos)  /*!< 0x00FF0000 */
+#define RCC_ICSCR_HSICAL                     RCC_ICSCR_HSICAL_Msk              /*!< HSICAL[7:0] bits */
+#define RCC_ICSCR_HSICAL_0                   (0x01U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00010000 */
+#define RCC_ICSCR_HSICAL_1                   (0x02U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00020000 */
+#define RCC_ICSCR_HSICAL_2                   (0x04U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00040000 */
+#define RCC_ICSCR_HSICAL_3                   (0x08U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00080000 */
+#define RCC_ICSCR_HSICAL_4                   (0x10U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00100000 */
+#define RCC_ICSCR_HSICAL_5                   (0x20U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00200000 */
+#define RCC_ICSCR_HSICAL_6                   (0x40U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00400000 */
+#define RCC_ICSCR_HSICAL_7                   (0x80U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00800000 */
+
+/*!< HSITRIM configuration */
+#define RCC_ICSCR_HSITRIM_Pos                (24U)
+#define RCC_ICSCR_HSITRIM_Msk                (0x7FUL << RCC_ICSCR_HSITRIM_Pos) /*!< 0x7F000000 */
+#define RCC_ICSCR_HSITRIM                    RCC_ICSCR_HSITRIM_Msk             /*!< HSITRIM[6:0] bits */
+#define RCC_ICSCR_HSITRIM_0                  (0x01U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x01000000 */
+#define RCC_ICSCR_HSITRIM_1                  (0x02U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x02000000 */
+#define RCC_ICSCR_HSITRIM_2                  (0x04U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x04000000 */
+#define RCC_ICSCR_HSITRIM_3                  (0x08U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x08000000 */
+#define RCC_ICSCR_HSITRIM_4                  (0x10U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x10000000 */
+#define RCC_ICSCR_HSITRIM_5                  (0x20U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x20000000 */
+#define RCC_ICSCR_HSITRIM_6                  (0x40U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                      (0U)
+#define RCC_CFGR_SW_Msk                      (0x3UL << RCC_CFGR_SW_Pos)        /*!< 0x00000003 */
+#define RCC_CFGR_SW                          RCC_CFGR_SW_Msk                   /*!< SW[1:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                        (0x1U << RCC_CFGR_SW_Pos)         /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                        (0x2U << RCC_CFGR_SW_Pos)         /*!< 0x00000002 */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos                     (2U)
+#define RCC_CFGR_SWS_Msk                     (0x3UL << RCC_CFGR_SWS_Pos)       /*!< 0x0000000C */
+#define RCC_CFGR_SWS                         RCC_CFGR_SWS_Msk                  /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                       (0x1U << RCC_CFGR_SWS_Pos)        /*!< 0x00000004 */
+#define RCC_CFGR_SWS_1                       (0x2U << RCC_CFGR_SWS_Pos)        /*!< 0x00000008 */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos                    (4U)
+#define RCC_CFGR_HPRE_Msk                    (0xFUL << RCC_CFGR_HPRE_Pos)      /*!< 0x000000F0 */
+#define RCC_CFGR_HPRE                        RCC_CFGR_HPRE_Msk                 /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                      (0x1U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000010 */
+#define RCC_CFGR_HPRE_1                      (0x2U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000020 */
+#define RCC_CFGR_HPRE_2                      (0x4U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000040 */
+#define RCC_CFGR_HPRE_3                      (0x8U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000080 */
+
+/*!< PPRE1 configuration */
+#define RCC_CFGR_PPRE1_Pos                   (8U)
+#define RCC_CFGR_PPRE1_Msk                   (0x7UL << RCC_CFGR_PPRE1_Pos)     /*!< 0x00000700 */
+#define RCC_CFGR_PPRE1                       RCC_CFGR_PPRE1_Msk                /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define RCC_CFGR_PPRE1_0                     (0x1U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000100 */
+#define RCC_CFGR_PPRE1_1                     (0x2U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000200 */
+#define RCC_CFGR_PPRE1_2                     (0x4U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000400 */
+
+/*!< PPRE2 configuration */
+#define RCC_CFGR_PPRE2_Pos                   (11U)
+#define RCC_CFGR_PPRE2_Msk                   (0x7UL << RCC_CFGR_PPRE2_Pos)     /*!< 0x00003800 */
+#define RCC_CFGR_PPRE2                       RCC_CFGR_PPRE2_Msk                /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define RCC_CFGR_PPRE2_0                     (0x1U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00000800 */
+#define RCC_CFGR_PPRE2_1                     (0x2U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00001000 */
+#define RCC_CFGR_PPRE2_2                     (0x4U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00002000 */
+
+/*!< STOPWUCK configuration */
+#define RCC_CFGR_STOPWUCK_Pos                (15U)
+#define RCC_CFGR_STOPWUCK_Msk                (0x1UL << RCC_CFGR_STOPWUCK_Pos)  /*!< 0x00008000 */
+#define RCC_CFGR_STOPWUCK                    RCC_CFGR_STOPWUCK_Msk             /*!< Wake Up from stop and CSS backup clock selection */
+
+/*!< HPREF configuration */
+#define RCC_CFGR_HPREF_Pos                   (16U)
+#define RCC_CFGR_HPREF_Msk                   (0x1UL << RCC_CFGR_HPREF_Pos)     /*!< 0x00010000 */
+#define RCC_CFGR_HPREF                       RCC_CFGR_HPREF_Msk                /*!< AHB prescaler flag */
+
+/*!< PPRE1F configuration */
+#define RCC_CFGR_PPRE1F_Pos                  (17U)
+#define RCC_CFGR_PPRE1F_Msk                  (0x1UL << RCC_CFGR_PPRE1F_Pos)    /*!< 0x00020000 */
+#define RCC_CFGR_PPRE1F                      RCC_CFGR_PPRE1F_Msk               /*!< CPU1 APB1 prescaler flag */
+
+/*!< PPRE2F configuration */
+#define RCC_CFGR_PPRE2F_Pos                  (18U)
+#define RCC_CFGR_PPRE2F_Msk                  (0x1UL << RCC_CFGR_PPRE2F_Pos)    /*!< 0x00040000 */
+#define RCC_CFGR_PPRE2F                      RCC_CFGR_PPRE2F_Msk               /*!< APB2 prescaler flag */
+
+/*!< MCOSEL configuration */
+#define RCC_CFGR_MCOSEL_Pos                  (24U)
+#define RCC_CFGR_MCOSEL_Msk                  (0xFUL << RCC_CFGR_MCOSEL_Pos)    /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL                      RCC_CFGR_MCOSEL_Msk               /*!< MCOSEL [3:0] bits (Clock output selection) */
+#define RCC_CFGR_MCOSEL_0                    (0x1U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x01000000 */
+#define RCC_CFGR_MCOSEL_1                    (0x2U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x02000000 */
+#define RCC_CFGR_MCOSEL_2                    (0x4U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x04000000 */
+#define RCC_CFGR_MCOSEL_3                    (0x8U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x08000000 */
+
+/*!< MCOPRE configuration */
+#define RCC_CFGR_MCOPRE_Pos                  (28U)
+#define RCC_CFGR_MCOPRE_Msk                  (0x7UL << RCC_CFGR_MCOPRE_Pos)    /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE                      RCC_CFGR_MCOPRE_Msk               /*!< MCO prescaler */
+#define RCC_CFGR_MCOPRE_0                    (0x1U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x10000000 */
+#define RCC_CFGR_MCOPRE_1                    (0x2U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x20000000 */
+#define RCC_CFGR_MCOPRE_2                    (0x4U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLSRC_Pos               (0U)
+#define RCC_PLLCFGR_PLLSRC_Msk               (0x3UL << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC                   RCC_PLLCFGR_PLLSRC_Msk
+#define RCC_PLLCFGR_PLLSRC_0                 (0x1U << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLSRC_1                 (0x2U << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000002 */
+
+#define RCC_PLLCFGR_PLLM_Pos                 (4U)
+#define RCC_PLLCFGR_PLLM_Msk                 (0x7UL << RCC_PLLCFGR_PLLM_Pos) /*!< 0x00000070 */
+#define RCC_PLLCFGR_PLLM                     RCC_PLLCFGR_PLLM_Msk
+#define RCC_PLLCFGR_PLLM_0                   (0x1U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_1                   (0x2U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000020 */
+#define RCC_PLLCFGR_PLLM_2                   (0x4U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000040 */
+
+#define RCC_PLLCFGR_PLLN_Pos                 (8U)
+#define RCC_PLLCFGR_PLLN_Msk                 (0x7FUL << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00007F00 */
+#define RCC_PLLCFGR_PLLN                     RCC_PLLCFGR_PLLN_Msk
+#define RCC_PLLCFGR_PLLN_0                   (0x01U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_1                   (0x02U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_2                   (0x04U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_3                   (0x08U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_4                   (0x10U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_5                   (0x20U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_6                   (0x40U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLPEN_Pos               (16U)
+#define RCC_PLLCFGR_PLLPEN_Msk               (0x1UL << RCC_PLLCFGR_PLLPEN_Pos) /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLPEN                   RCC_PLLCFGR_PLLPEN_Msk
+#define RCC_PLLCFGR_PLLP_Pos                 (17U)
+#define RCC_PLLCFGR_PLLP_Msk                 (0x1FUL << RCC_PLLCFGR_PLLP_Pos) /*!< 0x003E0000 */
+#define RCC_PLLCFGR_PLLP                     RCC_PLLCFGR_PLLP_Msk
+#define RCC_PLLCFGR_PLLP_0                   (0x01U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00020000 */
+#define RCC_PLLCFGR_PLLP_1                   (0x02U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00040000 */
+#define RCC_PLLCFGR_PLLP_2                   (0x04U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00080000 */
+#define RCC_PLLCFGR_PLLP_3                   (0x08U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00100000 */
+#define RCC_PLLCFGR_PLLP_4                   (0x10U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00200000 */
+
+#define RCC_PLLCFGR_PLLQEN_Pos               (24U)
+#define RCC_PLLCFGR_PLLQEN_Msk               (0x1UL << RCC_PLLCFGR_PLLQEN_Pos) /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQEN                   RCC_PLLCFGR_PLLQEN_Msk
+#define RCC_PLLCFGR_PLLQ_Pos                 (25U)
+#define RCC_PLLCFGR_PLLQ_Msk                 (0x7UL << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x0E000000 */
+#define RCC_PLLCFGR_PLLQ                     RCC_PLLCFGR_PLLQ_Msk
+#define RCC_PLLCFGR_PLLQ_0                   (0x1U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_1                   (0x2U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_2                   (0x4U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x08000000 */
+
+#define RCC_PLLCFGR_PLLREN_Pos               (28U)
+#define RCC_PLLCFGR_PLLREN_Msk               (0x1UL << RCC_PLLCFGR_PLLREN_Pos) /*!< 0x10000000 */
+#define RCC_PLLCFGR_PLLREN                   RCC_PLLCFGR_PLLREN_Msk
+#define RCC_PLLCFGR_PLLR_Pos                 (29U)
+#define RCC_PLLCFGR_PLLR_Msk                 (0x7UL << RCC_PLLCFGR_PLLR_Pos) /*!< 0xE0000000 */
+#define RCC_PLLCFGR_PLLR                     RCC_PLLCFGR_PLLR_Msk
+#define RCC_PLLCFGR_PLLR_0                   (0x1U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x20000000 */
+#define RCC_PLLCFGR_PLLR_1                   (0x2U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x40000000 */
+#define RCC_PLLCFGR_PLLR_2                   (0x4U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIER register  ******************/
+#define RCC_CIER_LSI1RDYIE_Pos               (0U)
+#define RCC_CIER_LSI1RDYIE_Msk               (0x1UL << RCC_CIER_LSI1RDYIE_Pos)  /*!< 0x00000001 */
+#define RCC_CIER_LSI1RDYIE                   RCC_CIER_LSI1RDYIE_Msk
+#define RCC_CIER_LSERDYIE_Pos                (1U)
+#define RCC_CIER_LSERDYIE_Msk                (0x1UL << RCC_CIER_LSERDYIE_Pos)   /*!< 0x00000002 */
+#define RCC_CIER_LSERDYIE                    RCC_CIER_LSERDYIE_Msk
+#define RCC_CIER_MSIRDYIE_Pos                (2U)
+#define RCC_CIER_MSIRDYIE_Msk                (0x1UL << RCC_CIER_MSIRDYIE_Pos)   /*!< 0x00000004 */
+#define RCC_CIER_MSIRDYIE                    RCC_CIER_MSIRDYIE_Msk
+#define RCC_CIER_HSIRDYIE_Pos                (3U)
+#define RCC_CIER_HSIRDYIE_Msk                (0x1UL << RCC_CIER_HSIRDYIE_Pos)   /*!< 0x00000008 */
+#define RCC_CIER_HSIRDYIE                    RCC_CIER_HSIRDYIE_Msk
+#define RCC_CIER_HSERDYIE_Pos                (4U)
+#define RCC_CIER_HSERDYIE_Msk                (0x1UL << RCC_CIER_HSERDYIE_Pos)   /*!< 0x00000010 */
+#define RCC_CIER_HSERDYIE                    RCC_CIER_HSERDYIE_Msk
+#define RCC_CIER_PLLRDYIE_Pos                (5U)
+#define RCC_CIER_PLLRDYIE_Msk                (0x1UL << RCC_CIER_PLLRDYIE_Pos) /*!< 0x00000020 */
+#define RCC_CIER_PLLRDYIE                    RCC_CIER_PLLRDYIE_Msk
+#define RCC_CIER_LSECSSIE_Pos                (9U)
+#define RCC_CIER_LSECSSIE_Msk                (0x1UL << RCC_CIER_LSECSSIE_Pos)   /*!< 0x00000200 */
+#define RCC_CIER_LSECSSIE                    RCC_CIER_LSECSSIE_Msk
+#define RCC_CIER_LSI2RDYIE_Pos               (11U)
+#define RCC_CIER_LSI2RDYIE_Msk               (0x1UL << RCC_CIER_LSI2RDYIE_Pos)  /*!< 0x00000800 */
+#define RCC_CIER_LSI2RDYIE                   RCC_CIER_LSI2RDYIE_Msk
+
+
+/********************  Bit definition for RCC_CIFR register  ******************/
+#define RCC_CIFR_LSI1RDYF_Pos                (0U)
+#define RCC_CIFR_LSI1RDYF_Msk                (0x1UL << RCC_CIFR_LSI1RDYF_Pos)  /*!< 0x00000001 */
+#define RCC_CIFR_LSI1RDYF                    RCC_CIFR_LSI1RDYF_Msk
+#define RCC_CIFR_LSERDYF_Pos                 (1U)
+#define RCC_CIFR_LSERDYF_Msk                 (0x1UL << RCC_CIFR_LSERDYF_Pos)   /*!< 0x00000002 */
+#define RCC_CIFR_LSERDYF                     RCC_CIFR_LSERDYF_Msk
+#define RCC_CIFR_MSIRDYF_Pos                 (2U)
+#define RCC_CIFR_MSIRDYF_Msk                 (0x1UL << RCC_CIFR_MSIRDYF_Pos)   /*!< 0x00000004 */
+#define RCC_CIFR_MSIRDYF                     RCC_CIFR_MSIRDYF_Msk
+#define RCC_CIFR_HSIRDYF_Pos                 (3U)
+#define RCC_CIFR_HSIRDYF_Msk                 (0x1UL << RCC_CIFR_HSIRDYF_Pos)   /*!< 0x00000008 */
+#define RCC_CIFR_HSIRDYF                     RCC_CIFR_HSIRDYF_Msk
+#define RCC_CIFR_HSERDYF_Pos                 (4U)
+#define RCC_CIFR_HSERDYF_Msk                 (0x1UL << RCC_CIFR_HSERDYF_Pos)   /*!< 0x00000010 */
+#define RCC_CIFR_HSERDYF                     RCC_CIFR_HSERDYF_Msk
+#define RCC_CIFR_PLLRDYF_Pos                 (5U)
+#define RCC_CIFR_PLLRDYF_Msk                 (0x1UL << RCC_CIFR_PLLRDYF_Pos) /*!< 0x00000020 */
+#define RCC_CIFR_PLLRDYF                     RCC_CIFR_PLLRDYF_Msk
+#define RCC_CIFR_CSSF_Pos                    (8U)
+#define RCC_CIFR_CSSF_Msk                    (0x1UL << RCC_CIFR_CSSF_Pos)   /*!< 0x00000100 */
+#define RCC_CIFR_CSSF                        RCC_CIFR_CSSF_Msk
+#define RCC_CIFR_LSECSSF_Pos                 (9U)
+#define RCC_CIFR_LSECSSF_Msk                 (0x1UL << RCC_CIFR_LSECSSF_Pos)   /*!< 0x00000200 */
+#define RCC_CIFR_LSECSSF                     RCC_CIFR_LSECSSF_Msk
+#define RCC_CIFR_LSI2RDYF_Pos                (11U)
+#define RCC_CIFR_LSI2RDYF_Msk                (0x1UL << RCC_CIFR_LSI2RDYF_Pos)  /*!< 0x00000800 */
+#define RCC_CIFR_LSI2RDYF                    RCC_CIFR_LSI2RDYF_Msk
+
+/********************  Bit definition for RCC_CICR register  ******************/
+#define RCC_CICR_LSI1RDYC_Pos               (0U)
+#define RCC_CICR_LSI1RDYC_Msk               (0x1UL << RCC_CICR_LSI1RDYC_Pos)  /*!< 0x00000001 */
+#define RCC_CICR_LSI1RDYC                   RCC_CICR_LSI1RDYC_Msk
+#define RCC_CICR_LSERDYC_Pos                (1U)
+#define RCC_CICR_LSERDYC_Msk                (0x1UL << RCC_CICR_LSERDYC_Pos)   /*!< 0x00000002 */
+#define RCC_CICR_LSERDYC                    RCC_CICR_LSERDYC_Msk
+#define RCC_CICR_MSIRDYC_Pos                (2U)
+#define RCC_CICR_MSIRDYC_Msk                (0x1UL << RCC_CICR_MSIRDYC_Pos)   /*!< 0x00000004 */
+#define RCC_CICR_MSIRDYC                    RCC_CICR_MSIRDYC_Msk
+#define RCC_CICR_HSIRDYC_Pos                (3U)
+#define RCC_CICR_HSIRDYC_Msk                (0x1UL << RCC_CICR_HSIRDYC_Pos)   /*!< 0x00000008 */
+#define RCC_CICR_HSIRDYC                    RCC_CICR_HSIRDYC_Msk
+#define RCC_CICR_HSERDYC_Pos                (4U)
+#define RCC_CICR_HSERDYC_Msk                (0x1UL << RCC_CICR_HSERDYC_Pos)   /*!< 0x00000010 */
+#define RCC_CICR_HSERDYC                    RCC_CICR_HSERDYC_Msk
+#define RCC_CICR_PLLRDYC_Pos                (5U)
+#define RCC_CICR_PLLRDYC_Msk                (0x1UL << RCC_CICR_PLLRDYC_Pos) /*!< 0x00000020 */
+#define RCC_CICR_PLLRDYC                    RCC_CICR_PLLRDYC_Msk
+#define RCC_CICR_CSSC_Pos                   (8U)
+#define RCC_CICR_CSSC_Msk                   (0x1UL << RCC_CICR_CSSC_Pos)   /*!< 0x00000100 */
+#define RCC_CICR_CSSC                       RCC_CICR_CSSC_Msk
+#define RCC_CICR_LSECSSC_Pos                (9U)
+#define RCC_CICR_LSECSSC_Msk                (0x1UL << RCC_CICR_LSECSSC_Pos)   /*!< 0x00000200 */
+#define RCC_CICR_LSECSSC                    RCC_CICR_LSECSSC_Msk
+#define RCC_CICR_LSI2RDYC_Pos               (11U)
+#define RCC_CICR_LSI2RDYC_Msk               (0x1UL << RCC_CICR_LSI2RDYC_Pos)  /*!< 0x00000800 */
+#define RCC_CICR_LSI2RDYC                   RCC_CICR_LSI2RDYC_Msk
+
+/********************  Bit definition for RCC_SMPSCR register  ******************/
+#define RCC_SMPSCR_SMPSSEL_Pos               (0U)
+#define RCC_SMPSCR_SMPSSEL_Msk               (0x3UL << RCC_SMPSCR_SMPSSEL_Pos)  /*!< 0x00000003 */
+#define RCC_SMPSCR_SMPSSEL                   RCC_SMPSCR_SMPSSEL_Msk
+#define RCC_SMPSCR_SMPSSEL_0                 (0x1U << RCC_SMPSCR_SMPSSEL_Pos)   /*!< 0x00000001 */
+#define RCC_SMPSCR_SMPSSEL_1                 (0x2U << RCC_SMPSCR_SMPSSEL_Pos)   /*!< 0x00000002 */
+
+#define RCC_SMPSCR_SMPSDIV_Pos               (4U)
+#define RCC_SMPSCR_SMPSDIV_Msk               (0x3UL << RCC_SMPSCR_SMPSDIV_Pos)  /*!< 0x00000030 */
+#define RCC_SMPSCR_SMPSDIV                   RCC_SMPSCR_SMPSDIV_Msk
+#define RCC_SMPSCR_SMPSDIV_0                 (0x1U << RCC_SMPSCR_SMPSDIV_Pos)   /*!< 0x00000010 */
+#define RCC_SMPSCR_SMPSDIV_1                 (0x2U << RCC_SMPSCR_SMPSDIV_Pos)   /*!< 0x00000020 */
+
+#define RCC_SMPSCR_SMPSSWS_Pos               (8U)
+#define RCC_SMPSCR_SMPSSWS_Msk               (0x3UL << RCC_SMPSCR_SMPSSWS_Pos)  /*!< 0x00000300 */
+#define RCC_SMPSCR_SMPSSWS                   RCC_SMPSCR_SMPSSWS_Msk
+#define RCC_SMPSCR_SMPSSWS_0                 (0x1U << RCC_SMPSCR_SMPSSWS_Pos)   /*!< 0x00000100 */
+#define RCC_SMPSCR_SMPSSWS_1                 (0x2U << RCC_SMPSCR_SMPSSWS_Pos)   /*!< 0x00000200 */
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define RCC_AHB1RSTR_DMA1RST_Pos             (0U)
+#define RCC_AHB1RSTR_DMA1RST_Msk             (0x1UL << RCC_AHB1RSTR_DMA1RST_Pos) /*!< 0x00000001 */
+#define RCC_AHB1RSTR_DMA1RST                 RCC_AHB1RSTR_DMA1RST_Msk
+#define RCC_AHB1RSTR_DMAMUX1RST_Pos          (2U)
+#define RCC_AHB1RSTR_DMAMUX1RST_Msk          (0x1UL << RCC_AHB1RSTR_DMAMUX1RST_Pos) /*!< 0x00000004 */
+#define RCC_AHB1RSTR_DMAMUX1RST              RCC_AHB1RSTR_DMAMUX1RST_Msk
+#define RCC_AHB1RSTR_CRCRST_Pos              (12U)
+#define RCC_AHB1RSTR_CRCRST_Msk              (0x1UL << RCC_AHB1RSTR_CRCRST_Pos) /*!< 0x00001000 */
+#define RCC_AHB1RSTR_CRCRST                  RCC_AHB1RSTR_CRCRST_Msk
+#define RCC_AHB1RSTR_TSCRST_Pos              (16U)
+#define RCC_AHB1RSTR_TSCRST_Msk              (0x1UL << RCC_AHB1RSTR_TSCRST_Pos) /*!< 0x00010000 */
+#define RCC_AHB1RSTR_TSCRST                  RCC_AHB1RSTR_TSCRST_Msk
+
+/********************  Bit definition for RCC_AHB2RSTR register  ***************/
+#define RCC_AHB2RSTR_GPIOARST_Pos           (0U)
+#define RCC_AHB2RSTR_GPIOARST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOARST_Pos) /*!< 0x00000001 */
+#define RCC_AHB2RSTR_GPIOARST               RCC_AHB2RSTR_GPIOARST_Msk
+#define RCC_AHB2RSTR_GPIOBRST_Pos           (1U)
+#define RCC_AHB2RSTR_GPIOBRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOBRST_Pos) /*!< 0x00000002 */
+#define RCC_AHB2RSTR_GPIOBRST               RCC_AHB2RSTR_GPIOBRST_Msk
+#define RCC_AHB2RSTR_GPIOCRST_Pos           (2U)
+#define RCC_AHB2RSTR_GPIOCRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOCRST_Pos) /*!< 0x00000004 */
+#define RCC_AHB2RSTR_GPIOCRST               RCC_AHB2RSTR_GPIOCRST_Msk
+#define RCC_AHB2RSTR_GPIOERST_Pos           (4U)
+#define RCC_AHB2RSTR_GPIOERST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOERST_Pos) /*!< 0x00000010 */
+#define RCC_AHB2RSTR_GPIOERST               RCC_AHB2RSTR_GPIOERST_Msk
+#define RCC_AHB2RSTR_GPIOHRST_Pos           (7U)
+#define RCC_AHB2RSTR_GPIOHRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOHRST_Pos) /*!< 0x00000080 */
+#define RCC_AHB2RSTR_GPIOHRST               RCC_AHB2RSTR_GPIOHRST_Msk
+
+/********************  Bit definition for RCC_AHB3RSTR register  ***************/
+#define RCC_AHB3RSTR_PKARST_Pos             (16U)
+#define RCC_AHB3RSTR_PKARST_Msk             (0x1UL << RCC_AHB3RSTR_PKARST_Pos) /*!< 0x00010000 */
+#define RCC_AHB3RSTR_PKARST                 RCC_AHB3RSTR_PKARST_Msk
+#define RCC_AHB3RSTR_AES2RST_Pos            (17U)
+#define RCC_AHB3RSTR_AES2RST_Msk            (0x1UL << RCC_AHB3RSTR_AES2RST_Pos) /*!< 0x00020000 */
+#define RCC_AHB3RSTR_AES2RST                RCC_AHB3RSTR_AES2RST_Msk
+#define RCC_AHB3RSTR_RNGRST_Pos             (18U)
+#define RCC_AHB3RSTR_RNGRST_Msk             (0x1UL << RCC_AHB3RSTR_RNGRST_Pos) /*!< 0x00040000 */
+#define RCC_AHB3RSTR_RNGRST                 RCC_AHB3RSTR_RNGRST_Msk
+#define RCC_AHB3RSTR_HSEMRST_Pos            (19U)
+#define RCC_AHB3RSTR_HSEMRST_Msk            (0x1UL << RCC_AHB3RSTR_HSEMRST_Pos) /*!< 0x00080000 */
+#define RCC_AHB3RSTR_HSEMRST                RCC_AHB3RSTR_HSEMRST_Msk
+#define RCC_AHB3RSTR_IPCCRST_Pos            (20U)
+#define RCC_AHB3RSTR_IPCCRST_Msk            (0x1UL << RCC_AHB3RSTR_IPCCRST_Pos) /*!< 0x00100000 */
+#define RCC_AHB3RSTR_IPCCRST                RCC_AHB3RSTR_IPCCRST_Msk
+#define RCC_AHB3RSTR_FLASHRST_Pos           (25U)
+#define RCC_AHB3RSTR_FLASHRST_Msk           (0x1UL << RCC_AHB3RSTR_FLASHRST_Pos) /*!< 0x02000000 */
+#define RCC_AHB3RSTR_FLASHRST               RCC_AHB3RSTR_FLASHRST_Msk
+
+/********************  Bit definition for RCC_APB1RSTR1 register  **************/
+#define RCC_APB1RSTR1_TIM2RST_Pos           (0U)
+#define RCC_APB1RSTR1_TIM2RST_Msk           (0x1UL << RCC_APB1RSTR1_TIM2RST_Pos) /*!< 0x00000001 */
+#define RCC_APB1RSTR1_TIM2RST               RCC_APB1RSTR1_TIM2RST_Msk
+#define RCC_APB1RSTR1_I2C1RST_Pos           (21U)
+#define RCC_APB1RSTR1_I2C1RST_Msk           (0x1UL << RCC_APB1RSTR1_I2C1RST_Pos) /*!< 0x00200000 */
+#define RCC_APB1RSTR1_I2C1RST               RCC_APB1RSTR1_I2C1RST_Msk
+#define RCC_APB1RSTR1_LPTIM1RST_Pos         (31U)
+#define RCC_APB1RSTR1_LPTIM1RST_Msk         (0x1UL << RCC_APB1RSTR1_LPTIM1RST_Pos) /*!< 0x80000000 */
+#define RCC_APB1RSTR1_LPTIM1RST             RCC_APB1RSTR1_LPTIM1RST_Msk
+
+/********************  Bit definition for RCC_APB1RSTR2 register  **************/
+#define RCC_APB1RSTR2_LPUART1RST_Pos        (0U)
+#define RCC_APB1RSTR2_LPUART1RST_Msk        (0x1UL << RCC_APB1RSTR2_LPUART1RST_Pos) /*!< 0x00000001 */
+#define RCC_APB1RSTR2_LPUART1RST            RCC_APB1RSTR2_LPUART1RST_Msk
+#define RCC_APB1RSTR2_LPTIM2RST_Pos         (5U)
+#define RCC_APB1RSTR2_LPTIM2RST_Msk         (0x1UL << RCC_APB1RSTR2_LPTIM2RST_Pos) /*!< 0x00000020 */
+#define RCC_APB1RSTR2_LPTIM2RST             RCC_APB1RSTR2_LPTIM2RST_Msk
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define RCC_APB2RSTR_ADCRST_Pos             (9U)
+#define RCC_APB2RSTR_ADCRST_Msk             (0x1UL << RCC_APB2RSTR_ADCRST_Pos)    /*!< 0x00000200 */
+#define RCC_APB2RSTR_ADCRST                 RCC_APB2RSTR_ADCRST_Msk
+#define RCC_APB2RSTR_TIM1RST_Pos            (11U)
+#define RCC_APB2RSTR_TIM1RST_Msk            (0x1UL << RCC_APB2RSTR_TIM1RST_Pos)   /*!< 0x00000800 */
+#define RCC_APB2RSTR_TIM1RST                RCC_APB2RSTR_TIM1RST_Msk
+#define RCC_APB2RSTR_SPI1RST_Pos            (12U)
+#define RCC_APB2RSTR_SPI1RST_Msk            (0x1UL << RCC_APB2RSTR_SPI1RST_Pos)   /*!< 0x00001000 */
+#define RCC_APB2RSTR_SPI1RST                RCC_APB2RSTR_SPI1RST_Msk
+#define RCC_APB2RSTR_USART1RST_Pos          (14U)
+#define RCC_APB2RSTR_USART1RST_Msk          (0x1UL << RCC_APB2RSTR_USART1RST_Pos) /*!< 0x00004000 */
+#define RCC_APB2RSTR_USART1RST              RCC_APB2RSTR_USART1RST_Msk
+
+/********************  Bit definition for RCC_APB3RSTR register  **************/
+#define RCC_APB3RSTR_RFRST_Pos             (0U)
+#define RCC_APB3RSTR_RFRST_Msk             (0x1UL << RCC_APB3RSTR_RFRST_Pos) /*!< 0x00000001 */
+#define RCC_APB3RSTR_RFRST                 RCC_APB3RSTR_RFRST_Msk
+
+/********************  Bit definition for RCC_AHB1ENR register  ****************/
+#define RCC_AHB1ENR_DMA1EN_Pos              (0U)
+#define RCC_AHB1ENR_DMA1EN_Msk              (0x1UL << RCC_AHB1ENR_DMA1EN_Pos)  /*!< 0x00000001 */
+#define RCC_AHB1ENR_DMA1EN                  RCC_AHB1ENR_DMA1EN_Msk
+#define RCC_AHB1ENR_DMAMUX1EN_Pos           (2U)
+#define RCC_AHB1ENR_DMAMUX1EN_Msk           (0x1UL << RCC_AHB1ENR_DMAMUX1EN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1ENR_DMAMUX1EN               RCC_AHB1ENR_DMAMUX1EN_Msk
+#define RCC_AHB1ENR_CRCEN_Pos               (12U)
+#define RCC_AHB1ENR_CRCEN_Msk               (0x1UL << RCC_AHB1ENR_CRCEN_Pos)   /*!< 0x00001000 */
+#define RCC_AHB1ENR_CRCEN                   RCC_AHB1ENR_CRCEN_Msk
+#define RCC_AHB1ENR_TSCEN_Pos               (16U)
+#define RCC_AHB1ENR_TSCEN_Msk               (0x1UL << RCC_AHB1ENR_TSCEN_Pos)   /*!< 0x00010000 */
+#define RCC_AHB1ENR_TSCEN                   RCC_AHB1ENR_TSCEN_Msk
+
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+#define RCC_AHB2ENR_GPIOAEN_Pos             (0U)
+#define RCC_AHB2ENR_GPIOAEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOAEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB2ENR_GPIOAEN                 RCC_AHB2ENR_GPIOAEN_Msk
+#define RCC_AHB2ENR_GPIOBEN_Pos             (1U)
+#define RCC_AHB2ENR_GPIOBEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOBEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB2ENR_GPIOBEN                 RCC_AHB2ENR_GPIOBEN_Msk
+#define RCC_AHB2ENR_GPIOCEN_Pos             (2U)
+#define RCC_AHB2ENR_GPIOCEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOCEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB2ENR_GPIOCEN                 RCC_AHB2ENR_GPIOCEN_Msk
+#define RCC_AHB2ENR_GPIOEEN_Pos             (4U)
+#define RCC_AHB2ENR_GPIOEEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOEEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB2ENR_GPIOEEN                 RCC_AHB2ENR_GPIOEEN_Msk
+#define RCC_AHB2ENR_GPIOHEN_Pos             (7U)
+#define RCC_AHB2ENR_GPIOHEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOHEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2ENR_GPIOHEN                 RCC_AHB2ENR_GPIOHEN_Msk
+
+/********************  Bit definition for RCC_AHB3ENR register  ***************/
+#define RCC_AHB3ENR_PKAEN_Pos               (16U)
+#define RCC_AHB3ENR_PKAEN_Msk               (0x1UL << RCC_AHB3ENR_PKAEN_Pos)   /*!< 0x00010000 */
+#define RCC_AHB3ENR_PKAEN                   RCC_AHB3ENR_PKAEN_Msk
+#define RCC_AHB3ENR_AES2EN_Pos              (17U)
+#define RCC_AHB3ENR_AES2EN_Msk              (0x1UL << RCC_AHB3ENR_AES2EN_Pos) /*!< 0x00020000 */
+#define RCC_AHB3ENR_AES2EN                  RCC_AHB3ENR_AES2EN_Msk
+#define RCC_AHB3ENR_RNGEN_Pos               (18U)
+#define RCC_AHB3ENR_RNGEN_Msk               (0x1UL << RCC_AHB3ENR_RNGEN_Pos)  /*!< 0x00040000 */
+#define RCC_AHB3ENR_RNGEN                   RCC_AHB3ENR_RNGEN_Msk
+#define RCC_AHB3ENR_HSEMEN_Pos              (19U)
+#define RCC_AHB3ENR_HSEMEN_Msk              (0x1UL << RCC_AHB3ENR_HSEMEN_Pos)  /*!< 0x00080000 */
+#define RCC_AHB3ENR_HSEMEN                  RCC_AHB3ENR_HSEMEN_Msk
+#define RCC_AHB3ENR_IPCCEN_Pos              (20U)
+#define RCC_AHB3ENR_IPCCEN_Msk              (0x1UL << RCC_AHB3ENR_IPCCEN_Pos)  /*!< 0x00100000 */
+#define RCC_AHB3ENR_IPCCEN                  RCC_AHB3ENR_IPCCEN_Msk
+#define RCC_AHB3ENR_FLASHEN_Pos             (25U)
+#define RCC_AHB3ENR_FLASHEN_Msk             (0x1UL << RCC_AHB3ENR_FLASHEN_Pos)   /*!< 0x02000000 */
+#define RCC_AHB3ENR_FLASHEN                 RCC_AHB3ENR_FLASHEN_Msk
+
+/********************  Bit definition for RCC_APB1ENR1 register  **************/
+#define RCC_APB1ENR1_TIM2EN_Pos             (0U)
+#define RCC_APB1ENR1_TIM2EN_Msk             (0x1UL << RCC_APB1ENR1_TIM2EN_Pos) /*!< 0x00000001 */
+#define RCC_APB1ENR1_TIM2EN                 RCC_APB1ENR1_TIM2EN_Msk
+#define RCC_APB1ENR1_RTCAPBEN_Pos           (10U)
+#define RCC_APB1ENR1_RTCAPBEN_Msk           (0x1UL << RCC_APB1ENR1_RTCAPBEN_Pos) /*!< 0x00000400 */
+#define RCC_APB1ENR1_RTCAPBEN               RCC_APB1ENR1_RTCAPBEN_Msk
+#define RCC_APB1ENR1_WWDGEN_Pos             (11U)
+#define RCC_APB1ENR1_WWDGEN_Msk             (0x1UL << RCC_APB1ENR1_WWDGEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1ENR1_WWDGEN                 RCC_APB1ENR1_WWDGEN_Msk
+#define RCC_APB1ENR1_I2C1EN_Pos             (21U)
+#define RCC_APB1ENR1_I2C1EN_Msk             (0x1UL << RCC_APB1ENR1_I2C1EN_Pos) /*!< 0x00200000 */
+#define RCC_APB1ENR1_I2C1EN                 RCC_APB1ENR1_I2C1EN_Msk
+#define RCC_APB1ENR1_LPTIM1EN_Pos           (31U)
+#define RCC_APB1ENR1_LPTIM1EN_Msk           (0x1UL << RCC_APB1ENR1_LPTIM1EN_Pos) /*!< 0x80000000 */
+#define RCC_APB1ENR1_LPTIM1EN               RCC_APB1ENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_APB1ENR2 register  **************/
+#define RCC_APB1ENR2_LPUART1EN_Pos          (0U)
+#define RCC_APB1ENR2_LPUART1EN_Msk         (0x1UL << RCC_APB1ENR2_LPUART1EN_Pos) /*!< 0x00000001 */
+#define RCC_APB1ENR2_LPUART1EN              RCC_APB1ENR2_LPUART1EN_Msk
+#define RCC_APB1ENR2_LPTIM2EN_Pos           (5U)
+#define RCC_APB1ENR2_LPTIM2EN_Msk           (0x1UL << RCC_APB1ENR2_LPTIM2EN_Pos) /*!< 0x00000020 */
+#define RCC_APB1ENR2_LPTIM2EN               RCC_APB1ENR2_LPTIM2EN_Msk
+
+/********************  Bit definition for RCC_APB2ENR register  **************/
+#define RCC_APB2ENR_ADCEN_Pos               (9U)
+#define RCC_APB2ENR_ADCEN_Msk               (0x1UL << RCC_APB2ENR_ADCEN_Pos)    /*!< 0x00000200 */
+#define RCC_APB2ENR_ADCEN                   RCC_APB2ENR_ADCEN_Msk
+#define RCC_APB2ENR_TIM1EN_Pos              (11U)
+#define RCC_APB2ENR_TIM1EN_Msk              (0x1UL << RCC_APB2ENR_TIM1EN_Pos)   /*!< 0x00000800 */
+#define RCC_APB2ENR_TIM1EN                  RCC_APB2ENR_TIM1EN_Msk
+#define RCC_APB2ENR_SPI1EN_Pos              (12U)
+#define RCC_APB2ENR_SPI1EN_Msk              (0x1UL << RCC_APB2ENR_SPI1EN_Pos)   /*!< 0x00001000 */
+#define RCC_APB2ENR_SPI1EN                  RCC_APB2ENR_SPI1EN_Msk
+#define RCC_APB2ENR_USART1EN_Pos            (14U)
+#define RCC_APB2ENR_USART1EN_Msk            (0x1UL << RCC_APB2ENR_USART1EN_Pos) /*!< 0x00004000 */
+#define RCC_APB2ENR_USART1EN                RCC_APB2ENR_USART1EN_Msk
+
+/********************  Bit definition for RCC_AHB1SMENR register  ****************/
+#define RCC_AHB1SMENR_DMA1SMEN_Pos          (0U)
+#define RCC_AHB1SMENR_DMA1SMEN_Msk          (0x1UL << RCC_AHB1SMENR_DMA1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB1SMENR_DMA1SMEN              RCC_AHB1SMENR_DMA1SMEN_Msk
+#define RCC_AHB1SMENR_DMAMUX1SMEN_Pos       (2U)
+#define RCC_AHB1SMENR_DMAMUX1SMEN_Msk       (0x1UL << RCC_AHB1SMENR_DMAMUX1SMEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1SMENR_DMAMUX1SMEN           RCC_AHB1SMENR_DMAMUX1SMEN_Msk
+#define RCC_AHB1SMENR_SRAM1SMEN_Pos         (9U)
+#define RCC_AHB1SMENR_SRAM1SMEN_Msk         (0x1UL << RCC_AHB1SMENR_SRAM1SMEN_Pos) /*!< 0x00000200 */
+#define RCC_AHB1SMENR_SRAM1SMEN             RCC_AHB1SMENR_SRAM1SMEN_Msk
+#define RCC_AHB1SMENR_CRCSMEN_Pos           (12U)
+#define RCC_AHB1SMENR_CRCSMEN_Msk           (0x1UL << RCC_AHB1SMENR_CRCSMEN_Pos) /*!< 0x00001000 */
+#define RCC_AHB1SMENR_CRCSMEN               RCC_AHB1SMENR_CRCSMEN_Msk
+#define RCC_AHB1SMENR_TSCSMEN_Pos           (16U)
+#define RCC_AHB1SMENR_TSCSMEN_Msk           (0x1UL << RCC_AHB1SMENR_TSCSMEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB1SMENR_TSCSMEN               RCC_AHB1SMENR_TSCSMEN_Msk
+
+/********************  Bit definition for RCC_AHB2SMENR register  ***************/
+#define RCC_AHB2SMENR_GPIOASMEN_Pos         (0U)
+#define RCC_AHB2SMENR_GPIOASMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOASMEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB2SMENR_GPIOASMEN             RCC_AHB2SMENR_GPIOASMEN_Msk
+#define RCC_AHB2SMENR_GPIOBSMEN_Pos         (1U)
+#define RCC_AHB2SMENR_GPIOBSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOBSMEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB2SMENR_GPIOBSMEN             RCC_AHB2SMENR_GPIOBSMEN_Msk
+#define RCC_AHB2SMENR_GPIOCSMEN_Pos         (2U)
+#define RCC_AHB2SMENR_GPIOCSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOCSMEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB2SMENR_GPIOCSMEN             RCC_AHB2SMENR_GPIOCSMEN_Msk
+#define RCC_AHB2SMENR_GPIOESMEN_Pos         (4U)
+#define RCC_AHB2SMENR_GPIOESMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOESMEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB2SMENR_GPIOESMEN             RCC_AHB2SMENR_GPIOESMEN_Msk
+#define RCC_AHB2SMENR_GPIOHSMEN_Pos         (7U)
+#define RCC_AHB2SMENR_GPIOHSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOHSMEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2SMENR_GPIOHSMEN             RCC_AHB2SMENR_GPIOHSMEN_Msk
+
+/********************  Bit definition for RCC_AHB3SMENR register  ***************/
+#define RCC_AHB3SMENR_PKASMEN_Pos           (16U)
+#define RCC_AHB3SMENR_PKASMEN_Msk           (0x1UL << RCC_AHB3SMENR_PKASMEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB3SMENR_PKASMEN               RCC_AHB3SMENR_PKASMEN_Msk
+#define RCC_AHB3SMENR_AES2SMEN_Pos          (17U)
+#define RCC_AHB3SMENR_AES2SMEN_Msk          (0x1UL << RCC_AHB3SMENR_AES2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_AHB3SMENR_AES2SMEN              RCC_AHB3SMENR_AES2SMEN_Msk
+#define RCC_AHB3SMENR_RNGSMEN_Pos           (18U)
+#define RCC_AHB3SMENR_RNGSMEN_Msk           (0x1UL << RCC_AHB3SMENR_RNGSMEN_Pos) /*!< 0x00040000 */
+#define RCC_AHB3SMENR_RNGSMEN                RCC_AHB3SMENR_RNGSMEN_Msk
+#define RCC_AHB3SMENR_SRAM2SMEN_Pos         (24U)
+#define RCC_AHB3SMENR_SRAM2SMEN_Msk         (0x1UL << RCC_AHB3SMENR_SRAM2SMEN_Pos) /*!< 0x01000000 */
+#define RCC_AHB3SMENR_SRAM2SMEN             RCC_AHB3SMENR_SRAM2SMEN_Msk
+#define RCC_AHB3SMENR_FLASHSMEN_Pos         (25U)
+#define RCC_AHB3SMENR_FLASHSMEN_Msk         (0x1UL << RCC_AHB3SMENR_FLASHSMEN_Pos) /*!< 0x02000000 */
+#define RCC_AHB3SMENR_FLASHSMEN             RCC_AHB3SMENR_FLASHSMEN_Msk
+
+/********************  Bit definition for RCC_APB1SMENR1 register  **************/
+#define RCC_APB1SMENR1_TIM2SMEN_Pos         (0U)
+#define RCC_APB1SMENR1_TIM2SMEN_Msk         (0x1UL << RCC_APB1SMENR1_TIM2SMEN_Pos) /*!< 0x00000001 */
+#define RCC_APB1SMENR1_TIM2SMEN             RCC_APB1SMENR1_TIM2SMEN_Msk
+#define RCC_APB1SMENR1_RTCAPBSMEN_Pos       (10U)
+#define RCC_APB1SMENR1_RTCAPBSMEN_Msk       (0x1UL << RCC_APB1SMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_APB1SMENR1_RTCAPBSMEN           RCC_APB1SMENR1_RTCAPBSMEN_Msk
+#define RCC_APB1SMENR1_WWDGSMEN_Pos         (11U)
+#define RCC_APB1SMENR1_WWDGSMEN_Msk         (0x1UL << RCC_APB1SMENR1_WWDGSMEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1SMENR1_WWDGSMEN             RCC_APB1SMENR1_WWDGSMEN_Msk
+#define RCC_APB1SMENR1_I2C1SMEN_Pos         (21U)
+#define RCC_APB1SMENR1_I2C1SMEN_Msk         (0x1UL << RCC_APB1SMENR1_I2C1SMEN_Pos) /*!< 0x00200000 */
+#define RCC_APB1SMENR1_I2C1SMEN             RCC_APB1SMENR1_I2C1SMEN_Msk
+#define RCC_APB1SMENR1_LPTIM1SMEN_Pos       (31U)
+#define RCC_APB1SMENR1_LPTIM1SMEN_Msk       (0x1UL << RCC_APB1SMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_APB1SMENR1_LPTIM1SMEN           RCC_APB1SMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_APB1SMENR2 register  **************/
+#define RCC_APB1SMENR2_LPUART1SMEN_Pos      (0U)
+#define RCC_APB1SMENR2_LPUART1SMEN_Msk      (0x1UL << RCC_APB1SMENR2_LPUART1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_APB1SMENR2_LPUART1SMEN          RCC_APB1SMENR2_LPUART1SMEN_Msk
+#define RCC_APB1SMENR2_LPTIM2SMEN_Pos       (5U)
+#define RCC_APB1SMENR2_LPTIM2SMEN_Msk       (0x1UL << RCC_APB1SMENR2_LPTIM2SMEN_Pos) /*!< 0x00000020 */
+#define RCC_APB1SMENR2_LPTIM2SMEN           RCC_APB1SMENR2_LPTIM2SMEN_Msk
+
+/********************  Bit definition for RCC_APB2SMENR register  **************/
+#define RCC_APB2SMENR_ADCSMEN_Pos           (9U)
+#define RCC_APB2SMENR_ADCSMEN_Msk           (0x1UL << RCC_APB2SMENR_ADCSMEN_Pos)    /*!< 0x00000200 */
+#define RCC_APB2SMENR_ADCSMEN               RCC_APB2SMENR_ADCSMEN_Msk
+#define RCC_APB2SMENR_TIM1SMEN_Pos          (11U)
+#define RCC_APB2SMENR_TIM1SMEN_Msk          (0x1UL << RCC_APB2SMENR_TIM1SMEN_Pos)   /*!< 0x00000800 */
+#define RCC_APB2SMENR_TIM1SMEN              RCC_APB2SMENR_TIM1SMEN_Msk
+#define RCC_APB2SMENR_SPI1SMEN_Pos          (12U)
+#define RCC_APB2SMENR_SPI1SMEN_Msk          (0x1UL << RCC_APB2SMENR_SPI1SMEN_Pos)   /*!< 0x00001000 */
+#define RCC_APB2SMENR_SPI1SMEN              RCC_APB2SMENR_SPI1SMEN_Msk
+#define RCC_APB2SMENR_USART1SMEN_Pos        (14U)
+#define RCC_APB2SMENR_USART1SMEN_Msk        (0x1UL << RCC_APB2SMENR_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_APB2SMENR_USART1SMEN            RCC_APB2SMENR_USART1SMEN_Msk
+
+/********************  Bit definition for RCC_CCIPR register  ******************/
+#define RCC_CCIPR_USART1SEL_Pos             (0U)
+#define RCC_CCIPR_USART1SEL_Msk             (0x3UL << RCC_CCIPR_USART1SEL_Pos) /*!< 0x00000003 */
+#define RCC_CCIPR_USART1SEL                 RCC_CCIPR_USART1SEL_Msk
+#define RCC_CCIPR_USART1SEL_0               (0x1U << RCC_CCIPR_USART1SEL_Pos)  /*!< 0x00000001 */
+#define RCC_CCIPR_USART1SEL_1               (0x2U << RCC_CCIPR_USART1SEL_Pos)  /*!< 0x00000002 */
+
+#define RCC_CCIPR_LPUART1SEL_Pos            (10U)
+#define RCC_CCIPR_LPUART1SEL_Msk            (0x3UL << RCC_CCIPR_LPUART1SEL_Pos) /*!< 0x00000C00 */
+#define RCC_CCIPR_LPUART1SEL                RCC_CCIPR_LPUART1SEL_Msk
+#define RCC_CCIPR_LPUART1SEL_0              (0x1U << RCC_CCIPR_LPUART1SEL_Pos)  /*!< 0x00000400 */
+#define RCC_CCIPR_LPUART1SEL_1              (0x2U << RCC_CCIPR_LPUART1SEL_Pos)  /*!< 0x00000800 */
+
+#define RCC_CCIPR_I2C1SEL_Pos               (12U)
+#define RCC_CCIPR_I2C1SEL_Msk               (0x3UL << RCC_CCIPR_I2C1SEL_Pos)   /*!< 0x00003000 */
+#define RCC_CCIPR_I2C1SEL                   RCC_CCIPR_I2C1SEL_Msk
+#define RCC_CCIPR_I2C1SEL_0                 (0x1U << RCC_CCIPR_I2C1SEL_Pos)    /*!< 0x00001000 */
+#define RCC_CCIPR_I2C1SEL_1                 (0x2U << RCC_CCIPR_I2C1SEL_Pos)    /*!< 0x00002000 */
+
+#define RCC_CCIPR_LPTIM1SEL_Pos             (18U)
+#define RCC_CCIPR_LPTIM1SEL_Msk             (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos) /*!< 0x000C0000 */
+#define RCC_CCIPR_LPTIM1SEL                 RCC_CCIPR_LPTIM1SEL_Msk
+#define RCC_CCIPR_LPTIM1SEL_0               (0x1U << RCC_CCIPR_LPTIM1SEL_Pos)  /*!< 0x00040000 */
+#define RCC_CCIPR_LPTIM1SEL_1               (0x2U << RCC_CCIPR_LPTIM1SEL_Pos)  /*!< 0x00080000 */
+
+#define RCC_CCIPR_LPTIM2SEL_Pos             (20U)
+#define RCC_CCIPR_LPTIM2SEL_Msk             (0x3UL << RCC_CCIPR_LPTIM2SEL_Pos) /*!< 0x00300000 */
+#define RCC_CCIPR_LPTIM2SEL                 RCC_CCIPR_LPTIM2SEL_Msk
+#define RCC_CCIPR_LPTIM2SEL_0               (0x1U << RCC_CCIPR_LPTIM2SEL_Pos)  /*!< 0x00100000 */
+#define RCC_CCIPR_LPTIM2SEL_1               (0x2U << RCC_CCIPR_LPTIM2SEL_Pos)  /*!< 0x00200000 */
+
+#define RCC_CCIPR_CLK48SEL_Pos              (26U)
+#define RCC_CCIPR_CLK48SEL_Msk              (0x3UL << RCC_CCIPR_CLK48SEL_Pos)  /*!< 0x0C000000 */
+#define RCC_CCIPR_CLK48SEL                  RCC_CCIPR_CLK48SEL_Msk
+#define RCC_CCIPR_CLK48SEL_0                (0x1U << RCC_CCIPR_CLK48SEL_Pos)   /*!< 0x04000000 */
+#define RCC_CCIPR_CLK48SEL_1                (0x2U << RCC_CCIPR_CLK48SEL_Pos)   /*!< 0x08000000 */
+
+#define RCC_CCIPR_ADCSEL_Pos                (28U)
+#define RCC_CCIPR_ADCSEL_Msk                (0x3UL << RCC_CCIPR_ADCSEL_Pos)    /*!< 0x30000000 */
+#define RCC_CCIPR_ADCSEL                    RCC_CCIPR_ADCSEL_Msk
+#define RCC_CCIPR_ADCSEL_0                  (0x1U << RCC_CCIPR_ADCSEL_Pos)     /*!< 0x10000000 */
+#define RCC_CCIPR_ADCSEL_1                  (0x2U << RCC_CCIPR_ADCSEL_Pos)     /*!< 0x20000000 */
+
+#define RCC_CCIPR_RNGSEL_Pos                (30U)
+#define RCC_CCIPR_RNGSEL_Msk                (0x3UL << RCC_CCIPR_RNGSEL_Pos)    /*!< 0xC0000000 */
+#define RCC_CCIPR_RNGSEL                    RCC_CCIPR_RNGSEL_Msk
+#define RCC_CCIPR_RNGSEL_0                  (0x1U << RCC_CCIPR_RNGSEL_Pos)     /*!< 0x40000000 */
+#define RCC_CCIPR_RNGSEL_1                  (0x2U << RCC_CCIPR_RNGSEL_Pos)     /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos                  (0U)
+#define RCC_BDCR_LSEON_Msk                  (0x1UL << RCC_BDCR_LSEON_Pos)      /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                      RCC_BDCR_LSEON_Msk
+#define RCC_BDCR_LSERDY_Pos                 (1U)
+#define RCC_BDCR_LSERDY_Msk                 (0x1UL << RCC_BDCR_LSERDY_Pos)     /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                     RCC_BDCR_LSERDY_Msk
+#define RCC_BDCR_LSEBYP_Pos                 (2U)
+#define RCC_BDCR_LSEBYP_Msk                 (0x1UL << RCC_BDCR_LSEBYP_Pos)     /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                     RCC_BDCR_LSEBYP_Msk
+
+#define RCC_BDCR_LSEDRV_Pos                 (3U)
+#define RCC_BDCR_LSEDRV_Msk                 (0x3UL << RCC_BDCR_LSEDRV_Pos)     /*!< 0x00000018 */
+#define RCC_BDCR_LSEDRV                     RCC_BDCR_LSEDRV_Msk
+#define RCC_BDCR_LSEDRV_0                   (0x1U << RCC_BDCR_LSEDRV_Pos)      /*!< 0x00000008 */
+#define RCC_BDCR_LSEDRV_1                   (0x2U << RCC_BDCR_LSEDRV_Pos)      /*!< 0x00000010 */
+
+#define RCC_BDCR_LSECSSON_Pos               (5U)
+#define RCC_BDCR_LSECSSON_Msk               (0x1UL << RCC_BDCR_LSECSSON_Pos)   /*!< 0x00000020 */
+#define RCC_BDCR_LSECSSON                   RCC_BDCR_LSECSSON_Msk
+#define RCC_BDCR_LSECSSD_Pos                (6U)
+#define RCC_BDCR_LSECSSD_Msk                (0x1UL << RCC_BDCR_LSECSSD_Pos)    /*!< 0x00000040 */
+#define RCC_BDCR_LSECSSD                    RCC_BDCR_LSECSSD_Msk
+
+#define RCC_BDCR_RTCSEL_Pos                 (8U)
+#define RCC_BDCR_RTCSEL_Msk                 (0x3UL << RCC_BDCR_RTCSEL_Pos)     /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                     RCC_BDCR_RTCSEL_Msk
+#define RCC_BDCR_RTCSEL_0                   (0x1U << RCC_BDCR_RTCSEL_Pos)      /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                   (0x2U << RCC_BDCR_RTCSEL_Pos)      /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos                  (15U)
+#define RCC_BDCR_RTCEN_Msk                  (0x1UL << RCC_BDCR_RTCEN_Pos)      /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                      RCC_BDCR_RTCEN_Msk
+
+#define RCC_BDCR_BDRST_Pos                  (16U)
+#define RCC_BDCR_BDRST_Msk                  (0x1UL << RCC_BDCR_BDRST_Pos)      /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                      RCC_BDCR_BDRST_Msk
+
+#define RCC_BDCR_LSCOEN_Pos                 (24U)
+#define RCC_BDCR_LSCOEN_Msk                 (0x1UL << RCC_BDCR_LSCOEN_Pos)     /*!< 0x01000000 */
+#define RCC_BDCR_LSCOEN                     RCC_BDCR_LSCOEN_Msk
+#define RCC_BDCR_LSCOSEL_Pos                (25U)
+#define RCC_BDCR_LSCOSEL_Msk                (0x1UL << RCC_BDCR_LSCOSEL_Pos)    /*!< 0x02000000 */
+#define RCC_BDCR_LSCOSEL                    RCC_BDCR_LSCOSEL_Msk
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSI1ON_Pos                  (0U)
+#define RCC_CSR_LSI1ON_Msk                  (0x1UL << RCC_CSR_LSI1ON_Pos)      /*!< 0x00000001 */
+#define RCC_CSR_LSI1ON                      RCC_CSR_LSI1ON_Msk
+#define RCC_CSR_LSI1RDY_Pos                 (1U)
+#define RCC_CSR_LSI1RDY_Msk                 (0x1UL << RCC_CSR_LSI1RDY_Pos)     /*!< 0x00000002 */
+#define RCC_CSR_LSI1RDY                     RCC_CSR_LSI1RDY_Msk
+#define RCC_CSR_LSI2ON_Pos                  (2U)
+#define RCC_CSR_LSI2ON_Msk                  (0x1UL << RCC_CSR_LSI2ON_Pos)      /*!< 0x00000004 */
+#define RCC_CSR_LSI2ON                      RCC_CSR_LSI2ON_Msk
+#define RCC_CSR_LSI2RDY_Pos                 (3U)
+#define RCC_CSR_LSI2RDY_Msk                 (0x1UL << RCC_CSR_LSI2RDY_Pos)     /*!< 0x00000008 */
+#define RCC_CSR_LSI2RDY                     RCC_CSR_LSI2RDY_Msk
+#define RCC_CSR_LSI2TRIM_Pos                (8U)
+#define RCC_CSR_LSI2TRIM_Msk                (0xFUL << RCC_CSR_LSI2TRIM_Pos)      /*!< 0x00000F00 */
+#define RCC_CSR_LSI2TRIM                    RCC_CSR_LSI2TRIM_Msk
+#define RCC_CSR_LSI2TRIM_0                  (0x1U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000100 */
+#define RCC_CSR_LSI2TRIM_1                  (0x2U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000200 */
+#define RCC_CSR_LSI2TRIM_2                  (0x4U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000400 */
+#define RCC_CSR_LSI2TRIM_3                  (0x8U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000800 */
+#define RCC_CSR_RFWKPSEL_Pos                (14U)
+#define RCC_CSR_RFWKPSEL_Msk                (0x3UL << RCC_CSR_RFWKPSEL_Pos)    /*!< 0x0000C000 */
+#define RCC_CSR_RFWKPSEL                    RCC_CSR_RFWKPSEL_Msk
+#define RCC_CSR_RFWKPSEL_0                  (0x1U << RCC_CSR_RFWKPSEL_Pos)     /*!< 0x00004000 */
+#define RCC_CSR_RFWKPSEL_1                  (0x2U << RCC_CSR_RFWKPSEL_Pos)     /*!< 0x00008000 */
+#define RCC_CSR_RFRSTS_Pos                  (16U)
+#define RCC_CSR_RFRSTS_Msk                  (0x1UL << RCC_CSR_RFRSTS_Pos)      /*!< 0x00010000 */
+#define RCC_CSR_RFRSTS                      RCC_CSR_RFRSTS_Msk
+#define RCC_CSR_RMVF_Pos                    (23U)
+#define RCC_CSR_RMVF_Msk                    (0x1UL << RCC_CSR_RMVF_Pos)        /*!< 0x00800000 */
+#define RCC_CSR_RMVF                        RCC_CSR_RMVF_Msk
+#define RCC_CSR_OBLRSTF_Pos                 (25U)
+#define RCC_CSR_OBLRSTF_Msk                 (0x1UL << RCC_CSR_OBLRSTF_Pos)     /*!< 0x02000000 */
+#define RCC_CSR_OBLRSTF                     RCC_CSR_OBLRSTF_Msk
+#define RCC_CSR_PINRSTF_Pos                 (26U)
+#define RCC_CSR_PINRSTF_Msk                 (0x1UL << RCC_CSR_PINRSTF_Pos)     /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                     RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_BORRSTF_Pos                 (27U)
+#define RCC_CSR_BORRSTF_Msk                 (0x1UL << RCC_CSR_BORRSTF_Pos)     /*!< 0x08000000 */
+#define RCC_CSR_BORRSTF                     RCC_CSR_BORRSTF_Msk
+#define RCC_CSR_SFTRSTF_Pos                 (28U)
+#define RCC_CSR_SFTRSTF_Msk                 (0x1UL << RCC_CSR_SFTRSTF_Pos)     /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                     RCC_CSR_SFTRSTF_Msk
+#define RCC_CSR_IWDGRSTF_Pos                (29U)
+#define RCC_CSR_IWDGRSTF_Msk                (0x1UL << RCC_CSR_IWDGRSTF_Pos)     /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                    RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos                (30U)
+#define RCC_CSR_WWDGRSTF_Msk                (0x1UL << RCC_CSR_WWDGRSTF_Pos)    /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                    RCC_CSR_WWDGRSTF_Msk
+#define RCC_CSR_LPWRRSTF_Pos                (31U)
+#define RCC_CSR_LPWRRSTF_Msk                (0x1UL << RCC_CSR_LPWRRSTF_Pos)    /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                    RCC_CSR_LPWRRSTF_Msk
+
+/********************  Bit definition for RCC_HSECR register  *******************/
+#define RCC_HSECR_UNLOCKED_Pos              (0U)
+#define RCC_HSECR_UNLOCKED_Msk              (0x1UL << RCC_HSECR_UNLOCKED_Pos)  /*!< 0x00000001 */
+#define RCC_HSECR_UNLOCKED                  RCC_HSECR_UNLOCKED_Msk
+
+#define RCC_HSECR_HSES_Pos                  (3U)
+#define RCC_HSECR_HSES_Msk                  (0x1UL << RCC_HSECR_HSES_Pos)      /*!< 0x00000008 */
+#define RCC_HSECR_HSES                      RCC_HSECR_HSES_Msk
+
+#define RCC_HSECR_HSEGMC_Pos                (4U)
+#define RCC_HSECR_HSEGMC_Msk                (0x7UL << RCC_HSECR_HSEGMC_Pos)       /*!< 0x00000070 */
+#define RCC_HSECR_HSEGMC                    RCC_HSECR_HSEGMC_Msk
+#define RCC_HSECR_HSEGMC0_Pos               (4U)
+#define RCC_HSECR_HSEGMC0_Msk               (0x1UL << RCC_HSECR_HSEGMC0_Pos)      /*!< 0x00000010 */
+#define RCC_HSECR_HSEGMC0                   RCC_HSECR_HSEGMC0_Msk
+#define RCC_HSECR_HSEGMC1_Pos               (5U)
+#define RCC_HSECR_HSEGMC1_Msk               (0x1UL << RCC_HSECR_HSEGMC1_Pos)      /*!< 0x00000020 */
+#define RCC_HSECR_HSEGMC1                   RCC_HSECR_HSEGMC1_Msk
+#define RCC_HSECR_HSEGMC2_Pos               (6U)
+#define RCC_HSECR_HSEGMC2_Msk               (0x1UL << RCC_HSECR_HSEGMC2_Pos)      /*!< 0x00000040 */
+#define RCC_HSECR_HSEGMC2                   RCC_HSECR_HSEGMC2_Msk
+
+#define RCC_HSECR_HSETUNE_Pos              (8U)
+#define RCC_HSECR_HSETUNE_Msk              (0x3FUL << RCC_HSECR_HSETUNE_Pos)   /*!< 0x00003F00 */
+#define RCC_HSECR_HSETUNE                  RCC_HSECR_HSETUNE_Msk
+#define RCC_HSECR_HSETUNE0_Pos             (8U)
+#define RCC_HSECR_HSETUNE0_Msk             (0x1UL << RCC_HSECR_HSETUNE0_Pos)   /*!< 0x00000100 */
+#define RCC_HSECR_HSETUNE0                 RCC_HSECR_HSETUNE0_Msk
+#define RCC_HSECR_HSETUNE1_Pos             (9U)
+#define RCC_HSECR_HSETUNE1_Msk             (0x1UL << RCC_HSECR_HSETUNE1_Pos)   /*!< 0x00000200 */
+#define RCC_HSECR_HSETUNE1                 RCC_HSECR_HSETUNE1_Msk
+#define RCC_HSECR_HSETUNE2_Pos             (10U)
+#define RCC_HSECR_HSETUNE2_Msk             (0x1UL << RCC_HSECR_HSETUNE2_Pos)   /*!< 0x00000400 */
+#define RCC_HSECR_HSETUNE2                 RCC_HSECR_HSETUNE2_Msk
+#define RCC_HSECR_HSETUNE3_Pos             (11U)
+#define RCC_HSECR_HSETUNE3_Msk             (0x1UL << RCC_HSECR_HSETUNE3_Pos)   /*!< 0x00000800 */
+#define RCC_HSECR_HSETUNE3                 RCC_HSECR_HSETUNE3_Msk
+#define RCC_HSECR_HSETUNE4_Pos             (12U)
+#define RCC_HSECR_HSETUNE4_Msk             (0x1UL << RCC_HSECR_HSETUNE4_Pos)   /*!< 0x00001000 */
+#define RCC_HSECR_HSETUNE4                 RCC_HSECR_HSETUNE4_Msk
+#define RCC_HSECR_HSETUNE5_Pos             (13U)
+#define RCC_HSECR_HSETUNE5_Msk             (0x1UL << RCC_HSECR_HSETUNE5_Pos)   /*!< 0x00002000 */
+#define RCC_HSECR_HSETUNE5                 RCC_HSECR_HSETUNE5_Msk
+
+/********************  Bit definition for RCC_EXTCFGR register  *******************/
+#define RCC_EXTCFGR_SHDHPRE_Pos             (0U)
+#define RCC_EXTCFGR_SHDHPRE_Msk             (0xFUL << RCC_EXTCFGR_SHDHPRE_Pos) /*!< 0x0000000F */
+#define RCC_EXTCFGR_SHDHPRE                 RCC_EXTCFGR_SHDHPRE_Msk
+#define RCC_EXTCFGR_SHDHPRE_0               (0x1U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000001 */
+#define RCC_EXTCFGR_SHDHPRE_1               (0x2U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000002 */
+#define RCC_EXTCFGR_SHDHPRE_2               (0x4U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000004 */
+#define RCC_EXTCFGR_SHDHPRE_3               (0x8U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000008 */
+
+#define RCC_EXTCFGR_C2HPRE_Pos              (4U)
+#define RCC_EXTCFGR_C2HPRE_Msk              (0xFUL << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x000000F0 */
+#define RCC_EXTCFGR_C2HPRE                  RCC_EXTCFGR_C2HPRE_Msk
+#define RCC_EXTCFGR_C2HPRE_0                (0x1U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000010 */
+#define RCC_EXTCFGR_C2HPRE_1                (0x2U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000020 */
+#define RCC_EXTCFGR_C2HPRE_2                (0x4U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000040 */
+#define RCC_EXTCFGR_C2HPRE_3                (0x8U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000080 */
+
+#define RCC_EXTCFGR_SHDHPREF_Pos            (16U)
+#define RCC_EXTCFGR_SHDHPREF_Msk            (0x1UL << RCC_EXTCFGR_SHDHPREF_Pos) /*!< 0x00010000 */
+#define RCC_EXTCFGR_SHDHPREF                RCC_EXTCFGR_SHDHPREF_Msk
+#define RCC_EXTCFGR_C2HPREF_Pos             (17U)
+#define RCC_EXTCFGR_C2HPREF_Msk             (0x1UL << RCC_EXTCFGR_C2HPREF_Pos) /*!< 0x00020000 */
+#define RCC_EXTCFGR_C2HPREF                 RCC_EXTCFGR_C2HPREF_Msk
+#define RCC_EXTCFGR_RFCSS_Pos               (20U)
+#define RCC_EXTCFGR_RFCSS_Msk               (0x1UL << RCC_EXTCFGR_RFCSS_Pos)   /*!< 0x00100000 */
+#define RCC_EXTCFGR_RFCSS                   RCC_EXTCFGR_RFCSS_Msk
+
+/********************  Bit definition for RCC_C2AHB1ENR register  ****************/
+#define RCC_C2AHB1ENR_DMA1EN_Pos            (0U)
+#define RCC_C2AHB1ENR_DMA1EN_Msk            (0x1UL << RCC_C2AHB1ENR_DMA1EN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB1ENR_DMA1EN                RCC_C2AHB1ENR_DMA1EN_Msk
+#define RCC_C2AHB1ENR_DMAMUX1EN_Pos         (2U)
+#define RCC_C2AHB1ENR_DMAMUX1EN_Msk         (0x1UL << RCC_C2AHB1ENR_DMAMUX1EN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB1ENR_DMAMUX1EN             RCC_C2AHB1ENR_DMAMUX1EN_Msk
+#define RCC_C2AHB1ENR_SRAM1EN_Pos           (9U)
+#define RCC_C2AHB1ENR_SRAM1EN_Msk           (0x1UL << RCC_C2AHB1ENR_SRAM1EN_Pos) /*!< 0x00000200 */
+#define RCC_C2AHB1ENR_SRAM1EN                RCC_C2AHB1ENR_SRAM1EN_Msk
+#define RCC_C2AHB1ENR_CRCEN_Pos             (12U)
+#define RCC_C2AHB1ENR_CRCEN_Msk             (0x1UL << RCC_C2AHB1ENR_CRCEN_Pos) /*!< 0x00001000 */
+#define RCC_C2AHB1ENR_CRCEN                  RCC_C2AHB1ENR_CRCEN_Msk
+#define RCC_C2AHB1ENR_TSCEN_Pos             (16U)
+#define RCC_C2AHB1ENR_TSCEN_Msk             (0x1UL << RCC_C2AHB1ENR_TSCEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB1ENR_TSCEN                 RCC_C2AHB1ENR_TSCEN_Msk
+
+/********************  Bit definition for RCC_C2AHB2ENR register  ***************/
+#define RCC_C2AHB2ENR_GPIOAEN_Pos          (0U)
+#define RCC_C2AHB2ENR_GPIOAEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOAEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB2ENR_GPIOAEN              RCC_C2AHB2ENR_GPIOAEN_Msk
+#define RCC_C2AHB2ENR_GPIOBEN_Pos          (1U)
+#define RCC_C2AHB2ENR_GPIOBEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOBEN_Pos) /*!< 0x00000002 */
+#define RCC_C2AHB2ENR_GPIOBEN              RCC_C2AHB2ENR_GPIOBEN_Msk
+#define RCC_C2AHB2ENR_GPIOCEN_Pos          (2U)
+#define RCC_C2AHB2ENR_GPIOCEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOCEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB2ENR_GPIOCEN              RCC_C2AHB2ENR_GPIOCEN_Msk
+#define RCC_C2AHB2ENR_GPIOEEN_Pos          (4U)
+#define RCC_C2AHB2ENR_GPIOEEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOEEN_Pos) /*!< 0x00000010 */
+#define RCC_C2AHB2ENR_GPIOEEN              RCC_C2AHB2ENR_GPIOEEN_Msk
+#define RCC_C2AHB2ENR_GPIOHEN_Pos          (7U)
+#define RCC_C2AHB2ENR_GPIOHEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOHEN_Pos) /*!< 0x00000080 */
+#define RCC_C2AHB2ENR_GPIOHEN              RCC_C2AHB2ENR_GPIOHEN_Msk
+
+/********************  Bit definition for RCC_C2AHB3ENR register  ***************/
+#define RCC_C2AHB3ENR_PKAEN_Pos            (16U)
+#define RCC_C2AHB3ENR_PKAEN_Msk            (0x1UL << RCC_C2AHB3ENR_PKAEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB3ENR_PKAEN                RCC_C2AHB3ENR_PKAEN_Msk
+#define RCC_C2AHB3ENR_AES2EN_Pos           (17U)
+#define RCC_C2AHB3ENR_AES2EN_Msk           (0x1UL << RCC_C2AHB3ENR_AES2EN_Pos) /*!< 0x00020000 */
+#define RCC_C2AHB3ENR_AES2EN               RCC_C2AHB3ENR_AES2EN_Msk
+#define RCC_C2AHB3ENR_RNGEN_Pos            (18U)
+#define RCC_C2AHB3ENR_RNGEN_Msk            (0x1UL << RCC_C2AHB3ENR_RNGEN_Pos) /*!< 0x00040000 */
+#define RCC_C2AHB3ENR_RNGEN                RCC_C2AHB3ENR_RNGEN_Msk
+#define RCC_C2AHB3ENR_HSEMEN_Pos           (19U)
+#define RCC_C2AHB3ENR_HSEMEN_Msk           (0x1UL << RCC_C2AHB3ENR_HSEMEN_Pos) /*!< 0x00080000 */
+#define RCC_C2AHB3ENR_HSEMEN               RCC_C2AHB3ENR_HSEMEN_Msk
+#define RCC_C2AHB3ENR_IPCCEN_Pos           (20U)
+#define RCC_C2AHB3ENR_IPCCEN_Msk           (0x1UL << RCC_C2AHB3ENR_IPCCEN_Pos) /*!< 0x00100000 */
+#define RCC_C2AHB3ENR_IPCCEN               RCC_C2AHB3ENR_IPCCEN_Msk
+#define RCC_C2AHB3ENR_FLASHEN_Pos          (25U)
+#define RCC_C2AHB3ENR_FLASHEN_Msk          (0x1UL << RCC_C2AHB3ENR_FLASHEN_Pos) /*!< 0x02000000 */
+#define RCC_C2AHB3ENR_FLASHEN              RCC_C2AHB3ENR_FLASHEN_Msk
+
+/********************  Bit definition for RCC_C2APB1ENR1 register  **************/
+#define RCC_C2APB1ENR1_TIM2EN_Pos          (0U)
+#define RCC_C2APB1ENR1_TIM2EN_Msk          (0x1UL << RCC_C2APB1ENR1_TIM2EN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1ENR1_TIM2EN              RCC_C2APB1ENR1_TIM2EN_Msk
+#define RCC_C2APB1ENR1_RTCAPBEN_Pos        (10U)
+#define RCC_C2APB1ENR1_RTCAPBEN_Msk        (0x1UL << RCC_C2APB1ENR1_RTCAPBEN_Pos) /*!< 0x00000400 */
+#define RCC_C2APB1ENR1_RTCAPBEN            RCC_C2APB1ENR1_RTCAPBEN_Msk
+#define RCC_C2APB1ENR1_I2C1EN_Pos          (21U)
+#define RCC_C2APB1ENR1_I2C1EN_Msk          (0x1UL << RCC_C2APB1ENR1_I2C1EN_Pos) /*!< 0x00200000 */
+#define RCC_C2APB1ENR1_I2C1EN              RCC_C2APB1ENR1_I2C1EN_Msk
+#define RCC_C2APB1ENR1_LPTIM1EN_Pos        (31U)
+#define RCC_C2APB1ENR1_LPTIM1EN_Msk        (0x1UL << RCC_C2APB1ENR1_LPTIM1EN_Pos) /*!< 0x80000000 */
+#define RCC_C2APB1ENR1_LPTIM1EN            RCC_C2APB1ENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_C2APB1ENR2 register  **************/
+#define RCC_C2APB1ENR2_LPUART1EN_Pos       (0U)
+#define RCC_C2APB1ENR2_LPUART1EN_Msk       (0x1UL << RCC_C2APB1ENR2_LPUART1EN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1ENR2_LPUART1EN           RCC_C2APB1ENR2_LPUART1EN_Msk
+#define RCC_C2APB1ENR2_LPTIM2EN_Pos        (5U)
+#define RCC_C2APB1ENR2_LPTIM2EN_Msk        (0x1UL << RCC_C2APB1ENR2_LPTIM2EN_Pos) /*!< 0x00000020 */
+#define RCC_C2APB1ENR2_LPTIM2EN            RCC_C2APB1ENR2_LPTIM2EN_Msk
+
+/********************  Bit definition for RCC_C2APB2ENR register  **************/
+#define RCC_C2APB2ENR_ADCEN_Pos            (9U)
+#define RCC_C2APB2ENR_ADCEN_Msk            (0x1UL << RCC_C2APB2ENR_ADCEN_Pos)    /*!< 0x00000200 */
+#define RCC_C2APB2ENR_ADCEN                RCC_C2APB2ENR_ADCEN_Msk
+#define RCC_C2APB2ENR_TIM1EN_Pos           (11U)
+#define RCC_C2APB2ENR_TIM1EN_Msk           (0x1UL << RCC_C2APB2ENR_TIM1EN_Pos)   /*!< 0x00000800 */
+#define RCC_C2APB2ENR_TIM1EN               RCC_C2APB2ENR_TIM1EN_Msk
+#define RCC_C2APB2ENR_SPI1EN_Pos           (12U)
+#define RCC_C2APB2ENR_SPI1EN_Msk           (0x1UL << RCC_C2APB2ENR_SPI1EN_Pos)   /*!< 0x00001000 */
+#define RCC_C2APB2ENR_SPI1EN               RCC_C2APB2ENR_SPI1EN_Msk
+#define RCC_C2APB2ENR_USART1EN_Pos         (14U)
+#define RCC_C2APB2ENR_USART1EN_Msk         (0x1UL << RCC_C2APB2ENR_USART1EN_Pos) /*!< 0x00004000 */
+#define RCC_C2APB2ENR_USART1EN             RCC_C2APB2ENR_USART1EN_Msk
+
+/********************  Bit definition for RCC_C2APB3ENR register  **************/
+#define RCC_C2APB3ENR_BLEEN_Pos            (0U)
+#define RCC_C2APB3ENR_BLEEN_Msk            (0x1UL << RCC_C2APB3ENR_BLEEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB3ENR_BLEEN                RCC_C2APB3ENR_BLEEN_Msk
+
+/********************  Bit definition for RCC_C2AHB1SMENR register  ****************/
+#define RCC_C2AHB1SMENR_DMA1SMEN_Pos       (0U)
+#define RCC_C2AHB1SMENR_DMA1SMEN_Msk       (0x1UL << RCC_C2AHB1SMENR_DMA1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB1SMENR_DMA1SMEN           RCC_C2AHB1SMENR_DMA1SMEN_Msk
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN_Pos    (2U)
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN_Msk    (0x1UL << RCC_C2AHB1SMENR_DMAMUX1SMEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN        RCC_C2AHB1SMENR_DMAMUX1SMEN_Msk
+#define RCC_C2AHB1SMENR_SRAM1SMEN_Pos      (9U)
+#define RCC_C2AHB1SMENR_SRAM1SMEN_Msk      (0x1UL << RCC_C2AHB1SMENR_SRAM1SMEN_Pos) /*!< 0x00000200 */
+#define RCC_C2AHB1SMENR_SRAM1SMEN          RCC_C2AHB1SMENR_SRAM1SMEN_Msk
+#define RCC_C2AHB1SMENR_CRCSMEN_Pos        (12U)
+#define RCC_C2AHB1SMENR_CRCSMEN_Msk        (0x1UL << RCC_C2AHB1SMENR_CRCSMEN_Pos) /*!< 0x00001000 */
+#define RCC_C2AHB1SMENR_CRCSMEN            RCC_C2AHB1SMENR_CRCSMEN_Msk
+#define RCC_C2AHB1SMENR_TSCSMEN_Pos        (16U)
+#define RCC_C2AHB1SMENR_TSCSMEN_Msk        (0x1UL << RCC_C2AHB1SMENR_TSCSMEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB1SMENR_TSCSMEN            RCC_C2AHB1SMENR_TSCSMEN_Msk
+
+/********************  Bit definition for RCC_C2AHB2SMENR register  ***************/
+#define RCC_C2AHB2SMENR_GPIOASMEN_Pos      (0U)
+#define RCC_C2AHB2SMENR_GPIOASMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOASMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB2SMENR_GPIOASMEN          RCC_C2AHB2SMENR_GPIOASMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOBSMEN_Pos      (1U)
+#define RCC_C2AHB2SMENR_GPIOBSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOBSMEN_Pos) /*!< 0x00000002 */
+#define RCC_C2AHB2SMENR_GPIOBSMEN          RCC_C2AHB2SMENR_GPIOBSMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOCSMEN_Pos      (2U)
+#define RCC_C2AHB2SMENR_GPIOCSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOCSMEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB2SMENR_GPIOCSMEN          RCC_C2AHB2SMENR_GPIOCSMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOESMEN_Pos      (4U)
+#define RCC_C2AHB2SMENR_GPIOESMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOESMEN_Pos) /*!< 0x00000010 */
+#define RCC_C2AHB2SMENR_GPIOESMEN          RCC_C2AHB2SMENR_GPIOESMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOHSMEN_Pos      (7U)
+#define RCC_C2AHB2SMENR_GPIOHSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOHSMEN_Pos) /*!< 0x00000080 */
+#define RCC_C2AHB2SMENR_GPIOHSMEN          RCC_C2AHB2SMENR_GPIOHSMEN_Msk
+
+/********************  Bit definition for RCC_C2AHB3SMENR register  ***************/
+#define RCC_C2AHB3SMENR_PKASMEN_Pos        (16U)
+#define RCC_C2AHB3SMENR_PKASMEN_Msk        (0x1UL << RCC_C2AHB3SMENR_PKASMEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB3SMENR_PKASMEN            RCC_C2AHB3SMENR_PKASMEN_Msk
+#define RCC_C2AHB3SMENR_AES2SMEN_Pos       (17U)
+#define RCC_C2AHB3SMENR_AES2SMEN_Msk       (0x1UL << RCC_C2AHB3SMENR_AES2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_C2AHB3SMENR_AES2SMEN           RCC_C2AHB3SMENR_AES2SMEN_Msk
+#define RCC_C2AHB3SMENR_RNGSMEN_Pos        (18U)
+#define RCC_C2AHB3SMENR_RNGSMEN_Msk        (0x1UL << RCC_C2AHB3SMENR_RNGSMEN_Pos) /*!< 0x00040000 */
+#define RCC_C2AHB3SMENR_RNGSMEN            RCC_C2AHB3SMENR_RNGSMEN_Msk
+#define RCC_C2AHB3SMENR_SRAM2SMEN_Pos      (24U)
+#define RCC_C2AHB3SMENR_SRAM2SMEN_Msk      (0x1UL << RCC_C2AHB3SMENR_SRAM2SMEN_Pos) /*!< 0x01000000 */
+#define RCC_C2AHB3SMENR_SRAM2SMEN           RCC_C2AHB3SMENR_SRAM2SMEN_Msk
+#define RCC_C2AHB3SMENR_FLASHSMEN_Pos      (25U)
+#define RCC_C2AHB3SMENR_FLASHSMEN_Msk      (0x1UL << RCC_C2AHB3SMENR_FLASHSMEN_Pos) /*!< 0x02000000 */
+#define RCC_C2AHB3SMENR_FLASHSMEN          RCC_C2AHB3SMENR_FLASHSMEN_Msk
+
+/********************  Bit definition for RCC_C2APB1SMENR1 register  **************/
+#define RCC_C2APB1SMENR1_TIM2SMEN_Pos      (0U)
+#define RCC_C2APB1SMENR1_TIM2SMEN_Msk      (0x1UL << RCC_C2APB1SMENR1_TIM2SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1SMENR1_TIM2SMEN          RCC_C2APB1SMENR1_TIM2SMEN_Msk
+#define RCC_C2APB1SMENR1_RTCAPBSMEN_Pos    (10U)
+#define RCC_C2APB1SMENR1_RTCAPBSMEN_Msk    (0x1UL << RCC_C2APB1SMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_C2APB1SMENR1_RTCAPBSMEN        RCC_C2APB1SMENR1_RTCAPBSMEN_Msk
+#define RCC_C2APB1SMENR1_I2C1SMEN_Pos      (21U)
+#define RCC_C2APB1SMENR1_I2C1SMEN_Msk      (0x1UL << RCC_C2APB1SMENR1_I2C1SMEN_Pos) /*!< 0x00200000 */
+#define RCC_C2APB1SMENR1_I2C1SMEN          RCC_C2APB1SMENR1_I2C1SMEN_Msk
+#define RCC_C2APB1SMENR1_LPTIM1SMEN_Pos    (31U)
+#define RCC_C2APB1SMENR1_LPTIM1SMEN_Msk    (0x1UL << RCC_C2APB1SMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_C2APB1SMENR1_LPTIM1SMEN        RCC_C2APB1SMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB1SMENR2 register  **************/
+#define RCC_C2APB1SMENR2_LPUART1SMEN_Pos    (0U)
+#define RCC_C2APB1SMENR2_LPUART1SMEN_Msk    (0x1UL << RCC_C2APB1SMENR2_LPUART1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1SMENR2_LPUART1SMEN        RCC_C2APB1SMENR2_LPUART1SMEN_Msk
+#define RCC_C2APB1SMENR2_LPTIM2SMEN_Pos     (5U)
+#define RCC_C2APB1SMENR2_LPTIM2SMEN_Msk     (0x1UL << RCC_C2APB1SMENR2_LPTIM2SMEN_Pos) /*!< 0x00000020 */
+#define RCC_C2APB1SMENR2_LPTIM2SMEN         RCC_C2APB1SMENR2_LPTIM2SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB2SMENR register  **************/
+#define RCC_C2APB2SMENR_ADCSMEN_Pos        (9U)
+#define RCC_C2APB2SMENR_ADCSMEN_Msk        (0x1UL << RCC_C2APB2SMENR_ADCSMEN_Pos)    /*!< 0x00000200 */
+#define RCC_C2APB2SMENR_ADCSMEN            RCC_C2APB2SMENR_ADCSMEN_Msk
+#define RCC_C2APB2SMENR_TIM1SMEN_Pos       (11U)
+#define RCC_C2APB2SMENR_TIM1SMEN_Msk       (0x1UL << RCC_C2APB2SMENR_TIM1SMEN_Pos)   /*!< 0x00000800 */
+#define RCC_C2APB2SMENR_TIM1SMEN           RCC_C2APB2SMENR_TIM1SMEN_Msk
+#define RCC_C2APB2SMENR_SPI1SMEN_Pos       (12U)
+#define RCC_C2APB2SMENR_SPI1SMEN_Msk       (0x1UL << RCC_C2APB2SMENR_SPI1SMEN_Pos)   /*!< 0x00001000 */
+#define RCC_C2APB2SMENR_SPI1SMEN           RCC_C2APB2SMENR_SPI1SMEN_Msk
+#define RCC_C2APB2SMENR_USART1SMEN_Pos     (14U)
+#define RCC_C2APB2SMENR_USART1SMEN_Msk     (0x1UL << RCC_C2APB2SMENR_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_C2APB2SMENR_USART1SMEN         RCC_C2APB2SMENR_USART1SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB3SMENR register  **************/
+#define RCC_C2APB3SMENR_BLESMEN_Pos        (0U)
+#define RCC_C2APB3SMENR_BLESMEN_Msk        (0x1UL << RCC_C2APB3SMENR_BLESMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB3SMENR_BLESMEN            RCC_C2APB3SMENR_BLESMEN_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for  register  *******************/
+#define RNG_CR_RNGEN_Pos    (2U)
+#define RNG_CR_RNGEN_Msk    (0x1UL << RNG_CR_RNGEN_Pos)                        /*!< 0x00000004 */
+#define RNG_CR_RNGEN        RNG_CR_RNGEN_Msk
+#define RNG_CR_IE_Pos       (3U)
+#define RNG_CR_IE_Msk       (0x1UL << RNG_CR_IE_Pos)                           /*!< 0x00000008 */
+#define RNG_CR_IE           RNG_CR_IE_Msk
+#define RNG_CR_CED_Pos      (5U)
+#define RNG_CR_CED_Msk      (0x1UL << RNG_CR_CED_Pos)                          /*!< 0x00000020 */
+#define RNG_CR_CED          RNG_CR_CED_Msk
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY_Pos     (0U)
+#define RNG_SR_DRDY_Msk     (0x1UL << RNG_SR_DRDY_Pos)                         /*!< 0x00000001 */
+#define RNG_SR_DRDY         RNG_SR_DRDY_Msk
+#define RNG_SR_CECS_Pos     (1U)
+#define RNG_SR_CECS_Msk     (0x1UL << RNG_SR_CECS_Pos)                         /*!< 0x00000002 */
+#define RNG_SR_CECS         RNG_SR_CECS_Msk
+#define RNG_SR_SECS_Pos     (2U)
+#define RNG_SR_SECS_Msk     (0x1UL << RNG_SR_SECS_Pos)                         /*!< 0x00000004 */
+#define RNG_SR_SECS         RNG_SR_SECS_Msk
+#define RNG_SR_CEIS_Pos     (5U)
+#define RNG_SR_CEIS_Msk     (0x1UL << RNG_SR_CEIS_Pos)                         /*!< 0x00000020 */
+#define RNG_SR_CEIS         RNG_SR_CEIS_Msk
+#define RNG_SR_SEIS_Pos     (6U)
+#define RNG_SR_SEIS_Msk     (0x1UL << RNG_SR_SEIS_Pos)                         /*!< 0x00000040 */
+#define RNG_SR_SEIS         RNG_SR_SEIS_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+  * @brief Specific device feature definitions
+  */
+#define RTC_TAMPER2_SUPPORT
+#define RTC_WAKEUP_SUPPORT
+#define RTC_BACKUP_SUPPORT
+#define RTC_CPU2_SUPPORT_D
+#define RTC_INTERNALTS_SUPPORT
+
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                  (22U)
+#define RTC_TR_PM_Msk                  (0x1UL << RTC_TR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TR_PM                      RTC_TR_PM_Msk                           /*!< AM/PM notation */
+#define RTC_TR_HT_Pos                  (20U)
+#define RTC_TR_HT_Msk                  (0x3UL << RTC_TR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TR_HT                      RTC_TR_HT_Msk                           /*!< Hour tens in BCD format */
+#define RTC_TR_HT_0                    (0x1U << RTC_TR_HT_Pos)                 /*!< 0x00100000 */
+#define RTC_TR_HT_1                    (0x2U << RTC_TR_HT_Pos)                 /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                  (16U)
+#define RTC_TR_HU_Msk                  (0xFUL << RTC_TR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TR_HU                      RTC_TR_HU_Msk                           /*!< Hour units in BCD format */
+#define RTC_TR_HU_0                    (0x1U << RTC_TR_HU_Pos)                 /*!< 0x00010000 */
+#define RTC_TR_HU_1                    (0x2U << RTC_TR_HU_Pos)                 /*!< 0x00020000 */
+#define RTC_TR_HU_2                    (0x4U << RTC_TR_HU_Pos)                 /*!< 0x00040000 */
+#define RTC_TR_HU_3                    (0x8U << RTC_TR_HU_Pos)                 /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos                 (12U)
+#define RTC_TR_MNT_Msk                 (0x7UL << RTC_TR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TR_MNT                     RTC_TR_MNT_Msk                          /*!< Minute tens in BCD format */
+#define RTC_TR_MNT_0                   (0x1U << RTC_TR_MNT_Pos)                /*!< 0x00001000 */
+#define RTC_TR_MNT_1                   (0x2U << RTC_TR_MNT_Pos)                /*!< 0x00002000 */
+#define RTC_TR_MNT_2                   (0x4U << RTC_TR_MNT_Pos)                /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos                 (8U)
+#define RTC_TR_MNU_Msk                 (0xFUL << RTC_TR_MNU_Pos)               /*!< 0x00000F00 */
+#define RTC_TR_MNU                     RTC_TR_MNU_Msk                          /*!< Minute unit in BCD format */
+#define RTC_TR_MNU_0                   (0x1U << RTC_TR_MNU_Pos)                /*!< 0x00000100 */
+#define RTC_TR_MNU_1                   (0x2U << RTC_TR_MNU_Pos)                /*!< 0x00000200 */
+#define RTC_TR_MNU_2                   (0x4U << RTC_TR_MNU_Pos)                /*!< 0x00000400 */
+#define RTC_TR_MNU_3                   (0x8U << RTC_TR_MNU_Pos)                /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                  (4U)
+#define RTC_TR_ST_Msk                  (0x7UL << RTC_TR_ST_Pos)                /*!< 0x00000070 */
+#define RTC_TR_ST                      RTC_TR_ST_Msk                           /*!< Second tens in BCD format */
+#define RTC_TR_ST_0                    (0x1U << RTC_TR_ST_Pos)                 /*!< 0x00000010 */
+#define RTC_TR_ST_1                    (0x2U << RTC_TR_ST_Pos)                 /*!< 0x00000020 */
+#define RTC_TR_ST_2                    (0x4U << RTC_TR_ST_Pos)                 /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                  (0U)
+#define RTC_TR_SU_Msk                  (0xFUL << RTC_TR_SU_Pos)                /*!< 0x0000000F */
+#define RTC_TR_SU                      RTC_TR_SU_Msk                           /*!< Second units in BCD format */
+#define RTC_TR_SU_0                    (0x1U << RTC_TR_SU_Pos)                 /*!< 0x00000001 */
+#define RTC_TR_SU_1                    (0x2U << RTC_TR_SU_Pos)                 /*!< 0x00000002 */
+#define RTC_TR_SU_2                    (0x4U << RTC_TR_SU_Pos)                 /*!< 0x00000004 */
+#define RTC_TR_SU_3                    (0x8U << RTC_TR_SU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                  (20U)
+#define RTC_DR_YT_Msk                  (0xFUL << RTC_DR_YT_Pos)                /*!< 0x00F00000 */
+#define RTC_DR_YT                      RTC_DR_YT_Msk                           /*!< Year tens in BCD format */
+#define RTC_DR_YT_0                    (0x1U << RTC_DR_YT_Pos)                 /*!< 0x00100000 */
+#define RTC_DR_YT_1                    (0x2U << RTC_DR_YT_Pos)                 /*!< 0x00200000 */
+#define RTC_DR_YT_2                    (0x4U << RTC_DR_YT_Pos)                 /*!< 0x00400000 */
+#define RTC_DR_YT_3                    (0x8U << RTC_DR_YT_Pos)                 /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                  (16U)
+#define RTC_DR_YU_Msk                  (0xFUL << RTC_DR_YU_Pos)                /*!< 0x000F0000 */
+#define RTC_DR_YU                      RTC_DR_YU_Msk                           /*!< Years units in BCD format */
+#define RTC_DR_YU_0                    (0x1U << RTC_DR_YU_Pos)                 /*!< 0x00010000 */
+#define RTC_DR_YU_1                    (0x2U << RTC_DR_YU_Pos)                 /*!< 0x00020000 */
+#define RTC_DR_YU_2                    (0x4U << RTC_DR_YU_Pos)                 /*!< 0x00040000 */
+#define RTC_DR_YU_3                    (0x8U << RTC_DR_YU_Pos)                 /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos                 (13U)
+#define RTC_DR_WDU_Msk                 (0x7UL << RTC_DR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_DR_WDU                     RTC_DR_WDU_Msk                          /*!< Week day units */
+#define RTC_DR_WDU_0                   (0x1U << RTC_DR_WDU_Pos)                /*!< 0x00002000 */
+#define RTC_DR_WDU_1                   (0x2U << RTC_DR_WDU_Pos)                /*!< 0x00004000 */
+#define RTC_DR_WDU_2                   (0x4U << RTC_DR_WDU_Pos)                /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                  (12U)
+#define RTC_DR_MT_Msk                  (0x1UL << RTC_DR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_DR_MT                      RTC_DR_MT_Msk                           /*!< Month tens in BCD format */
+#define RTC_DR_MU_Pos                  (8U)
+#define RTC_DR_MU_Msk                  (0xFUL << RTC_DR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_DR_MU                      RTC_DR_MU_Msk                           /*!< Month units in BCD format */
+#define RTC_DR_MU_0                    (0x1U << RTC_DR_MU_Pos)                 /*!< 0x00000100 */
+#define RTC_DR_MU_1                    (0x2U << RTC_DR_MU_Pos)                 /*!< 0x00000200 */
+#define RTC_DR_MU_2                    (0x4U << RTC_DR_MU_Pos)                 /*!< 0x00000400 */
+#define RTC_DR_MU_3                    (0x8U << RTC_DR_MU_Pos)                 /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                  (4U)
+#define RTC_DR_DT_Msk                  (0x3UL << RTC_DR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_DR_DT                      RTC_DR_DT_Msk                           /*!< Date tens in BCD format */
+#define RTC_DR_DT_0                    (0x1U << RTC_DR_DT_Pos)                 /*!< 0x00000010 */
+#define RTC_DR_DT_1                    (0x2U << RTC_DR_DT_Pos)                 /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                  (0U)
+#define RTC_DR_DU_Msk                  (0xFUL << RTC_DR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_DR_DU                      RTC_DR_DU_Msk                           /*!< Date units in BCD format */
+#define RTC_DR_DU_0                    (0x1U << RTC_DR_DU_Pos)                 /*!< 0x00000001 */
+#define RTC_DR_DU_1                    (0x2U << RTC_DR_DU_Pos)                 /*!< 0x00000002 */
+#define RTC_DR_DU_2                    (0x4U << RTC_DR_DU_Pos)                 /*!< 0x00000004 */
+#define RTC_DR_DU_3                    (0x8U << RTC_DR_DU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_ITSE_Pos                (24U)
+#define RTC_CR_ITSE_Msk                (0x1UL << RTC_CR_ITSE_Pos)              /*!< 0x01000000 */
+#define RTC_CR_ITSE                    RTC_CR_ITSE_Msk                         /*!< Timestamp on internal event enable */
+#define RTC_CR_COE_Pos                 (23U)
+#define RTC_CR_COE_Msk                 (0x1UL << RTC_CR_COE_Pos)               /*!< 0x00800000 */
+#define RTC_CR_COE                     RTC_CR_COE_Msk                          /*!< Calibration output enable */
+#define RTC_CR_OSEL_Pos                (21U)
+#define RTC_CR_OSEL_Msk                (0x3UL << RTC_CR_OSEL_Pos)              /*!< 0x00600000 */
+#define RTC_CR_OSEL                    RTC_CR_OSEL_Msk                         /*!< Output selection */
+#define RTC_CR_OSEL_0                  (0x1U << RTC_CR_OSEL_Pos)               /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
+#define RTC_CR_POL_Pos                 (20U)
+#define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
+#define RTC_CR_COSEL_Pos               (19U)
+#define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
+#define RTC_CR_BKP_Pos                 (18U)
+#define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
+#define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
+#define RTC_CR_SUB1H_Pos               (17U)
+#define RTC_CR_SUB1H_Msk               (0x1UL << RTC_CR_SUB1H_Pos)             /*!< 0x00020000 */
+#define RTC_CR_SUB1H                   RTC_CR_SUB1H_Msk                        /*!< Subtract 1 hour (winter time change) */
+#define RTC_CR_ADD1H_Pos               (16U)
+#define RTC_CR_ADD1H_Msk               (0x1UL << RTC_CR_ADD1H_Pos)             /*!< 0x00010000 */
+#define RTC_CR_ADD1H                   RTC_CR_ADD1H_Msk                        /*!< Add 1 hour (summer time change) */
+#define RTC_CR_TSIE_Pos                (15U)
+#define RTC_CR_TSIE_Msk                (0x1UL << RTC_CR_TSIE_Pos)              /*!< 0x00008000 */
+#define RTC_CR_TSIE                    RTC_CR_TSIE_Msk                         /*!< Time-stamp interrupt enable */
+#define RTC_CR_WUTIE_Pos               (14U)
+#define RTC_CR_WUTIE_Msk               (0x1UL << RTC_CR_WUTIE_Pos)             /*!< 0x00004000 */
+#define RTC_CR_WUTIE                   RTC_CR_WUTIE_Msk                        /*!< Wakeup timer interrupt enable */
+#define RTC_CR_ALRBIE_Pos              (13U)
+#define RTC_CR_ALRBIE_Msk              (0x1UL << RTC_CR_ALRBIE_Pos)            /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                  RTC_CR_ALRBIE_Msk                       /*!< Alarm B interrupt enable */
+#define RTC_CR_ALRAIE_Pos              (12U)
+#define RTC_CR_ALRAIE_Msk              (0x1UL << RTC_CR_ALRAIE_Pos)            /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                  RTC_CR_ALRAIE_Msk                       /*!< Alarm A interrupt enable */
+#define RTC_CR_TSE_Pos                 (11U)
+#define RTC_CR_TSE_Msk                 (0x1UL << RTC_CR_TSE_Pos)               /*!< 0x00000800 */
+#define RTC_CR_TSE                     RTC_CR_TSE_Msk                          /*!< Timestamp on RTC TS input edge enable */
+#define RTC_CR_WUTE_Pos                (10U)
+#define RTC_CR_WUTE_Msk                (0x1UL << RTC_CR_WUTE_Pos)              /*!< 0x00000400 */
+#define RTC_CR_WUTE                    RTC_CR_WUTE_Msk                         /*!< Wakeup timer enable */
+#define RTC_CR_ALRBE_Pos               (9U)
+#define RTC_CR_ALRBE_Msk               (0x1UL << RTC_CR_ALRBE_Pos)             /*!< 0x00000200 */
+#define RTC_CR_ALRBE                   RTC_CR_ALRBE_Msk                        /*!< Alarm B enable */
+#define RTC_CR_ALRAE_Pos               (8U)
+#define RTC_CR_ALRAE_Msk               (0x1UL << RTC_CR_ALRAE_Pos)             /*!< 0x00000100 */
+#define RTC_CR_ALRAE                   RTC_CR_ALRAE_Msk                        /*!< Alarm A enable */
+#define RTC_CR_FMT_Pos                 (6U)
+#define RTC_CR_FMT_Msk                 (0x1UL << RTC_CR_FMT_Pos)               /*!< 0x00000040 */
+#define RTC_CR_FMT                     RTC_CR_FMT_Msk                          /*!< Hour AM/PM or 24H format */
+#define RTC_CR_BYPSHAD_Pos             (5U)
+#define RTC_CR_BYPSHAD_Msk             (0x1UL << RTC_CR_BYPSHAD_Pos)           /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD                 RTC_CR_BYPSHAD_Msk                      /*!< Bypass the shadow registers */
+#define RTC_CR_REFCKON_Pos             (4U)
+#define RTC_CR_REFCKON_Msk             (0x1UL << RTC_CR_REFCKON_Pos)           /*!< 0x00000010 */
+#define RTC_CR_REFCKON                 RTC_CR_REFCKON_Msk                      /*!< RTC_REFIN reference clock detection enable (50 or 60 Hz) */
+#define RTC_CR_TSEDGE_Pos              (3U)
+#define RTC_CR_TSEDGE_Msk              (0x1UL << RTC_CR_TSEDGE_Pos)            /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                  RTC_CR_TSEDGE_Msk                       /*!< Timestamp event active edge */
+#define RTC_CR_WUCKSEL_Pos             (0U)
+#define RTC_CR_WUCKSEL_Msk             (0x7UL << RTC_CR_WUCKSEL_Pos)           /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL                 RTC_CR_WUCKSEL_Msk                      /*!< Wakekup clock selection */
+#define RTC_CR_WUCKSEL_0               (0x1U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1               (0x2U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2               (0x4U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000004 */
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_ITSF_Pos               (17U)
+#define RTC_ISR_ITSF_Msk               (0x1UL << RTC_ISR_ITSF_Pos)             /*!< 0x00020000 */
+#define RTC_ISR_ITSF                   RTC_ISR_ITSF_Msk                        /*!< Internal timestamp flag */
+#define RTC_ISR_RECALPF_Pos            (16U)
+#define RTC_ISR_RECALPF_Msk            (0x1UL << RTC_ISR_RECALPF_Pos)          /*!< 0x00010000 */
+#define RTC_ISR_RECALPF                RTC_ISR_RECALPF_Msk                     /*!< Recalibration pending flag */
+#define RTC_ISR_TAMP2F_Pos             (14U)
+#define RTC_ISR_TAMP2F_Msk             (0x1UL << RTC_ISR_TAMP2F_Pos)           /*!< 0x00004000 */
+#define RTC_ISR_TAMP2F                 RTC_ISR_TAMP2F_Msk                      /*!< RTC_TAMP2 detection flag */
+#define RTC_ISR_TSOVF_Pos              (12U)
+#define RTC_ISR_TSOVF_Msk              (0x1UL << RTC_ISR_TSOVF_Pos)            /*!< 0x00001000 */
+#define RTC_ISR_TSOVF                  RTC_ISR_TSOVF_Msk                       /*!< Timestamp overflow flag */
+#define RTC_ISR_TSF_Pos                (11U)
+#define RTC_ISR_TSF_Msk                (0x1UL << RTC_ISR_TSF_Pos)              /*!< 0x00000800 */
+#define RTC_ISR_TSF                    RTC_ISR_TSF_Msk                         /*!< Timestamp flag */
+#define RTC_ISR_WUTF_Pos               (10U)
+#define RTC_ISR_WUTF_Msk               (0x1UL << RTC_ISR_WUTF_Pos)             /*!< 0x00000400 */
+#define RTC_ISR_WUTF                   RTC_ISR_WUTF_Msk                        /*!< Wakeup timer flag */
+#define RTC_ISR_ALRBF_Pos              (9U)
+#define RTC_ISR_ALRBF_Msk              (0x1UL << RTC_ISR_ALRBF_Pos)            /*!< 0x00000200 */
+#define RTC_ISR_ALRBF                  RTC_ISR_ALRBF_Msk                       /*!< Alarm B flag */
+#define RTC_ISR_ALRAF_Pos              (8U)
+#define RTC_ISR_ALRAF_Msk              (0x1UL << RTC_ISR_ALRAF_Pos)            /*!< 0x00000100 */
+#define RTC_ISR_ALRAF                  RTC_ISR_ALRAF_Msk                       /*!< Alarm A flag */
+#define RTC_ISR_INIT_Pos               (7U)
+#define RTC_ISR_INIT_Msk               (0x1UL << RTC_ISR_INIT_Pos)             /*!< 0x00000080 */
+#define RTC_ISR_INIT                   RTC_ISR_INIT_Msk                        /*!< Initialization mode */
+#define RTC_ISR_INITF_Pos              (6U)
+#define RTC_ISR_INITF_Msk              (0x1UL << RTC_ISR_INITF_Pos)            /*!< 0x00000040 */
+#define RTC_ISR_INITF                  RTC_ISR_INITF_Msk                       /*!< Initialization flag */
+#define RTC_ISR_RSF_Pos                (5U)
+#define RTC_ISR_RSF_Msk                (0x1UL << RTC_ISR_RSF_Pos)              /*!< 0x00000020 */
+#define RTC_ISR_RSF                    RTC_ISR_RSF_Msk                         /*!< Registers synchronization flag */
+#define RTC_ISR_INITS_Pos              (4U)
+#define RTC_ISR_INITS_Msk              (0x1UL << RTC_ISR_INITS_Pos)            /*!< 0x00000010 */
+#define RTC_ISR_INITS                  RTC_ISR_INITS_Msk                       /*!< Initialization status flag */
+#define RTC_ISR_SHPF_Pos               (3U)
+#define RTC_ISR_SHPF_Msk               (0x1UL << RTC_ISR_SHPF_Pos)             /*!< 0x00000008 */
+#define RTC_ISR_SHPF                   RTC_ISR_SHPF_Msk                        /*!< Shift operation pending */
+#define RTC_ISR_WUTWF_Pos              (2U)
+#define RTC_ISR_WUTWF_Msk              (0x1UL << RTC_ISR_WUTWF_Pos)            /*!< 0x00000004 */
+#define RTC_ISR_WUTWF                  RTC_ISR_WUTWF_Msk                       /*!< Wakeup timer write flag */
+#define RTC_ISR_ALRBWF_Pos             (1U)
+#define RTC_ISR_ALRBWF_Msk             (0x1UL << RTC_ISR_ALRBWF_Pos)           /*!< 0x00000002 */
+#define RTC_ISR_ALRBWF                 RTC_ISR_ALRBWF_Msk                      /*!< Alarm B write flag */
+#define RTC_ISR_ALRAWF_Pos             (0U)
+#define RTC_ISR_ALRAWF_Msk             (0x1UL << RTC_ISR_ALRAWF_Pos)           /*!< 0x00000001 */
+#define RTC_ISR_ALRAWF                 RTC_ISR_ALRAWF_Msk                      /*!< Alarm A write flag */
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos          (16U)
+#define RTC_PRER_PREDIV_A_Msk          (0x7FUL << RTC_PRER_PREDIV_A_Pos)       /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A              RTC_PRER_PREDIV_A_Msk                   /*!< Asynchronous prescaler factor */
+#define RTC_PRER_PREDIV_S_Pos          (0U)
+#define RTC_PRER_PREDIV_S_Msk          (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)     /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S              RTC_PRER_PREDIV_S_Msk                   /*!< Synchronous prescaler factor */
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos               (0U)
+#define RTC_WUTR_WUT_Msk               (0xFFFFUL << RTC_WUTR_WUT_Pos)          /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                   RTC_WUTR_WUT_Msk                        /*!< Wakeup auto-reload value bits */
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos            (31U)
+#define RTC_ALRMAR_MSK4_Msk            (0x1UL << RTC_ALRMAR_MSK4_Pos)          /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4                RTC_ALRMAR_MSK4_Msk                     /*!< Alarm A date mask */
+#define RTC_ALRMAR_WDSEL_Pos           (30U)
+#define RTC_ALRMAR_WDSEL_Msk           (0x1UL << RTC_ALRMAR_WDSEL_Pos)         /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL               RTC_ALRMAR_WDSEL_Msk                    /*!< Alarm A week day selection */
+#define RTC_ALRMAR_DT_Pos              (28U)
+#define RTC_ALRMAR_DT_Msk              (0x3UL << RTC_ALRMAR_DT_Pos)            /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                  RTC_ALRMAR_DT_Msk                       /*!< Alarm A date tens in BCD format */
+#define RTC_ALRMAR_DT_0                (0x1U << RTC_ALRMAR_DT_Pos)             /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1                (0x2U << RTC_ALRMAR_DT_Pos)             /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos              (24U)
+#define RTC_ALRMAR_DU_Msk              (0xFUL << RTC_ALRMAR_DU_Pos)            /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                  RTC_ALRMAR_DU_Msk                       /*!< Alarm A date units in BCD format */
+#define RTC_ALRMAR_DU_0                (0x1U << RTC_ALRMAR_DU_Pos)             /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1                (0x2U << RTC_ALRMAR_DU_Pos)             /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2                (0x4U << RTC_ALRMAR_DU_Pos)             /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3                (0x8U << RTC_ALRMAR_DU_Pos)             /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos            (23U)
+#define RTC_ALRMAR_MSK3_Msk            (0x1UL << RTC_ALRMAR_MSK3_Pos)          /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3                RTC_ALRMAR_MSK3_Msk                     /*!< Alarm A hours mask */
+#define RTC_ALRMAR_PM_Pos              (22U)
+#define RTC_ALRMAR_PM_Msk              (0x1UL << RTC_ALRMAR_PM_Pos)            /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                  RTC_ALRMAR_PM_Msk                       /*!< Alarm A AM/PM or 24H format */
+#define RTC_ALRMAR_HT_Pos              (20U)
+#define RTC_ALRMAR_HT_Msk              (0x3UL << RTC_ALRMAR_HT_Pos)            /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                  RTC_ALRMAR_HT_Msk                       /*!< Alarm A hour tens in BCD format */
+#define RTC_ALRMAR_HT_0                (0x1U << RTC_ALRMAR_HT_Pos)             /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1                (0x2U << RTC_ALRMAR_HT_Pos)             /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos              (16U)
+#define RTC_ALRMAR_HU_Msk              (0xFUL << RTC_ALRMAR_HU_Pos)            /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                  RTC_ALRMAR_HU_Msk                       /*!< Alarm A hour units in BCD format */
+#define RTC_ALRMAR_HU_0                (0x1U << RTC_ALRMAR_HU_Pos)             /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1                (0x2U << RTC_ALRMAR_HU_Pos)             /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2                (0x4U << RTC_ALRMAR_HU_Pos)             /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3                (0x8U << RTC_ALRMAR_HU_Pos)             /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos            (15U)
+#define RTC_ALRMAR_MSK2_Msk            (0x1UL << RTC_ALRMAR_MSK2_Pos)          /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2                RTC_ALRMAR_MSK2_Msk                     /*!< Alarm A minutes mask */
+#define RTC_ALRMAR_MNT_Pos             (12U)
+#define RTC_ALRMAR_MNT_Msk             (0x7UL << RTC_ALRMAR_MNT_Pos)           /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT                 RTC_ALRMAR_MNT_Msk                      /*!< Alarm A minute tens in BCD format */
+#define RTC_ALRMAR_MNT_0               (0x1U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1               (0x2U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2               (0x4U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos             (8U)
+#define RTC_ALRMAR_MNU_Msk             (0xFUL << RTC_ALRMAR_MNU_Pos)           /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU                 RTC_ALRMAR_MNU_Msk                      /*!< Alarm A minute units in BCD format */
+#define RTC_ALRMAR_MNU_0               (0x1U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1               (0x2U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2               (0x4U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3               (0x8U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos            (7U)
+#define RTC_ALRMAR_MSK1_Msk            (0x1UL << RTC_ALRMAR_MSK1_Pos)          /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1                RTC_ALRMAR_MSK1_Msk                     /*!< Alarm A seconds mask */
+#define RTC_ALRMAR_ST_Pos              (4U)
+#define RTC_ALRMAR_ST_Msk              (0x7UL << RTC_ALRMAR_ST_Pos)            /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                  RTC_ALRMAR_ST_Msk                       /*!< Alarm A second tens in BCD format */
+#define RTC_ALRMAR_ST_0                (0x1U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1                (0x2U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2                (0x4U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos              (0U)
+#define RTC_ALRMAR_SU_Msk              (0xFUL << RTC_ALRMAR_SU_Pos)            /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                  RTC_ALRMAR_SU_Msk                       /*!< Alarm A second units in BCD format */
+#define RTC_ALRMAR_SU_0                (0x1U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1                (0x2U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2                (0x4U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3                (0x8U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos            (31U)
+#define RTC_ALRMBR_MSK4_Msk            (0x1UL << RTC_ALRMBR_MSK4_Pos)          /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4                RTC_ALRMBR_MSK4_Msk                     /*!< Alarm B date mask */
+#define RTC_ALRMBR_WDSEL_Pos           (30U)
+#define RTC_ALRMBR_WDSEL_Msk           (0x1UL << RTC_ALRMBR_WDSEL_Pos)         /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL               RTC_ALRMBR_WDSEL_Msk                    /*!< Alarm B week day selection */
+#define RTC_ALRMBR_DT_Pos              (28U)
+#define RTC_ALRMBR_DT_Msk              (0x3UL << RTC_ALRMBR_DT_Pos)            /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                  RTC_ALRMBR_DT_Msk                       /*!< Alarm B data tens in BCD format */
+#define RTC_ALRMBR_DT_0                (0x1U << RTC_ALRMBR_DT_Pos)             /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1                (0x2U << RTC_ALRMBR_DT_Pos)             /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos              (24U)
+#define RTC_ALRMBR_DU_Msk              (0xFUL << RTC_ALRMBR_DU_Pos)            /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                  RTC_ALRMBR_DU_Msk                       /*!< Alarm B data units or day in BCD format */
+#define RTC_ALRMBR_DU_0                (0x1U << RTC_ALRMBR_DU_Pos)             /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1                (0x2U << RTC_ALRMBR_DU_Pos)             /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2                (0x4U << RTC_ALRMBR_DU_Pos)             /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3                (0x8U << RTC_ALRMBR_DU_Pos)             /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos            (23U)
+#define RTC_ALRMBR_MSK3_Msk            (0x1UL << RTC_ALRMBR_MSK3_Pos)          /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3                RTC_ALRMBR_MSK3_Msk                     /*!< Alarm B hour mask */
+#define RTC_ALRMBR_PM_Pos              (22U)
+#define RTC_ALRMBR_PM_Msk              (0x1UL << RTC_ALRMBR_PM_Pos)            /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                  RTC_ALRMBR_PM_Msk                       /*!< Alarm B AM/PM or 24H format */
+#define RTC_ALRMBR_HT_Pos              (20U)
+#define RTC_ALRMBR_HT_Msk              (0x3UL << RTC_ALRMBR_HT_Pos)            /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                  RTC_ALRMBR_HT_Msk                       /*!< Alarm B hour tens in BCD format */
+#define RTC_ALRMBR_HT_0                (0x1U << RTC_ALRMBR_HT_Pos)             /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1                (0x2U << RTC_ALRMBR_HT_Pos)             /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos              (16U)
+#define RTC_ALRMBR_HU_Msk              (0xFUL << RTC_ALRMBR_HU_Pos)            /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                  RTC_ALRMBR_HU_Msk                       /*!< Alarm B hour units in BCD format */
+#define RTC_ALRMBR_HU_0                (0x1U << RTC_ALRMBR_HU_Pos)             /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1                (0x2U << RTC_ALRMBR_HU_Pos)             /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2                (0x4U << RTC_ALRMBR_HU_Pos)             /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3                (0x8U << RTC_ALRMBR_HU_Pos)             /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos            (15U)
+#define RTC_ALRMBR_MSK2_Msk            (0x1UL << RTC_ALRMBR_MSK2_Pos)          /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2                RTC_ALRMBR_MSK2_Msk                     /*!< Alarm B minutes mask */
+#define RTC_ALRMBR_MNT_Pos             (12U)
+#define RTC_ALRMBR_MNT_Msk             (0x7UL << RTC_ALRMBR_MNT_Pos)           /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT                 RTC_ALRMBR_MNT_Msk                      /*!< Alarm B minute tens in BCD format */
+#define RTC_ALRMBR_MNT_0               (0x1U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1               (0x2U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2               (0x4U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos             (8U)
+#define RTC_ALRMBR_MNU_Msk             (0xFUL << RTC_ALRMBR_MNU_Pos)           /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU                 RTC_ALRMBR_MNU_Msk                      /*!< Alarm B minute units in BCD format */
+#define RTC_ALRMBR_MNU_0               (0x1U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1               (0x2U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2               (0x4U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3               (0x8U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos            (7U)
+#define RTC_ALRMBR_MSK1_Msk            (0x1UL << RTC_ALRMBR_MSK1_Pos)          /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1                RTC_ALRMBR_MSK1_Msk                     /*!< Alarm B seconds mask */
+#define RTC_ALRMBR_ST_Pos              (4U)
+#define RTC_ALRMBR_ST_Msk              (0x7UL << RTC_ALRMBR_ST_Pos)            /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                  RTC_ALRMBR_ST_Msk                       /*!< Alarm B second tens in BCD format */
+#define RTC_ALRMBR_ST_0                (0x1U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1                (0x2U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2                (0x4U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos              (0U)
+#define RTC_ALRMBR_SU_Msk              (0xFUL << RTC_ALRMBR_SU_Pos)            /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                  RTC_ALRMBR_SU_Msk                       /*!< Alarm B second units in BCD format */
+#define RTC_ALRMBR_SU_0                (0x1U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1                (0x2U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2                (0x4U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3                (0x8U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos                (0U)
+#define RTC_WPR_KEY_Msk                (0xFFUL << RTC_WPR_KEY_Pos)             /*!< 0x000000FF */
+#define RTC_WPR_KEY                    RTC_WPR_KEY_Msk                         /*!< Write protection key */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos                 (0U)
+#define RTC_SSR_SS_Msk                 (0xFFFFUL << RTC_SSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_SSR_SS                     RTC_SSR_SS_Msk                          /*!< Sub second value */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos           (0U)
+#define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
+#define RTC_SHIFTR_ADD1S_Pos           (31U)
+#define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos                (22U)
+#define RTC_TSTR_PM_Msk                (0x1UL << RTC_TSTR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_TSTR_PM                    RTC_TSTR_PM_Msk                         /*!< Timestamp AM/PM or 24H format */
+#define RTC_TSTR_HT_Pos                (20U)
+#define RTC_TSTR_HT_Msk                (0x3UL << RTC_TSTR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_TSTR_HT                    RTC_TSTR_HT_Msk                         /*!< Timestamp hour tens in BCD format */
+#define RTC_TSTR_HT_0                  (0x1U << RTC_TSTR_HT_Pos)               /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                  (0x2U << RTC_TSTR_HT_Pos)               /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos                (16U)
+#define RTC_TSTR_HU_Msk                (0xFUL << RTC_TSTR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_TSTR_HU                    RTC_TSTR_HU_Msk                         /*!< Timestamp hour units in BCD format */
+#define RTC_TSTR_HU_0                  (0x1U << RTC_TSTR_HU_Pos)               /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                  (0x2U << RTC_TSTR_HU_Pos)               /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                  (0x4U << RTC_TSTR_HU_Pos)               /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                  (0x8U << RTC_TSTR_HU_Pos)               /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos               (12U)
+#define RTC_TSTR_MNT_Msk               (0x7UL << RTC_TSTR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_TSTR_MNT                   RTC_TSTR_MNT_Msk                        /*!< Timestamp minute tens in BCD format */
+#define RTC_TSTR_MNT_0                 (0x1U << RTC_TSTR_MNT_Pos)              /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1                 (0x2U << RTC_TSTR_MNT_Pos)              /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2                 (0x4U << RTC_TSTR_MNT_Pos)              /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos               (8U)
+#define RTC_TSTR_MNU_Msk               (0xFUL << RTC_TSTR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                   RTC_TSTR_MNU_Msk                        /*!< Timestamp minute units in BCD format */
+#define RTC_TSTR_MNU_0                 (0x1U << RTC_TSTR_MNU_Pos)              /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1                 (0x2U << RTC_TSTR_MNU_Pos)              /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2                 (0x4U << RTC_TSTR_MNU_Pos)              /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3                 (0x8U << RTC_TSTR_MNU_Pos)              /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos                (4U)
+#define RTC_TSTR_ST_Msk                (0x7UL << RTC_TSTR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_TSTR_ST                    RTC_TSTR_ST_Msk                         /*!< Timestamp second tens in BCD format */
+#define RTC_TSTR_ST_0                  (0x1U << RTC_TSTR_ST_Pos)               /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                  (0x2U << RTC_TSTR_ST_Pos)               /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                  (0x4U << RTC_TSTR_ST_Pos)               /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos                (0U)
+#define RTC_TSTR_SU_Msk                (0xFUL << RTC_TSTR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_TSTR_SU                    RTC_TSTR_SU_Msk                         /*!< Timestamp second units in BCD format */
+#define RTC_TSTR_SU_0                  (0x1U << RTC_TSTR_SU_Pos)               /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                  (0x2U << RTC_TSTR_SU_Pos)               /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                  (0x4U << RTC_TSTR_SU_Pos)               /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                  (0x8U << RTC_TSTR_SU_Pos)               /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos               (13U)
+#define RTC_TSDR_WDU_Msk               (0x7UL << RTC_TSDR_WDU_Pos)             /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                   RTC_TSDR_WDU_Msk                        /*!< Timestamp week day units */
+#define RTC_TSDR_WDU_0                 (0x1U << RTC_TSDR_WDU_Pos)              /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1                 (0x2U << RTC_TSDR_WDU_Pos)              /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2                 (0x4U << RTC_TSDR_WDU_Pos)              /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos                (12U)
+#define RTC_TSDR_MT_Msk                (0x1UL << RTC_TSDR_MT_Pos)              /*!< 0x00001000 */
+#define RTC_TSDR_MT                    RTC_TSDR_MT_Msk                         /*!< Timestamp month tens in BCD format */
+#define RTC_TSDR_MU_Pos                (8U)
+#define RTC_TSDR_MU_Msk                (0xFUL << RTC_TSDR_MU_Pos)              /*!< 0x00000F00 */
+#define RTC_TSDR_MU                    RTC_TSDR_MU_Msk                         /*!< Timestamp month units in BCD format */
+#define RTC_TSDR_MU_0                  (0x1U << RTC_TSDR_MU_Pos)               /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                  (0x2U << RTC_TSDR_MU_Pos)               /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                  (0x4U << RTC_TSDR_MU_Pos)               /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                  (0x8U << RTC_TSDR_MU_Pos)               /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos                (4U)
+#define RTC_TSDR_DT_Msk                (0x3UL << RTC_TSDR_DT_Pos)              /*!< 0x00000030 */
+#define RTC_TSDR_DT                    RTC_TSDR_DT_Msk                         /*!< Timestamp date tens in BCD format */
+#define RTC_TSDR_DT_0                  (0x1U << RTC_TSDR_DT_Pos)               /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                  (0x2U << RTC_TSDR_DT_Pos)               /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos                (0U)
+#define RTC_TSDR_DU_Msk                (0xFUL << RTC_TSDR_DU_Pos)              /*!< 0x0000000F */
+#define RTC_TSDR_DU                    RTC_TSDR_DU_Msk                         /*!< Timestamp date units in BCD format */
+#define RTC_TSDR_DU_0                  (0x1U << RTC_TSDR_DU_Pos)               /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                  (0x2U << RTC_TSDR_DU_Pos)               /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                  (0x4U << RTC_TSDR_DU_Pos)               /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                  (0x8U << RTC_TSDR_DU_Pos)               /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos               (0U)
+#define RTC_TSSSR_SS_Msk               (0xFFFFUL << RTC_TSSSR_SS_Pos)          /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                   RTC_TSSSR_SS_Msk                        /*!< Timestamp sub second value */
+
+/********************  Bits definition for RTC_CALR register  *****************/
+#define RTC_CALR_CALP_Pos              (15U)
+#define RTC_CALR_CALP_Msk              (0x1UL << RTC_CALR_CALP_Pos)            /*!< 0x00008000 */
+#define RTC_CALR_CALP                  RTC_CALR_CALP_Msk                       /*!< Increase frequency of RTC 488.5 ppm */
+#define RTC_CALR_CALW8_Pos             (14U)
+#define RTC_CALR_CALW8_Msk             (0x1UL << RTC_CALR_CALW8_Pos)           /*!< 0x00004000 */
+#define RTC_CALR_CALW8                 RTC_CALR_CALW8_Msk                      /*!< Use a 8-second calibration cycle period */
+#define RTC_CALR_CALW16_Pos            (13U)
+#define RTC_CALR_CALW16_Msk            (0x1UL << RTC_CALR_CALW16_Pos)          /*!< 0x00002000 */
+#define RTC_CALR_CALW16                RTC_CALR_CALW16_Msk                     /*!< Use a 16-second calibration cycle period */
+#define RTC_CALR_CALM_Pos              (0U)
+#define RTC_CALR_CALM_Msk              (0x1FFUL << RTC_CALR_CALM_Pos)          /*!< 0x000001FF */
+#define RTC_CALR_CALM                  RTC_CALR_CALM_Msk                       /*!< Calibration minus */
+#define RTC_CALR_CALM_0                (0x001U << RTC_CALR_CALM_Pos)           /*!< 0x00000001 */
+#define RTC_CALR_CALM_1                (0x002U << RTC_CALR_CALM_Pos)           /*!< 0x00000002 */
+#define RTC_CALR_CALM_2                (0x004U << RTC_CALR_CALM_Pos)           /*!< 0x00000004 */
+#define RTC_CALR_CALM_3                (0x008U << RTC_CALR_CALM_Pos)           /*!< 0x00000008 */
+#define RTC_CALR_CALM_4                (0x010U << RTC_CALR_CALM_Pos)           /*!< 0x00000010 */
+#define RTC_CALR_CALM_5                (0x020U << RTC_CALR_CALM_Pos)           /*!< 0x00000020 */
+#define RTC_CALR_CALM_6                (0x040U << RTC_CALR_CALM_Pos)           /*!< 0x00000040 */
+#define RTC_CALR_CALM_7                (0x080U << RTC_CALR_CALM_Pos)           /*!< 0x00000080 */
+#define RTC_CALR_CALM_8                (0x100U << RTC_CALR_CALM_Pos)           /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP2MF_Pos         (21U)
+#define RTC_TAMPCR_TAMP2MF_Msk         (0x1UL << RTC_TAMPCR_TAMP2MF_Pos)       /*!< 0x00200000 */
+#define RTC_TAMPCR_TAMP2MF             RTC_TAMPCR_TAMP2MF_Msk                  /*!< Tamper 2 generates a trigger event */
+#define RTC_TAMPCR_TAMP2NOERASE_Pos    (20U)
+#define RTC_TAMPCR_TAMP2NOERASE_Msk    (0x1UL << RTC_TAMPCR_TAMP2NOERASE_Pos)  /*!< 0x00100000 */
+#define RTC_TAMPCR_TAMP2NOERASE        RTC_TAMPCR_TAMP2NOERASE_Msk             /*!< Tamper 2 no erase backup registers */
+#define RTC_TAMPCR_TAMP2IE_Pos         (19U)
+#define RTC_TAMPCR_TAMP2IE_Msk         (0x1UL << RTC_TAMPCR_TAMP2IE_Pos)       /*!< 0x00080000 */
+#define RTC_TAMPCR_TAMP2IE             RTC_TAMPCR_TAMP2IE_Msk                  /*!< Tamper 2 interrupt enable */
+#define RTC_TAMPCR_TAMPPUDIS_Pos       (15U)
+#define RTC_TAMPCR_TAMPPUDIS_Msk       (0x1UL << RTC_TAMPCR_TAMPPUDIS_Pos)     /*!< 0x00008000 */
+#define RTC_TAMPCR_TAMPPUDIS           RTC_TAMPCR_TAMPPUDIS_Msk                /*!< RTC_TAMPx pull-up disable */
+#define RTC_TAMPCR_TAMPPRCH_Pos        (13U)
+#define RTC_TAMPCR_TAMPPRCH_Msk        (0x3UL << RTC_TAMPCR_TAMPPRCH_Pos)      /*!< 0x00006000 */
+#define RTC_TAMPCR_TAMPPRCH            RTC_TAMPCR_TAMPPRCH_Msk                 /*!< RTC_TAMPx precharge duration */
+#define RTC_TAMPCR_TAMPPRCH_0          (0x1U << RTC_TAMPCR_TAMPPRCH_Pos)       /*!< 0x00002000 */
+#define RTC_TAMPCR_TAMPPRCH_1          (0x2U << RTC_TAMPCR_TAMPPRCH_Pos)       /*!< 0x00004000 */
+#define RTC_TAMPCR_TAMPFLT_Pos         (11U)
+#define RTC_TAMPCR_TAMPFLT_Msk         (0x3UL << RTC_TAMPCR_TAMPFLT_Pos)       /*!< 0x00001800 */
+#define RTC_TAMPCR_TAMPFLT             RTC_TAMPCR_TAMPFLT_Msk                  /*!< RTC_TAMPx filter count */
+#define RTC_TAMPCR_TAMPFLT_0           (0x1U << RTC_TAMPCR_TAMPFLT_Pos)        /*!< 0x00000800 */
+#define RTC_TAMPCR_TAMPFLT_1           (0x2U << RTC_TAMPCR_TAMPFLT_Pos)        /*!< 0x00001000 */
+#define RTC_TAMPCR_TAMPFREQ_Pos        (8U)
+#define RTC_TAMPCR_TAMPFREQ_Msk        (0x7UL << RTC_TAMPCR_TAMPFREQ_Pos)      /*!< 0x00000700 */
+#define RTC_TAMPCR_TAMPFREQ            RTC_TAMPCR_TAMPFREQ_Msk                 /*!< Tamper sampling frequency */
+#define RTC_TAMPCR_TAMPFREQ_0          (0x1U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000100 */
+#define RTC_TAMPCR_TAMPFREQ_1          (0x2U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000200 */
+#define RTC_TAMPCR_TAMPFREQ_2          (0x4U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000400 */
+#define RTC_TAMPCR_TAMPTS_Pos          (7U)
+#define RTC_TAMPCR_TAMPTS_Msk          (0x1UL << RTC_TAMPCR_TAMPTS_Pos)        /*!< 0x00000080 */
+#define RTC_TAMPCR_TAMPTS              RTC_TAMPCR_TAMPTS_Msk                   /*!< Activate timestamp on tamper detection event */
+#define RTC_TAMPCR_TAMP2TRG_Pos        (4U)
+#define RTC_TAMPCR_TAMP2TRG_Msk        (0x1UL << RTC_TAMPCR_TAMP2TRG_Pos)      /*!< 0x00000010 */
+#define RTC_TAMPCR_TAMP2TRG            RTC_TAMPCR_TAMP2TRG_Msk                 /*!< Active level for RTC_TAMP2 input */
+#define RTC_TAMPCR_TAMP2E_Pos          (3U)
+#define RTC_TAMPCR_TAMP2E_Msk          (0x1UL << RTC_TAMPCR_TAMP2E_Pos)        /*!< 0x00000008 */
+#define RTC_TAMPCR_TAMP2E              RTC_TAMPCR_TAMP2E_Msk                   /*!< RTC_TAMP2 detection enable */
+#define RTC_TAMPCR_TAMPIE_Pos          (2U)
+#define RTC_TAMPCR_TAMPIE_Msk          (0x1UL << RTC_TAMPCR_TAMPIE_Pos)        /*!< 0x00000004 */
+#define RTC_TAMPCR_TAMPIE              RTC_TAMPCR_TAMPIE_Msk                   /*!< Tampers interrupt enable */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos        (24U)
+#define RTC_ALRMASSR_MASKSS_Msk        (0xFUL << RTC_ALRMASSR_MASKSS_Pos)      /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS            RTC_ALRMASSR_MASKSS_Msk                 /*!< Alarm A mask the most-significant bits starting at this bit */
+#define RTC_ALRMASSR_MASKSS_0          (0x1U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1          (0x2U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2          (0x4U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3          (0x8U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos            (0U)                                    /*!< Alarm A sub seconds value*/
+#define RTC_ALRMASSR_SS_Msk            (0x7FFFUL << RTC_ALRMASSR_SS_Pos)       /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS                RTC_ALRMASSR_SS_Msk
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos        (24U)
+#define RTC_ALRMBSSR_MASKSS_Msk        (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)      /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS            RTC_ALRMBSSR_MASKSS_Msk                 /*!< Alarm B mask the most-significant bits starting at this bit */
+#define RTC_ALRMBSSR_MASKSS_0          (0x1U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1          (0x2U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2          (0x4U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3          (0x8U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos            (0U)                                    /*!< Alarm B sub seconds value*/
+#define RTC_ALRMBSSR_SS_Msk            (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)       /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS                RTC_ALRMBSSR_SS_Msk
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_OUT_RMP_Pos             (1U)
+#define RTC_OR_OUT_RMP_Msk             (0x1UL << RTC_OR_OUT_RMP_Pos)       /*!< 0x00000002 */
+#define RTC_OR_OUT_RMP                 RTC_OR_OUT_RMP_Msk                  /*!< RTC_OUT remap */
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R_Pos                  (0U)
+#define RTC_BKP0R_Msk                  (0xFFFFFFFFUL << RTC_BKP0R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP0R                      RTC_BKP0R_Msk                           /*!< RTC backup register 0 */
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R_Pos                  (0U)
+#define RTC_BKP1R_Msk                  (0xFFFFFFFFUL << RTC_BKP1R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP1R                      RTC_BKP1R_Msk                           /*!< RTC backup register 1 */
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R_Pos                  (0U)
+#define RTC_BKP2R_Msk                  (0xFFFFFFFFUL << RTC_BKP2R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP2R                      RTC_BKP2R_Msk                           /*!< RTC backup register 2 */
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R_Pos                  (0U)
+#define RTC_BKP3R_Msk                  (0xFFFFFFFFUL << RTC_BKP3R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP3R                      RTC_BKP3R_Msk                           /*!< RTC backup register 3 */
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R_Pos                  (0U)
+#define RTC_BKP4R_Msk                  (0xFFFFFFFFUL << RTC_BKP4R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP4R                      RTC_BKP4R_Msk                           /*!< RTC backup register 4 */
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R_Pos                  (0U)
+#define RTC_BKP5R_Msk                  (0xFFFFFFFFUL << RTC_BKP5R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP5R                      RTC_BKP5R_Msk                           /*!< RTC backup register 5 */
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R_Pos                  (0U)
+#define RTC_BKP6R_Msk                  (0xFFFFFFFFUL << RTC_BKP6R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP6R                      RTC_BKP6R_Msk                           /*!< RTC backup register 6 */
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R_Pos                  (0U)
+#define RTC_BKP7R_Msk                  (0xFFFFFFFFUL << RTC_BKP7R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP7R                      RTC_BKP7R_Msk                           /*!< RTC backup register 7 */
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R_Pos                  (0U)
+#define RTC_BKP8R_Msk                  (0xFFFFFFFFUL << RTC_BKP8R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP8R                      RTC_BKP8R_Msk                           /*!< RTC backup register 8 */
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R_Pos                  (0U)
+#define RTC_BKP9R_Msk                  (0xFFFFFFFFUL << RTC_BKP9R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP9R                      RTC_BKP9R_Msk                           /*!< RTC backup register 9 */
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R_Pos                 (0U)
+#define RTC_BKP10R_Msk                 (0xFFFFFFFFUL << RTC_BKP10R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP10R                     RTC_BKP10R_Msk                          /*!< RTC backup register 10 */
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R_Pos                 (0U)
+#define RTC_BKP11R_Msk                 (0xFFFFFFFFUL << RTC_BKP11R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP11R                     RTC_BKP11R_Msk                          /*!< RTC backup register 11 */
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R_Pos                 (0U)
+#define RTC_BKP12R_Msk                 (0xFFFFFFFFUL << RTC_BKP12R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP12R                     RTC_BKP12R_Msk                          /*!< RTC backup register 12 */
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R_Pos                 (0U)
+#define RTC_BKP13R_Msk                 (0xFFFFFFFFUL << RTC_BKP13R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP13R                     RTC_BKP13R_Msk                          /*!< RTC backup register 13 */
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R_Pos                 (0U)
+#define RTC_BKP14R_Msk                 (0xFFFFFFFFUL << RTC_BKP14R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP14R                     RTC_BKP14R_Msk                          /*!< RTC backup register 14 */
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R_Pos                 (0U)
+#define RTC_BKP15R_Msk                 (0xFFFFFFFFUL << RTC_BKP15R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP15R                     RTC_BKP15R_Msk                          /*!< RTC backup register 15 */
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R_Pos                 (0U)
+#define RTC_BKP16R_Msk                 (0xFFFFFFFFUL << RTC_BKP16R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP16R                     RTC_BKP16R_Msk                          /*!< RTC backup register 16 */
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R_Pos                 (0U)
+#define RTC_BKP17R_Msk                 (0xFFFFFFFFUL << RTC_BKP17R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP17R                     RTC_BKP17R_Msk                          /*!< RTC backup register 17 */
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R_Pos                 (0U)
+#define RTC_BKP18R_Msk                 (0xFFFFFFFFUL << RTC_BKP18R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP18R                     RTC_BKP18R_Msk                          /*!< RTC backup register 18 */
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R_Pos                 (0U)
+#define RTC_BKP19R_Msk                 (0xFFFFFFFFUL << RTC_BKP19R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP19R                     RTC_BKP19R_Msk                          /*!< RTC backup register 19 */
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                 (20U)
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                  /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                  /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                  /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                  /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                 /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)            /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                 /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                 /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)              /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_CRCL_Pos            (11U)
+#define SPI_CR1_CRCL_Msk            (0x1UL << SPI_CR1_CRCL_Pos)                /*!< 0x00000800 */
+#define SPI_CR1_CRCL                SPI_CR1_CRCL_Msk                           /*!< CRC Length */
+#define SPI_CR1_CRCNEXT_Pos         (12U)
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)             /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)               /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)              /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)            /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)             /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!< Rx Buffer DMA Enable */
+#define SPI_CR2_TXDMAEN_Pos         (1U)
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)             /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!< Tx Buffer DMA Enable */
+#define SPI_CR2_SSOE_Pos            (2U)
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!< SS Output Enable */
+#define SPI_CR2_NSSP_Pos            (3U)
+#define SPI_CR2_NSSP_Msk            (0x1UL << SPI_CR2_NSSP_Pos)                /*!< 0x00000008 */
+#define SPI_CR2_NSSP                SPI_CR2_NSSP_Msk                           /*!< NSS pulse management Enable */
+#define SPI_CR2_FRF_Pos             (4U)
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                 /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!< Frame Format Enable */
+#define SPI_CR2_ERRIE_Pos           (5U)
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)               /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!< Error Interrupt Enable */
+#define SPI_CR2_RXNEIE_Pos          (6U)
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)              /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!< RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)               /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!< Tx buffer Empty Interrupt Enable */
+#define SPI_CR2_DS_Pos              (8U)
+#define SPI_CR2_DS_Msk              (0xFUL << SPI_CR2_DS_Pos)                  /*!< 0x00000F00 */
+#define SPI_CR2_DS                  SPI_CR2_DS_Msk                             /*!< DS[3:0] Data Size */
+#define SPI_CR2_DS_0                (0x1UL << SPI_CR2_DS_Pos)                  /*!< 0x00000100 */
+#define SPI_CR2_DS_1                (0x2UL << SPI_CR2_DS_Pos)                  /*!< 0x00000200 */
+#define SPI_CR2_DS_2                (0x4UL << SPI_CR2_DS_Pos)                  /*!< 0x00000400 */
+#define SPI_CR2_DS_3                (0x8UL << SPI_CR2_DS_Pos)                  /*!< 0x00000800 */
+#define SPI_CR2_FRXTH_Pos           (12U)
+#define SPI_CR2_FRXTH_Msk           (0x1UL << SPI_CR2_FRXTH_Pos)               /*!< 0x00001000 */
+#define SPI_CR2_FRXTH               SPI_CR2_FRXTH_Msk                          /*!< FIFO reception Threshold */
+#define SPI_CR2_LDMARX_Pos          (13U)
+#define SPI_CR2_LDMARX_Msk          (0x1UL << SPI_CR2_LDMARX_Pos)              /*!< 0x00002000 */
+#define SPI_CR2_LDMARX              SPI_CR2_LDMARX_Msk                         /*!< Last DMA transfer for reception */
+#define SPI_CR2_LDMATX_Pos          (14U)
+#define SPI_CR2_LDMATX_Msk          (0x1UL << SPI_CR2_LDMATX_Pos)              /*!< 0x00004000 */
+#define SPI_CR2_LDMATX              SPI_CR2_LDMATX_Msk                         /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                 /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!< Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                  /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!< Transmit buffer Empty */
+#define SPI_SR_CRCERR_Pos           (4U)
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)               /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!< CRC Error flag */
+#define SPI_SR_MODF_Pos             (5U)
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                 /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!< Mode fault */
+#define SPI_SR_OVR_Pos              (6U)
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                  /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!< Overrun flag */
+#define SPI_SR_BSY_Pos              (7U)
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                  /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!< Busy flag */
+#define SPI_SR_FRE_Pos              (8U)
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                  /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!< TI frame format error */
+#define SPI_SR_FRLVL_Pos            (9U)
+#define SPI_SR_FRLVL_Msk            (0x3UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000600 */
+#define SPI_SR_FRLVL                SPI_SR_FRLVL_Msk                           /*!< FIFO Reception Level */
+#define SPI_SR_FRLVL_0              (0x1UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000200 */
+#define SPI_SR_FRLVL_1              (0x2UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000400 */
+#define SPI_SR_FTLVL_Pos            (11U)
+#define SPI_SR_FTLVL_Msk            (0x3UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001800 */
+#define SPI_SR_FTLVL                SPI_SR_FTLVL_Msk                           /*!< FIFO Transmission Level */
+#define SPI_SR_FTLVL_0              (0x1UL << SPI_SR_FTLVL_Pos)                /*!< 0x00000800 */
+#define SPI_SR_FTLVL_1              (0x2UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001000 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)        /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Touch Sensing Controller (TSC)                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TSC_CR register  *********************/
+#define TSC_CR_TSCE_Pos          (0U)
+#define TSC_CR_TSCE_Msk          (0x1UL << TSC_CR_TSCE_Pos)                    /*!< 0x00000001 */
+#define TSC_CR_TSCE              TSC_CR_TSCE_Msk                               /*!< Touch sensing controller enable */
+#define TSC_CR_START_Pos         (1U)
+#define TSC_CR_START_Msk         (0x1UL << TSC_CR_START_Pos)                   /*!< 0x00000002 */
+#define TSC_CR_START             TSC_CR_START_Msk                              /*!< Start a new acquisition */
+#define TSC_CR_AM_Pos            (2U)
+#define TSC_CR_AM_Msk            (0x1UL << TSC_CR_AM_Pos)                      /*!< 0x00000004 */
+#define TSC_CR_AM                TSC_CR_AM_Msk                                 /*!< Acquisition mode */
+#define TSC_CR_SYNCPOL_Pos       (3U)
+#define TSC_CR_SYNCPOL_Msk       (0x1UL << TSC_CR_SYNCPOL_Pos)                 /*!< 0x00000008 */
+#define TSC_CR_SYNCPOL           TSC_CR_SYNCPOL_Msk                            /*!< Synchronization pin polarity */
+#define TSC_CR_IODEF_Pos         (4U)
+#define TSC_CR_IODEF_Msk         (0x1UL << TSC_CR_IODEF_Pos)                   /*!< 0x00000010 */
+#define TSC_CR_IODEF             TSC_CR_IODEF_Msk                              /*!< IO default mode */
+
+#define TSC_CR_MCV_Pos           (5U)
+#define TSC_CR_MCV_Msk           (0x7UL << TSC_CR_MCV_Pos)                     /*!< 0x000000E0 */
+#define TSC_CR_MCV               TSC_CR_MCV_Msk                                /*!< MCV[2:0] bits (Max Count Value) */
+#define TSC_CR_MCV_0             (0x1U << TSC_CR_MCV_Pos)                      /*!< 0x00000020 */
+#define TSC_CR_MCV_1             (0x2U << TSC_CR_MCV_Pos)                      /*!< 0x00000040 */
+#define TSC_CR_MCV_2             (0x4U << TSC_CR_MCV_Pos)                      /*!< 0x00000080 */
+
+#define TSC_CR_PGPSC_Pos         (12U)
+#define TSC_CR_PGPSC_Msk         (0x7UL << TSC_CR_PGPSC_Pos)                   /*!< 0x00007000 */
+#define TSC_CR_PGPSC             TSC_CR_PGPSC_Msk                              /*!< PGPSC[2:0] bits (Pulse Generator Prescaler) */
+#define TSC_CR_PGPSC_0           (0x1U << TSC_CR_PGPSC_Pos)                    /*!< 0x00001000 */
+#define TSC_CR_PGPSC_1           (0x2U << TSC_CR_PGPSC_Pos)                    /*!< 0x00002000 */
+#define TSC_CR_PGPSC_2           (0x4U << TSC_CR_PGPSC_Pos)                    /*!< 0x00004000 */
+
+#define TSC_CR_SSPSC_Pos         (15U)
+#define TSC_CR_SSPSC_Msk         (0x1UL << TSC_CR_SSPSC_Pos)                   /*!< 0x00008000 */
+#define TSC_CR_SSPSC             TSC_CR_SSPSC_Msk                              /*!< Spread Spectrum Prescaler */
+#define TSC_CR_SSE_Pos           (16U)
+#define TSC_CR_SSE_Msk           (0x1UL << TSC_CR_SSE_Pos)                     /*!< 0x00010000 */
+#define TSC_CR_SSE               TSC_CR_SSE_Msk                                /*!< Spread Spectrum Enable */
+
+#define TSC_CR_SSD_Pos           (17U)
+#define TSC_CR_SSD_Msk           (0x7FUL << TSC_CR_SSD_Pos)                    /*!< 0x00FE0000 */
+#define TSC_CR_SSD               TSC_CR_SSD_Msk                                /*!< SSD[6:0] bits (Spread Spectrum Deviation) */
+#define TSC_CR_SSD_0             (0x01U << TSC_CR_SSD_Pos)                     /*!< 0x00020000 */
+#define TSC_CR_SSD_1             (0x02U << TSC_CR_SSD_Pos)                     /*!< 0x00040000 */
+#define TSC_CR_SSD_2             (0x04U << TSC_CR_SSD_Pos)                     /*!< 0x00080000 */
+#define TSC_CR_SSD_3             (0x08U << TSC_CR_SSD_Pos)                     /*!< 0x00100000 */
+#define TSC_CR_SSD_4             (0x10U << TSC_CR_SSD_Pos)                     /*!< 0x00200000 */
+#define TSC_CR_SSD_5             (0x20U << TSC_CR_SSD_Pos)                     /*!< 0x00400000 */
+#define TSC_CR_SSD_6             (0x40U << TSC_CR_SSD_Pos)                     /*!< 0x00800000 */
+
+#define TSC_CR_CTPL_Pos          (24U)
+#define TSC_CR_CTPL_Msk          (0xFUL << TSC_CR_CTPL_Pos)                    /*!< 0x0F000000 */
+#define TSC_CR_CTPL              TSC_CR_CTPL_Msk                               /*!< CTPL[3:0] bits (Charge Transfer pulse low) */
+#define TSC_CR_CTPL_0            (0x1U << TSC_CR_CTPL_Pos)                     /*!< 0x01000000 */
+#define TSC_CR_CTPL_1            (0x2U << TSC_CR_CTPL_Pos)                     /*!< 0x02000000 */
+#define TSC_CR_CTPL_2            (0x4U << TSC_CR_CTPL_Pos)                     /*!< 0x04000000 */
+#define TSC_CR_CTPL_3            (0x8U << TSC_CR_CTPL_Pos)                     /*!< 0x08000000 */
+
+#define TSC_CR_CTPH_Pos          (28U)
+#define TSC_CR_CTPH_Msk          (0xFUL << TSC_CR_CTPH_Pos)                    /*!< 0xF0000000 */
+#define TSC_CR_CTPH              TSC_CR_CTPH_Msk                               /*!< CTPH[3:0] bits (Charge Transfer pulse high) */
+#define TSC_CR_CTPH_0            (0x1U << TSC_CR_CTPH_Pos)                     /*!< 0x10000000 */
+#define TSC_CR_CTPH_1            (0x2U << TSC_CR_CTPH_Pos)                     /*!< 0x20000000 */
+#define TSC_CR_CTPH_2            (0x4U << TSC_CR_CTPH_Pos)                     /*!< 0x40000000 */
+#define TSC_CR_CTPH_3            (0x8U << TSC_CR_CTPH_Pos)                     /*!< 0x80000000 */
+
+/*******************  Bit definition for TSC_IER register  ********************/
+#define TSC_IER_EOAIE_Pos        (0U)
+#define TSC_IER_EOAIE_Msk        (0x1UL << TSC_IER_EOAIE_Pos)                  /*!< 0x00000001 */
+#define TSC_IER_EOAIE            TSC_IER_EOAIE_Msk                             /*!< End of acquisition interrupt enable */
+#define TSC_IER_MCEIE_Pos        (1U)
+#define TSC_IER_MCEIE_Msk        (0x1UL << TSC_IER_MCEIE_Pos)                  /*!< 0x00000002 */
+#define TSC_IER_MCEIE            TSC_IER_MCEIE_Msk                             /*!< Max count error interrupt enable */
+
+/*******************  Bit definition for TSC_ICR register  ********************/
+#define TSC_ICR_EOAIC_Pos        (0U)
+#define TSC_ICR_EOAIC_Msk        (0x1UL << TSC_ICR_EOAIC_Pos)                  /*!< 0x00000001 */
+#define TSC_ICR_EOAIC            TSC_ICR_EOAIC_Msk                             /*!< End of acquisition interrupt clear */
+#define TSC_ICR_MCEIC_Pos        (1U)
+#define TSC_ICR_MCEIC_Msk        (0x1UL << TSC_ICR_MCEIC_Pos)                  /*!< 0x00000002 */
+#define TSC_ICR_MCEIC            TSC_ICR_MCEIC_Msk                             /*!< Max count error interrupt clear */
+
+/*******************  Bit definition for TSC_ISR register  ********************/
+#define TSC_ISR_EOAF_Pos         (0U)
+#define TSC_ISR_EOAF_Msk         (0x1UL << TSC_ISR_EOAF_Pos)                   /*!< 0x00000001 */
+#define TSC_ISR_EOAF             TSC_ISR_EOAF_Msk                              /*!< End of acquisition flag */
+#define TSC_ISR_MCEF_Pos         (1U)
+#define TSC_ISR_MCEF_Msk         (0x1UL << TSC_ISR_MCEF_Pos)                   /*!< 0x00000002 */
+#define TSC_ISR_MCEF             TSC_ISR_MCEF_Msk                              /*!< Max count error flag */
+
+/*******************  Bit definition for TSC_IOHCR register  ******************/
+#define TSC_IOHCR_G1_IO1_Pos     (0U)
+#define TSC_IOHCR_G1_IO1_Msk     (0x1UL << TSC_IOHCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOHCR_G1_IO1         TSC_IOHCR_G1_IO1_Msk                          /*!< GROUP1_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO2_Pos     (1U)
+#define TSC_IOHCR_G1_IO2_Msk     (0x1UL << TSC_IOHCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOHCR_G1_IO2         TSC_IOHCR_G1_IO2_Msk                          /*!< GROUP1_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO3_Pos     (2U)
+#define TSC_IOHCR_G1_IO3_Msk     (0x1UL << TSC_IOHCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOHCR_G1_IO3         TSC_IOHCR_G1_IO3_Msk                          /*!< GROUP1_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO4_Pos     (3U)
+#define TSC_IOHCR_G1_IO4_Msk     (0x1UL << TSC_IOHCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOHCR_G1_IO4         TSC_IOHCR_G1_IO4_Msk                          /*!< GROUP1_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO1_Pos     (4U)
+#define TSC_IOHCR_G2_IO1_Msk     (0x1UL << TSC_IOHCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOHCR_G2_IO1         TSC_IOHCR_G2_IO1_Msk                          /*!< GROUP2_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO2_Pos     (5U)
+#define TSC_IOHCR_G2_IO2_Msk     (0x1UL << TSC_IOHCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOHCR_G2_IO2         TSC_IOHCR_G2_IO2_Msk                          /*!< GROUP2_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO3_Pos     (6U)
+#define TSC_IOHCR_G2_IO3_Msk     (0x1UL << TSC_IOHCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOHCR_G2_IO3         TSC_IOHCR_G2_IO3_Msk                          /*!< GROUP2_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO4_Pos     (7U)
+#define TSC_IOHCR_G2_IO4_Msk     (0x1UL << TSC_IOHCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOHCR_G2_IO4         TSC_IOHCR_G2_IO4_Msk                          /*!< GROUP2_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO1_Pos     (8U)
+#define TSC_IOHCR_G3_IO1_Msk     (0x1UL << TSC_IOHCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOHCR_G3_IO1         TSC_IOHCR_G3_IO1_Msk                          /*!< GROUP3_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO2_Pos     (9U)
+#define TSC_IOHCR_G3_IO2_Msk     (0x1UL << TSC_IOHCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOHCR_G3_IO2         TSC_IOHCR_G3_IO2_Msk                          /*!< GROUP3_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO3_Pos     (10U)
+#define TSC_IOHCR_G3_IO3_Msk     (0x1UL << TSC_IOHCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOHCR_G3_IO3         TSC_IOHCR_G3_IO3_Msk                          /*!< GROUP3_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO4_Pos     (11U)
+#define TSC_IOHCR_G3_IO4_Msk     (0x1UL << TSC_IOHCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOHCR_G3_IO4         TSC_IOHCR_G3_IO4_Msk                          /*!< GROUP3_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO1_Pos     (12U)
+#define TSC_IOHCR_G4_IO1_Msk     (0x1UL << TSC_IOHCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOHCR_G4_IO1         TSC_IOHCR_G4_IO1_Msk                          /*!< GROUP4_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO2_Pos     (13U)
+#define TSC_IOHCR_G4_IO2_Msk     (0x1UL << TSC_IOHCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOHCR_G4_IO2         TSC_IOHCR_G4_IO2_Msk                          /*!< GROUP4_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO3_Pos     (14U)
+#define TSC_IOHCR_G4_IO3_Msk     (0x1UL << TSC_IOHCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOHCR_G4_IO3         TSC_IOHCR_G4_IO3_Msk                          /*!< GROUP4_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO4_Pos     (15U)
+#define TSC_IOHCR_G4_IO4_Msk     (0x1UL << TSC_IOHCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOHCR_G4_IO4         TSC_IOHCR_G4_IO4_Msk                          /*!< GROUP4_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO1_Pos     (16U)
+#define TSC_IOHCR_G5_IO1_Msk     (0x1UL << TSC_IOHCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOHCR_G5_IO1         TSC_IOHCR_G5_IO1_Msk                          /*!< GROUP5_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO2_Pos     (17U)
+#define TSC_IOHCR_G5_IO2_Msk     (0x1UL << TSC_IOHCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOHCR_G5_IO2         TSC_IOHCR_G5_IO2_Msk                          /*!< GROUP5_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO3_Pos     (18U)
+#define TSC_IOHCR_G5_IO3_Msk     (0x1UL << TSC_IOHCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOHCR_G5_IO3         TSC_IOHCR_G5_IO3_Msk                          /*!< GROUP5_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO4_Pos     (19U)
+#define TSC_IOHCR_G5_IO4_Msk     (0x1UL << TSC_IOHCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOHCR_G5_IO4         TSC_IOHCR_G5_IO4_Msk                          /*!< GROUP5_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO1_Pos     (20U)
+#define TSC_IOHCR_G6_IO1_Msk     (0x1UL << TSC_IOHCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOHCR_G6_IO1         TSC_IOHCR_G6_IO1_Msk                          /*!< GROUP6_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO2_Pos     (21U)
+#define TSC_IOHCR_G6_IO2_Msk     (0x1UL << TSC_IOHCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOHCR_G6_IO2         TSC_IOHCR_G6_IO2_Msk                          /*!< GROUP6_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO3_Pos     (22U)
+#define TSC_IOHCR_G6_IO3_Msk     (0x1UL << TSC_IOHCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOHCR_G6_IO3         TSC_IOHCR_G6_IO3_Msk                          /*!< GROUP6_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO4_Pos     (23U)
+#define TSC_IOHCR_G6_IO4_Msk     (0x1UL << TSC_IOHCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOHCR_G6_IO4         TSC_IOHCR_G6_IO4_Msk                          /*!< GROUP6_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO1_Pos     (24U)
+#define TSC_IOHCR_G7_IO1_Msk     (0x1UL << TSC_IOHCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOHCR_G7_IO1         TSC_IOHCR_G7_IO1_Msk                          /*!< GROUP7_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO2_Pos     (25U)
+#define TSC_IOHCR_G7_IO2_Msk     (0x1UL << TSC_IOHCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOHCR_G7_IO2         TSC_IOHCR_G7_IO2_Msk                          /*!< GROUP7_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO3_Pos     (26U)
+#define TSC_IOHCR_G7_IO3_Msk     (0x1UL << TSC_IOHCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOHCR_G7_IO3         TSC_IOHCR_G7_IO3_Msk                          /*!< GROUP7_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO4_Pos     (27U)
+#define TSC_IOHCR_G7_IO4_Msk     (0x1UL << TSC_IOHCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOHCR_G7_IO4         TSC_IOHCR_G7_IO4_Msk                          /*!< GROUP7_IO4 schmitt trigger hysteresis mode */
+
+/*******************  Bit definition for TSC_IOASCR register  *****************/
+#define TSC_IOASCR_G1_IO1_Pos    (0U)
+#define TSC_IOASCR_G1_IO1_Msk    (0x1UL << TSC_IOASCR_G1_IO1_Pos)              /*!< 0x00000001 */
+#define TSC_IOASCR_G1_IO1        TSC_IOASCR_G1_IO1_Msk                         /*!< GROUP1_IO1 analog switch enable */
+#define TSC_IOASCR_G1_IO2_Pos    (1U)
+#define TSC_IOASCR_G1_IO2_Msk    (0x1UL << TSC_IOASCR_G1_IO2_Pos)              /*!< 0x00000002 */
+#define TSC_IOASCR_G1_IO2        TSC_IOASCR_G1_IO2_Msk                         /*!< GROUP1_IO2 analog switch enable */
+#define TSC_IOASCR_G1_IO3_Pos    (2U)
+#define TSC_IOASCR_G1_IO3_Msk    (0x1UL << TSC_IOASCR_G1_IO3_Pos)              /*!< 0x00000004 */
+#define TSC_IOASCR_G1_IO3        TSC_IOASCR_G1_IO3_Msk                         /*!< GROUP1_IO3 analog switch enable */
+#define TSC_IOASCR_G1_IO4_Pos    (3U)
+#define TSC_IOASCR_G1_IO4_Msk    (0x1UL << TSC_IOASCR_G1_IO4_Pos)              /*!< 0x00000008 */
+#define TSC_IOASCR_G1_IO4        TSC_IOASCR_G1_IO4_Msk                         /*!< GROUP1_IO4 analog switch enable */
+#define TSC_IOASCR_G2_IO1_Pos    (4U)
+#define TSC_IOASCR_G2_IO1_Msk    (0x1UL << TSC_IOASCR_G2_IO1_Pos)              /*!< 0x00000010 */
+#define TSC_IOASCR_G2_IO1        TSC_IOASCR_G2_IO1_Msk                         /*!< GROUP2_IO1 analog switch enable */
+#define TSC_IOASCR_G2_IO2_Pos    (5U)
+#define TSC_IOASCR_G2_IO2_Msk    (0x1UL << TSC_IOASCR_G2_IO2_Pos)              /*!< 0x00000020 */
+#define TSC_IOASCR_G2_IO2        TSC_IOASCR_G2_IO2_Msk                         /*!< GROUP2_IO2 analog switch enable */
+#define TSC_IOASCR_G2_IO3_Pos    (6U)
+#define TSC_IOASCR_G2_IO3_Msk    (0x1UL << TSC_IOASCR_G2_IO3_Pos)              /*!< 0x00000040 */
+#define TSC_IOASCR_G2_IO3        TSC_IOASCR_G2_IO3_Msk                         /*!< GROUP2_IO3 analog switch enable */
+#define TSC_IOASCR_G2_IO4_Pos    (7U)
+#define TSC_IOASCR_G2_IO4_Msk    (0x1UL << TSC_IOASCR_G2_IO4_Pos)              /*!< 0x00000080 */
+#define TSC_IOASCR_G2_IO4        TSC_IOASCR_G2_IO4_Msk                         /*!< GROUP2_IO4 analog switch enable */
+#define TSC_IOASCR_G3_IO1_Pos    (8U)
+#define TSC_IOASCR_G3_IO1_Msk    (0x1UL << TSC_IOASCR_G3_IO1_Pos)              /*!< 0x00000100 */
+#define TSC_IOASCR_G3_IO1        TSC_IOASCR_G3_IO1_Msk                         /*!< GROUP3_IO1 analog switch enable */
+#define TSC_IOASCR_G3_IO2_Pos    (9U)
+#define TSC_IOASCR_G3_IO2_Msk    (0x1UL << TSC_IOASCR_G3_IO2_Pos)              /*!< 0x00000200 */
+#define TSC_IOASCR_G3_IO2        TSC_IOASCR_G3_IO2_Msk                         /*!< GROUP3_IO2 analog switch enable */
+#define TSC_IOASCR_G3_IO3_Pos    (10U)
+#define TSC_IOASCR_G3_IO3_Msk    (0x1UL << TSC_IOASCR_G3_IO3_Pos)              /*!< 0x00000400 */
+#define TSC_IOASCR_G3_IO3        TSC_IOASCR_G3_IO3_Msk                         /*!< GROUP3_IO3 analog switch enable */
+#define TSC_IOASCR_G3_IO4_Pos    (11U)
+#define TSC_IOASCR_G3_IO4_Msk    (0x1UL << TSC_IOASCR_G3_IO4_Pos)              /*!< 0x00000800 */
+#define TSC_IOASCR_G3_IO4        TSC_IOASCR_G3_IO4_Msk                         /*!< GROUP3_IO4 analog switch enable */
+#define TSC_IOASCR_G4_IO1_Pos    (12U)
+#define TSC_IOASCR_G4_IO1_Msk    (0x1UL << TSC_IOASCR_G4_IO1_Pos)              /*!< 0x00001000 */
+#define TSC_IOASCR_G4_IO1        TSC_IOASCR_G4_IO1_Msk                         /*!< GROUP4_IO1 analog switch enable */
+#define TSC_IOASCR_G4_IO2_Pos    (13U)
+#define TSC_IOASCR_G4_IO2_Msk    (0x1UL << TSC_IOASCR_G4_IO2_Pos)              /*!< 0x00002000 */
+#define TSC_IOASCR_G4_IO2        TSC_IOASCR_G4_IO2_Msk                         /*!< GROUP4_IO2 analog switch enable */
+#define TSC_IOASCR_G4_IO3_Pos    (14U)
+#define TSC_IOASCR_G4_IO3_Msk    (0x1UL << TSC_IOASCR_G4_IO3_Pos)              /*!< 0x00004000 */
+#define TSC_IOASCR_G4_IO3        TSC_IOASCR_G4_IO3_Msk                         /*!< GROUP4_IO3 analog switch enable */
+#define TSC_IOASCR_G4_IO4_Pos    (15U)
+#define TSC_IOASCR_G4_IO4_Msk    (0x1UL << TSC_IOASCR_G4_IO4_Pos)              /*!< 0x00008000 */
+#define TSC_IOASCR_G4_IO4        TSC_IOASCR_G4_IO4_Msk                         /*!< GROUP4_IO4 analog switch enable */
+#define TSC_IOASCR_G5_IO1_Pos    (16U)
+#define TSC_IOASCR_G5_IO1_Msk    (0x1UL << TSC_IOASCR_G5_IO1_Pos)              /*!< 0x00010000 */
+#define TSC_IOASCR_G5_IO1        TSC_IOASCR_G5_IO1_Msk                         /*!< GROUP5_IO1 analog switch enable */
+#define TSC_IOASCR_G5_IO2_Pos    (17U)
+#define TSC_IOASCR_G5_IO2_Msk    (0x1UL << TSC_IOASCR_G5_IO2_Pos)              /*!< 0x00020000 */
+#define TSC_IOASCR_G5_IO2        TSC_IOASCR_G5_IO2_Msk                         /*!< GROUP5_IO2 analog switch enable */
+#define TSC_IOASCR_G5_IO3_Pos    (18U)
+#define TSC_IOASCR_G5_IO3_Msk    (0x1UL << TSC_IOASCR_G5_IO3_Pos)              /*!< 0x00040000 */
+#define TSC_IOASCR_G5_IO3        TSC_IOASCR_G5_IO3_Msk                         /*!< GROUP5_IO3 analog switch enable */
+#define TSC_IOASCR_G5_IO4_Pos    (19U)
+#define TSC_IOASCR_G5_IO4_Msk    (0x1UL << TSC_IOASCR_G5_IO4_Pos)              /*!< 0x00080000 */
+#define TSC_IOASCR_G5_IO4        TSC_IOASCR_G5_IO4_Msk                         /*!< GROUP5_IO4 analog switch enable */
+#define TSC_IOASCR_G6_IO1_Pos    (20U)
+#define TSC_IOASCR_G6_IO1_Msk    (0x1UL << TSC_IOASCR_G6_IO1_Pos)              /*!< 0x00100000 */
+#define TSC_IOASCR_G6_IO1        TSC_IOASCR_G6_IO1_Msk                         /*!< GROUP6_IO1 analog switch enable */
+#define TSC_IOASCR_G6_IO2_Pos    (21U)
+#define TSC_IOASCR_G6_IO2_Msk    (0x1UL << TSC_IOASCR_G6_IO2_Pos)              /*!< 0x00200000 */
+#define TSC_IOASCR_G6_IO2        TSC_IOASCR_G6_IO2_Msk                         /*!< GROUP6_IO2 analog switch enable */
+#define TSC_IOASCR_G6_IO3_Pos    (22U)
+#define TSC_IOASCR_G6_IO3_Msk    (0x1UL << TSC_IOASCR_G6_IO3_Pos)              /*!< 0x00400000 */
+#define TSC_IOASCR_G6_IO3        TSC_IOASCR_G6_IO3_Msk                         /*!< GROUP6_IO3 analog switch enable */
+#define TSC_IOASCR_G6_IO4_Pos    (23U)
+#define TSC_IOASCR_G6_IO4_Msk    (0x1UL << TSC_IOASCR_G6_IO4_Pos)              /*!< 0x00800000 */
+#define TSC_IOASCR_G6_IO4        TSC_IOASCR_G6_IO4_Msk                         /*!< GROUP6_IO4 analog switch enable */
+#define TSC_IOASCR_G7_IO1_Pos    (24U)
+#define TSC_IOASCR_G7_IO1_Msk    (0x1UL << TSC_IOASCR_G7_IO1_Pos)              /*!< 0x01000000 */
+#define TSC_IOASCR_G7_IO1        TSC_IOASCR_G7_IO1_Msk                         /*!< GROUP7_IO1 analog switch enable */
+#define TSC_IOASCR_G7_IO2_Pos    (25U)
+#define TSC_IOASCR_G7_IO2_Msk    (0x1UL << TSC_IOASCR_G7_IO2_Pos)              /*!< 0x02000000 */
+#define TSC_IOASCR_G7_IO2        TSC_IOASCR_G7_IO2_Msk                         /*!< GROUP7_IO2 analog switch enable */
+#define TSC_IOASCR_G7_IO3_Pos    (26U)
+#define TSC_IOASCR_G7_IO3_Msk    (0x1UL << TSC_IOASCR_G7_IO3_Pos)              /*!< 0x04000000 */
+#define TSC_IOASCR_G7_IO3        TSC_IOASCR_G7_IO3_Msk                         /*!< GROUP7_IO3 analog switch enable */
+#define TSC_IOASCR_G7_IO4_Pos    (27U)
+#define TSC_IOASCR_G7_IO4_Msk    (0x1UL << TSC_IOASCR_G7_IO4_Pos)              /*!< 0x08000000 */
+#define TSC_IOASCR_G7_IO4        TSC_IOASCR_G7_IO4_Msk                         /*!< GROUP7_IO4 analog switch enable */
+
+/*******************  Bit definition for TSC_IOSCR register  ******************/
+#define TSC_IOSCR_G1_IO1_Pos     (0U)
+#define TSC_IOSCR_G1_IO1_Msk     (0x1UL << TSC_IOSCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOSCR_G1_IO1         TSC_IOSCR_G1_IO1_Msk                          /*!< GROUP1_IO1 sampling mode */
+#define TSC_IOSCR_G1_IO2_Pos     (1U)
+#define TSC_IOSCR_G1_IO2_Msk     (0x1UL << TSC_IOSCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOSCR_G1_IO2         TSC_IOSCR_G1_IO2_Msk                          /*!< GROUP1_IO2 sampling mode */
+#define TSC_IOSCR_G1_IO3_Pos     (2U)
+#define TSC_IOSCR_G1_IO3_Msk     (0x1UL << TSC_IOSCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOSCR_G1_IO3         TSC_IOSCR_G1_IO3_Msk                          /*!< GROUP1_IO3 sampling mode */
+#define TSC_IOSCR_G1_IO4_Pos     (3U)
+#define TSC_IOSCR_G1_IO4_Msk     (0x1UL << TSC_IOSCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOSCR_G1_IO4         TSC_IOSCR_G1_IO4_Msk                          /*!< GROUP1_IO4 sampling mode */
+#define TSC_IOSCR_G2_IO1_Pos     (4U)
+#define TSC_IOSCR_G2_IO1_Msk     (0x1UL << TSC_IOSCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOSCR_G2_IO1         TSC_IOSCR_G2_IO1_Msk                          /*!< GROUP2_IO1 sampling mode */
+#define TSC_IOSCR_G2_IO2_Pos     (5U)
+#define TSC_IOSCR_G2_IO2_Msk     (0x1UL << TSC_IOSCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOSCR_G2_IO2         TSC_IOSCR_G2_IO2_Msk                          /*!< GROUP2_IO2 sampling mode */
+#define TSC_IOSCR_G2_IO3_Pos     (6U)
+#define TSC_IOSCR_G2_IO3_Msk     (0x1UL << TSC_IOSCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOSCR_G2_IO3         TSC_IOSCR_G2_IO3_Msk                          /*!< GROUP2_IO3 sampling mode */
+#define TSC_IOSCR_G2_IO4_Pos     (7U)
+#define TSC_IOSCR_G2_IO4_Msk     (0x1UL << TSC_IOSCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOSCR_G2_IO4         TSC_IOSCR_G2_IO4_Msk                          /*!< GROUP2_IO4 sampling mode */
+#define TSC_IOSCR_G3_IO1_Pos     (8U)
+#define TSC_IOSCR_G3_IO1_Msk     (0x1UL << TSC_IOSCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOSCR_G3_IO1         TSC_IOSCR_G3_IO1_Msk                          /*!< GROUP3_IO1 sampling mode */
+#define TSC_IOSCR_G3_IO2_Pos     (9U)
+#define TSC_IOSCR_G3_IO2_Msk     (0x1UL << TSC_IOSCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOSCR_G3_IO2         TSC_IOSCR_G3_IO2_Msk                          /*!< GROUP3_IO2 sampling mode */
+#define TSC_IOSCR_G3_IO3_Pos     (10U)
+#define TSC_IOSCR_G3_IO3_Msk     (0x1UL << TSC_IOSCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOSCR_G3_IO3         TSC_IOSCR_G3_IO3_Msk                          /*!< GROUP3_IO3 sampling mode */
+#define TSC_IOSCR_G3_IO4_Pos     (11U)
+#define TSC_IOSCR_G3_IO4_Msk     (0x1UL << TSC_IOSCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOSCR_G3_IO4         TSC_IOSCR_G3_IO4_Msk                          /*!< GROUP3_IO4 sampling mode */
+#define TSC_IOSCR_G4_IO1_Pos     (12U)
+#define TSC_IOSCR_G4_IO1_Msk     (0x1UL << TSC_IOSCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOSCR_G4_IO1         TSC_IOSCR_G4_IO1_Msk                          /*!< GROUP4_IO1 sampling mode */
+#define TSC_IOSCR_G4_IO2_Pos     (13U)
+#define TSC_IOSCR_G4_IO2_Msk     (0x1UL << TSC_IOSCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOSCR_G4_IO2         TSC_IOSCR_G4_IO2_Msk                          /*!< GROUP4_IO2 sampling mode */
+#define TSC_IOSCR_G4_IO3_Pos     (14U)
+#define TSC_IOSCR_G4_IO3_Msk     (0x1UL << TSC_IOSCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOSCR_G4_IO3         TSC_IOSCR_G4_IO3_Msk                          /*!< GROUP4_IO3 sampling mode */
+#define TSC_IOSCR_G4_IO4_Pos     (15U)
+#define TSC_IOSCR_G4_IO4_Msk     (0x1UL << TSC_IOSCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOSCR_G4_IO4         TSC_IOSCR_G4_IO4_Msk                          /*!< GROUP4_IO4 sampling mode */
+#define TSC_IOSCR_G5_IO1_Pos     (16U)
+#define TSC_IOSCR_G5_IO1_Msk     (0x1UL << TSC_IOSCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOSCR_G5_IO1         TSC_IOSCR_G5_IO1_Msk                          /*!< GROUP5_IO1 sampling mode */
+#define TSC_IOSCR_G5_IO2_Pos     (17U)
+#define TSC_IOSCR_G5_IO2_Msk     (0x1UL << TSC_IOSCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOSCR_G5_IO2         TSC_IOSCR_G5_IO2_Msk                          /*!< GROUP5_IO2 sampling mode */
+#define TSC_IOSCR_G5_IO3_Pos     (18U)
+#define TSC_IOSCR_G5_IO3_Msk     (0x1UL << TSC_IOSCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOSCR_G5_IO3         TSC_IOSCR_G5_IO3_Msk                          /*!< GROUP5_IO3 sampling mode */
+#define TSC_IOSCR_G5_IO4_Pos     (19U)
+#define TSC_IOSCR_G5_IO4_Msk     (0x1UL << TSC_IOSCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOSCR_G5_IO4         TSC_IOSCR_G5_IO4_Msk                          /*!< GROUP5_IO4 sampling mode */
+#define TSC_IOSCR_G6_IO1_Pos     (20U)
+#define TSC_IOSCR_G6_IO1_Msk     (0x1UL << TSC_IOSCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOSCR_G6_IO1         TSC_IOSCR_G6_IO1_Msk                          /*!< GROUP6_IO1 sampling mode */
+#define TSC_IOSCR_G6_IO2_Pos     (21U)
+#define TSC_IOSCR_G6_IO2_Msk     (0x1UL << TSC_IOSCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOSCR_G6_IO2         TSC_IOSCR_G6_IO2_Msk                          /*!< GROUP6_IO2 sampling mode */
+#define TSC_IOSCR_G6_IO3_Pos     (22U)
+#define TSC_IOSCR_G6_IO3_Msk     (0x1UL << TSC_IOSCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOSCR_G6_IO3         TSC_IOSCR_G6_IO3_Msk                          /*!< GROUP6_IO3 sampling mode */
+#define TSC_IOSCR_G6_IO4_Pos     (23U)
+#define TSC_IOSCR_G6_IO4_Msk     (0x1UL << TSC_IOSCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOSCR_G6_IO4         TSC_IOSCR_G6_IO4_Msk                          /*!< GROUP6_IO4 sampling mode */
+#define TSC_IOSCR_G7_IO1_Pos     (24U)
+#define TSC_IOSCR_G7_IO1_Msk     (0x1UL << TSC_IOSCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOSCR_G7_IO1         TSC_IOSCR_G7_IO1_Msk                          /*!< GROUP7_IO1 sampling mode */
+#define TSC_IOSCR_G7_IO2_Pos     (25U)
+#define TSC_IOSCR_G7_IO2_Msk     (0x1UL << TSC_IOSCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOSCR_G7_IO2         TSC_IOSCR_G7_IO2_Msk                          /*!< GROUP7_IO2 sampling mode */
+#define TSC_IOSCR_G7_IO3_Pos     (26U)
+#define TSC_IOSCR_G7_IO3_Msk     (0x1UL << TSC_IOSCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOSCR_G7_IO3         TSC_IOSCR_G7_IO3_Msk                          /*!< GROUP7_IO3 sampling mode */
+#define TSC_IOSCR_G7_IO4_Pos     (27U)
+#define TSC_IOSCR_G7_IO4_Msk     (0x1UL << TSC_IOSCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOSCR_G7_IO4         TSC_IOSCR_G7_IO4_Msk                          /*!< GROUP7_IO4 sampling mode */
+
+/*******************  Bit definition for TSC_IOCCR register  ******************/
+#define TSC_IOCCR_G1_IO1_Pos     (0U)
+#define TSC_IOCCR_G1_IO1_Msk     (0x1UL << TSC_IOCCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOCCR_G1_IO1         TSC_IOCCR_G1_IO1_Msk                          /*!< GROUP1_IO1 channel mode */
+#define TSC_IOCCR_G1_IO2_Pos     (1U)
+#define TSC_IOCCR_G1_IO2_Msk     (0x1UL << TSC_IOCCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOCCR_G1_IO2         TSC_IOCCR_G1_IO2_Msk                          /*!< GROUP1_IO2 channel mode */
+#define TSC_IOCCR_G1_IO3_Pos     (2U)
+#define TSC_IOCCR_G1_IO3_Msk     (0x1UL << TSC_IOCCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOCCR_G1_IO3         TSC_IOCCR_G1_IO3_Msk                          /*!< GROUP1_IO3 channel mode */
+#define TSC_IOCCR_G1_IO4_Pos     (3U)
+#define TSC_IOCCR_G1_IO4_Msk     (0x1UL << TSC_IOCCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOCCR_G1_IO4         TSC_IOCCR_G1_IO4_Msk                          /*!< GROUP1_IO4 channel mode */
+#define TSC_IOCCR_G2_IO1_Pos     (4U)
+#define TSC_IOCCR_G2_IO1_Msk     (0x1UL << TSC_IOCCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOCCR_G2_IO1         TSC_IOCCR_G2_IO1_Msk                          /*!< GROUP2_IO1 channel mode */
+#define TSC_IOCCR_G2_IO2_Pos     (5U)
+#define TSC_IOCCR_G2_IO2_Msk     (0x1UL << TSC_IOCCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOCCR_G2_IO2         TSC_IOCCR_G2_IO2_Msk                          /*!< GROUP2_IO2 channel mode */
+#define TSC_IOCCR_G2_IO3_Pos     (6U)
+#define TSC_IOCCR_G2_IO3_Msk     (0x1UL << TSC_IOCCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOCCR_G2_IO3         TSC_IOCCR_G2_IO3_Msk                          /*!< GROUP2_IO3 channel mode */
+#define TSC_IOCCR_G2_IO4_Pos     (7U)
+#define TSC_IOCCR_G2_IO4_Msk     (0x1UL << TSC_IOCCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOCCR_G2_IO4         TSC_IOCCR_G2_IO4_Msk                          /*!< GROUP2_IO4 channel mode */
+#define TSC_IOCCR_G3_IO1_Pos     (8U)
+#define TSC_IOCCR_G3_IO1_Msk     (0x1UL << TSC_IOCCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOCCR_G3_IO1         TSC_IOCCR_G3_IO1_Msk                          /*!< GROUP3_IO1 channel mode */
+#define TSC_IOCCR_G3_IO2_Pos     (9U)
+#define TSC_IOCCR_G3_IO2_Msk     (0x1UL << TSC_IOCCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOCCR_G3_IO2         TSC_IOCCR_G3_IO2_Msk                          /*!< GROUP3_IO2 channel mode */
+#define TSC_IOCCR_G3_IO3_Pos     (10U)
+#define TSC_IOCCR_G3_IO3_Msk     (0x1UL << TSC_IOCCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOCCR_G3_IO3         TSC_IOCCR_G3_IO3_Msk                          /*!< GROUP3_IO3 channel mode */
+#define TSC_IOCCR_G3_IO4_Pos     (11U)
+#define TSC_IOCCR_G3_IO4_Msk     (0x1UL << TSC_IOCCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOCCR_G3_IO4         TSC_IOCCR_G3_IO4_Msk                          /*!< GROUP3_IO4 channel mode */
+#define TSC_IOCCR_G4_IO1_Pos     (12U)
+#define TSC_IOCCR_G4_IO1_Msk     (0x1UL << TSC_IOCCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOCCR_G4_IO1         TSC_IOCCR_G4_IO1_Msk                          /*!< GROUP4_IO1 channel mode */
+#define TSC_IOCCR_G4_IO2_Pos     (13U)
+#define TSC_IOCCR_G4_IO2_Msk     (0x1UL << TSC_IOCCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOCCR_G4_IO2         TSC_IOCCR_G4_IO2_Msk                          /*!< GROUP4_IO2 channel mode */
+#define TSC_IOCCR_G4_IO3_Pos     (14U)
+#define TSC_IOCCR_G4_IO3_Msk     (0x1UL << TSC_IOCCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOCCR_G4_IO3         TSC_IOCCR_G4_IO3_Msk                          /*!< GROUP4_IO3 channel mode */
+#define TSC_IOCCR_G4_IO4_Pos     (15U)
+#define TSC_IOCCR_G4_IO4_Msk     (0x1UL << TSC_IOCCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOCCR_G4_IO4         TSC_IOCCR_G4_IO4_Msk                          /*!< GROUP4_IO4 channel mode */
+#define TSC_IOCCR_G5_IO1_Pos     (16U)
+#define TSC_IOCCR_G5_IO1_Msk     (0x1UL << TSC_IOCCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOCCR_G5_IO1         TSC_IOCCR_G5_IO1_Msk                          /*!< GROUP5_IO1 channel mode */
+#define TSC_IOCCR_G5_IO2_Pos     (17U)
+#define TSC_IOCCR_G5_IO2_Msk     (0x1UL << TSC_IOCCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOCCR_G5_IO2         TSC_IOCCR_G5_IO2_Msk                          /*!< GROUP5_IO2 channel mode */
+#define TSC_IOCCR_G5_IO3_Pos     (18U)
+#define TSC_IOCCR_G5_IO3_Msk     (0x1UL << TSC_IOCCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOCCR_G5_IO3         TSC_IOCCR_G5_IO3_Msk                          /*!< GROUP5_IO3 channel mode */
+#define TSC_IOCCR_G5_IO4_Pos     (19U)
+#define TSC_IOCCR_G5_IO4_Msk     (0x1UL << TSC_IOCCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOCCR_G5_IO4         TSC_IOCCR_G5_IO4_Msk                          /*!< GROUP5_IO4 channel mode */
+#define TSC_IOCCR_G6_IO1_Pos     (20U)
+#define TSC_IOCCR_G6_IO1_Msk     (0x1UL << TSC_IOCCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOCCR_G6_IO1         TSC_IOCCR_G6_IO1_Msk                          /*!< GROUP6_IO1 channel mode */
+#define TSC_IOCCR_G6_IO2_Pos     (21U)
+#define TSC_IOCCR_G6_IO2_Msk     (0x1UL << TSC_IOCCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOCCR_G6_IO2         TSC_IOCCR_G6_IO2_Msk                          /*!< GROUP6_IO2 channel mode */
+#define TSC_IOCCR_G6_IO3_Pos     (22U)
+#define TSC_IOCCR_G6_IO3_Msk     (0x1UL << TSC_IOCCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOCCR_G6_IO3         TSC_IOCCR_G6_IO3_Msk                          /*!< GROUP6_IO3 channel mode */
+#define TSC_IOCCR_G6_IO4_Pos     (23U)
+#define TSC_IOCCR_G6_IO4_Msk     (0x1UL << TSC_IOCCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOCCR_G6_IO4         TSC_IOCCR_G6_IO4_Msk                          /*!< GROUP6_IO4 channel mode */
+#define TSC_IOCCR_G7_IO1_Pos     (24U)
+#define TSC_IOCCR_G7_IO1_Msk     (0x1UL << TSC_IOCCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOCCR_G7_IO1         TSC_IOCCR_G7_IO1_Msk                          /*!< GROUP7_IO1 channel mode */
+#define TSC_IOCCR_G7_IO2_Pos     (25U)
+#define TSC_IOCCR_G7_IO2_Msk     (0x1UL << TSC_IOCCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOCCR_G7_IO2         TSC_IOCCR_G7_IO2_Msk                          /*!< GROUP7_IO2 channel mode */
+#define TSC_IOCCR_G7_IO3_Pos     (26U)
+#define TSC_IOCCR_G7_IO3_Msk     (0x1UL << TSC_IOCCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOCCR_G7_IO3         TSC_IOCCR_G7_IO3_Msk                          /*!< GROUP7_IO3 channel mode */
+#define TSC_IOCCR_G7_IO4_Pos     (27U)
+#define TSC_IOCCR_G7_IO4_Msk     (0x1UL << TSC_IOCCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOCCR_G7_IO4         TSC_IOCCR_G7_IO4_Msk                          /*!< GROUP7_IO4 channel mode */
+
+/*******************  Bit definition for TSC_IOGCSR register  *****************/
+#define TSC_IOGCSR_G1E_Pos       (0U)
+#define TSC_IOGCSR_G1E_Msk       (0x1UL << TSC_IOGCSR_G1E_Pos)                 /*!< 0x00000001 */
+#define TSC_IOGCSR_G1E           TSC_IOGCSR_G1E_Msk                            /*!< Analog IO GROUP1 enable */
+#define TSC_IOGCSR_G2E_Pos       (1U)
+#define TSC_IOGCSR_G2E_Msk       (0x1UL << TSC_IOGCSR_G2E_Pos)                 /*!< 0x00000002 */
+#define TSC_IOGCSR_G2E           TSC_IOGCSR_G2E_Msk                            /*!< Analog IO GROUP2 enable */
+#define TSC_IOGCSR_G3E_Pos       (2U)
+#define TSC_IOGCSR_G3E_Msk       (0x1UL << TSC_IOGCSR_G3E_Pos)                 /*!< 0x00000004 */
+#define TSC_IOGCSR_G3E           TSC_IOGCSR_G3E_Msk                            /*!< Analog IO GROUP3 enable */
+#define TSC_IOGCSR_G4E_Pos       (3U)
+#define TSC_IOGCSR_G4E_Msk       (0x1UL << TSC_IOGCSR_G4E_Pos)                 /*!< 0x00000008 */
+#define TSC_IOGCSR_G4E           TSC_IOGCSR_G4E_Msk                            /*!< Analog IO GROUP4 enable */
+#define TSC_IOGCSR_G5E_Pos       (4U)
+#define TSC_IOGCSR_G5E_Msk       (0x1UL << TSC_IOGCSR_G5E_Pos)                 /*!< 0x00000010 */
+#define TSC_IOGCSR_G5E           TSC_IOGCSR_G5E_Msk                            /*!< Analog IO GROUP5 enable */
+#define TSC_IOGCSR_G6E_Pos       (5U)
+#define TSC_IOGCSR_G6E_Msk       (0x1UL << TSC_IOGCSR_G6E_Pos)                 /*!< 0x00000020 */
+#define TSC_IOGCSR_G6E           TSC_IOGCSR_G6E_Msk                            /*!< Analog IO GROUP6 enable */
+#define TSC_IOGCSR_G7E_Pos       (6U)
+#define TSC_IOGCSR_G7E_Msk       (0x1UL << TSC_IOGCSR_G7E_Pos)                 /*!< 0x00000040 */
+#define TSC_IOGCSR_G7E           TSC_IOGCSR_G7E_Msk                            /*!< Analog IO GROUP7 enable */
+#define TSC_IOGCSR_G1S_Pos       (16U)
+#define TSC_IOGCSR_G1S_Msk       (0x1UL << TSC_IOGCSR_G1S_Pos)                 /*!< 0x00010000 */
+#define TSC_IOGCSR_G1S           TSC_IOGCSR_G1S_Msk                            /*!< Analog IO GROUP1 status */
+#define TSC_IOGCSR_G2S_Pos       (17U)
+#define TSC_IOGCSR_G2S_Msk       (0x1UL << TSC_IOGCSR_G2S_Pos)                 /*!< 0x00020000 */
+#define TSC_IOGCSR_G2S           TSC_IOGCSR_G2S_Msk                            /*!< Analog IO GROUP2 status */
+#define TSC_IOGCSR_G3S_Pos       (18U)
+#define TSC_IOGCSR_G3S_Msk       (0x1UL << TSC_IOGCSR_G3S_Pos)                 /*!< 0x00040000 */
+#define TSC_IOGCSR_G3S           TSC_IOGCSR_G3S_Msk                            /*!< Analog IO GROUP3 status */
+#define TSC_IOGCSR_G4S_Pos       (19U)
+#define TSC_IOGCSR_G4S_Msk       (0x1UL << TSC_IOGCSR_G4S_Pos)                 /*!< 0x00080000 */
+#define TSC_IOGCSR_G4S           TSC_IOGCSR_G4S_Msk                            /*!< Analog IO GROUP4 status */
+#define TSC_IOGCSR_G5S_Pos       (20U)
+#define TSC_IOGCSR_G5S_Msk       (0x1UL << TSC_IOGCSR_G5S_Pos)                 /*!< 0x00100000 */
+#define TSC_IOGCSR_G5S           TSC_IOGCSR_G5S_Msk                            /*!< Analog IO GROUP5 status */
+#define TSC_IOGCSR_G6S_Pos       (21U)
+#define TSC_IOGCSR_G6S_Msk       (0x1UL << TSC_IOGCSR_G6S_Pos)                 /*!< 0x00200000 */
+#define TSC_IOGCSR_G6S           TSC_IOGCSR_G6S_Msk                            /*!< Analog IO GROUP6 status */
+#define TSC_IOGCSR_G7S_Pos       (22U)
+#define TSC_IOGCSR_G7S_Msk       (0x1UL << TSC_IOGCSR_G7S_Pos)                 /*!< 0x00400000 */
+#define TSC_IOGCSR_G7S           TSC_IOGCSR_G7S_Msk                            /*!< Analog IO GROUP7 status */
+
+/*******************  Bit definition for TSC_IOGXCR register  *****************/
+#define TSC_IOGXCR_CNT_Pos       (0U)
+#define TSC_IOGXCR_CNT_Msk       (0x3FFFUL << TSC_IOGXCR_CNT_Pos)              /*!< 0x00003FFF */
+#define TSC_IOGXCR_CNT           TSC_IOGXCR_CNT_Msk                            /*!< CNT[13:0] bits (Counter value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for SYSCFG_MEMRMP register  (SYSCFG memory remap register) ***********************************/
+#define SYSCFG_MEMRMP_MEM_MODE_Pos              (0U)
+#define SYSCFG_MEMRMP_MEM_MODE_Msk              (0x7UL << SYSCFG_MEMRMP_MEM_MODE_Pos)           /*!< 0x00000007 */
+#define SYSCFG_MEMRMP_MEM_MODE                  SYSCFG_MEMRMP_MEM_MODE_Msk                      /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_MEMRMP_MEM_MODE_0                (0x1U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000001 */
+#define SYSCFG_MEMRMP_MEM_MODE_1                (0x2U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000002 */
+#define SYSCFG_MEMRMP_MEM_MODE_2                (0x4U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000004 */
+
+/*****************  Bit definition for SYSCFG_CFGR1 register  (SYSCFG configuration register 1) ****************************************************************/
+#define SYSCFG_CFGR1_BOOSTEN_Pos                (8U)
+#define SYSCFG_CFGR1_BOOSTEN_Msk                (0x1UL << SYSCFG_CFGR1_BOOSTEN_Pos)             /*!< 0x00000100 */
+#define SYSCFG_CFGR1_BOOSTEN                    SYSCFG_CFGR1_BOOSTEN_Msk                        /*!< I/O analog switch voltage booster enable                  */
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Pos            (16U)
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB6_FMP_Pos)         /*!< 0x00010000 */
+#define SYSCFG_CFGR1_I2C_PB6_FMP                SYSCFG_CFGR1_I2C_PB6_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB6 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Pos            (17U)
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB7_FMP_Pos)         /*!< 0x00020000 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP                SYSCFG_CFGR1_I2C_PB7_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB7 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Pos            (18U)
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB8_FMP_Pos)         /*!< 0x00040000 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP                SYSCFG_CFGR1_I2C_PB8_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB8 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Pos            (19U)
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB9_FMP_Pos)         /*!< 0x00080000 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP                SYSCFG_CFGR1_I2C_PB9_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB9 */
+#define SYSCFG_CFGR1_I2C1_FMP_Pos               (20U)
+#define SYSCFG_CFGR1_I2C1_FMP_Msk               (0x1UL << SYSCFG_CFGR1_I2C1_FMP_Pos)            /*!< 0x00100000 */
+#define SYSCFG_CFGR1_I2C1_FMP                   SYSCFG_CFGR1_I2C1_FMP_Msk                       /*!< I2C1 Fast-mode Plus (Fm+) driving capability activation   */
+#define SYSCFG_CFGR1_FPU_IE_Pos                 (26U)
+#define SYSCFG_CFGR1_FPU_IE_Msk                 (0x3FUL << SYSCFG_CFGR1_FPU_IE_Pos)             /*!< 0xFC000000 */
+#define SYSCFG_CFGR1_FPU_IE                     SYSCFG_CFGR1_FPU_IE_Msk                         /*!< Cortex M4 Floating Point Unit interrupts enable bits      */
+#define SYSCFG_CFGR1_FPU_IE_0                   (0x01U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x04000000 */
+#define SYSCFG_CFGR1_FPU_IE_1                   (0x02U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x08000000 */
+#define SYSCFG_CFGR1_FPU_IE_2                   (0x04U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x10000000 */
+#define SYSCFG_CFGR1_FPU_IE_3                   (0x08U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x20000000 */
+#define SYSCFG_CFGR1_FPU_IE_4                   (0x10U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x40000000 */
+#define SYSCFG_CFGR1_FPU_IE_5                   (0x20U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x80000000 */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  (External interrupt configuration register 1) ********************************/
+#define SYSCFG_EXTICR1_EXTI0_Pos                (0U)
+#define SYSCFG_EXTICR1_EXTI0_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI0_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR1_EXTI0                    SYSCFG_EXTICR1_EXTI0_Msk                        /*!< External Interrupt Line 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1_Pos                (4U)
+#define SYSCFG_EXTICR1_EXTI1_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI1_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR1_EXTI1                    SYSCFG_EXTICR1_EXTI1_Msk                        /*!< External Interrupt Line 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2_Pos                (8U)
+#define SYSCFG_EXTICR1_EXTI2_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI2_Pos)             /*!< 0x00000700 */
+#define SYSCFG_EXTICR1_EXTI2                    SYSCFG_EXTICR1_EXTI2_Msk                        /*!< External Interrupt Line 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3_Pos                (12U)
+#define SYSCFG_EXTICR1_EXTI3_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI3_Pos)             /*!< 0x00007000 */
+#define SYSCFG_EXTICR1_EXTI3                    SYSCFG_EXTICR1_EXTI3_Msk                        /*!< External Interrupt Line 3 configuration */
+
+/**
+  * @brief  External Interrupt Line 0 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA                 (0x00000000UL)  /*!< PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB                 (0x00000001UL)  /*!< PB[0] pin */
+
+/**
+  * @brief  External Interrupt Line 1 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA                 (0x00000000UL)  /*!< PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB                 (0x00000010UL)  /*!< PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC                 (0x00000020UL)  /*!< PC[1] pin */
+
+/**
+  * @brief  External Interrupt Line 2 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA                 (0x00000000UL)  /*!< PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB                 (0x00000100UL)  /*!< PB[2] pin */
+
+/**
+  * @brief  External Interrupt Line 3 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA                 (0x00000000UL)  /*!< PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB                 (0x00001000UL)  /*!< PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH                 (0x00007000UL)  /*!< PH[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  (External interrupt configuration register 2) ********************************/
+#define SYSCFG_EXTICR2_EXTI4_Pos                (0U)
+#define SYSCFG_EXTICR2_EXTI4_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI4_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR2_EXTI4                    SYSCFG_EXTICR2_EXTI4_Msk                        /*!< External Interrupt Line 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5_Pos                (4U)
+#define SYSCFG_EXTICR2_EXTI5_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI5_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR2_EXTI5                    SYSCFG_EXTICR2_EXTI5_Msk                        /*!< External Interrupt Line 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6_Pos                (8U)
+#define SYSCFG_EXTICR2_EXTI6_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI6_Pos)             /*!< 0x00000700 */
+#define SYSCFG_EXTICR2_EXTI6                    SYSCFG_EXTICR2_EXTI6_Msk                        /*!< External Interrupt Line 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7_Pos                (12U)
+#define SYSCFG_EXTICR2_EXTI7_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI7_Pos)             /*!< 0x00007000 */
+#define SYSCFG_EXTICR2_EXTI7                    SYSCFG_EXTICR2_EXTI7_Msk                        /*!< External Interrupt Line 7 configuration */
+
+/**
+  * @brief  External Interrupt Line 4 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA                 (0x00000000UL)  /*!< PA[4] pin  */
+#define SYSCFG_EXTICR2_EXTI4_PB                 (0x00000001UL)  /*!< PB[4] pin  */
+#define SYSCFG_EXTICR2_EXTI4_PE                 (0x00000004UL)  /*!< PE[4] pin  */
+
+/**
+  * @brief  External Interrupt Line 5 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA                 (0x00000000UL)  /*!< PA[5] pin  */
+#define SYSCFG_EXTICR2_EXTI5_PB                 (0x00000010UL)  /*!< PB[5] pin  */
+
+/**
+  * @brief  External Interrupt Line 6 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA                 (0x00000000UL)  /*!< PA[6] pin  */
+#define SYSCFG_EXTICR2_EXTI6_PB                 (0x00000100UL)  /*!< PB[6] pin  */
+
+/**
+  * @brief  External Interrupt Line 7 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA                 (0x00000000UL)  /*!< PA[7] pin  */
+#define SYSCFG_EXTICR2_EXTI7_PB                 (0x00001000UL)  /*!< PB[7] pin  */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  (External interrupt configuration register 3) ********************************/
+#define SYSCFG_EXTICR3_EXTI8_Pos                (0U)
+#define SYSCFG_EXTICR3_EXTI8_Msk                (0x7UL << SYSCFG_EXTICR3_EXTI8_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR3_EXTI8                    SYSCFG_EXTICR3_EXTI8_Msk                        /*!< External Interrupt Line 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9_Pos                (4U)
+#define SYSCFG_EXTICR3_EXTI9_Msk                (0x7UL << SYSCFG_EXTICR3_EXTI9_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR3_EXTI9                    SYSCFG_EXTICR3_EXTI9_Msk                        /*!< External Interrupt Line 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10_Pos               (8U)
+#define SYSCFG_EXTICR3_EXTI10_Msk               (0x7UL << SYSCFG_EXTICR3_EXTI10_Pos)            /*!< 0x00000700 */
+#define SYSCFG_EXTICR3_EXTI10                   SYSCFG_EXTICR3_EXTI10_Msk                       /*!< External Interrupt Line 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11_Pos               (12U)
+#define SYSCFG_EXTICR3_EXTI11_Msk               (0xFUL << SYSCFG_EXTICR3_EXTI11_Pos)            /*!< 0x0000F000 */
+#define SYSCFG_EXTICR3_EXTI11                   SYSCFG_EXTICR3_EXTI11_Msk                       /*!< External Interrupt Line 11 configuration */
+
+/**
+  * @brief  External Interrupt Line 8 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA                 (0x00000000UL)  /*!< PA[8] pin  */
+#define SYSCFG_EXTICR3_EXTI8_PB                 (0x00000001UL)  /*!< PB[8] pin  */
+
+/**
+  * @brief  External Interrupt Line 9 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA                 (0x00000000UL)  /*!< PA[9] pin  */
+#define SYSCFG_EXTICR3_EXTI9_PB                 (0x00000010UL)  /*!< PB[9] pin  */
+
+/**
+  * @brief  External Interrupt Line 10 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA                (0x00000000UL)  /*!< PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB                (0x00000100UL)  /*!< PB[10] pin */
+
+/**
+  * @brief  External Interrupt Line 11 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA                (0x00000000UL)  /*!< PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB                (0x00001000UL)  /*!< PB[11] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  (External interrupt configuration register 4) *********************************/
+#define SYSCFG_EXTICR4_EXTI12_Pos               (0U)
+#define SYSCFG_EXTICR4_EXTI12_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI12_Pos)            /*!< 0x00000007 */
+#define SYSCFG_EXTICR4_EXTI12                   SYSCFG_EXTICR4_EXTI12_Msk                       /*!< External Interrupt Line 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13_Pos               (4U)
+#define SYSCFG_EXTICR4_EXTI13_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI13_Pos)            /*!< 0x00000070 */
+#define SYSCFG_EXTICR4_EXTI13                   SYSCFG_EXTICR4_EXTI13_Msk                       /*!< External Interrupt Line 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14_Pos               (8U)
+#define SYSCFG_EXTICR4_EXTI14_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI14_Pos)            /*!< 0x00000700 */
+#define SYSCFG_EXTICR4_EXTI14                   SYSCFG_EXTICR4_EXTI14_Msk                       /*!< External Interrupt Line 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15_Pos               (12U)
+#define SYSCFG_EXTICR4_EXTI15_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI15_Pos)            /*!< 0x00007000 */
+#define SYSCFG_EXTICR4_EXTI15                   SYSCFG_EXTICR4_EXTI15_Msk                       /*!< External Interrupt Line 15 configuration */
+
+/**
+  * @brief  External Interrupt Line 12 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA                (0x00000000UL)  /*!< PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB                (0x00000001UL)  /*!< PB[12] pin */
+
+/**
+  * @brief  External Interrupt Line 13 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA                (0x00000000UL)  /*!< PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB                (0x00000010UL)  /*!< PB[13] pin */
+
+/**
+  * @brief  External Interrupt Line 14 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA                (0x00000000UL)  /*!< PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB                (0x00000100UL)  /*!< PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC                (0x00000200UL)  /*!< PC[14] pin */
+
+/**
+  * @brief  External Interrupt Line 15 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA                (0x00000000UL)  /*!< PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB                (0x00001000UL)  /*!< PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC                (0x00002000UL)  /*!< PC[15] pin */
+
+/*****************  Bit definition for SYSCFG_SCSR register  (SYSCFG SRAM2 control and status register) *********************************************************/
+#define SYSCFG_SCSR_SRAM2ER_Pos                 (0U)
+#define SYSCFG_SCSR_SRAM2ER_Msk                 (0x1UL << SYSCFG_SCSR_SRAM2ER_Pos)              /*!< 0x00000001 */
+#define SYSCFG_SCSR_SRAM2ER                     SYSCFG_SCSR_SRAM2ER_Msk                         /*!< SRAM2 and PKA RAM Erase                                    */
+#define SYSCFG_SCSR_SRAM2BSY_Pos                (1U)
+#define SYSCFG_SCSR_SRAM2BSY_Msk                (0x1UL << SYSCFG_SCSR_SRAM2BSY_Pos)             /*!< 0x00000002 */
+#define SYSCFG_SCSR_SRAM2BSY                    SYSCFG_SCSR_SRAM2BSY_Msk                        /*!< SRAM2 and PKA RAM busy by erase operation                  */
+#define SYSCFG_SCSR_C2RFD_Pos                   (31U)
+#define SYSCFG_SCSR_C2RFD_Msk                   (0x1UL << SYSCFG_SCSR_C2RFD_Pos)                /*!< 0x80000000 */
+#define SYSCFG_SCSR_C2RFD                       SYSCFG_SCSR_C2RFD_Msk                           /*!< CPU2 SRAM fetch (execution) disable                        */
+
+/*****************  Bit definition for SYSCFG_CFGR2 register  (SYSCFG configuration register 2) *****************************************************************/
+#define SYSCFG_CFGR2_CLL_Pos                    (0U)
+#define SYSCFG_CFGR2_CLL_Msk                    (0x1UL << SYSCFG_CFGR2_CLL_Pos)                 /*!< 0x00000001 */
+#define SYSCFG_CFGR2_CLL                        SYSCFG_CFGR2_CLL_Msk                            /*!< Cortex M4 LOCKUP (hardfault) output enable                 */
+#define SYSCFG_CFGR2_SPL_Pos                    (1U)
+#define SYSCFG_CFGR2_SPL_Msk                    (0x1UL << SYSCFG_CFGR2_SPL_Pos)                 /*!< 0x00000002 */
+#define SYSCFG_CFGR2_SPL                        SYSCFG_CFGR2_SPL_Msk                            /*!< SRAM2 Parity Lock                                          */
+#define SYSCFG_CFGR2_PVDL_Pos                   (2U)
+#define SYSCFG_CFGR2_PVDL_Msk                   (0x1UL << SYSCFG_CFGR2_PVDL_Pos)                /*!< 0x00000004 */
+#define SYSCFG_CFGR2_PVDL                       SYSCFG_CFGR2_PVDL_Msk                           /*!< PVD Lock                                                   */
+#define SYSCFG_CFGR2_ECCL_Pos                   (3U)
+#define SYSCFG_CFGR2_ECCL_Msk                   (0x1UL << SYSCFG_CFGR2_ECCL_Pos)                /*!< 0x00000008 */
+#define SYSCFG_CFGR2_ECCL                       SYSCFG_CFGR2_ECCL_Msk                           /*!< ECC Lock                                                   */
+#define SYSCFG_CFGR2_SPF_Pos                    (8U)
+#define SYSCFG_CFGR2_SPF_Msk                    (0x1UL << SYSCFG_CFGR2_SPF_Pos)                 /*!< 0x00000100 */
+#define SYSCFG_CFGR2_SPF                        SYSCFG_CFGR2_SPF_Msk                            /*!< SRAM2 Parity Lock                                          */
+
+/*****************  Bit definition for SYSCFG_SWPR1 register  (SYSCFG SRAM2A write protection register) *********************************************************/
+#define SYSCFG_SWPR1_PAGE0_Pos                  (0U)
+#define SYSCFG_SWPR1_PAGE0_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE0_Pos)               /*!< 0x00000001 */
+#define SYSCFG_SWPR1_PAGE0                      SYSCFG_SWPR1_PAGE0_Msk                          /*!< SRAM2A Write protection page 0 (0x20030000 - 0x200303FF)   */
+#define SYSCFG_SWPR1_PAGE1_Pos                  (1U)
+#define SYSCFG_SWPR1_PAGE1_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE1_Pos)               /*!< 0x00000002 */
+#define SYSCFG_SWPR1_PAGE1                      SYSCFG_SWPR1_PAGE1_Msk                          /*!< SRAM2A Write protection page 1 (0x20030400 - 0x200307FF)   */
+#define SYSCFG_SWPR1_PAGE2_Pos                  (2U)
+#define SYSCFG_SWPR1_PAGE2_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE2_Pos)               /*!< 0x00000004 */
+#define SYSCFG_SWPR1_PAGE2                      SYSCFG_SWPR1_PAGE2_Msk                          /*!< SRAM2A Write protection page 2 (0x20030800 - 0x20030BFF)   */
+#define SYSCFG_SWPR1_PAGE3_Pos                  (3U)
+#define SYSCFG_SWPR1_PAGE3_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE3_Pos)               /*!< 0x00000008 */
+#define SYSCFG_SWPR1_PAGE3                      SYSCFG_SWPR1_PAGE3_Msk                          /*!< SRAM2A Write protection page 3 (0x20030C00 - 0x20030FFF)   */
+#define SYSCFG_SWPR1_PAGE4_Pos                  (4U)
+#define SYSCFG_SWPR1_PAGE4_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE4_Pos)               /*!< 0x00000010 */
+#define SYSCFG_SWPR1_PAGE4                      SYSCFG_SWPR1_PAGE4_Msk                          /*!< SRAM2A Write protection page 4 (0x20031000 - 0x200313FF)   */
+#define SYSCFG_SWPR1_PAGE5_Pos                  (5U)
+#define SYSCFG_SWPR1_PAGE5_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE5_Pos)               /*!< 0x00000020 */
+#define SYSCFG_SWPR1_PAGE5                      SYSCFG_SWPR1_PAGE5_Msk                          /*!< SRAM2A Write protection page 5 (0x20031400 - 0x200317FF)   */
+#define SYSCFG_SWPR1_PAGE6_Pos                  (6U)
+#define SYSCFG_SWPR1_PAGE6_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE6_Pos)               /*!< 0x00000040 */
+#define SYSCFG_SWPR1_PAGE6                      SYSCFG_SWPR1_PAGE6_Msk                          /*!< SRAM2A Write protection page 6 (0x20031800 - 0x20031BFF)   */
+#define SYSCFG_SWPR1_PAGE7_Pos                  (7U)
+#define SYSCFG_SWPR1_PAGE7_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE7_Pos)               /*!< 0x00000080 */
+#define SYSCFG_SWPR1_PAGE7                      SYSCFG_SWPR1_PAGE7_Msk                          /*!< SRAM2A Write protection page 7 (0x20031C00 - 0x20031FFF)   */
+#define SYSCFG_SWPR1_PAGE8_Pos                  (8U)
+#define SYSCFG_SWPR1_PAGE8_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE8_Pos)               /*!< 0x00000100 */
+#define SYSCFG_SWPR1_PAGE8                      SYSCFG_SWPR1_PAGE8_Msk                          /*!< SRAM2A Write protection page 8 (0x20032000 - 0x200323FF)   */
+#define SYSCFG_SWPR1_PAGE9_Pos                  (9U)
+#define SYSCFG_SWPR1_PAGE9_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE9_Pos)               /*!< 0x00000200 */
+#define SYSCFG_SWPR1_PAGE9                      SYSCFG_SWPR1_PAGE9_Msk                          /*!< SRAM2A Write protection page 9 (0x20032400 - 0x200327FF)   */
+#define SYSCFG_SWPR1_PAGE10_Pos                 (10U)
+#define SYSCFG_SWPR1_PAGE10_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE10_Pos)              /*!< 0x00000400 */
+#define SYSCFG_SWPR1_PAGE10                     SYSCFG_SWPR1_PAGE10_Msk                         /*!< SRAM2A Write protection page 10 (0x20032800 - 0x20032BFF)  */
+#define SYSCFG_SWPR1_PAGE11_Pos                 (11U)
+#define SYSCFG_SWPR1_PAGE11_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE11_Pos)              /*!< 0x00000800 */
+#define SYSCFG_SWPR1_PAGE11                     SYSCFG_SWPR1_PAGE11_Msk                         /*!< SRAM2A Write protection page 11 (0x20032C00 - 0x20032FFF)  */
+#define SYSCFG_SWPR1_PAGE12_Pos                 (12U)
+#define SYSCFG_SWPR1_PAGE12_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE12_Pos)              /*!< 0x00001000 */
+#define SYSCFG_SWPR1_PAGE12                     SYSCFG_SWPR1_PAGE12_Msk                         /*!< SRAM2A Write protection page 12 (0x20033000 - 0x200333FF)  */
+#define SYSCFG_SWPR1_PAGE13_Pos                 (13U)
+#define SYSCFG_SWPR1_PAGE13_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE13_Pos)              /*!< 0x00002000 */
+#define SYSCFG_SWPR1_PAGE13                     SYSCFG_SWPR1_PAGE13_Msk                         /*!< SRAM2A Write protection page 13 (0x20033400 - 0x200337FF)  */
+#define SYSCFG_SWPR1_PAGE14_Pos                 (14U)
+#define SYSCFG_SWPR1_PAGE14_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE14_Pos)              /*!< 0x00004000 */
+#define SYSCFG_SWPR1_PAGE14                     SYSCFG_SWPR1_PAGE14_Msk                         /*!< SRAM2A Write protection page 14 (0x20033800 - 0x20033BFF)  */
+#define SYSCFG_SWPR1_PAGE15_Pos                 (15U)
+#define SYSCFG_SWPR1_PAGE15_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE15_Pos)              /*!< 0x00008000 */
+#define SYSCFG_SWPR1_PAGE15                     SYSCFG_SWPR1_PAGE15_Msk                         /*!< SRAM2A Write protection page 15 (0x20033C00 - 0x20033FFF)  */
+#define SYSCFG_SWPR1_PAGE16_Pos                 (16U)
+#define SYSCFG_SWPR1_PAGE16_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE16_Pos)              /*!< 0x00010000 */
+#define SYSCFG_SWPR1_PAGE16                     SYSCFG_SWPR1_PAGE16_Msk                         /*!< SRAM2A Write protection page 16 (0x20034000 - 0x200343FF)  */
+#define SYSCFG_SWPR1_PAGE17_Pos                 (17U)
+#define SYSCFG_SWPR1_PAGE17_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE17_Pos)              /*!< 0x00020000 */
+#define SYSCFG_SWPR1_PAGE17                     SYSCFG_SWPR1_PAGE17_Msk                         /*!< SRAM2A Write protection page 17 (0x20034400 - 0x200347FF)  */
+#define SYSCFG_SWPR1_PAGE18_Pos                 (18U)
+#define SYSCFG_SWPR1_PAGE18_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE18_Pos)              /*!< 0x00040000 */
+#define SYSCFG_SWPR1_PAGE18                     SYSCFG_SWPR1_PAGE18_Msk                         /*!< SRAM2A Write protection page 18 (0x20034800 - 0x20034BFF)  */
+#define SYSCFG_SWPR1_PAGE19_Pos                 (19U)
+#define SYSCFG_SWPR1_PAGE19_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE19_Pos)              /*!< 0x00080000 */
+#define SYSCFG_SWPR1_PAGE19                     SYSCFG_SWPR1_PAGE19_Msk                         /*!< SRAM2A Write protection page 19 (0x20034C00 - 0x20034FFF)  */
+#define SYSCFG_SWPR1_PAGE20_Pos                 (20U)
+#define SYSCFG_SWPR1_PAGE20_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE20_Pos)              /*!< 0x00100000 */
+#define SYSCFG_SWPR1_PAGE20                     SYSCFG_SWPR1_PAGE20_Msk                         /*!< SRAM2A Write protection page 20 (0x20035000 - 0x200353FF)  */
+#define SYSCFG_SWPR1_PAGE21_Pos                 (21U)
+#define SYSCFG_SWPR1_PAGE21_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE21_Pos)              /*!< 0x00200000 */
+#define SYSCFG_SWPR1_PAGE21                     SYSCFG_SWPR1_PAGE21_Msk                         /*!< SRAM2A Write protection page 21 (0x20035400 - 0x200357FF)  */
+#define SYSCFG_SWPR1_PAGE22_Pos                 (22U)
+#define SYSCFG_SWPR1_PAGE22_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE22_Pos)              /*!< 0x00400000 */
+#define SYSCFG_SWPR1_PAGE22                     SYSCFG_SWPR1_PAGE22_Msk                         /*!< SRAM2A Write protection page 22 (0x20035800 - 0x20035BFF)  */
+#define SYSCFG_SWPR1_PAGE23_Pos                 (23U)
+#define SYSCFG_SWPR1_PAGE23_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE23_Pos)              /*!< 0x00800000 */
+#define SYSCFG_SWPR1_PAGE23                     SYSCFG_SWPR1_PAGE23_Msk                         /*!< SRAM2A Write protection page 23 (0x20035C00 - 0x20035FFF)  */
+#define SYSCFG_SWPR1_PAGE24_Pos                 (24U)
+#define SYSCFG_SWPR1_PAGE24_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE24_Pos)              /*!< 0x01000000 */
+#define SYSCFG_SWPR1_PAGE24                     SYSCFG_SWPR1_PAGE24_Msk                         /*!< SRAM2A Write protection page 24 (0x20036000 - 0x200363FF)  */
+#define SYSCFG_SWPR1_PAGE25_Pos                 (25U)
+#define SYSCFG_SWPR1_PAGE25_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE25_Pos)              /*!< 0x02000000 */
+#define SYSCFG_SWPR1_PAGE25                     SYSCFG_SWPR1_PAGE25_Msk                         /*!< SRAM2A Write protection page 25 (0x20036400 - 0x200367FF)  */
+#define SYSCFG_SWPR1_PAGE26_Pos                 (26U)
+#define SYSCFG_SWPR1_PAGE26_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE26_Pos)              /*!< 0x04000000 */
+#define SYSCFG_SWPR1_PAGE26                     SYSCFG_SWPR1_PAGE26_Msk                         /*!< SRAM2A Write protection page 26 (0x20036800 - 0x20036BFF)  */
+#define SYSCFG_SWPR1_PAGE27_Pos                 (27U)
+#define SYSCFG_SWPR1_PAGE27_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE27_Pos)              /*!< 0x08000000 */
+#define SYSCFG_SWPR1_PAGE27                     SYSCFG_SWPR1_PAGE27_Msk                         /*!< SRAM2A Write protection page 27 (0x20036C00 - 0x20036FFF)  */
+#define SYSCFG_SWPR1_PAGE28_Pos                 (28U)
+#define SYSCFG_SWPR1_PAGE28_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE28_Pos)              /*!< 0x10000000 */
+#define SYSCFG_SWPR1_PAGE28                     SYSCFG_SWPR1_PAGE28_Msk                         /*!< SRAM2A Write protection page 28 (0x20037000 - 0x200373FF)  */
+#define SYSCFG_SWPR1_PAGE29_Pos                 (29U)
+#define SYSCFG_SWPR1_PAGE29_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE29_Pos)              /*!< 0x20000000 */
+#define SYSCFG_SWPR1_PAGE29                     SYSCFG_SWPR1_PAGE29_Msk                         /*!< SRAM2A Write protection page 29 (0x20037400 - 0x200377FF)  */
+#define SYSCFG_SWPR1_PAGE30_Pos                 (30U)
+#define SYSCFG_SWPR1_PAGE30_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE30_Pos)              /*!< 0x40000000 */
+#define SYSCFG_SWPR1_PAGE30                     SYSCFG_SWPR1_PAGE30_Msk                         /*!< SRAM2A Write protection page 30 (0x20037800 - 0x20037BFF)  */
+#define SYSCFG_SWPR1_PAGE31_Pos                 (31U)
+#define SYSCFG_SWPR1_PAGE31_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE31_Pos)              /*!< 0x80000000 */
+#define SYSCFG_SWPR1_PAGE31                     SYSCFG_SWPR1_PAGE31_Msk                         /*!< SRAM2A Write protection page 31 (0x20037C00 - 0x20037FFF)  */
+
+/*****************  Bit definition for SYSCFG_SKR register  (SYSCFG SRAM2 key register) *************************************************************************/
+#define SYSCFG_SKR_KEY_Pos                      (0U)
+#define SYSCFG_SKR_KEY_Msk                      (0xFFUL << SYSCFG_SKR_KEY_Pos)                  /*!< 0x000000FF */
+#define SYSCFG_SKR_KEY                          SYSCFG_SKR_KEY_Msk                              /*!< SRAM2 write protection key for software erase              */
+
+/*****************  Bit definition for SYSCFG_SWPR2 register  (SYSCFG SRAM2 write protection register) **********************************************************/
+#define SYSCFG_SWPR2_PAGE32_Pos                 (0U)
+#define SYSCFG_SWPR2_PAGE32_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE32_Pos)              /*!< 0x00000001 */
+#define SYSCFG_SWPR2_PAGE32                     SYSCFG_SWPR2_PAGE32_Msk                         /*!< SRAM2B Write protection page 0 (0x20038000 - 0x200383FF)   */
+#define SYSCFG_SWPR2_PAGE33_Pos                 (1U)
+#define SYSCFG_SWPR2_PAGE33_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE33_Pos)              /*!< 0x00000002 */
+#define SYSCFG_SWPR2_PAGE33                     SYSCFG_SWPR2_PAGE33_Msk                         /*!< SRAM2B Write protection page 1 (0x20038400 - 0x200387FF)   */
+#define SYSCFG_SWPR2_PAGE34_Pos                 (2U)
+#define SYSCFG_SWPR2_PAGE34_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE34_Pos)              /*!< 0x00000004 */
+#define SYSCFG_SWPR2_PAGE34                     SYSCFG_SWPR2_PAGE34_Msk                         /*!< SRAM2B Write protection page 2 (0x20038800 - 0x20038bFF)   */
+#define SYSCFG_SWPR2_PAGE35_Pos                 (3U)
+#define SYSCFG_SWPR2_PAGE35_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE35_Pos)              /*!< 0x00000008 */
+#define SYSCFG_SWPR2_PAGE35                     SYSCFG_SWPR2_PAGE35_Msk                         /*!< SRAM2B Write protection page 3 (0x20038C00 - 0x20038FFF)   */
+
+/*****************  Bit definition for SYSCFG_IMR1 register (Interrupt masks control and status register on CPU1 - part 1) *******************************************/
+#define SYSCFG_IMR1_TIM1IM_Pos                  (13U)
+#define SYSCFG_IMR1_TIM1IM_Msk                  (0x1UL << SYSCFG_IMR1_TIM1IM_Pos)             /*!< 0x00002000 */
+#define SYSCFG_IMR1_TIM1IM                      SYSCFG_IMR1_TIM1IM_Msk                        /*!< Enabling of interrupt from Timer 1 to CPU1                        */
+#define SYSCFG_IMR1_EXTI5IM_Pos                 (21U)
+#define SYSCFG_IMR1_EXTI5IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI5IM_Pos)            /*!< 0x00200000 */
+#define SYSCFG_IMR1_EXTI5IM                     SYSCFG_IMR1_EXTI5IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 5 to CPU1      */
+#define SYSCFG_IMR1_EXTI6IM_Pos                 (22U)
+#define SYSCFG_IMR1_EXTI6IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI6IM_Pos)            /*!< 0x00400000 */
+#define SYSCFG_IMR1_EXTI6IM                     SYSCFG_IMR1_EXTI6IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 6 to CPU1      */
+#define SYSCFG_IMR1_EXTI7IM_Pos                 (23U)
+#define SYSCFG_IMR1_EXTI7IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI7IM_Pos)            /*!< 0x00800000 */
+#define SYSCFG_IMR1_EXTI7IM                     SYSCFG_IMR1_EXTI7IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 7 to CPU1      */
+#define SYSCFG_IMR1_EXTI8IM_Pos                 (24U)
+#define SYSCFG_IMR1_EXTI8IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI8IM_Pos)            /*!< 0x01000000 */
+#define SYSCFG_IMR1_EXTI8IM                     SYSCFG_IMR1_EXTI8IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 8 to CPU1      */
+#define SYSCFG_IMR1_EXTI9IM_Pos                 (25U)
+#define SYSCFG_IMR1_EXTI9IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI9IM_Pos)            /*!< 0x02000000 */
+#define SYSCFG_IMR1_EXTI9IM                     SYSCFG_IMR1_EXTI9IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 9 to CPU1      */
+#define SYSCFG_IMR1_EXTI10IM_Pos                (26U)
+#define SYSCFG_IMR1_EXTI10IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI10IM_Pos)           /*!< 0x04000000 */
+#define SYSCFG_IMR1_EXTI10IM                    SYSCFG_IMR1_EXTI10IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 10 to CPU1     */
+#define SYSCFG_IMR1_EXTI11IM_Pos                (27U)
+#define SYSCFG_IMR1_EXTI11IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI11IM_Pos)           /*!< 0x08000000 */
+#define SYSCFG_IMR1_EXTI11IM                    SYSCFG_IMR1_EXTI11IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 11 to CPU1     */
+#define SYSCFG_IMR1_EXTI12IM_Pos                (28U)
+#define SYSCFG_IMR1_EXTI12IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI12IM_Pos)           /*!< 0x10000000 */
+#define SYSCFG_IMR1_EXTI12IM                    SYSCFG_IMR1_EXTI12IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 12 to CPU1     */
+#define SYSCFG_IMR1_EXTI13IM_Pos                (29U)
+#define SYSCFG_IMR1_EXTI13IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI13IM_Pos)           /*!< 0x20000000 */
+#define SYSCFG_IMR1_EXTI13IM                    SYSCFG_IMR1_EXTI13IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 13 to CPU1     */
+#define SYSCFG_IMR1_EXTI14IM_Pos                (30U)
+#define SYSCFG_IMR1_EXTI14IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI14IM_Pos)           /*!< 0x40000000 */
+#define SYSCFG_IMR1_EXTI14IM                    SYSCFG_IMR1_EXTI14IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 14 to CPU1     */
+#define SYSCFG_IMR1_EXTI15IM_Pos                (31U)
+#define SYSCFG_IMR1_EXTI15IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI15IM_Pos)           /*!< 0x80000000 */
+#define SYSCFG_IMR1_EXTI15IM                    SYSCFG_IMR1_EXTI15IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 15 to CPU1     */
+
+/*****************  Bit definition for SYSCFG_IMR2 register (Interrupt masks control and status register on CPU1 - part 2) *******************************************/
+#define SYSCFG_IMR2_PVM3IM_Pos                  (18U)
+#define SYSCFG_IMR2_PVM3IM_Msk                  (0x1UL << SYSCFG_IMR2_PVM3IM_Pos)             /*!< 0x00040000 */
+#define SYSCFG_IMR2_PVM3IM                      SYSCFG_IMR2_PVM3IM_Msk                        /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU1     */
+#define SYSCFG_IMR2_PVDIM_Pos                   (20U)
+#define SYSCFG_IMR2_PVDIM_Msk                   (0x1UL << SYSCFG_IMR2_PVDIM_Pos)              /*!< 0x00100000 */
+#define SYSCFG_IMR2_PVDIM                       SYSCFG_IMR2_PVDIM_Msk                         /*!< Enabling of interrupt from Power Voltage Detector to CPU1         */
+
+/*****************  Bit definition for SYSCFG_C2IMR1 register (Interrupt masks control and status register on CPU2 - part 1) *******************************************/
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Pos    (0U)
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Msk    (0x1UL << SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Pos) /*!< 0x00000001 */
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM        SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Msk            /* !< Enabling of interrupt from RTC TimeStamp, RTC Tampers
+                                                                                                      and LSE Clock Security System to CPU2                            */
+#define SYSCFG_C2IMR1_RTCWKUPIM_Pos             (3U)
+#define SYSCFG_C2IMR1_RTCWKUPIM_Msk             (0x1UL << SYSCFG_C2IMR1_RTCWKUPIM_Pos)          /*!< 0x00000008 */
+#define SYSCFG_C2IMR1_RTCWKUPIM                 SYSCFG_C2IMR1_RTCWKUPIM_Msk                     /*!< Enabling of interrupt from RTC Wakeup to CPU2                     */
+#define SYSCFG_C2IMR1_RTCALARMIM_Pos            (4U)
+#define SYSCFG_C2IMR1_RTCALARMIM_Msk            (0x1UL << SYSCFG_C2IMR1_RTCALARMIM_Pos)         /*!< 0x00000010 */
+#define SYSCFG_C2IMR1_RTCALARMIM                SYSCFG_C2IMR1_RTCALARMIM_Msk                    /*!< Enabling of interrupt from RTC Alarms to CPU2                     */
+#define SYSCFG_C2IMR1_RCCIM_Pos                 (5U)
+#define SYSCFG_C2IMR1_RCCIM_Msk                 (0x1UL << SYSCFG_C2IMR1_RCCIM_Pos)              /*!< 0x00000020 */
+#define SYSCFG_C2IMR1_RCCIM                     SYSCFG_C2IMR1_RCCIM_Msk                         /*!< Enabling of interrupt from RCC to CPU2                            */
+#define SYSCFG_C2IMR1_FLASHIM_Pos               (6U)
+#define SYSCFG_C2IMR1_FLASHIM_Msk               (0x1UL << SYSCFG_C2IMR1_FLASHIM_Pos)            /*!< 0x00000040 */
+#define SYSCFG_C2IMR1_FLASHIM                   SYSCFG_C2IMR1_FLASHIM_Msk                       /*!< Enabling of interrupt from FLASH to CPU2                          */
+#define SYSCFG_C2IMR1_PKAIM_Pos                 (8U)
+#define SYSCFG_C2IMR1_PKAIM_Msk                 (0x1UL << SYSCFG_C2IMR1_PKAIM_Pos)              /*!< 0x00000100 */
+#define SYSCFG_C2IMR1_PKAIM                     SYSCFG_C2IMR1_PKAIM_Msk                         /*!< Enabling of interrupt from Public Key Accelerator to CPU2         */
+#define SYSCFG_C2IMR1_RNGIM_Pos                 (9U)
+#define SYSCFG_C2IMR1_RNGIM_Msk                 (0x1UL << SYSCFG_C2IMR1_RNGIM_Pos)              /*!< 0x00000200 */
+#define SYSCFG_C2IMR1_RNGIM                     SYSCFG_C2IMR1_RNGIM_Msk                         /*!< Enabling of interrupt from Random Number Generator to CPU2        */
+#define SYSCFG_C2IMR1_COMPIM_Pos                (11U)
+#define SYSCFG_C2IMR1_COMPIM_Msk                (0x1UL << SYSCFG_C2IMR1_COMPIM_Pos)             /*!< 0x00000800 */
+#define SYSCFG_C2IMR1_COMPIM                    SYSCFG_C2IMR1_COMPIM_Msk                        /*!< Enabling of interrupt from Comparator to CPU2                     */
+#define SYSCFG_C2IMR1_ADCIM_Pos                 (12U)
+#define SYSCFG_C2IMR1_ADCIM_Msk                 (0x1UL << SYSCFG_C2IMR1_ADCIM_Pos)              /*!< 0x00001000 */
+#define SYSCFG_C2IMR1_ADCIM                     SYSCFG_C2IMR1_ADCIM_Msk                         /*!< Enabling of interrupt from Analog Digital Converter to CPU2       */
+#define SYSCFG_C2IMR1_EXTI0IM_Pos               (16U)
+#define SYSCFG_C2IMR1_EXTI0IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI0IM_Pos)            /*!< 0x00010000 */
+#define SYSCFG_C2IMR1_EXTI0IM                   SYSCFG_C2IMR1_EXTI0IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 0 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI1IM_Pos               (17U)
+#define SYSCFG_C2IMR1_EXTI1IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI1IM_Pos)            /*!< 0x00020000 */
+#define SYSCFG_C2IMR1_EXTI1IM                   SYSCFG_C2IMR1_EXTI1IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 1 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI2IM_Pos               (18U)
+#define SYSCFG_C2IMR1_EXTI2IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI2IM_Pos)            /*!< 0x00040000 */
+#define SYSCFG_C2IMR1_EXTI2IM                   SYSCFG_C2IMR1_EXTI2IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 2 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI3IM_Pos               (19U)
+#define SYSCFG_C2IMR1_EXTI3IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI3IM_Pos)            /*!< 0x00080000 */
+#define SYSCFG_C2IMR1_EXTI3IM                   SYSCFG_C2IMR1_EXTI3IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 3 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI4IM_Pos               (20U)
+#define SYSCFG_C2IMR1_EXTI4IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI4IM_Pos)            /*!< 0x00100000 */
+#define SYSCFG_C2IMR1_EXTI4IM                   SYSCFG_C2IMR1_EXTI4IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 4 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI5IM_Pos               (21U)
+#define SYSCFG_C2IMR1_EXTI5IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI5IM_Pos)            /*!< 0x00200000 */
+#define SYSCFG_C2IMR1_EXTI5IM                   SYSCFG_C2IMR1_EXTI5IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 5 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI6IM_Pos               (22U)
+#define SYSCFG_C2IMR1_EXTI6IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI6IM_Pos)            /*!< 0x00400000 */
+#define SYSCFG_C2IMR1_EXTI6IM                   SYSCFG_C2IMR1_EXTI6IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 6 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI7IM_Pos               (23U)
+#define SYSCFG_C2IMR1_EXTI7IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI7IM_Pos)            /*!< 0x00800000 */
+#define SYSCFG_C2IMR1_EXTI7IM                   SYSCFG_C2IMR1_EXTI7IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 7 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI8IM_Pos               (24U)
+#define SYSCFG_C2IMR1_EXTI8IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI8IM_Pos)            /*!< 0x01000000 */
+#define SYSCFG_C2IMR1_EXTI8IM                   SYSCFG_C2IMR1_EXTI8IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 8 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI9IM_Pos               (25U)
+#define SYSCFG_C2IMR1_EXTI9IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI9IM_Pos)            /*!< 0x02000000 */
+#define SYSCFG_C2IMR1_EXTI9IM                   SYSCFG_C2IMR1_EXTI9IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 9 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI10IM_Pos              (26U)
+#define SYSCFG_C2IMR1_EXTI10IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI10IM_Pos)           /*!< 0x04000000 */
+#define SYSCFG_C2IMR1_EXTI10IM                  SYSCFG_C2IMR1_EXTI10IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 10 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI11IM_Pos              (27U)
+#define SYSCFG_C2IMR1_EXTI11IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI11IM_Pos)           /*!< 0x08000000 */
+#define SYSCFG_C2IMR1_EXTI11IM                  SYSCFG_C2IMR1_EXTI11IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 11 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI12IM_Pos              (28U)
+#define SYSCFG_C2IMR1_EXTI12IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI12IM_Pos)           /*!< 0x10000000 */
+#define SYSCFG_C2IMR1_EXTI12IM                  SYSCFG_C2IMR1_EXTI12IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 12 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI13IM_Pos              (29U)
+#define SYSCFG_C2IMR1_EXTI13IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI13IM_Pos)           /*!< 0x20000000 */
+#define SYSCFG_C2IMR1_EXTI13IM                  SYSCFG_C2IMR1_EXTI13IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 13 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI14IM_Pos              (30U)
+#define SYSCFG_C2IMR1_EXTI14IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI14IM_Pos)           /*!< 0x40000000 */
+#define SYSCFG_C2IMR1_EXTI14IM                  SYSCFG_C2IMR1_EXTI14IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 14 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI15IM_Pos              (31U)
+#define SYSCFG_C2IMR1_EXTI15IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI15IM_Pos)           /*!< 0x80000000 */
+#define SYSCFG_C2IMR1_EXTI15IM                  SYSCFG_C2IMR1_EXTI15IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 15 to CPU2     */
+
+/*****************  Bit definition for SYSCFG_C2IMR2 register (Interrupt masks control and status register on CPU2 - part 2) *******************************************/
+#define SYSCFG_C2IMR2_DMA1CH1IM_Pos             (0U)
+#define SYSCFG_C2IMR2_DMA1CH1IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH1IM_Pos)          /*!< 0x00000001 */
+#define SYSCFG_C2IMR2_DMA1CH1IM                 SYSCFG_C2IMR2_DMA1CH1IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 1 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH2IM_Pos             (1U)
+#define SYSCFG_C2IMR2_DMA1CH2IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH2IM_Pos)          /*!< 0x00000002 */
+#define SYSCFG_C2IMR2_DMA1CH2IM                 SYSCFG_C2IMR2_DMA1CH2IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 2 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH3IM_Pos             (2U)
+#define SYSCFG_C2IMR2_DMA1CH3IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH3IM_Pos)          /*!< 0x00000004 */
+#define SYSCFG_C2IMR2_DMA1CH3IM                 SYSCFG_C2IMR2_DMA1CH3IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 3 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH4IM_Pos             (3U)
+#define SYSCFG_C2IMR2_DMA1CH4IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH4IM_Pos)          /*!< 0x00000008 */
+#define SYSCFG_C2IMR2_DMA1CH4IM                 SYSCFG_C2IMR2_DMA1CH4IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 4 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH5IM_Pos             (4U)
+#define SYSCFG_C2IMR2_DMA1CH5IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH5IM_Pos)          /*!< 0x00000010 */
+#define SYSCFG_C2IMR2_DMA1CH5IM                 SYSCFG_C2IMR2_DMA1CH5IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 5 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH6IM_Pos             (5U)
+#define SYSCFG_C2IMR2_DMA1CH6IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH6IM_Pos)          /*!< 0x00000020 */
+#define SYSCFG_C2IMR2_DMA1CH6IM                 SYSCFG_C2IMR2_DMA1CH6IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 6 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH7IM_Pos             (6U)
+#define SYSCFG_C2IMR2_DMA1CH7IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH7IM_Pos)          /*!< 0x00000040 */
+#define SYSCFG_C2IMR2_DMA1CH7IM                 SYSCFG_C2IMR2_DMA1CH7IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 7 to CPU2                 */
+#define SYSCFG_C2IMR2_DMAMUX1IM_Pos             (15U)
+#define SYSCFG_C2IMR2_DMAMUX1IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMAMUX1IM_Pos)          /*!< 0x00008000 */
+#define SYSCFG_C2IMR2_DMAMUX1IM                 SYSCFG_C2IMR2_DMAMUX1IM_Msk                     /*!< Enabling of interrupt from DMAMUX1 to CPU2                        */
+#define SYSCFG_C2IMR2_PVM3IM_Pos                (18U)
+#define SYSCFG_C2IMR2_PVM3IM_Msk                (0x1UL << SYSCFG_C2IMR2_PVM3IM_Pos)             /*!< 0x00040000 */
+#define SYSCFG_C2IMR2_PVM3IM                    SYSCFG_C2IMR2_PVM3IM_Msk                        /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU2     */
+#define SYSCFG_C2IMR2_PVDIM_Pos                 (20U)
+#define SYSCFG_C2IMR2_PVDIM_Msk                 (0x1UL << SYSCFG_C2IMR2_PVDIM_Pos)              /*!< 0x00100000 */
+#define SYSCFG_C2IMR2_PVDIM                     SYSCFG_C2IMR2_PVDIM_Msk                         /*!< Enabling of interrupt from Power Voltage Detector to CPU2         */
+#define SYSCFG_C2IMR2_TSCIM_Pos                 (21U)
+#define SYSCFG_C2IMR2_TSCIM_Msk                 (0x1UL << SYSCFG_C2IMR2_TSCIM_Pos)              /*!< 0x00200000 */
+#define SYSCFG_C2IMR2_TSCIM                     SYSCFG_C2IMR2_TSCIM_Msk                         /*!< Enabling of interrupt from Touch Sensing Controller to CPU2       */
+
+/*****************  Bit definition for SYSCFG_SIPCR register (SYSCFG secure IP control register) *****************************************************************************/
+#define SYSCFG_SIPCR_SAES2_Pos                  (1U)
+#define SYSCFG_SIPCR_SAES2_Msk                  (0x1UL << SYSCFG_SIPCR_SAES2_Pos)               /*!< 0x00000002 */
+#define SYSCFG_SIPCR_SAES2                      SYSCFG_SIPCR_SAES2_Msk                          /*!< Enabling the security access of Advanced Encryption Standard 2          */
+#define SYSCFG_SIPCR_SPKA_Pos                   (2U)
+#define SYSCFG_SIPCR_SPKA_Msk                   (0x1UL << SYSCFG_SIPCR_SPKA_Pos)                /*!< 0x00000004 */
+#define SYSCFG_SIPCR_SPKA                       SYSCFG_SIPCR_SPKA_Msk                           /*!< Enabling the security access of Public Key Accelerator                  */
+#define SYSCFG_SIPCR_SRNG_Pos                   (3U)
+#define SYSCFG_SIPCR_SRNG_Msk                   (0x1UL << SYSCFG_SIPCR_SRNG_Pos)                /*!< 0x00000008 */
+#define SYSCFG_SIPCR_SRNG                       SYSCFG_SIPCR_SRNG_Msk                           /*!< Enabling the security access of Random Number Generator                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                   /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable */
+#define TIM_CR1_UDIS_Pos          (1U)
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                  /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable */
+#define TIM_CR1_URS_Pos           (2U)
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                   /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode */
+#define TIM_CR1_DIR_Pos           (4U)
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                   /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction */
+
+#define TIM_CR1_CMS_Pos           (5U)
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1U << TIM_CR1_CMS_Pos)                    /*!< 0x00000020 */
+#define TIM_CR1_CMS_1             (0x2U << TIM_CR1_CMS_Pos)                    /*!< 0x00000040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                  /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable */
+
+#define TIM_CR1_CKD_Pos           (8U)
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1U << TIM_CR1_CKD_Pos)                    /*!< 0x00000100 */
+#define TIM_CR1_CKD_1             (0x2U << TIM_CR1_CKD_Pos)                    /*!< 0x00000200 */
+
+#define TIM_CR1_UIFREMAP_Pos      (11U)
+#define TIM_CR1_UIFREMAP_Msk      (0x1UL << TIM_CR1_UIFREMAP_Pos)              /*!< 0x00000800 */
+#define TIM_CR1_UIFREMAP          TIM_CR1_UIFREMAP_Msk                         /*!<Update interrupt flag remap */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                  /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control */
+#define TIM_CR2_CCUS_Pos          (2U)
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                  /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                  /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection */
+
+#define TIM_CR2_MMS_Pos           (4U)
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1U << TIM_CR2_MMS_Pos)                    /*!< 0x00000010 */
+#define TIM_CR2_MMS_1             (0x2U << TIM_CR2_MMS_Pos)                    /*!< 0x00000020 */
+#define TIM_CR2_MMS_2             (0x4U << TIM_CR2_MMS_Pos)                    /*!< 0x00000040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                  /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                  /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output) */
+#define TIM_CR2_OIS1N_Pos         (9U)
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                 /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                  /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output) */
+#define TIM_CR2_OIS2N_Pos         (11U)
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                 /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                  /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output) */
+#define TIM_CR2_OIS3N_Pos         (13U)
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                 /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                  /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output) */
+#define TIM_CR2_OIS5_Pos          (16U)
+#define TIM_CR2_OIS5_Msk          (0x1UL << TIM_CR2_OIS5_Pos)                  /*!< 0x00010000 */
+#define TIM_CR2_OIS5              TIM_CR2_OIS5_Msk                             /*!<Output Idle state 5 (OC5 output) */
+#define TIM_CR2_OIS6_Pos          (18U)
+#define TIM_CR2_OIS6_Msk          (0x1UL << TIM_CR2_OIS6_Pos)                  /*!< 0x00040000 */
+#define TIM_CR2_OIS6              TIM_CR2_OIS6_Msk                             /*!<Output Idle state 6 (OC6 output) */
+
+#define TIM_CR2_MMS2_Pos          (20U)
+#define TIM_CR2_MMS2_Msk          (0xFUL << TIM_CR2_MMS2_Pos)                  /*!< 0x00F00000 */
+#define TIM_CR2_MMS2              TIM_CR2_MMS2_Msk                             /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS2_0            (0x1U << TIM_CR2_MMS2_Pos)                   /*!< 0x00100000 */
+#define TIM_CR2_MMS2_1            (0x2U << TIM_CR2_MMS2_Pos)                   /*!< 0x00200000 */
+#define TIM_CR2_MMS2_2            (0x4U << TIM_CR2_MMS2_Pos)                   /*!< 0x00400000 */
+#define TIM_CR2_MMS2_3            (0x8U << TIM_CR2_MMS2_Pos)                   /*!< 0x00800000 */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)
+#define TIM_SMCR_SMS_Msk          (0x10007UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMCR_SMS_0            (0x00001U << TIM_SMCR_SMS_Pos)               /*!< 0x00000001 */
+#define TIM_SMCR_SMS_1            (0x00002U << TIM_SMCR_SMS_Pos)               /*!< 0x00000002 */
+#define TIM_SMCR_SMS_2            (0x00004U << TIM_SMCR_SMS_Pos)               /*!< 0x00000004 */
+#define TIM_SMCR_SMS_3            (0x10000U << TIM_SMCR_SMS_Pos)               /*!< 0x00010000 */
+
+#define TIM_SMCR_OCCS_Pos         (3U)
+#define TIM_SMCR_OCCS_Msk         (0x1UL << TIM_SMCR_OCCS_Pos)                 /*!< 0x00000008 */
+#define TIM_SMCR_OCCS             TIM_SMCR_OCCS_Msk                            /*!< OCREF clear selection */
+
+#define TIM_SMCR_TS_Pos           (4U)
+#define TIM_SMCR_TS_Msk           (0x30007UL << TIM_SMCR_TS_Pos)               /*!< 0x00300070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection) */
+#define TIM_SMCR_TS_0             (0x00001U << TIM_SMCR_TS_Pos)                /*!< 0x00000010 */
+#define TIM_SMCR_TS_1             (0x00002U << TIM_SMCR_TS_Pos)                /*!< 0x00000020 */
+#define TIM_SMCR_TS_2             (0x00004U << TIM_SMCR_TS_Pos)                /*!< 0x00000040 */
+#define TIM_SMCR_TS_3             (0x10000U << TIM_SMCR_TS_Pos)                /*!< 0x00100000 */
+#define TIM_SMCR_TS_4             (0x20000U << TIM_SMCR_TS_Pos)                /*!< 0x00200000 */
+
+#define TIM_SMCR_MSM_Pos          (7U)
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                  /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode */
+
+#define TIM_SMCR_ETF_Pos          (8U)
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000100 */
+#define TIM_SMCR_ETF_1            (0x2U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000200 */
+#define TIM_SMCR_ETF_2            (0x4U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000400 */
+#define TIM_SMCR_ETF_3            (0x8U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1U << TIM_SMCR_ETPS_Pos)                  /*!< 0x00001000 */
+#define TIM_SMCR_ETPS_1           (0x2U << TIM_SMCR_ETPS_Pos)                  /*!< 0x00002000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                  /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable */
+#define TIM_SMCR_ETP_Pos          (15U)
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                  /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                  /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable */
+#define TIM_DIER_CC2IE_Pos        (2U)
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable */
+#define TIM_DIER_CC3IE_Pos        (3U)
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable */
+#define TIM_DIER_CC4IE_Pos        (4U)
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable */
+#define TIM_DIER_COMIE_Pos        (5U)
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable */
+#define TIM_DIER_TIE_Pos          (6U)
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                  /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable */
+#define TIM_DIER_BIE_Pos          (7U)
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                  /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable */
+#define TIM_DIER_UDE_Pos          (8U)
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                  /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable */
+#define TIM_DIER_CC1DE_Pos        (9U)
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable */
+#define TIM_DIER_TDE_Pos          (14U)
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                  /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                    /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag */
+#define TIM_SR_CC1IF_Pos          (1U)
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                  /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag */
+#define TIM_SR_CC2IF_Pos          (2U)
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                  /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag */
+#define TIM_SR_CC3IF_Pos          (3U)
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                  /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag */
+#define TIM_SR_CC4IF_Pos          (4U)
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                  /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag */
+#define TIM_SR_COMIF_Pos          (5U)
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                  /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag */
+#define TIM_SR_TIF_Pos            (6U)
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                    /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag */
+#define TIM_SR_BIF_Pos            (7U)
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                    /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag */
+#define TIM_SR_B2IF_Pos           (8U)
+#define TIM_SR_B2IF_Msk           (0x1UL << TIM_SR_B2IF_Pos)                   /*!< 0x00000100 */
+#define TIM_SR_B2IF               TIM_SR_B2IF_Msk                              /*!<Break 2 interrupt Flag */
+#define TIM_SR_CC1OF_Pos          (9U)
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                  /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                  /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                  /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                  /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+#define TIM_SR_SBIF_Pos           (13U)
+#define TIM_SR_SBIF_Msk           (0x1UL << TIM_SR_SBIF_Pos)                   /*!< 0x00002000 */
+#define TIM_SR_SBIF               TIM_SR_SBIF_Msk                              /*!<System Break interrupt Flag */
+#define TIM_SR_CC5IF_Pos          (16U)
+#define TIM_SR_CC5IF_Msk          (0x1UL << TIM_SR_CC5IF_Pos)                  /*!< 0x00010000 */
+#define TIM_SR_CC5IF              TIM_SR_CC5IF_Msk                             /*!<Capture/Compare 5 interrupt Flag */
+#define TIM_SR_CC6IF_Pos          (17U)
+#define TIM_SR_CC6IF_Msk          (0x1UL << TIM_SR_CC6IF_Pos)                  /*!< 0x00020000 */
+#define TIM_SR_CC6IF              TIM_SR_CC6IF_Msk                             /*!<Capture/Compare 6 interrupt Flag */
+
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                    /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation */
+#define TIM_EGR_CC1G_Pos          (1U)
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                  /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation */
+#define TIM_EGR_CC2G_Pos          (2U)
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                  /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation */
+#define TIM_EGR_CC3G_Pos          (3U)
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                  /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation */
+#define TIM_EGR_CC4G_Pos          (4U)
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                  /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation */
+#define TIM_EGR_COMG_Pos          (5U)
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                  /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                    /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation */
+#define TIM_EGR_BG_Pos            (7U)
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                    /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation */
+#define TIM_EGR_B2G_Pos           (8U)
+#define TIM_EGR_B2G_Msk           (0x1UL << TIM_EGR_B2G_Pos)                   /*!< 0x00000100 */
+#define TIM_EGR_B2G               TIM_EGR_B2G_Msk                              /*!<Break 2 Generation */
+
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1U << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000001 */
+#define TIM_CCMR1_CC1S_1          (0x2U << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable */
+#define TIM_CCMR1_OC1PE_Pos       (3U)
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)
+#define TIM_CCMR1_OC1M_Msk        (0x1007UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_CCMR1_OC1M_0          (0x0001U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR1_OC1M_1          (0x0002U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR1_OC1M_2          (0x0004U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR1_OC1M_3          (0x1000U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1 Clear Enable */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1U << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000100 */
+#define TIM_CCMR1_CC2S_1          (0x2U << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable */
+#define TIM_CCMR1_OC2PE_Pos       (11U)
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)
+#define TIM_CCMR1_OC2M_Msk        (0x1007UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_CCMR1_OC2M_0          (0x0001U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR1_OC2M_1          (0x0002U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR1_OC2M_2          (0x0004U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR1_OC2M_3          (0x1000U << TIM_CCMR1_OC2M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR1_IC1PSC_Pos      (2U)
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1U << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2U << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x00000008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_CCMR1_IC1F_0          (0x1U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000010 */
+#define TIM_CCMR1_IC1F_1          (0x2U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000020 */
+#define TIM_CCMR1_IC1F_2          (0x4U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000040 */
+#define TIM_CCMR1_IC1F_3          (0x8U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_CCMR1_IC2PSC_0        (0x1U << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2U << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_CCMR1_IC2F_0          (0x1U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00001000 */
+#define TIM_CCMR1_IC2F_1          (0x2U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00002000 */
+#define TIM_CCMR1_IC2F_2          (0x4U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00004000 */
+#define TIM_CCMR1_IC2F_3          (0x8U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CCMR2_CC3S_0          (0x1U << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000001 */
+#define TIM_CCMR2_CC3S_1          (0x2U << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable */
+#define TIM_CCMR2_OC3PE_Pos       (3U)
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)
+#define TIM_CCMR2_OC3M_Msk        (0x1007UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x0001U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR2_OC3M_1          (0x0002U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR2_OC3M_2          (0x0004U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR2_OC3M_3          (0x1000U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1U << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000100 */
+#define TIM_CCMR2_CC4S_1          (0x2U << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable */
+#define TIM_CCMR2_OC4PE_Pos       (11U)
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)
+#define TIM_CCMR2_OC4M_Msk        (0x1007UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x0001U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR2_OC4M_1          (0x0002U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR2_OC4M_2          (0x0004U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR2_OC4M_3          (0x1000U << TIM_CCMR2_OC4M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR2_IC3PSC_Pos      (2U)
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1U << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2U << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x00000008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000010 */
+#define TIM_CCMR2_IC3F_1          (0x2U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000020 */
+#define TIM_CCMR2_IC3F_2          (0x4U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000040 */
+#define TIM_CCMR2_IC3F_3          (0x8U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1U << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2U << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00001000 */
+#define TIM_CCMR2_IC4F_1          (0x2U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00002000 */
+#define TIM_CCMR2_IC4F_2          (0x4U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00004000 */
+#define TIM_CCMR2_IC4F_3          (0x8U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define TIM_CCMR3_OC5FE_Pos       (2U)
+#define TIM_CCMR3_OC5FE_Msk       (0x1UL << TIM_CCMR3_OC5FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR3_OC5FE           TIM_CCMR3_OC5FE_Msk                          /*!<Output Compare 5 Fast enable */
+#define TIM_CCMR3_OC5PE_Pos       (3U)
+#define TIM_CCMR3_OC5PE_Msk       (0x1UL << TIM_CCMR3_OC5PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR3_OC5PE           TIM_CCMR3_OC5PE_Msk                          /*!<Output Compare 5 Preload enable */
+
+#define TIM_CCMR3_OC5M_Pos        (4U)
+#define TIM_CCMR3_OC5M_Msk        (0x1007UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR3_OC5M            TIM_CCMR3_OC5M_Msk                           /*!<OC5M[3:0] bits (Output Compare 5 Mode) */
+#define TIM_CCMR3_OC5M_0          (0x0001U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR3_OC5M_1          (0x0002U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR3_OC5M_2          (0x0004U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR3_OC5M_3          (0x1000U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR3_OC5CE_Pos       (7U)
+#define TIM_CCMR3_OC5CE_Msk       (0x1UL << TIM_CCMR3_OC5CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR3_OC5CE           TIM_CCMR3_OC5CE_Msk                          /*!<Output Compare 5 Clear Enable */
+
+#define TIM_CCMR3_OC6FE_Pos       (10U)
+#define TIM_CCMR3_OC6FE_Msk       (0x1UL << TIM_CCMR3_OC6FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR3_OC6FE           TIM_CCMR3_OC6FE_Msk                          /*!<Output Compare 6 Fast enable */
+#define TIM_CCMR3_OC6PE_Pos       (11U)
+#define TIM_CCMR3_OC6PE_Msk       (0x1UL << TIM_CCMR3_OC6PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR3_OC6PE           TIM_CCMR3_OC6PE_Msk                          /*!<Output Compare 6 Preload enable */
+
+#define TIM_CCMR3_OC6M_Pos        (12U)
+#define TIM_CCMR3_OC6M_Msk        (0x1007UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR3_OC6M            TIM_CCMR3_OC6M_Msk                           /*!<OC6M[3:0] bits (Output Compare 6 Mode) */
+#define TIM_CCMR3_OC6M_0          (0x0001U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR3_OC6M_1          (0x0002U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR3_OC6M_2          (0x0004U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR3_OC6M_3          (0x1000U << TIM_CCMR3_OC6M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR3_OC6CE_Pos       (15U)
+#define TIM_CCMR3_OC6CE_Msk       (0x1UL << TIM_CCMR3_OC6CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR3_OC6CE           TIM_CCMR3_OC6CE_Msk                          /*!<Output Compare 6 Clear Enable */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                 /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable */
+#define TIM_CCER_CC1P_Pos         (1U)
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                 /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity */
+#define TIM_CCER_CC1NE_Pos        (2U)
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable */
+#define TIM_CCER_CC1NP_Pos        (3U)
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                 /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable */
+#define TIM_CCER_CC2P_Pos         (5U)
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                 /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity */
+#define TIM_CCER_CC2NE_Pos        (6U)
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable */
+#define TIM_CCER_CC2NP_Pos        (7U)
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                 /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable */
+#define TIM_CCER_CC3P_Pos         (9U)
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                 /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity */
+#define TIM_CCER_CC3NE_Pos        (10U)
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable */
+#define TIM_CCER_CC3NP_Pos        (11U)
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                 /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable */
+#define TIM_CCER_CC4P_Pos         (13U)
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                 /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity */
+#define TIM_CCER_CC4NP_Pos        (15U)
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+#define TIM_CCER_CC5E_Pos         (16U)
+#define TIM_CCER_CC5E_Msk         (0x1UL << TIM_CCER_CC5E_Pos)                 /*!< 0x00010000 */
+#define TIM_CCER_CC5E             TIM_CCER_CC5E_Msk                            /*!<Capture/Compare 5 output enable */
+#define TIM_CCER_CC5P_Pos         (17U)
+#define TIM_CCER_CC5P_Msk         (0x1UL << TIM_CCER_CC5P_Pos)                 /*!< 0x00020000 */
+#define TIM_CCER_CC5P             TIM_CCER_CC5P_Msk                            /*!<Capture/Compare 5 output Polarity */
+#define TIM_CCER_CC6E_Pos         (20U)
+#define TIM_CCER_CC6E_Msk         (0x1UL << TIM_CCER_CC6E_Pos)                 /*!< 0x00100000 */
+#define TIM_CCER_CC6E             TIM_CCER_CC6E_Msk                            /*!<Capture/Compare 6 output enable */
+#define TIM_CCER_CC6P_Pos         (21U)
+#define TIM_CCER_CC6P_Msk         (0x1UL << TIM_CCER_CC6P_Pos)                 /*!< 0x00200000 */
+#define TIM_CCER_CC6P             TIM_CCER_CC6P_Msk                            /*!<Capture/Compare 6 output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                              /*!<Counter Value */
+#define TIM_CNT_UIFCPY_Pos        (31U)
+#define TIM_CNT_UIFCPY_Msk        (0x1UL << TIM_CNT_UIFCPY_Pos)                /*!< 0x80000000 */
+#define TIM_CNT_UIFCPY            TIM_CNT_UIFCPY_Msk                           /*!<Update interrupt flag copy (if UIFREMAP=1) */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<Actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)
+#define TIM_RCR_REP_Msk           (0xFFFFUL << TIM_RCR_REP_Pos)                /*!< 0x0000FFFF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define TIM_CCR5_CCR5_Pos         (0U)
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
+#define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
+#define TIM_CCR5_GC5C1_Pos        (29U)
+#define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
+#define TIM_CCR5_GC5C1            TIM_CCR5_GC5C1_Msk                           /*!<Group Channel 5 and Channel 1 */
+#define TIM_CCR5_GC5C2_Pos        (30U)
+#define TIM_CCR5_GC5C2_Msk        (0x1UL << TIM_CCR5_GC5C2_Pos)                /*!< 0x40000000 */
+#define TIM_CCR5_GC5C2            TIM_CCR5_GC5C2_Msk                           /*!<Group Channel 5 and Channel 2 */
+#define TIM_CCR5_GC5C3_Pos        (31U)
+#define TIM_CCR5_GC5C3_Msk        (0x1UL << TIM_CCR5_GC5C3_Pos)                /*!< 0x80000000 */
+#define TIM_CCR5_GC5C3            TIM_CCR5_GC5C3_Msk                           /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define TIM_CCR6_CCR6_Pos         (0U)
+#define TIM_CCR6_CCR6_Msk         (0xFFFFUL << TIM_CCR6_CCR6_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6             TIM_CCR6_CCR6_Msk                            /*!<Capture/Compare 6 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                 /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000001 */
+#define TIM_BDTR_DTG_1            (0x02U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000002 */
+#define TIM_BDTR_DTG_2            (0x04U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000004 */
+#define TIM_BDTR_DTG_3            (0x08U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000008 */
+#define TIM_BDTR_DTG_4            (0x10U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000010 */
+#define TIM_BDTR_DTG_5            (0x20U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000020 */
+#define TIM_BDTR_DTG_6            (0x40U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000040 */
+#define TIM_BDTR_DTG_7            (0x80U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1U << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000100 */
+#define TIM_BDTR_LOCK_1           (0x2U << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                 /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                 /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode */
+#define TIM_BDTR_BKE_Pos          (12U)
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                  /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable for Break 1 */
+#define TIM_BDTR_BKP_Pos          (13U)
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                  /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity for Break 1 */
+#define TIM_BDTR_AOE_Pos          (14U)
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                  /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable */
+#define TIM_BDTR_MOE_Pos          (15U)
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                  /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable */
+
+#define TIM_BDTR_BKF_Pos          (16U)
+#define TIM_BDTR_BKF_Msk          (0xFUL << TIM_BDTR_BKF_Pos)                  /*!< 0x000F0000 */
+#define TIM_BDTR_BKF              TIM_BDTR_BKF_Msk                             /*!<Break Filter for Break 1 */
+#define TIM_BDTR_BK2F_Pos         (20U)
+#define TIM_BDTR_BK2F_Msk         (0xFUL << TIM_BDTR_BK2F_Pos)                 /*!< 0x00F00000 */
+#define TIM_BDTR_BK2F             TIM_BDTR_BK2F_Msk                            /*!<Break Filter for Break 2 */
+
+#define TIM_BDTR_BK2E_Pos         (24U)
+#define TIM_BDTR_BK2E_Msk         (0x1UL << TIM_BDTR_BK2E_Pos)                 /*!< 0x01000000 */
+#define TIM_BDTR_BK2E             TIM_BDTR_BK2E_Msk                            /*!<Break enable for Break 2 */
+#define TIM_BDTR_BK2P_Pos         (25U)
+#define TIM_BDTR_BK2P_Msk         (0x1UL << TIM_BDTR_BK2P_Pos)                 /*!< 0x02000000 */
+#define TIM_BDTR_BK2P             TIM_BDTR_BK2P_Msk                            /*!<Break Polarity for Break 2 */
+
+#define TIM_BDTR_BKDSRM_Pos       (26U)
+#define TIM_BDTR_BKDSRM_Msk       (0x1UL << TIM_BDTR_BKDSRM_Pos)               /*!< 0x04000000 */
+#define TIM_BDTR_BKDSRM           TIM_BDTR_BKDSRM_Msk                          /*!<Break disarming/re-arming */
+#define TIM_BDTR_BK2DSRM_Pos      (27U)
+#define TIM_BDTR_BK2DSRM_Msk      (0x1UL << TIM_BDTR_BK2DSRM_Pos)              /*!< 0x08000000 */
+#define TIM_BDTR_BK2DSRM          TIM_BDTR_BK2DSRM_Msk                         /*!<Break2 disarming/re-arming */
+
+#define TIM_BDTR_BKBID_Pos        (28U)
+#define TIM_BDTR_BKBID_Msk        (0x1UL << TIM_BDTR_BKBID_Pos)                /*!< 0x10000000 */
+#define TIM_BDTR_BKBID            TIM_BDTR_BKBID_Msk                           /*!<Break BIDirectional */
+#define TIM_BDTR_BK2BID_Pos       (29U)
+#define TIM_BDTR_BK2BID_Msk       (0x1UL << TIM_BDTR_BK2BID_Pos)               /*!< 0x20000000 */
+#define TIM_BDTR_BK2BID           TIM_BDTR_BK2BID_Msk                          /*!<Break2 BIDirectional */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                  /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01U << TIM_DCR_DBA_Pos)                   /*!< 0x00000001 */
+#define TIM_DCR_DBA_1             (0x02U << TIM_DCR_DBA_Pos)                   /*!< 0x00000002 */
+#define TIM_DCR_DBA_2             (0x04U << TIM_DCR_DBA_Pos)                   /*!< 0x00000004 */
+#define TIM_DCR_DBA_3             (0x08U << TIM_DCR_DBA_Pos)                   /*!< 0x00000008 */
+#define TIM_DCR_DBA_4             (0x10U << TIM_DCR_DBA_Pos)                   /*!< 0x00000010 */
+
+#define TIM_DCR_DBL_Pos           (8U)
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                  /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01U << TIM_DCR_DBL_Pos)                   /*!< 0x00000100 */
+#define TIM_DCR_DBL_1             (0x02U << TIM_DCR_DBL_Pos)                   /*!< 0x00000200 */
+#define TIM_DCR_DBL_2             (0x04U << TIM_DCR_DBL_Pos)                   /*!< 0x00000400 */
+#define TIM_DCR_DBL_3             (0x08U << TIM_DCR_DBL_Pos)                   /*!< 0x00000800 */
+#define TIM_DCR_DBL_4             (0x10U << TIM_DCR_DBL_Pos)                   /*!< 0x00001000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)              /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM1_OR register  *******************/
+#define TIM1_OR_ETR_ADC1_RMP_Pos      (0U)
+#define TIM1_OR_ETR_ADC1_RMP_Msk      (0x3UL << TIM1_OR_ETR_ADC1_RMP_Pos)    /*!< 0x00000003 */
+#define TIM1_OR_ETR_ADC1_RMP          TIM1_OR_ETR_ADC1_RMP_Msk               /*!< TIM1_ETR_ADC1 remapping capability*/
+#define TIM1_OR_ETR_ADC1_RMP_0        (0x1U << TIM1_OR_ETR_ADC1_RMP_Pos)     /*!< 0x00000001 */
+#define TIM1_OR_ETR_ADC1_RMP_1        (0x2U << TIM1_OR_ETR_ADC1_RMP_Pos)     /*!< 0x00000002 */
+#define TIM1_OR_TI1_RMP_Pos            (4U)
+#define TIM1_OR_TI1_RMP_Msk            (0x1UL << TIM1_OR_TI1_RMP_Pos)          /*!< 0x00000010 */
+#define TIM1_OR_TI1_RMP                TIM1_OR_TI1_RMP_Msk                     /*!< Input Capture 1 remap*/
+
+/*******************  Bit definition for TIM2_OR register  *******************/
+#define TIM2_OR_TI4_RMP_Pos      (2U)
+#define TIM2_OR_TI4_RMP_Msk      (0x3UL << TIM2_OR_TI4_RMP_Pos)              /*!< 0x0000000C */
+#define TIM2_OR_TI4_RMP          TIM2_OR_TI4_RMP_Msk                         /*!< TI4 Input capture 4 remap*/
+#define TIM2_OR_TI4_RMP_0        (0x1U << TIM2_OR_TI4_RMP_Pos)               /*!< 0x00000004 */
+#define TIM2_OR_ETR_RMP_Pos      (1U)
+#define TIM2_OR_ETR_RMP_Msk      (0x1UL << TIM2_OR_ETR_RMP_Pos)              /*!< 0x00000002 */
+#define TIM2_OR_ETR_RMP          TIM2_OR_ETR_RMP_Msk                         /*!< External trigger remap*/
+
+/*******************  Bit definition for TIM1_AF1 register  *******************/
+#define TIM1_AF1_BKINE_Pos             (0U)
+#define TIM1_AF1_BKINE_Msk             (0x1UL << TIM1_AF1_BKINE_Pos)           /*!< 0x00000001 */
+#define TIM1_AF1_BKINE                 TIM1_AF1_BKINE_Msk                      /*!<BRK BKIN input enable */
+#define TIM1_AF1_BKCMP1E_Pos           (1U)
+#define TIM1_AF1_BKCMP1E_Msk           (0x1UL << TIM1_AF1_BKCMP1E_Pos)         /*!< 0x00000002 */
+#define TIM1_AF1_BKCMP1E               TIM1_AF1_BKCMP1E_Msk                    /*!<BRK COMP1 enable */
+#define TIM1_AF1_BKINP_Pos             (9U)
+#define TIM1_AF1_BKINP_Msk             (0x1UL << TIM1_AF1_BKINP_Pos)           /*!< 0x00000200 */
+#define TIM1_AF1_BKINP                 TIM1_AF1_BKINP_Msk                      /*!<BRK BKIN input polarity */
+#define TIM1_AF1_BKCMP1P_Pos           (10U)
+#define TIM1_AF1_BKCMP1P_Msk           (0x1UL << TIM1_AF1_BKCMP1P_Pos)         /*!< 0x00000400 */
+#define TIM1_AF1_BKCMP1P               TIM1_AF1_BKCMP1P_Msk                    /*!<BRK COMP1 input polarity */
+#define TIM1_AF1_ETRSEL_Pos            (14U)
+#define TIM1_AF1_ETRSEL_Msk            (0x7UL << TIM1_AF1_ETRSEL_Pos)          /*!< 0x0001C000 */
+#define TIM1_AF1_ETRSEL                TIM1_AF1_ETRSEL_Msk                     /*!<ETRSEL[2:0] bits (TIM1 ETR source selection) */
+#define TIM1_AF1_ETRSEL_0              (0x1U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00004000 */
+#define TIM1_AF1_ETRSEL_1              (0x2U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00008000 */
+#define TIM1_AF1_ETRSEL_2              (0x4U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00010000 */
+
+/*******************  Bit definition for TIM2_AF1 register  *******************/
+#define TIM2_AF1_ETRSEL_Pos       (14U)
+#define TIM2_AF1_ETRSEL_Msk       (0x7UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x0001C000 */
+#define TIM2_AF1_ETRSEL           (0x00001C000)                                /*!< External trigger source selection */
+#define TIM2_AF1_ETRSEL_0         (0x000004000)                                /*!< Bit_0 */
+#define TIM2_AF1_ETRSEL_1         (0x000008000)                                /*!< Bit_1 */
+#define TIM2_AF1_ETRSEL_2         (0x000010000)                                /*!< Bit_2 */
+
+/*******************  Bit definition for TIM17_AF1 register  *******************/
+#define TIM17_AF1_BKINE_Pos             (0U)
+#define TIM17_AF1_BKINE_Msk             (0x1UL << TIM17_AF1_BKINE_Pos)           /*!< 0x00000001 */
+#define TIM17_AF1_BKINE                 TIM17_AF1_BKINE_Msk                      /*!<BRK BKIN input enable */
+#define TIM17_AF1_BKINP_Pos            (9U)
+#define TIM17_AF1_BKINP_Msk            (0x1UL << TIM17_AF1_BKINP_Pos)          /*!< 0x00000200 */
+#define TIM17_AF1_BKINP                TIM17_AF1_BKINP_Msk                     /*!<BRK BKIN2 input polarity */
+
+/*******************  Bit definition for TIM1_AF2 register  *******************/
+#define TIM1_AF2_BK2INE_Pos            (0U)
+#define TIM1_AF2_BK2INE_Msk            (0x1UL << TIM1_AF2_BK2INE_Pos)          /*!< 0x00000001 */
+#define TIM1_AF2_BK2INE                TIM1_AF2_BK2INE_Msk                     /*!<BRK2 BKIN2 input enable */
+#define TIM1_AF2_BK2CMP1E_Pos          (1U)
+#define TIM1_AF2_BK2CMP1E_Msk          (0x1UL << TIM1_AF2_BK2CMP1E_Pos)        /*!< 0x00000002 */
+#define TIM1_AF2_BK2CMP1E              TIM1_AF2_BK2CMP1E_Msk                   /*!<BRK2 COMP1 enable */
+#define TIM1_AF2_BK2INP_Pos            (9U)
+#define TIM1_AF2_BK2INP_Msk            (0x1UL << TIM1_AF2_BK2INP_Pos)          /*!< 0x00000200 */
+#define TIM1_AF2_BK2INP                TIM1_AF2_BK2INP_Msk                     /*!<BRK2 BKIN2 input polarity */
+#define TIM1_AF2_BK2CMP1P_Pos          (10U)
+#define TIM1_AF2_BK2CMP1P_Msk          (0x1UL << TIM1_AF2_BK2CMP1P_Pos)        /*!< 0x00000400 */
+#define TIM1_AF2_BK2CMP1P              TIM1_AF2_BK2CMP1P_Msk                   /*!<BRK2 COMP1 input polarity */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define LPTIM_ISR_CMPM_Pos          (0U)
+#define LPTIM_ISR_CMPM_Msk          (0x1UL << LPTIM_ISR_CMPM_Pos)              /*!< 0x00000001 */
+#define LPTIM_ISR_CMPM              LPTIM_ISR_CMPM_Msk                         /*!< Compare match */
+#define LPTIM_ISR_ARRM_Pos          (1U)
+#define LPTIM_ISR_ARRM_Msk          (0x1UL << LPTIM_ISR_ARRM_Pos)              /*!< 0x00000002 */
+#define LPTIM_ISR_ARRM              LPTIM_ISR_ARRM_Msk                         /*!< Autoreload match */
+#define LPTIM_ISR_EXTTRIG_Pos       (2U)
+#define LPTIM_ISR_EXTTRIG_Msk       (0x1UL << LPTIM_ISR_EXTTRIG_Pos)           /*!< 0x00000004 */
+#define LPTIM_ISR_EXTTRIG           LPTIM_ISR_EXTTRIG_Msk                      /*!< External trigger edge event */
+#define LPTIM_ISR_CMPOK_Pos         (3U)
+#define LPTIM_ISR_CMPOK_Msk         (0x1UL << LPTIM_ISR_CMPOK_Pos)             /*!< 0x00000008 */
+#define LPTIM_ISR_CMPOK             LPTIM_ISR_CMPOK_Msk                        /*!< Compare register update OK */
+#define LPTIM_ISR_ARROK_Pos         (4U)
+#define LPTIM_ISR_ARROK_Msk         (0x1UL << LPTIM_ISR_ARROK_Pos)             /*!< 0x00000010 */
+#define LPTIM_ISR_ARROK             LPTIM_ISR_ARROK_Msk                        /*!< Autoreload register update OK */
+#define LPTIM_ISR_UP_Pos            (5U)
+#define LPTIM_ISR_UP_Msk            (0x1UL << LPTIM_ISR_UP_Pos)                /*!< 0x00000020 */
+#define LPTIM_ISR_UP                LPTIM_ISR_UP_Msk                           /*!< Counter direction change down to up */
+#define LPTIM_ISR_DOWN_Pos          (6U)
+#define LPTIM_ISR_DOWN_Msk          (0x1UL << LPTIM_ISR_DOWN_Pos)              /*!< 0x00000040 */
+#define LPTIM_ISR_DOWN              LPTIM_ISR_DOWN_Msk                         /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define LPTIM_ICR_CMPMCF_Pos        (0U)
+#define LPTIM_ICR_CMPMCF_Msk        (0x1UL << LPTIM_ICR_CMPMCF_Pos)            /*!< 0x00000001 */
+#define LPTIM_ICR_CMPMCF            LPTIM_ICR_CMPMCF_Msk                       /*!< Compare match Clear Flag */
+#define LPTIM_ICR_ARRMCF_Pos        (1U)
+#define LPTIM_ICR_ARRMCF_Msk        (0x1UL << LPTIM_ICR_ARRMCF_Pos)            /*!< 0x00000002 */
+#define LPTIM_ICR_ARRMCF            LPTIM_ICR_ARRMCF_Msk                       /*!< Autoreload match Clear Flag */
+#define LPTIM_ICR_EXTTRIGCF_Pos     (2U)
+#define LPTIM_ICR_EXTTRIGCF_Msk     (0x1UL << LPTIM_ICR_EXTTRIGCF_Pos)         /*!< 0x00000004 */
+#define LPTIM_ICR_EXTTRIGCF         LPTIM_ICR_EXTTRIGCF_Msk                    /*!< External trigger edge event Clear Flag */
+#define LPTIM_ICR_CMPOKCF_Pos       (3U)
+#define LPTIM_ICR_CMPOKCF_Msk       (0x1UL << LPTIM_ICR_CMPOKCF_Pos)           /*!< 0x00000008 */
+#define LPTIM_ICR_CMPOKCF           LPTIM_ICR_CMPOKCF_Msk                      /*!< Compare register update OK Clear Flag */
+#define LPTIM_ICR_ARROKCF_Pos       (4U)
+#define LPTIM_ICR_ARROKCF_Msk       (0x1UL << LPTIM_ICR_ARROKCF_Pos)           /*!< 0x00000010 */
+#define LPTIM_ICR_ARROKCF           LPTIM_ICR_ARROKCF_Msk                      /*!< Autoreload register update OK Clear Flag */
+#define LPTIM_ICR_UPCF_Pos          (5U)
+#define LPTIM_ICR_UPCF_Msk          (0x1UL << LPTIM_ICR_UPCF_Pos)              /*!< 0x00000020 */
+#define LPTIM_ICR_UPCF              LPTIM_ICR_UPCF_Msk                         /*!< Counter direction change down to up Clear Flag */
+#define LPTIM_ICR_DOWNCF_Pos        (6U)
+#define LPTIM_ICR_DOWNCF_Msk        (0x1UL << LPTIM_ICR_DOWNCF_Pos)            /*!< 0x00000040 */
+#define LPTIM_ICR_DOWNCF            LPTIM_ICR_DOWNCF_Msk                       /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define LPTIM_IER_CMPMIE_Pos        (0U)
+#define LPTIM_IER_CMPMIE_Msk        (0x1UL << LPTIM_IER_CMPMIE_Pos)            /*!< 0x00000001 */
+#define LPTIM_IER_CMPMIE            LPTIM_IER_CMPMIE_Msk                       /*!< Compare match Interrupt Enable */
+#define LPTIM_IER_ARRMIE_Pos        (1U)
+#define LPTIM_IER_ARRMIE_Msk        (0x1UL << LPTIM_IER_ARRMIE_Pos)            /*!< 0x00000002 */
+#define LPTIM_IER_ARRMIE            LPTIM_IER_ARRMIE_Msk                       /*!< Autoreload match Interrupt Enable */
+#define LPTIM_IER_EXTTRIGIE_Pos     (2U)
+#define LPTIM_IER_EXTTRIGIE_Msk     (0x1UL << LPTIM_IER_EXTTRIGIE_Pos)         /*!< 0x00000004 */
+#define LPTIM_IER_EXTTRIGIE         LPTIM_IER_EXTTRIGIE_Msk                    /*!< External trigger edge event Interrupt Enable */
+#define LPTIM_IER_CMPOKIE_Pos       (3U)
+#define LPTIM_IER_CMPOKIE_Msk       (0x1UL << LPTIM_IER_CMPOKIE_Pos)           /*!< 0x00000008 */
+#define LPTIM_IER_CMPOKIE           LPTIM_IER_CMPOKIE_Msk                      /*!< Compare register update OK Interrupt Enable */
+#define LPTIM_IER_ARROKIE_Pos       (4U)
+#define LPTIM_IER_ARROKIE_Msk       (0x1UL << LPTIM_IER_ARROKIE_Pos)           /*!< 0x00000010 */
+#define LPTIM_IER_ARROKIE           LPTIM_IER_ARROKIE_Msk                      /*!< Autoreload register update OK Interrupt Enable */
+#define LPTIM_IER_UPIE_Pos          (5U)
+#define LPTIM_IER_UPIE_Msk          (0x1UL << LPTIM_IER_UPIE_Pos)              /*!< 0x00000020 */
+#define LPTIM_IER_UPIE              LPTIM_IER_UPIE_Msk                         /*!< Counter direction change down to up Interrupt Enable */
+#define LPTIM_IER_DOWNIE_Pos        (6U)
+#define LPTIM_IER_DOWNIE_Msk        (0x1UL << LPTIM_IER_DOWNIE_Pos)            /*!< 0x00000040 */
+#define LPTIM_IER_DOWNIE            LPTIM_IER_DOWNIE_Msk                       /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define LPTIM_CFGR_CKSEL_Pos        (0U)
+#define LPTIM_CFGR_CKSEL_Msk        (0x1UL << LPTIM_CFGR_CKSEL_Pos)            /*!< 0x00000001 */
+#define LPTIM_CFGR_CKSEL            LPTIM_CFGR_CKSEL_Msk                       /*!< Clock selector */
+
+#define LPTIM_CFGR_CKPOL_Pos        (1U)
+#define LPTIM_CFGR_CKPOL_Msk        (0x3UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000006 */
+#define LPTIM_CFGR_CKPOL            LPTIM_CFGR_CKPOL_Msk                       /*!< CKPOL[1:0] bits (Clock polarity) */
+#define LPTIM_CFGR_CKPOL_0          (0x1U << LPTIM_CFGR_CKPOL_Pos)             /*!< 0x00000002 */
+#define LPTIM_CFGR_CKPOL_1          (0x2U << LPTIM_CFGR_CKPOL_Pos)             /*!< 0x00000004 */
+
+#define LPTIM_CFGR_CKFLT_Pos        (3U)
+#define LPTIM_CFGR_CKFLT_Msk        (0x3UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000018 */
+#define LPTIM_CFGR_CKFLT            LPTIM_CFGR_CKFLT_Msk                       /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define LPTIM_CFGR_CKFLT_0          (0x1U << LPTIM_CFGR_CKFLT_Pos)             /*!< 0x00000008 */
+#define LPTIM_CFGR_CKFLT_1          (0x2U << LPTIM_CFGR_CKFLT_Pos)             /*!< 0x00000010 */
+
+#define LPTIM_CFGR_TRGFLT_Pos       (6U)
+#define LPTIM_CFGR_TRGFLT_Msk       (0x3UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x000000C0 */
+#define LPTIM_CFGR_TRGFLT           LPTIM_CFGR_TRGFLT_Msk                      /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define LPTIM_CFGR_TRGFLT_0         (0x1U << LPTIM_CFGR_TRGFLT_Pos)            /*!< 0x00000040 */
+#define LPTIM_CFGR_TRGFLT_1         (0x2U << LPTIM_CFGR_TRGFLT_Pos)            /*!< 0x00000080 */
+
+#define LPTIM_CFGR_PRESC_Pos        (9U)
+#define LPTIM_CFGR_PRESC_Msk        (0x7UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000E00 */
+#define LPTIM_CFGR_PRESC            LPTIM_CFGR_PRESC_Msk                       /*!< PRESC[2:0] bits (Clock prescaler) */
+#define LPTIM_CFGR_PRESC_0          (0x1U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000200 */
+#define LPTIM_CFGR_PRESC_1          (0x2U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000400 */
+#define LPTIM_CFGR_PRESC_2          (0x4U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000800 */
+
+#define LPTIM_CFGR_TRIGSEL_Pos      (13U)
+#define LPTIM_CFGR_TRIGSEL_Msk      (0x7UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x0000E000 */
+#define LPTIM_CFGR_TRIGSEL          LPTIM_CFGR_TRIGSEL_Msk                     /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define LPTIM_CFGR_TRIGSEL_0        (0x1U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00002000 */
+#define LPTIM_CFGR_TRIGSEL_1        (0x2U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00004000 */
+#define LPTIM_CFGR_TRIGSEL_2        (0x4U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00008000 */
+
+#define LPTIM_CFGR_TRIGEN_Pos       (17U)
+#define LPTIM_CFGR_TRIGEN_Msk       (0x3UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00060000 */
+#define LPTIM_CFGR_TRIGEN           LPTIM_CFGR_TRIGEN_Msk                      /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define LPTIM_CFGR_TRIGEN_0         (0x1U << LPTIM_CFGR_TRIGEN_Pos)            /*!< 0x00020000 */
+#define LPTIM_CFGR_TRIGEN_1         (0x2U << LPTIM_CFGR_TRIGEN_Pos)            /*!< 0x00040000 */
+
+#define LPTIM_CFGR_TIMOUT_Pos       (19U)
+#define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
+#define LPTIM_CFGR_WAVE_Pos         (20U)
+#define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
+#define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
+#define LPTIM_CFGR_WAVPOL_Pos       (21U)
+#define LPTIM_CFGR_WAVPOL_Msk       (0x1UL << LPTIM_CFGR_WAVPOL_Pos)           /*!< 0x00200000 */
+#define LPTIM_CFGR_WAVPOL           LPTIM_CFGR_WAVPOL_Msk                      /*!< Waveform shape polarity */
+#define LPTIM_CFGR_PRELOAD_Pos      (22U)
+#define LPTIM_CFGR_PRELOAD_Msk      (0x1UL << LPTIM_CFGR_PRELOAD_Pos)          /*!< 0x00400000 */
+#define LPTIM_CFGR_PRELOAD          LPTIM_CFGR_PRELOAD_Msk                     /*!< Reg update mode */
+#define LPTIM_CFGR_COUNTMODE_Pos    (23U)
+#define LPTIM_CFGR_COUNTMODE_Msk    (0x1UL << LPTIM_CFGR_COUNTMODE_Pos)        /*!< 0x00800000 */
+#define LPTIM_CFGR_COUNTMODE        LPTIM_CFGR_COUNTMODE_Msk                   /*!< Counter mode enable */
+#define LPTIM_CFGR_ENC_Pos          (24U)
+#define LPTIM_CFGR_ENC_Msk          (0x1UL << LPTIM_CFGR_ENC_Pos)              /*!< 0x01000000 */
+#define LPTIM_CFGR_ENC              LPTIM_CFGR_ENC_Msk                         /*!< Encoder mode enable */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define LPTIM_CR_ENABLE_Pos         (0U)
+#define LPTIM_CR_ENABLE_Msk         (0x1UL << LPTIM_CR_ENABLE_Pos)             /*!< 0x00000001 */
+#define LPTIM_CR_ENABLE             LPTIM_CR_ENABLE_Msk                        /*!< LPTIMer enable */
+#define LPTIM_CR_SNGSTRT_Pos        (1U)
+#define LPTIM_CR_SNGSTRT_Msk        (0x1UL << LPTIM_CR_SNGSTRT_Pos)            /*!< 0x00000002 */
+#define LPTIM_CR_SNGSTRT            LPTIM_CR_SNGSTRT_Msk                       /*!< Timer start in single mode */
+#define LPTIM_CR_CNTSTRT_Pos        (2U)
+#define LPTIM_CR_CNTSTRT_Msk        (0x1UL << LPTIM_CR_CNTSTRT_Pos)            /*!< 0x00000004 */
+#define LPTIM_CR_CNTSTRT            LPTIM_CR_CNTSTRT_Msk                       /*!< Timer start in continuous mode */
+#define LPTIM_CR_COUNTRST_Pos       (3U)
+#define LPTIM_CR_COUNTRST_Msk       (0x1UL << LPTIM_CR_COUNTRST_Pos)           /*!< 0x00000008 */
+#define LPTIM_CR_COUNTRST           LPTIM_CR_COUNTRST_Msk                      /*!< Counter reset */
+#define LPTIM_CR_RSTARE_Pos         (4U)
+#define LPTIM_CR_RSTARE_Msk         (0x1UL << LPTIM_CR_RSTARE_Pos)             /*!< 0x00000010 */
+#define LPTIM_CR_RSTARE             LPTIM_CR_RSTARE_Msk                        /*!< Reset after read enable */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define LPTIM_CMP_CMP_Pos           (0U)
+#define LPTIM_CMP_CMP_Msk           (0xFFFFUL << LPTIM_CMP_CMP_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CMP_CMP               LPTIM_CMP_CMP_Msk                          /*!< Compare register */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define LPTIM_ARR_ARR_Pos           (0U)
+#define LPTIM_ARR_ARR_Msk           (0xFFFFUL << LPTIM_ARR_ARR_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_ARR_ARR               LPTIM_ARR_ARR_Msk                          /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define LPTIM_CNT_CNT_Pos           (0U)
+#define LPTIM_CNT_CNT_Msk           (0xFFFFUL << LPTIM_CNT_CNT_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CNT_CNT               LPTIM_CNT_CNT_Msk                          /*!< Counter register */
+
+/******************  Bit definition for LPTIM_OR register  *******************/
+#define LPTIM_OR_OR_Pos             (0U)
+#define LPTIM_OR_OR_Msk             (0x1UL << LPTIM_OR_OR_Pos)                 /*!< 0x00000001 */
+#define LPTIM_OR_OR                 LPTIM_OR_OR_Msk                            /*!< OR[1:0] bits (Remap selection) */
+#define LPTIM_OR_OR_0               (0x1U << LPTIM_OR_OR_Pos)                  /*!< 0x00000001 */
+
+/******************************************************************************/
+/*                                                                            */
+/*         Inter-Processor Communication Controller (IPCC)                    */
+/*                                                                            */
+/******************************************************************************/
+
+/**********************  Bit definition for IPCC_C1CR register  ***************/
+#define IPCC_C1CR_RXOIE_Pos      (0U)
+#define IPCC_C1CR_RXOIE_Msk      (0x1UL << IPCC_C1CR_RXOIE_Pos)                /*!< 0x00000001 */
+#define IPCC_C1CR_RXOIE          IPCC_C1CR_RXOIE_Msk                           /*!< Processor M4 Receive channel occupied interrupt enable */
+#define IPCC_C1CR_TXFIE_Pos      (16U)
+#define IPCC_C1CR_TXFIE_Msk      (0x1UL << IPCC_C1CR_TXFIE_Pos)                /*!< 0x00010000 */
+#define IPCC_C1CR_TXFIE          IPCC_C1CR_TXFIE_Msk                           /*!< Processor M4 Transmit channel free interrupt enable */
+
+/**********************  Bit definition for IPCC_C1MR register  **************/
+#define IPCC_C1MR_CH1OM_Pos      (0U)
+#define IPCC_C1MR_CH1OM_Msk      (0x1UL << IPCC_C1MR_CH1OM_Pos)                /*!< 0x00000001 */
+#define IPCC_C1MR_CH1OM          IPCC_C1MR_CH1OM_Msk                           /*!< M4 Channel1 occupied interrupt mask */
+#define IPCC_C1MR_CH2OM_Pos      (1U)
+#define IPCC_C1MR_CH2OM_Msk      (0x1UL << IPCC_C1MR_CH2OM_Pos)                /*!< 0x00000002 */
+#define IPCC_C1MR_CH2OM          IPCC_C1MR_CH2OM_Msk                           /*!< M4 Channel2 occupied interrupt mask */
+#define IPCC_C1MR_CH3OM_Pos      (2U)
+#define IPCC_C1MR_CH3OM_Msk      (0x1UL << IPCC_C1MR_CH3OM_Pos)                /*!< 0x00000004 */
+#define IPCC_C1MR_CH3OM          IPCC_C1MR_CH3OM_Msk                           /*!< M4 Channel3 occupied interrupt mask */
+#define IPCC_C1MR_CH4OM_Pos      (3U)
+#define IPCC_C1MR_CH4OM_Msk      (0x1UL << IPCC_C1MR_CH4OM_Pos)                /*!< 0x00000008 */
+#define IPCC_C1MR_CH4OM          IPCC_C1MR_CH4OM_Msk                           /*!< M4 Channel4 occupied interrupt mask */
+#define IPCC_C1MR_CH5OM_Pos      (4U)
+#define IPCC_C1MR_CH5OM_Msk      (0x1UL << IPCC_C1MR_CH5OM_Pos)                /*!< 0x00000010 */
+#define IPCC_C1MR_CH5OM          IPCC_C1MR_CH5OM_Msk                           /*!< M4 Channel5 occupied interrupt mask */
+#define IPCC_C1MR_CH6OM_Pos      (5U)
+#define IPCC_C1MR_CH6OM_Msk      (0x1UL << IPCC_C1MR_CH6OM_Pos)                /*!< 0x00000020 */
+#define IPCC_C1MR_CH6OM          IPCC_C1MR_CH6OM_Msk                           /*!< M4 Channel6 occupied interrupt mask */
+
+#define IPCC_C1MR_CH1FM_Pos      (16U)
+#define IPCC_C1MR_CH1FM_Msk      (0x1UL << IPCC_C1MR_CH1FM_Pos)                /*!< 0x00010000 */
+#define IPCC_C1MR_CH1FM          IPCC_C1MR_CH1FM_Msk                           /*!< M4 Transmit Channel1 free interrupt mask */
+#define IPCC_C1MR_CH2FM_Pos      (17U)
+#define IPCC_C1MR_CH2FM_Msk      (0x1UL << IPCC_C1MR_CH2FM_Pos)                /*!< 0x00020000 */
+#define IPCC_C1MR_CH2FM          IPCC_C1MR_CH2FM_Msk                           /*!< M4 Transmit Channel2 free interrupt mask */
+#define IPCC_C1MR_CH3FM_Pos      (18U)
+#define IPCC_C1MR_CH3FM_Msk      (0x1UL << IPCC_C1MR_CH3FM_Pos)                /*!< 0x00040000 */
+#define IPCC_C1MR_CH3FM          IPCC_C1MR_CH3FM_Msk                           /*!< M4 Transmit Channel3 free interrupt mask */
+#define IPCC_C1MR_CH4FM_Pos      (19U)
+#define IPCC_C1MR_CH4FM_Msk      (0x1UL << IPCC_C1MR_CH4FM_Pos)                /*!< 0x00080000 */
+#define IPCC_C1MR_CH4FM          IPCC_C1MR_CH4FM_Msk                           /*!< M4 Transmit Channel4 free interrupt mask */
+#define IPCC_C1MR_CH5FM_Pos      (20U)
+#define IPCC_C1MR_CH5FM_Msk      (0x1UL << IPCC_C1MR_CH5FM_Pos)                /*!< 0x00100000 */
+#define IPCC_C1MR_CH5FM          IPCC_C1MR_CH5FM_Msk                           /*!< M4 Transmit Channel5 free interrupt mask */
+#define IPCC_C1MR_CH6FM_Pos      (21U)
+#define IPCC_C1MR_CH6FM_Msk      (0x1UL << IPCC_C1MR_CH6FM_Pos)                /*!< 0x00200000 */
+#define IPCC_C1MR_CH6FM          IPCC_C1MR_CH6FM_Msk                           /*!< M4 Transmit Channel6 free interrupt mask */
+
+/**********************  Bit definition for IPCC_C1SCR register  ***************/
+#define IPCC_C1SCR_CH1C_Pos      (0U)
+#define IPCC_C1SCR_CH1C_Msk      (0x1UL << IPCC_C1SCR_CH1C_Pos)                /*!< 0x00000001 */
+#define IPCC_C1SCR_CH1C          IPCC_C1SCR_CH1C_Msk                           /*!< M4 receive Channel1 status clear */
+#define IPCC_C1SCR_CH2C_Pos      (1U)
+#define IPCC_C1SCR_CH2C_Msk      (0x1UL << IPCC_C1SCR_CH2C_Pos)                /*!< 0x00000002 */
+#define IPCC_C1SCR_CH2C          IPCC_C1SCR_CH2C_Msk                           /*!< M4 receive Channel2 status clear */
+#define IPCC_C1SCR_CH3C_Pos      (2U)
+#define IPCC_C1SCR_CH3C_Msk      (0x1UL << IPCC_C1SCR_CH3C_Pos)                /*!< 0x00000004 */
+#define IPCC_C1SCR_CH3C          IPCC_C1SCR_CH3C_Msk                           /*!< M4 receive Channel3 status clear */
+#define IPCC_C1SCR_CH4C_Pos      (3U)
+#define IPCC_C1SCR_CH4C_Msk      (0x1UL << IPCC_C1SCR_CH4C_Pos)                /*!< 0x00000008 */
+#define IPCC_C1SCR_CH4C          IPCC_C1SCR_CH4C_Msk                           /*!< M4 receive Channel4 status clear */
+#define IPCC_C1SCR_CH5C_Pos      (4U)
+#define IPCC_C1SCR_CH5C_Msk      (0x1UL << IPCC_C1SCR_CH5C_Pos)                /*!< 0x00000010 */
+#define IPCC_C1SCR_CH5C          IPCC_C1SCR_CH5C_Msk                           /*!< M4 receive Channel5 status clear */
+#define IPCC_C1SCR_CH6C_Pos      (5U)
+#define IPCC_C1SCR_CH6C_Msk      (0x1UL << IPCC_C1SCR_CH6C_Pos)                /*!< 0x00000020 */
+#define IPCC_C1SCR_CH6C          IPCC_C1SCR_CH6C_Msk                           /*!< M4 receive Channel6 status clear */
+
+#define IPCC_C1SCR_CH1S_Pos      (16U)
+#define IPCC_C1SCR_CH1S_Msk      (0x1UL << IPCC_C1SCR_CH1S_Pos)                /*!< 0x00010000 */
+#define IPCC_C1SCR_CH1S          IPCC_C1SCR_CH1S_Msk                           /*!< M4 transmit Channel1 status set */
+#define IPCC_C1SCR_CH2S_Pos      (17U)
+#define IPCC_C1SCR_CH2S_Msk      (0x1UL << IPCC_C1SCR_CH2S_Pos)                /*!< 0x00020000 */
+#define IPCC_C1SCR_CH2S          IPCC_C1SCR_CH2S_Msk                           /*!< M4 transmit Channel2 status set  */
+#define IPCC_C1SCR_CH3S_Pos      (18U)
+#define IPCC_C1SCR_CH3S_Msk      (0x1UL << IPCC_C1SCR_CH3S_Pos)                /*!< 0x00040000 */
+#define IPCC_C1SCR_CH3S          IPCC_C1SCR_CH3S_Msk                           /*!< M4 transmit Channel3 status set  */
+#define IPCC_C1SCR_CH4S_Pos      (19U)
+#define IPCC_C1SCR_CH4S_Msk      (0x1UL << IPCC_C1SCR_CH4S_Pos)                /*!< 0x00080000 */
+#define IPCC_C1SCR_CH4S          IPCC_C1SCR_CH4S_Msk                           /*!< M4 transmit Channel4 status set  */
+#define IPCC_C1SCR_CH5S_Pos      (20U)
+#define IPCC_C1SCR_CH5S_Msk      (0x1UL << IPCC_C1SCR_CH5S_Pos)                /*!< 0x00100000 */
+#define IPCC_C1SCR_CH5S          IPCC_C1SCR_CH5S_Msk                           /*!< M4 transmit Channel5 status set  */
+#define IPCC_C1SCR_CH6S_Pos      (21U)
+#define IPCC_C1SCR_CH6S_Msk      (0x1UL << IPCC_C1SCR_CH6S_Pos)                /*!< 0x00200000 */
+#define IPCC_C1SCR_CH6S          IPCC_C1SCR_CH6S_Msk                           /*!< M4 transmit Channel6 status set  */
+
+/**********************  Bit definition for IPCC_C1TOC2SR register  ***************/
+#define IPCC_C1TOC2SR_CH1F_Pos    (0U)
+#define IPCC_C1TOC2SR_CH1F_Msk    (0x1UL << IPCC_C1TOC2SR_CH1F_Pos)            /*!< 0x00000001 */
+#define IPCC_C1TOC2SR_CH1F        IPCC_C1TOC2SR_CH1F_Msk                       /*!< M4 transmit to M4 receive Channel1 status flag before masking */
+#define IPCC_C1TOC2SR_CH2F_Pos    (1U)
+#define IPCC_C1TOC2SR_CH2F_Msk    (0x1UL << IPCC_C1TOC2SR_CH2F_Pos)            /*!< 0x00000002 */
+#define IPCC_C1TOC2SR_CH2F        IPCC_C1TOC2SR_CH2F_Msk                       /*!< M4 transmit to M4 receive Channel2 status flag before masking */
+#define IPCC_C1TOC2SR_CH3F_Pos    (2U)
+#define IPCC_C1TOC2SR_CH3F_Msk    (0x1UL << IPCC_C1TOC2SR_CH3F_Pos)            /*!< 0x00000004 */
+#define IPCC_C1TOC2SR_CH3F        IPCC_C1TOC2SR_CH3F_Msk                       /*!< M4 transmit to M4 receive Channel3 status flag before masking */
+#define IPCC_C1TOC2SR_CH4F_Pos    (3U)
+#define IPCC_C1TOC2SR_CH4F_Msk    (0x1UL << IPCC_C1TOC2SR_CH4F_Pos)            /*!< 0x00000008 */
+#define IPCC_C1TOC2SR_CH4F        IPCC_C1TOC2SR_CH4F_Msk                       /*!< M4 transmit to M4 receive Channel4 status flag before masking */
+#define IPCC_C1TOC2SR_CH5F_Pos    (4U)
+#define IPCC_C1TOC2SR_CH5F_Msk    (0x1UL << IPCC_C1TOC2SR_CH5F_Pos)            /*!< 0x00000010 */
+#define IPCC_C1TOC2SR_CH5F        IPCC_C1TOC2SR_CH5F_Msk                       /*!< M4 transmit to M4 receive Channel5 status flag before masking */
+#define IPCC_C1TOC2SR_CH6F_Pos    (5U)
+#define IPCC_C1TOC2SR_CH6F_Msk    (0x1UL << IPCC_C1TOC2SR_CH6F_Pos)            /*!< 0x00000020 */
+#define IPCC_C1TOC2SR_CH6F        IPCC_C1TOC2SR_CH6F_Msk                       /*!< M4 transmit to M4 receive Channel6 status flag before masking */
+
+/**********************  Bit definition for IPCC_C2CR register  ***************/
+#define IPCC_C2CR_RXOIE_Pos      (0U)
+#define IPCC_C2CR_RXOIE_Msk      (0x1UL << IPCC_C2CR_RXOIE_Pos)                /*!< 0x00000001 */
+#define IPCC_C2CR_RXOIE          IPCC_C2CR_RXOIE_Msk                           /*!< Processor M0+ Receive channel occupied interrupt enable */
+#define IPCC_C2CR_TXFIE_Pos      (16U)
+#define IPCC_C2CR_TXFIE_Msk      (0x1UL << IPCC_C2CR_TXFIE_Pos)                /*!< 0x00010000 */
+#define IPCC_C2CR_TXFIE          IPCC_C2CR_TXFIE_Msk                           /*!< Processor M0+ Transmit channel free interrupt enable */
+
+/**********************  Bit definition for IPCC_C2MR register  ***************/
+#define IPCC_C2MR_CH1OM_Pos      (0U)
+#define IPCC_C2MR_CH1OM_Msk      (0x1UL << IPCC_C2MR_CH1OM_Pos)                /*!< 0x00000001 */
+#define IPCC_C2MR_CH1OM          IPCC_C2MR_CH1OM_Msk                           /*!< M0+ Channel1 occupied interrupt mask */
+#define IPCC_C2MR_CH2OM_Pos      (1U)
+#define IPCC_C2MR_CH2OM_Msk      (0x1UL << IPCC_C2MR_CH2OM_Pos)                /*!< 0x00000002 */
+#define IPCC_C2MR_CH2OM          IPCC_C2MR_CH2OM_Msk                           /*!< M0+ Channel2 occupied interrupt mask */
+#define IPCC_C2MR_CH3OM_Pos      (2U)
+#define IPCC_C2MR_CH3OM_Msk      (0x1UL << IPCC_C2MR_CH3OM_Pos)                /*!< 0x00000004 */
+#define IPCC_C2MR_CH3OM          IPCC_C2MR_CH3OM_Msk                           /*!< M0+ Channel3 occupied interrupt mask */
+#define IPCC_C2MR_CH4OM_Pos      (3U)
+#define IPCC_C2MR_CH4OM_Msk      (0x1UL << IPCC_C2MR_CH4OM_Pos)                /*!< 0x00000008 */
+#define IPCC_C2MR_CH4OM          IPCC_C2MR_CH4OM_Msk                           /*!< M0+ Channel4 occupied interrupt mask */
+#define IPCC_C2MR_CH5OM_Pos      (4U)
+#define IPCC_C2MR_CH5OM_Msk      (0x1UL << IPCC_C2MR_CH5OM_Pos)                /*!< 0x00000010 */
+#define IPCC_C2MR_CH5OM          IPCC_C2MR_CH5OM_Msk                           /*!< M0+ Channel5 occupied interrupt mask */
+#define IPCC_C2MR_CH6OM_Pos      (5U)
+#define IPCC_C2MR_CH6OM_Msk      (0x1UL << IPCC_C2MR_CH6OM_Pos)                /*!< 0x00000020 */
+#define IPCC_C2MR_CH6OM          IPCC_C2MR_CH6OM_Msk                           /*!< M0+ Channel6 occupied interrupt mask */
+
+#define IPCC_C2MR_CH1FM_Pos      (16U)
+#define IPCC_C2MR_CH1FM_Msk      (0x1UL << IPCC_C2MR_CH1FM_Pos)                /*!< 0x00010000 */
+#define IPCC_C2MR_CH1FM          IPCC_C2MR_CH1FM_Msk                           /*!< M0+ Transmit Channel1 free interrupt mask */
+#define IPCC_C2MR_CH2FM_Pos      (17U)
+#define IPCC_C2MR_CH2FM_Msk      (0x1UL << IPCC_C2MR_CH2FM_Pos)                /*!< 0x00020000 */
+#define IPCC_C2MR_CH2FM          IPCC_C2MR_CH2FM_Msk                           /*!< M0+ Transmit Channel2 free interrupt mask */
+#define IPCC_C2MR_CH3FM_Pos      (18U)
+#define IPCC_C2MR_CH3FM_Msk      (0x1UL << IPCC_C2MR_CH3FM_Pos)                /*!< 0x00040000 */
+#define IPCC_C2MR_CH3FM          IPCC_C2MR_CH3FM_Msk                           /*!< M0+ Transmit Channel3 free interrupt mask */
+#define IPCC_C2MR_CH4FM_Pos      (19U)
+#define IPCC_C2MR_CH4FM_Msk      (0x1UL << IPCC_C2MR_CH4FM_Pos)                /*!< 0x00080000 */
+#define IPCC_C2MR_CH4FM          IPCC_C2MR_CH4FM_Msk                           /*!< M0+ Transmit Channel4 free interrupt mask */
+#define IPCC_C2MR_CH5FM_Pos      (20U)
+#define IPCC_C2MR_CH5FM_Msk      (0x1UL << IPCC_C2MR_CH5FM_Pos)                /*!< 0x00100000 */
+#define IPCC_C2MR_CH5FM          IPCC_C2MR_CH5FM_Msk                           /*!< M0+ Transmit Channel5 free interrupt mask */
+#define IPCC_C2MR_CH6FM_Pos      (21U)
+#define IPCC_C2MR_CH6FM_Msk      (0x1UL << IPCC_C2MR_CH6FM_Pos)                /*!< 0x00200000 */
+#define IPCC_C2MR_CH6FM          IPCC_C2MR_CH6FM_Msk                           /*!< M0+ Transmit Channel6 free interrupt mask */
+
+/**********************  Bit definition for IPCC_C2SCR register  ***************/
+#define IPCC_C2SCR_CH1C_Pos      (0U)
+#define IPCC_C2SCR_CH1C_Msk      (0x1UL << IPCC_C2SCR_CH1C_Pos)                /*!< 0x00000001 */
+#define IPCC_C2SCR_CH1C          IPCC_C2SCR_CH1C_Msk                           /*!< M0+ receive Channel1 status clear */
+#define IPCC_C2SCR_CH2C_Pos      (1U)
+#define IPCC_C2SCR_CH2C_Msk      (0x1UL << IPCC_C2SCR_CH2C_Pos)                /*!< 0x00000002 */
+#define IPCC_C2SCR_CH2C          IPCC_C2SCR_CH2C_Msk                           /*!< M0+ receive Channel2 status clear */
+#define IPCC_C2SCR_CH3C_Pos      (2U)
+#define IPCC_C2SCR_CH3C_Msk      (0x1UL << IPCC_C2SCR_CH3C_Pos)                /*!< 0x00000004 */
+#define IPCC_C2SCR_CH3C          IPCC_C2SCR_CH3C_Msk                           /*!< M0+ receive Channel3 status clear */
+#define IPCC_C2SCR_CH4C_Pos      (3U)
+#define IPCC_C2SCR_CH4C_Msk      (0x1UL << IPCC_C2SCR_CH4C_Pos)                /*!< 0x00000008 */
+#define IPCC_C2SCR_CH4C          IPCC_C2SCR_CH4C_Msk                           /*!< M0+ receive Channel4 status clear */
+#define IPCC_C2SCR_CH5C_Pos      (4U)
+#define IPCC_C2SCR_CH5C_Msk      (0x1UL << IPCC_C2SCR_CH5C_Pos)                /*!< 0x00000010 */
+#define IPCC_C2SCR_CH5C          IPCC_C2SCR_CH5C_Msk                           /*!< M0+ receive Channel5 status clear */
+#define IPCC_C2SCR_CH6C_Pos      (5U)
+#define IPCC_C2SCR_CH6C_Msk      (0x1UL << IPCC_C2SCR_CH6C_Pos)                /*!< 0x00000020 */
+#define IPCC_C2SCR_CH6C          IPCC_C2SCR_CH6C_Msk                           /*!< M0+ receive Channel6 status clear */
+
+#define IPCC_C2SCR_CH1S_Pos      (16U)
+#define IPCC_C2SCR_CH1S_Msk      (0x1UL << IPCC_C2SCR_CH1S_Pos)                /*!< 0x00010000 */
+#define IPCC_C2SCR_CH1S          IPCC_C2SCR_CH1S_Msk                           /*!< M0+ transmit Channel1 status set  */
+#define IPCC_C2SCR_CH2S_Pos      (17U)
+#define IPCC_C2SCR_CH2S_Msk      (0x1UL << IPCC_C2SCR_CH2S_Pos)                /*!< 0x00020000 */
+#define IPCC_C2SCR_CH2S          IPCC_C2SCR_CH2S_Msk                           /*!< M0+ transmit Channel2 status set  */
+#define IPCC_C2SCR_CH3S_Pos      (18U)
+#define IPCC_C2SCR_CH3S_Msk      (0x1UL << IPCC_C2SCR_CH3S_Pos)                /*!< 0x00040000 */
+#define IPCC_C2SCR_CH3S          IPCC_C2SCR_CH3S_Msk                           /*!< M0+ transmit Channel3 status set  */
+#define IPCC_C2SCR_CH4S_Pos      (19U)
+#define IPCC_C2SCR_CH4S_Msk      (0x1UL << IPCC_C2SCR_CH4S_Pos)                /*!< 0x00080000 */
+#define IPCC_C2SCR_CH4S          IPCC_C2SCR_CH4S_Msk                           /*!< M0+ transmit Channel4 status set  */
+#define IPCC_C2SCR_CH5S_Pos      (20U)
+#define IPCC_C2SCR_CH5S_Msk      (0x1UL << IPCC_C2SCR_CH5S_Pos)                /*!< 0x00100000 */
+#define IPCC_C2SCR_CH5S          IPCC_C2SCR_CH5S_Msk                           /*!< M0+ transmit Channel5 status set  */
+#define IPCC_C2SCR_CH6S_Pos      (21U)
+#define IPCC_C2SCR_CH6S_Msk      (0x1UL << IPCC_C2SCR_CH6S_Pos)                /*!< 0x00200000 */
+#define IPCC_C2SCR_CH6S          IPCC_C2SCR_CH6S_Msk                           /*!< M0+ transmit Channel6 status set  */
+
+/**********************  Bit definition for IPCC_C2TOC1SR register  ***************/
+#define IPCC_C2TOC1SR_CH1F_Pos    (0U)
+#define IPCC_C2TOC1SR_CH1F_Msk    (0x1UL << IPCC_C2TOC1SR_CH1F_Pos)            /*!< 0x00000001 */
+#define IPCC_C2TOC1SR_CH1F        IPCC_C2TOC1SR_CH1F_Msk                       /*!< M0+ transmit to M0 receive Channel1 status flag before masking */
+#define IPCC_C2TOC1SR_CH2F_Pos    (1U)
+#define IPCC_C2TOC1SR_CH2F_Msk    (0x1UL << IPCC_C2TOC1SR_CH2F_Pos)            /*!< 0x00000002 */
+#define IPCC_C2TOC1SR_CH2F        IPCC_C2TOC1SR_CH2F_Msk                       /*!< M0+ transmit to M0 receive Channel2 status flag before masking */
+#define IPCC_C2TOC1SR_CH3F_Pos    (2U)
+#define IPCC_C2TOC1SR_CH3F_Msk    (0x1UL << IPCC_C2TOC1SR_CH3F_Pos)            /*!< 0x00000004 */
+#define IPCC_C2TOC1SR_CH3F        IPCC_C2TOC1SR_CH3F_Msk                       /*!< M0+ transmit to M0 receive Channel3 status flag before masking */
+#define IPCC_C2TOC1SR_CH4F_Pos    (3U)
+#define IPCC_C2TOC1SR_CH4F_Msk    (0x1UL << IPCC_C2TOC1SR_CH4F_Pos)            /*!< 0x00000008 */
+#define IPCC_C2TOC1SR_CH4F        IPCC_C2TOC1SR_CH4F_Msk                       /*!< M0+ transmit to M0 receive Channel4 status flag before masking */
+#define IPCC_C2TOC1SR_CH5F_Pos    (4U)
+#define IPCC_C2TOC1SR_CH5F_Msk    (0x1UL << IPCC_C2TOC1SR_CH5F_Pos)            /*!< 0x00000010 */
+#define IPCC_C2TOC1SR_CH5F        IPCC_C2TOC1SR_CH5F_Msk                       /*!< M0+ transmit to M0 receive Channel5 status flag before masking */
+#define IPCC_C2TOC1SR_CH6F_Pos    (5U)
+#define IPCC_C2TOC1SR_CH6F_Msk    (0x1UL << IPCC_C2TOC1SR_CH6F_Pos)            /*!< 0x00000020 */
+#define IPCC_C2TOC1SR_CH6F        IPCC_C2TOC1SR_CH6F_Msk                       /*!< M0+ transmit to M0 receive Channel6 status flag before masking */
+
+/**********************  Bit definition for IPCC_C1CR register  ***************/
+#define IPCC_CR_RXOIE_Pos         IPCC_C1CR_RXOIE_Pos
+#define IPCC_CR_RXOIE_Msk         IPCC_C1CR_RXOIE_Msk
+#define IPCC_CR_RXOIE             IPCC_C1CR_RXOIE
+#define IPCC_CR_TXFIE_Pos         IPCC_C1CR_TXFIE_Pos
+#define IPCC_CR_TXFIE_Msk         IPCC_C1CR_TXFIE_Msk
+#define IPCC_CR_TXFIE             IPCC_C1CR_TXFIE
+
+/**********************  Bit definition for IPCC_C1MR register  **************/
+#define IPCC_MR_CH1OM_Pos         IPCC_C1MR_CH1OM_Pos
+#define IPCC_MR_CH1OM_Msk         IPCC_C1MR_CH1OM_Msk
+#define IPCC_MR_CH1OM             IPCC_C1MR_CH1OM
+#define IPCC_MR_CH2OM_Pos         IPCC_C1MR_CH2OM_Pos
+#define IPCC_MR_CH2OM_Msk         IPCC_C1MR_CH2OM_Msk
+#define IPCC_MR_CH2OM             IPCC_C1MR_CH2OM
+#define IPCC_MR_CH3OM_Pos         IPCC_C1MR_CH3OM_Pos
+#define IPCC_MR_CH3OM_Msk         IPCC_C1MR_CH3OM_Msk
+#define IPCC_MR_CH3OM             IPCC_C1MR_CH3OM
+#define IPCC_MR_CH4OM_Pos         IPCC_C1MR_CH4OM_Pos
+#define IPCC_MR_CH4OM_Msk         IPCC_C1MR_CH4OM_Msk
+#define IPCC_MR_CH4OM             IPCC_C1MR_CH4OM
+#define IPCC_MR_CH5OM_Pos         IPCC_C1MR_CH5OM_Pos
+#define IPCC_MR_CH5OM_Msk         IPCC_C1MR_CH5OM_Msk
+#define IPCC_MR_CH5OM             IPCC_C1MR_CH5OM
+#define IPCC_MR_CH6OM_Pos         IPCC_C1MR_CH6OM_Pos
+#define IPCC_MR_CH6OM_Msk         IPCC_C1MR_CH6OM_Msk
+#define IPCC_MR_CH6OM             IPCC_C1MR_CH6OM
+
+#define IPCC_MR_CH1FM_Pos         IPCC_C1MR_CH1FM_Pos
+#define IPCC_MR_CH1FM_Msk         IPCC_C1MR_CH1FM_Msk
+#define IPCC_MR_CH1FM             IPCC_C1MR_CH1FM
+#define IPCC_MR_CH2FM_Pos         IPCC_C1MR_CH2FM_Pos
+#define IPCC_MR_CH2FM_Msk         IPCC_C1MR_CH2FM_Msk
+#define IPCC_MR_CH2FM             IPCC_C1MR_CH2FM
+#define IPCC_MR_CH3FM_Pos         IPCC_C1MR_CH3FM_Pos
+#define IPCC_MR_CH3FM_Msk         IPCC_C1MR_CH3FM_Msk
+#define IPCC_MR_CH3FM             IPCC_C1MR_CH3FM
+#define IPCC_MR_CH4FM_Pos         IPCC_C1MR_CH4FM_Pos
+#define IPCC_MR_CH4FM_Msk         IPCC_C1MR_CH4FM_Msk
+#define IPCC_MR_CH4FM             IPCC_C1MR_CH4FM
+#define IPCC_MR_CH5FM_Pos         IPCC_C1MR_CH5FM_Pos
+#define IPCC_MR_CH5FM_Msk         IPCC_C1MR_CH5FM_Msk
+#define IPCC_MR_CH5FM             IPCC_C1MR_CH5FM
+#define IPCC_MR_CH6FM_Pos         IPCC_C1MR_CH6FM_Pos
+#define IPCC_MR_CH6FM_Msk         IPCC_C1MR_CH6FM_Msk
+#define IPCC_MR_CH6FM             IPCC_C1MR_CH6FM
+
+/**********************  Bit definition for IPCC_C1SCR register  ***************/
+#define IPCC_SCR_CH1C_Pos         IPCC_C1SCR_CH1C_Pos
+#define IPCC_SCR_CH1C_Msk         IPCC_C1SCR_CH1C_Msk
+#define IPCC_SCR_CH1C             IPCC_C1SCR_CH1C
+#define IPCC_SCR_CH2C_Pos         IPCC_C1SCR_CH2C_Pos
+#define IPCC_SCR_CH2C_Msk         IPCC_C1SCR_CH2C_Msk
+#define IPCC_SCR_CH2C             IPCC_C1SCR_CH2C
+#define IPCC_SCR_CH3C_Pos         IPCC_C1SCR_CH3C_Pos
+#define IPCC_SCR_CH3C_Msk         IPCC_C1SCR_CH3C_Msk
+#define IPCC_SCR_CH3C             IPCC_C1SCR_CH3C
+#define IPCC_SCR_CH4C_Pos         IPCC_C1SCR_CH4C_Pos
+#define IPCC_SCR_CH4C_Msk         IPCC_C1SCR_CH4C_Msk
+#define IPCC_SCR_CH4C             IPCC_C1SCR_CH4C
+#define IPCC_SCR_CH5C_Pos         IPCC_C1SCR_CH5C_Pos
+#define IPCC_SCR_CH5C_Msk         IPCC_C1SCR_CH5C_Msk
+#define IPCC_SCR_CH5C             IPCC_C1SCR_CH5C
+#define IPCC_SCR_CH6C_Pos         IPCC_C1SCR_CH6C_Pos
+#define IPCC_SCR_CH6C_Msk         IPCC_C1SCR_CH6C_Msk
+#define IPCC_SCR_CH6C             IPCC_C1SCR_CH6C
+
+#define IPCC_SCR_CH1S_Pos         IPCC_C1SCR_CH1S_Pos
+#define IPCC_SCR_CH1S_Msk         IPCC_C1SCR_CH1S_Msk
+#define IPCC_SCR_CH1S             IPCC_C1SCR_CH1S
+#define IPCC_SCR_CH2S_Pos         IPCC_C1SCR_CH2S_Pos
+#define IPCC_SCR_CH2S_Msk         IPCC_C1SCR_CH2S_Msk
+#define IPCC_SCR_CH2S             IPCC_C1SCR_CH2S
+#define IPCC_SCR_CH3S_Pos         IPCC_C1SCR_CH3S_Pos
+#define IPCC_SCR_CH3S_Msk         IPCC_C1SCR_CH3S_Msk
+#define IPCC_SCR_CH3S             IPCC_C1SCR_CH3S
+#define IPCC_SCR_CH4S_Pos         IPCC_C1SCR_CH4S_Pos
+#define IPCC_SCR_CH4S_Msk         IPCC_C1SCR_CH4S_Msk
+#define IPCC_SCR_CH4S             IPCC_C1SCR_CH4S
+#define IPCC_SCR_CH5S_Pos         IPCC_C1SCR_CH5S_Pos
+#define IPCC_SCR_CH5S_Msk         IPCC_C1SCR_CH5S_Msk
+#define IPCC_SCR_CH5S             IPCC_C1SCR_CH5S
+#define IPCC_SCR_CH6S_Pos         IPCC_C1SCR_CH6S_Pos
+#define IPCC_SCR_CH6S_Msk         IPCC_C1SCR_CH6S_Msk
+#define IPCC_SCR_CH6S             IPCC_C1SCR_CH6S
+
+/**********************  Bit definition for IPCC_C1TOC2SR register  ***************/
+#define IPCC_SR_CH1F_Pos          IPCC_C1TOC2SR_CH1F_Pos
+#define IPCC_SR_CH1F_Msk          IPCC_C1TOC2SR_CH1F_Msk
+#define IPCC_SR_CH1F              IPCC_C1TOC2SR_CH1F
+#define IPCC_SR_CH2F_Pos          IPCC_C1TOC2SR_CH2F_Pos
+#define IPCC_SR_CH2F_Msk          IPCC_C1TOC2SR_CH2F_Msk
+#define IPCC_SR_CH2F              IPCC_C1TOC2SR_CH2F
+#define IPCC_SR_CH3F_Pos          IPCC_C1TOC2SR_CH3F_Pos
+#define IPCC_SR_CH3F_Msk          IPCC_C1TOC2SR_CH3F_Msk
+#define IPCC_SR_CH3F              IPCC_C1TOC2SR_CH3F
+#define IPCC_SR_CH4F_Pos          IPCC_C1TOC2SR_CH4F_Pos
+#define IPCC_SR_CH4F_Msk          IPCC_C1TOC2SR_CH4F_Msk
+#define IPCC_SR_CH4F              IPCC_C1TOC2SR_CH4F
+#define IPCC_SR_CH5F_Pos          IPCC_C1TOC2SR_CH5F_Pos
+#define IPCC_SR_CH5F_Msk          IPCC_C1TOC2SR_CH5F_Msk
+#define IPCC_SR_CH5F              IPCC_C1TOC2SR_CH5F
+#define IPCC_SR_CH6F_Pos          IPCC_C1TOC2SR_CH6F_Pos
+#define IPCC_SR_CH6F_Msk          IPCC_C1TOC2SR_CH6F_Msk
+#define IPCC_SR_CH6F              IPCC_C1TOC2SR_CH6F
+
+/******************** Number of IPCC channels ******************************/
+#define IPCC_CHANNEL_NUMBER       6U
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_UE_Pos                (0U)
+#define USART_CR1_UE_Msk                (0x1UL << USART_CR1_UE_Pos)            /*!< 0x00000001 */
+#define USART_CR1_UE                    USART_CR1_UE_Msk                        /*!< USART Enable */
+#define USART_CR1_UESM_Pos              (1U)
+#define USART_CR1_UESM_Msk              (0x1UL << USART_CR1_UESM_Pos)           /*!< 0x00000002 */
+#define USART_CR1_UESM                  USART_CR1_UESM_Msk                      /*!< USART Enable in STOP Mode */
+#define USART_CR1_RE_Pos                (2U)
+#define USART_CR1_RE_Msk                (0x1UL << USART_CR1_RE_Pos)             /*!< 0x00000004 */
+#define USART_CR1_RE                    USART_CR1_RE_Msk                        /*!< Receiver Enable */
+#define USART_CR1_TE_Pos                (3U)
+#define USART_CR1_TE_Msk                (0x1UL << USART_CR1_TE_Pos)             /*!< 0x00000008 */
+#define USART_CR1_TE                    USART_CR1_TE_Msk                        /*!< Transmitter Enable */
+#define USART_CR1_IDLEIE_Pos            (4U)
+#define USART_CR1_IDLEIE_Msk            (0x1UL << USART_CR1_IDLEIE_Pos)         /*!< 0x00000010 */
+#define USART_CR1_IDLEIE                USART_CR1_IDLEIE_Msk                    /*!< IDLE Interrupt Enable */
+#define USART_CR1_RXNEIE_Pos            (5U)
+#define USART_CR1_RXNEIE_Msk            (0x1UL << USART_CR1_RXNEIE_Pos)         /*!< 0x00000020 */
+#define USART_CR1_RXNEIE                USART_CR1_RXNEIE_Msk                    /*!< RXNE Interrupt Enable */
+#define USART_CR1_RXNEIE_RXFNEIE_Pos    USART_CR1_RXNEIE_Pos
+#define USART_CR1_RXNEIE_RXFNEIE_Msk    USART_CR1_RXNEIE_Msk                    /*!< 0x00000020 */
+#define USART_CR1_RXNEIE_RXFNEIE        USART_CR1_RXNEIE_Msk                    /*!< RXNE and RX FIFO Not Empty Interrupt Enable */
+#define USART_CR1_TCIE_Pos              (6U)
+#define USART_CR1_TCIE_Msk              (0x1UL << USART_CR1_TCIE_Pos)           /*!< 0x00000040 */
+#define USART_CR1_TCIE                  USART_CR1_TCIE_Msk                      /*!< Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_Pos             (7U)
+#define USART_CR1_TXEIE_Msk             (0x1UL << USART_CR1_TXEIE_Pos)          /*!< 0x00000080 */
+#define USART_CR1_TXEIE                 USART_CR1_TXEIE_Msk                     /*!< TXE Interrupt Enable */
+#define USART_CR1_TXEIE_TXFNFIE_Pos     (7U)
+#define USART_CR1_TXEIE_TXFNFIE_Msk     (0x1UL << USART_CR1_TXEIE_Pos)          /*!< 0x00000080 */
+#define USART_CR1_TXEIE_TXFNFIE         USART_CR1_TXEIE                         /*!< TXE and TX FIFO Not Full Interrupt Enable */
+#define USART_CR1_PEIE_Pos              (8U)
+#define USART_CR1_PEIE_Msk              (0x1UL << USART_CR1_PEIE_Pos)           /*!< 0x00000100 */
+#define USART_CR1_PEIE                  USART_CR1_PEIE_Msk                      /*!< PE Interrupt Enable */
+#define USART_CR1_PS_Pos                (9U)
+#define USART_CR1_PS_Msk                (0x1UL << USART_CR1_PS_Pos)             /*!< 0x00000200 */
+#define USART_CR1_PS                    USART_CR1_PS_Msk                        /*!< Parity Selection */
+#define USART_CR1_PCE_Pos               (10U)
+#define USART_CR1_PCE_Msk               (0x1UL << USART_CR1_PCE_Pos)            /*!< 0x00000400 */
+#define USART_CR1_PCE                   USART_CR1_PCE_Msk                       /*!< Parity Control Enable */
+#define USART_CR1_WAKE_Pos              (11U)
+#define USART_CR1_WAKE_Msk              (0x1UL << USART_CR1_WAKE_Pos)           /*!< 0x00000800 */
+#define USART_CR1_WAKE                  USART_CR1_WAKE_Msk                      /*!< Receiver Wakeup method */
+#define USART_CR1_M0_Pos                (12U)
+#define USART_CR1_M0_Msk                (0x1UL << USART_CR1_M0_Pos)             /*!< 0x00001000 */
+#define USART_CR1_M0                    USART_CR1_M0_Msk                        /*!< Word length - Bit 0 */
+#define USART_CR1_MME_Pos               (13U)
+#define USART_CR1_MME_Msk               (0x1UL << USART_CR1_MME_Pos)            /*!< 0x00002000 */
+#define USART_CR1_MME                   USART_CR1_MME_Msk                       /*!< Mute Mode Enable */
+#define USART_CR1_CMIE_Pos              (14U)
+#define USART_CR1_CMIE_Msk              (0x1UL << USART_CR1_CMIE_Pos)           /*!< 0x00004000 */
+#define USART_CR1_CMIE                  USART_CR1_CMIE_Msk                      /*!< Character match interrupt enable */
+#define USART_CR1_OVER8_Pos             (15U)
+#define USART_CR1_OVER8_Msk             (0x1UL << USART_CR1_OVER8_Pos)          /*!< 0x00008000 */
+#define USART_CR1_OVER8                 USART_CR1_OVER8_Msk                     /*!< Oversampling by 8-bit or 16-bit mode */
+#define USART_CR1_DEDT_Pos              (16U)
+#define USART_CR1_DEDT_Msk              (0x1FUL << USART_CR1_DEDT_Pos)          /*!< 0x001F0000 */
+#define USART_CR1_DEDT                  USART_CR1_DEDT_Msk                      /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define USART_CR1_DEDT_0                (0x01U << USART_CR1_DEDT_Pos)           /*!< 0x00010000 */
+#define USART_CR1_DEDT_1                (0x02U << USART_CR1_DEDT_Pos)           /*!< 0x00020000 */
+#define USART_CR1_DEDT_2                (0x04U << USART_CR1_DEDT_Pos)           /*!< 0x00040000 */
+#define USART_CR1_DEDT_3                (0x08U << USART_CR1_DEDT_Pos)           /*!< 0x00080000 */
+#define USART_CR1_DEDT_4                (0x10U << USART_CR1_DEDT_Pos)           /*!< 0x00100000 */
+#define USART_CR1_DEAT_Pos              (21U)
+#define USART_CR1_DEAT_Msk              (0x1FUL << USART_CR1_DEAT_Pos)          /*!< 0x03E00000 */
+#define USART_CR1_DEAT                  USART_CR1_DEAT_Msk                      /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define USART_CR1_DEAT_0                (0x01U << USART_CR1_DEAT_Pos)           /*!< 0x00200000 */
+#define USART_CR1_DEAT_1                (0x02U << USART_CR1_DEAT_Pos)           /*!< 0x00400000 */
+#define USART_CR1_DEAT_2                (0x04U << USART_CR1_DEAT_Pos)           /*!< 0x00800000 */
+#define USART_CR1_DEAT_3                (0x08U << USART_CR1_DEAT_Pos)           /*!< 0x01000000 */
+#define USART_CR1_DEAT_4                (0x10U << USART_CR1_DEAT_Pos)           /*!< 0x02000000 */
+#define USART_CR1_RTOIE_Pos             (26U)
+#define USART_CR1_RTOIE_Msk             (0x1UL << USART_CR1_RTOIE_Pos)          /*!< 0x04000000 */
+#define USART_CR1_RTOIE                 USART_CR1_RTOIE_Msk                     /*!< Receive Time Out Interrupt Enable */
+#define USART_CR1_EOBIE_Pos             (27U)
+#define USART_CR1_EOBIE_Msk             (0x1UL << USART_CR1_EOBIE_Pos)          /*!< 0x08000000 */
+#define USART_CR1_EOBIE                 USART_CR1_EOBIE_Msk                     /*!< End of Block Interrupt Enable */
+#define USART_CR1_M1_Pos                (28U)
+#define USART_CR1_M1_Msk                (0x1UL << USART_CR1_M1_Pos)             /*!< 0x10000000 */
+#define USART_CR1_M1                    USART_CR1_M1_Msk                        /*!< Word length - Bit 1 */
+#define USART_CR1_M                     (uint32_t)(USART_CR1_M1 | USART_CR1_M0) /*!< Word length */
+#define USART_CR1_FIFOEN_Pos            (29U)
+#define USART_CR1_FIFOEN_Msk            (0x1UL << USART_CR1_FIFOEN_Pos)         /*!< 0x20000000 */
+#define USART_CR1_FIFOEN                USART_CR1_FIFOEN_Msk                    /*!< FIFO mode enable */
+#define USART_CR1_TXFEIE_Pos            (30U)
+#define USART_CR1_TXFEIE_Msk            (0x1UL << USART_CR1_TXFEIE_Pos)         /*!< 0x40000000 */
+#define USART_CR1_TXFEIE                USART_CR1_TXFEIE_Msk                    /*!< TX FIFO Empty Interrupt Enable */
+#define USART_CR1_RXFFIE_Pos            (31U)
+#define USART_CR1_RXFFIE_Msk            (0x1UL << USART_CR1_RXFFIE_Pos)         /*!< 0x80000000 */
+#define USART_CR1_RXFFIE                USART_CR1_RXFFIE_Msk                    /*!< RX FIFO Full Interrupt Enable */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_SLVEN_Pos             (0U)
+#define USART_CR2_SLVEN_Msk             (0x1UL << USART_CR2_SLVEN_Pos)          /*!< 0x00000001 */
+#define USART_CR2_SLVEN                 USART_CR2_SLVEN_Msk                     /*!< Synchronous Slave mode enable */
+#define USART_CR2_DIS_NSS_Pos           (3U)
+#define USART_CR2_DIS_NSS_Msk           (0x1UL << USART_CR2_DIS_NSS_Pos)        /*!< 0x00000008 */
+#define USART_CR2_DIS_NSS               USART_CR2_DIS_NSS_Msk                   /*!< Slave Select (NSS) pin management */
+#define USART_CR2_ADDM7_Pos             (4U)
+#define USART_CR2_ADDM7_Msk             (0x1UL << USART_CR2_ADDM7_Pos)          /*!< 0x00000010 */
+#define USART_CR2_ADDM7                 USART_CR2_ADDM7_Msk                     /*!< 7-bit or 4-bit Address Detection */
+#define USART_CR2_LBDL_Pos              (5U)
+#define USART_CR2_LBDL_Msk              (0x1UL << USART_CR2_LBDL_Pos)           /*!< 0x00000020 */
+#define USART_CR2_LBDL                  USART_CR2_LBDL_Msk                      /*!< LIN Break Detection Length */
+#define USART_CR2_LBDIE_Pos             (6U)
+#define USART_CR2_LBDIE_Msk             (0x1UL << USART_CR2_LBDIE_Pos)          /*!< 0x00000040 */
+#define USART_CR2_LBDIE                 USART_CR2_LBDIE_Msk                     /*!< LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos              (8U)
+#define USART_CR2_LBCL_Msk              (0x1UL << USART_CR2_LBCL_Pos)           /*!< 0x00000100 */
+#define USART_CR2_LBCL                  USART_CR2_LBCL_Msk                      /*!< Last Bit Clock pulse */
+#define USART_CR2_CPHA_Pos              (9U)
+#define USART_CR2_CPHA_Msk              (0x1UL << USART_CR2_CPHA_Pos)           /*!< 0x00000200 */
+#define USART_CR2_CPHA                  USART_CR2_CPHA_Msk                      /*!< Clock Phase */
+#define USART_CR2_CPOL_Pos              (10U)
+#define USART_CR2_CPOL_Msk              (0x1UL << USART_CR2_CPOL_Pos)           /*!< 0x00000400 */
+#define USART_CR2_CPOL                  USART_CR2_CPOL_Msk                      /*!< Clock Polarity */
+#define USART_CR2_CLKEN_Pos             (11U)
+#define USART_CR2_CLKEN_Msk             (0x1UL << USART_CR2_CLKEN_Pos)          /*!< 0x00000800 */
+#define USART_CR2_CLKEN                 USART_CR2_CLKEN_Msk                     /*!< Clock Enable */
+#define USART_CR2_STOP_Pos              (12U)
+#define USART_CR2_STOP_Msk              (0x3UL << USART_CR2_STOP_Pos)           /*!< 0x00003000 */
+#define USART_CR2_STOP                  USART_CR2_STOP_Msk                      /*!< STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0                (0x1U << USART_CR2_STOP_Pos)            /*!< 0x00001000 */
+#define USART_CR2_STOP_1                (0x2U << USART_CR2_STOP_Pos)            /*!< 0x00002000 */
+#define USART_CR2_LINEN_Pos             (14U)
+#define USART_CR2_LINEN_Msk             (0x1UL << USART_CR2_LINEN_Pos)          /*!< 0x00004000 */
+#define USART_CR2_LINEN                 USART_CR2_LINEN_Msk                     /*!< LIN mode enable */
+#define USART_CR2_SWAP_Pos              (15U)
+#define USART_CR2_SWAP_Msk              (0x1UL << USART_CR2_SWAP_Pos)           /*!< 0x00008000 */
+#define USART_CR2_SWAP                  USART_CR2_SWAP_Msk                      /*!< SWAP TX/RX pins */
+#define USART_CR2_RXINV_Pos             (16U)
+#define USART_CR2_RXINV_Msk             (0x1UL << USART_CR2_RXINV_Pos)          /*!< 0x00010000 */
+#define USART_CR2_RXINV                 USART_CR2_RXINV_Msk                     /*!< RX pin active level inversion */
+#define USART_CR2_TXINV_Pos             (17U)
+#define USART_CR2_TXINV_Msk             (0x1UL << USART_CR2_TXINV_Pos)          /*!< 0x00020000 */
+#define USART_CR2_TXINV                 USART_CR2_TXINV_Msk                     /*!< TX pin active level inversion */
+#define USART_CR2_DATAINV_Pos           (18U)
+#define USART_CR2_DATAINV_Msk           (0x1UL << USART_CR2_DATAINV_Pos)        /*!< 0x00040000 */
+#define USART_CR2_DATAINV               USART_CR2_DATAINV_Msk                   /*!< Binary data inversion */
+#define USART_CR2_MSBFIRST_Pos          (19U)
+#define USART_CR2_MSBFIRST_Msk          (0x1UL << USART_CR2_MSBFIRST_Pos)       /*!< 0x00080000 */
+#define USART_CR2_MSBFIRST              USART_CR2_MSBFIRST_Msk                  /*!< Most Significant Bit First */
+#define USART_CR2_ABREN_Pos             (20U)
+#define USART_CR2_ABREN_Msk             (0x1UL << USART_CR2_ABREN_Pos)          /*!< 0x00100000 */
+#define USART_CR2_ABREN                 USART_CR2_ABREN_Msk                     /*!< Auto Baud-Rate Enable*/
+#define USART_CR2_ABRMODE_Pos           (21U)
+#define USART_CR2_ABRMODE_Msk           (0x3UL << USART_CR2_ABRMODE_Pos)        /*!< 0x00600000 */
+#define USART_CR2_ABRMODE               USART_CR2_ABRMODE_Msk                   /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define USART_CR2_ABRMODE_0             (0x1U << USART_CR2_ABRMODE_Pos)         /*!< 0x00200000 */
+#define USART_CR2_ABRMODE_1             (0x2U << USART_CR2_ABRMODE_Pos)         /*!< 0x00400000 */
+#define USART_CR2_RTOEN_Pos             (23U)
+#define USART_CR2_RTOEN_Msk             (0x1UL << USART_CR2_RTOEN_Pos)          /*!< 0x00800000 */
+#define USART_CR2_RTOEN                 USART_CR2_RTOEN_Msk                     /*!< Receiver Time-Out enable */
+#define USART_CR2_ADD_Pos               (24U)
+#define USART_CR2_ADD_Msk               (0xFFUL << USART_CR2_ADD_Pos)           /*!< 0xFF000000 */
+#define USART_CR2_ADD                   USART_CR2_ADD_Msk                       /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos               (0U)
+#define USART_CR3_EIE_Msk               (0x1UL << USART_CR3_EIE_Pos)            /*!< 0x00000001 */
+#define USART_CR3_EIE                   USART_CR3_EIE_Msk                       /*!< Error Interrupt Enable */
+#define USART_CR3_IREN_Pos              (1U)
+#define USART_CR3_IREN_Msk              (0x1UL << USART_CR3_IREN_Pos)           /*!< 0x00000002 */
+#define USART_CR3_IREN                  USART_CR3_IREN_Msk                      /*!< IrDA mode Enable */
+#define USART_CR3_IRLP_Pos              (2U)
+#define USART_CR3_IRLP_Msk              (0x1UL << USART_CR3_IRLP_Pos)           /*!< 0x00000004 */
+#define USART_CR3_IRLP                  USART_CR3_IRLP_Msk                      /*!< IrDA Low-Power */
+#define USART_CR3_HDSEL_Pos             (3U)
+#define USART_CR3_HDSEL_Msk             (0x1UL << USART_CR3_HDSEL_Pos)          /*!< 0x00000008 */
+#define USART_CR3_HDSEL                 USART_CR3_HDSEL_Msk                     /*!< Half-Duplex Selection */
+#define USART_CR3_NACK_Pos              (4U)
+#define USART_CR3_NACK_Msk              (0x1UL << USART_CR3_NACK_Pos)           /*!< 0x00000010 */
+#define USART_CR3_NACK                  USART_CR3_NACK_Msk                      /*!< SmartCard NACK enable */
+#define USART_CR3_SCEN_Pos              (5U)
+#define USART_CR3_SCEN_Msk              (0x1UL << USART_CR3_SCEN_Pos)           /*!< 0x00000020 */
+#define USART_CR3_SCEN                  USART_CR3_SCEN_Msk                      /*!< SmartCard mode enable */
+#define USART_CR3_DMAR_Pos              (6U)
+#define USART_CR3_DMAR_Msk              (0x1UL << USART_CR3_DMAR_Pos)           /*!< 0x00000040 */
+#define USART_CR3_DMAR                  USART_CR3_DMAR_Msk                      /*!< DMA Enable Receiver */
+#define USART_CR3_DMAT_Pos              (7U)
+#define USART_CR3_DMAT_Msk              (0x1UL << USART_CR3_DMAT_Pos)           /*!< 0x00000080 */
+#define USART_CR3_DMAT                  USART_CR3_DMAT_Msk                      /*!< DMA Enable Transmitter */
+#define USART_CR3_RTSE_Pos              (8U)
+#define USART_CR3_RTSE_Msk              (0x1UL << USART_CR3_RTSE_Pos)           /*!< 0x00000100 */
+#define USART_CR3_RTSE                  USART_CR3_RTSE_Msk                      /*!< RTS Enable */
+#define USART_CR3_CTSE_Pos              (9U)
+#define USART_CR3_CTSE_Msk              (0x1UL << USART_CR3_CTSE_Pos)           /*!< 0x00000200 */
+#define USART_CR3_CTSE                  USART_CR3_CTSE_Msk
+#define USART_CR3_CTSIE_Pos             (10U)
+#define USART_CR3_CTSIE_Msk             (0x1UL << USART_CR3_CTSIE_Pos)          /*!< 0x00000400 */
+#define USART_CR3_CTSIE                 USART_CR3_CTSIE_Msk                     /*!< CTS Interrupt Enable */
+#define USART_CR3_ONEBIT_Pos            (11U)
+#define USART_CR3_ONEBIT_Msk            (0x1UL << USART_CR3_ONEBIT_Pos)         /*!< 0x00000800 */
+#define USART_CR3_ONEBIT                USART_CR3_ONEBIT_Msk                    /*!< One sample bit method enable */
+#define USART_CR3_OVRDIS_Pos            (12U)
+#define USART_CR3_OVRDIS_Msk            (0x1UL << USART_CR3_OVRDIS_Pos)         /*!< 0x00001000 */
+#define USART_CR3_OVRDIS                USART_CR3_OVRDIS_Msk                    /*!< Overrun Disable */
+#define USART_CR3_DDRE_Pos              (13U)
+#define USART_CR3_DDRE_Msk              (0x1UL << USART_CR3_DDRE_Pos)           /*!< 0x00002000 */
+#define USART_CR3_DDRE                  USART_CR3_DDRE_Msk                      /*!< DMA Disable on Reception Error */
+#define USART_CR3_DEM_Pos               (14U)
+#define USART_CR3_DEM_Msk               (0x1UL << USART_CR3_DEM_Pos)            /*!< 0x00004000 */
+#define USART_CR3_DEM                   USART_CR3_DEM_Msk                       /*!< Driver Enable Mode */
+#define USART_CR3_DEP_Pos               (15U)
+#define USART_CR3_DEP_Msk               (0x1UL << USART_CR3_DEP_Pos)            /*!< 0x00008000 */
+#define USART_CR3_DEP                   USART_CR3_DEP_Msk                       /*!< Driver Enable Polarity Selection */
+#define USART_CR3_SCARCNT_Pos           (17U)
+#define USART_CR3_SCARCNT_Msk           (0x7UL << USART_CR3_SCARCNT_Pos)        /*!< 0x000E0000 */
+#define USART_CR3_SCARCNT               USART_CR3_SCARCNT_Msk                   /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define USART_CR3_SCARCNT_0             (0x1U << USART_CR3_SCARCNT_Pos)         /*!< 0x00020000 */
+#define USART_CR3_SCARCNT_1             (0x2U << USART_CR3_SCARCNT_Pos)         /*!< 0x00040000 */
+#define USART_CR3_SCARCNT_2             (0x4U << USART_CR3_SCARCNT_Pos)         /*!< 0x00080000 */
+#define USART_CR3_WUS_Pos               (20U)
+#define USART_CR3_WUS_Msk               (0x3UL << USART_CR3_WUS_Pos)            /*!< 0x00300000 */
+#define USART_CR3_WUS                   USART_CR3_WUS_Msk                       /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define USART_CR3_WUS_0                 (0x1U << USART_CR3_WUS_Pos)             /*!< 0x00100000 */
+#define USART_CR3_WUS_1                 (0x2U << USART_CR3_WUS_Pos)             /*!< 0x00200000 */
+#define USART_CR3_WUFIE_Pos             (22U)
+#define USART_CR3_WUFIE_Msk             (0x1UL << USART_CR3_WUFIE_Pos)          /*!< 0x00400000 */
+#define USART_CR3_WUFIE                 USART_CR3_WUFIE_Msk                     /*!< Wake Up Interrupt Enable */
+#define USART_CR3_TXFTIE_Pos            (23U)
+#define USART_CR3_TXFTIE_Msk            (0x1UL << USART_CR3_TXFTIE_Pos)         /*!< 0x00800000 */
+#define USART_CR3_TXFTIE                USART_CR3_TXFTIE_Msk                    /*!< TX FIFO Threshold Interrupt Enable */
+#define USART_CR3_TCBGTIE_Pos           (24U)
+#define USART_CR3_TCBGTIE_Msk           (0x1UL << USART_CR3_TCBGTIE_Pos)        /*!< 0x01000000 */
+#define USART_CR3_TCBGTIE               USART_CR3_TCBGTIE_Msk                   /*!< Transmission Complete Before Guard Time Interrupt Enable */
+#define USART_CR3_RXFTCFG_Pos           (25U)
+#define USART_CR3_RXFTCFG_Msk           (0x7UL << USART_CR3_RXFTCFG_Pos)        /*!< 0x0E000000 */
+#define USART_CR3_RXFTCFG               USART_CR3_RXFTCFG_Msk                   /*!< RX FIFO Threshold Configuration */
+#define USART_CR3_RXFTCFG_0             (0x1U << USART_CR3_RXFTCFG_Pos)         /*!< 0x02000000 */
+#define USART_CR3_RXFTCFG_1             (0x2U << USART_CR3_RXFTCFG_Pos)         /*!< 0x04000000 */
+#define USART_CR3_RXFTCFG_2             (0x4U << USART_CR3_RXFTCFG_Pos)         /*!< 0x08000000 */
+#define USART_CR3_RXFTIE_Pos            (28U)
+#define USART_CR3_RXFTIE_Msk            (0x1UL << USART_CR3_RXFTIE_Pos)         /*!< 0x10000000 */
+#define USART_CR3_RXFTIE                USART_CR3_RXFTIE_Msk                    /*!< RX FIFO Threshold Interrupt Enable */
+#define USART_CR3_TXFTCFG_Pos           (29U)
+#define USART_CR3_TXFTCFG_Msk           (0x7UL << USART_CR3_TXFTCFG_Pos)        /*!< 0xE0000000 */
+#define USART_CR3_TXFTCFG               USART_CR3_TXFTCFG_Msk                   /*!< TX FIFO Threshold configuration */
+#define USART_CR3_TXFTCFG_0             (0x1U << USART_CR3_TXFTCFG_Pos)         /*!< 0x20000000 */
+#define USART_CR3_TXFTCFG_1             (0x2U << USART_CR3_TXFTCFG_Pos)         /*!< 0x40000000 */
+#define USART_CR3_TXFTCFG_2             (0x4U << USART_CR3_TXFTCFG_Pos)         /*!< 0x80000000 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_BRR                   ((uint16_t)0xFFFF)                      /*!< USART  Baud rate register [15:0] */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos              (0U)
+#define USART_GTPR_PSC_Msk              (0xFFUL << USART_GTPR_PSC_Pos)          /*!< 0x000000FF */
+#define USART_GTPR_PSC                  USART_GTPR_PSC_Msk                      /*!< PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_GT_Pos               (8U)
+#define USART_GTPR_GT_Msk               (0xFFUL << USART_GTPR_GT_Pos)           /*!< 0x0000FF00 */
+#define USART_GTPR_GT                   USART_GTPR_GT_Msk                       /*!< GT[7:0] bits (Guard time value) */
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define USART_RTOR_RTO_Pos              (0U)
+#define USART_RTOR_RTO_Msk              (0xFFFFFFUL << USART_RTOR_RTO_Pos)      /*!< 0x00FFFFFF */
+#define USART_RTOR_RTO                  USART_RTOR_RTO_Msk                      /*!< Receiver Timeout Value */
+#define USART_RTOR_BLEN_Pos             (24U)
+#define USART_RTOR_BLEN_Msk             (0xFFUL << USART_RTOR_BLEN_Pos)         /*!< 0xFF000000 */
+#define USART_RTOR_BLEN                 USART_RTOR_BLEN_Msk                     /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define USART_RQR_ABRRQ_Pos             (0U)
+#define USART_RQR_ABRRQ_Msk             (0x1UL << USART_RQR_ABRRQ_Pos)          /*!< 0x00000001 */
+#define USART_RQR_ABRRQ                 USART_RQR_ABRRQ_Msk                     /*!< Auto-Baud Rate Request */
+#define USART_RQR_SBKRQ_Pos             (1U)
+#define USART_RQR_SBKRQ_Msk             (0x1UL << USART_RQR_SBKRQ_Pos)          /*!< 0x00000002 */
+#define USART_RQR_SBKRQ                 USART_RQR_SBKRQ_Msk                     /*!< Send Break Request */
+#define USART_RQR_MMRQ_Pos              (2U)
+#define USART_RQR_MMRQ_Msk              (0x1UL << USART_RQR_MMRQ_Pos)           /*!< 0x00000004 */
+#define USART_RQR_MMRQ                  USART_RQR_MMRQ_Msk                      /*!< Mute Mode Request */
+#define USART_RQR_RXFRQ_Pos             (3U)
+#define USART_RQR_RXFRQ_Msk             (0x1UL << USART_RQR_RXFRQ_Pos)          /*!< 0x00000008 */
+#define USART_RQR_RXFRQ                 USART_RQR_RXFRQ_Msk                     /*!< Receive Data flush Request */
+#define USART_RQR_TXFRQ_Pos             (4U)
+#define USART_RQR_TXFRQ_Msk             (0x1UL << USART_RQR_TXFRQ_Pos)          /*!< 0x00000010 */
+#define USART_RQR_TXFRQ                 USART_RQR_TXFRQ_Msk                     /*!< Transmit Data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define USART_ISR_PE_Pos                (0U)
+#define USART_ISR_PE_Msk                (0x1UL << USART_ISR_PE_Pos)             /*!< 0x00000001 */
+#define USART_ISR_PE                    USART_ISR_PE_Msk                        /*!< Parity Error */
+#define USART_ISR_FE_Pos                (1U)
+#define USART_ISR_FE_Msk                (0x1UL << USART_ISR_FE_Pos)             /*!< 0x00000002 */
+#define USART_ISR_FE                    USART_ISR_FE_Msk                        /*!< Framing Error */
+#define USART_ISR_NE_Pos                (2U)
+#define USART_ISR_NE_Msk                (0x1UL << USART_ISR_NE_Pos)             /*!< 0x00000004 */
+#define USART_ISR_NE                    USART_ISR_NE_Msk                        /*!< START bit Noise Error detection Flag */
+#define USART_ISR_ORE_Pos               (3U)
+#define USART_ISR_ORE_Msk               (0x1UL << USART_ISR_ORE_Pos)            /*!< 0x00000008 */
+#define USART_ISR_ORE                   USART_ISR_ORE_Msk                       /*!< OverRun Error */
+#define USART_ISR_IDLE_Pos              (4U)
+#define USART_ISR_IDLE_Msk              (0x1UL << USART_ISR_IDLE_Pos)           /*!< 0x00000010 */
+#define USART_ISR_IDLE                  USART_ISR_IDLE_Msk                      /*!< IDLE line detected */
+#define USART_ISR_RXNE_Pos              (5U)
+#define USART_ISR_RXNE_Msk              (0x1UL << USART_ISR_RXNE_Pos)           /*!< 0x00000020 */
+#define USART_ISR_RXNE                  USART_ISR_RXNE_Msk                      /*!< Read Data Register Not Empty */
+#define USART_ISR_RXNE_RXFNE_Pos        USART_ISR_RXNE_Pos
+#define USART_ISR_RXNE_RXFNE_Msk        USART_ISR_RXNE_Msk                      /*!< 0x00000020 */
+#define USART_ISR_RXNE_RXFNE            USART_ISR_RXNE_Msk                      /*!< Read Data Register or RX FIFO Not Empty */
+#define USART_ISR_TC_Pos                (6U)
+#define USART_ISR_TC_Msk                (0x1UL << USART_ISR_TC_Pos)             /*!< 0x00000040 */
+#define USART_ISR_TC                    USART_ISR_TC_Msk                        /*!< Transmission Complete */
+#define USART_ISR_TXE_Pos               (7U)
+#define USART_ISR_TXE_Msk               (0x1UL << USART_ISR_TXE_Pos)            /*!< 0x00000080 */
+#define USART_ISR_TXE                   USART_ISR_TXE_Msk                       /*!< Transmit Data Register Empty */
+#define USART_ISR_TXE_TXFNF_Pos         USART_ISR_TXE_Pos
+#define USART_ISR_TXE_TXFNF_Msk         USART_ISR_TXE_Msk                       /*!< 0x00000080 */
+#define USART_ISR_TXE_TXFNF             USART_ISR_TXE_Msk                       /*!< Transmit Data Register Empty or TX FIFO Not Full Flag */
+#define USART_ISR_LBDF_Pos              (8U)
+#define USART_ISR_LBDF_Msk              (0x1UL << USART_ISR_LBDF_Pos)           /*!< 0x00000100 */
+#define USART_ISR_LBDF                  USART_ISR_LBDF_Msk                      /*!< LIN Break Detection Flag */
+#define USART_ISR_CTSIF_Pos             (9U)
+#define USART_ISR_CTSIF_Msk             (0x1UL << USART_ISR_CTSIF_Pos)          /*!< 0x00000200 */
+#define USART_ISR_CTSIF                 USART_ISR_CTSIF_Msk                     /*!< CTS interrupt Flag */
+#define USART_ISR_CTS_Pos               (10U)
+#define USART_ISR_CTS_Msk               (0x1UL << USART_ISR_CTS_Pos)            /*!< 0x00000400 */
+#define USART_ISR_CTS                   USART_ISR_CTS_Msk                       /*!< CTS Flag */
+#define USART_ISR_RTOF_Pos              (11U)
+#define USART_ISR_RTOF_Msk              (0x1UL << USART_ISR_RTOF_Pos)           /*!< 0x00000800 */
+#define USART_ISR_RTOF                  USART_ISR_RTOF_Msk                      /*!< Receiver Timeout */
+#define USART_ISR_EOBF_Pos              (12U)
+#define USART_ISR_EOBF_Msk              (0x1UL << USART_ISR_EOBF_Pos)           /*!< 0x00001000 */
+#define USART_ISR_EOBF                  USART_ISR_EOBF_Msk                      /*!< End Of Block Flag */
+#define USART_ISR_UDR_Pos               (13U)
+#define USART_ISR_UDR_Msk               (0x1UL << USART_ISR_UDR_Pos)            /*!< 0x00002000 */
+#define USART_ISR_UDR                   USART_ISR_UDR_Msk                       /*!< SPI Slave Underrun error Flag */
+#define USART_ISR_ABRE_Pos              (14U)
+#define USART_ISR_ABRE_Msk              (0x1UL << USART_ISR_ABRE_Pos)           /*!< 0x00004000 */
+#define USART_ISR_ABRE                  USART_ISR_ABRE_Msk                      /*!< Auto-Baud Rate Error */
+#define USART_ISR_ABRF_Pos              (15U)
+#define USART_ISR_ABRF_Msk              (0x1UL << USART_ISR_ABRF_Pos)           /*!< 0x00008000 */
+#define USART_ISR_ABRF                  USART_ISR_ABRF_Msk                      /*!< Auto-Baud Rate Flag */
+#define USART_ISR_BUSY_Pos              (16U)
+#define USART_ISR_BUSY_Msk              (0x1UL << USART_ISR_BUSY_Pos)           /*!< 0x00010000 */
+#define USART_ISR_BUSY                  USART_ISR_BUSY_Msk                      /*!< Busy Flag */
+#define USART_ISR_CMF_Pos               (17U)
+#define USART_ISR_CMF_Msk               (0x1UL << USART_ISR_CMF_Pos)            /*!< 0x00020000 */
+#define USART_ISR_CMF                   USART_ISR_CMF_Msk                       /*!< Character Match Flag */
+#define USART_ISR_SBKF_Pos              (18U)
+#define USART_ISR_SBKF_Msk              (0x1UL << USART_ISR_SBKF_Pos)           /*!< 0x00040000 */
+#define USART_ISR_SBKF                  USART_ISR_SBKF_Msk                      /*!< Send Break Flag */
+#define USART_ISR_RWU_Pos               (19U)
+#define USART_ISR_RWU_Msk               (0x1UL << USART_ISR_RWU_Pos)            /*!< 0x00080000 */
+#define USART_ISR_RWU                   USART_ISR_RWU_Msk                       /*!< Receive Wake Up from mute mode Flag */
+#define USART_ISR_WUF_Pos               (20U)
+#define USART_ISR_WUF_Msk               (0x1UL << USART_ISR_WUF_Pos)            /*!< 0x00100000 */
+#define USART_ISR_WUF                   USART_ISR_WUF_Msk                       /*!< Wake Up from stop mode Flag */
+#define USART_ISR_TEACK_Pos             (21U)
+#define USART_ISR_TEACK_Msk             (0x1UL << USART_ISR_TEACK_Pos)          /*!< 0x00200000 */
+#define USART_ISR_TEACK                 USART_ISR_TEACK_Msk                     /*!< Transmit Enable Acknowledge Flag */
+#define USART_ISR_REACK_Pos             (22U)
+#define USART_ISR_REACK_Msk             (0x1UL << USART_ISR_REACK_Pos)          /*!< 0x00400000 */
+#define USART_ISR_REACK                 USART_ISR_REACK_Msk                     /*!< Receive Enable Acknowledge Flag */
+#define USART_ISR_TXFE_Pos              (23U)
+#define USART_ISR_TXFE_Msk              (0x1UL << USART_ISR_TXFE_Pos)           /*!< 0x00800000 */
+#define USART_ISR_TXFE                  USART_ISR_TXFE_Msk                      /*!< TX FIFO Empty Flag */
+#define USART_ISR_RXFF_Pos              (24U)
+#define USART_ISR_RXFF_Msk              (0x1UL << USART_ISR_RXFF_Pos)           /*!< 0x01000000 */
+#define USART_ISR_RXFF                  USART_ISR_RXFF_Msk                      /*!< RX FIFO Full Flag */
+#define USART_ISR_TCBGT_Pos             (25U)
+#define USART_ISR_TCBGT_Msk             (0x1UL << USART_ISR_TCBGT_Pos)          /*!< 0x02000000 */
+#define USART_ISR_TCBGT                 USART_ISR_TCBGT_Msk                     /*!< Transmission Complete Before Guard Time completion */
+#define USART_ISR_RXFT_Pos              (26U)
+#define USART_ISR_RXFT_Msk              (0x1UL << USART_ISR_RXFT_Pos)           /*!< 0x04000000 */
+#define USART_ISR_RXFT                  USART_ISR_RXFT_Msk                      /*!< RX FIFO Threshold Flag */
+#define USART_ISR_TXFT_Pos              (27U)
+#define USART_ISR_TXFT_Msk              (0x1UL << USART_ISR_TXFT_Pos)           /*!< 0x08000000 */
+#define USART_ISR_TXFT                  USART_ISR_TXFT_Msk                      /*!< TX FIFO Threshold Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define USART_ICR_PECF_Pos              (0U)
+#define USART_ICR_PECF_Msk              (0x1UL << USART_ICR_PECF_Pos)           /*!< 0x00000001 */
+#define USART_ICR_PECF                  USART_ICR_PECF_Msk                      /*!< Parity Error Clear Flag */
+#define USART_ICR_FECF_Pos              (1U)
+#define USART_ICR_FECF_Msk              (0x1UL << USART_ICR_FECF_Pos)           /*!< 0x00000002 */
+#define USART_ICR_FECF                  USART_ICR_FECF_Msk                      /*!< Framing Error Clear Flag */
+#define USART_ICR_NECF_Pos              (2U)
+#define USART_ICR_NECF_Msk              (0x1UL << USART_ICR_NECF_Pos)           /*!< 0x00000004 */
+#define USART_ICR_NECF                  USART_ICR_NECF_Msk                      /*!< Noise Error detected Clear Flag */
+#define USART_ICR_ORECF_Pos             (3U)
+#define USART_ICR_ORECF_Msk             (0x1UL << USART_ICR_ORECF_Pos)          /*!< 0x00000008 */
+#define USART_ICR_ORECF                 USART_ICR_ORECF_Msk                     /*!< OverRun Error Clear Flag */
+#define USART_ICR_IDLECF_Pos            (4U)
+#define USART_ICR_IDLECF_Msk            (0x1UL << USART_ICR_IDLECF_Pos)         /*!< 0x00000010 */
+#define USART_ICR_IDLECF                USART_ICR_IDLECF_Msk                    /*!< IDLE line detected Clear Flag */
+#define USART_ICR_TXFECF_Pos            (5U)
+#define USART_ICR_TXFECF_Msk            (0x1UL << USART_ICR_TXFECF_Pos)         /*!< 0x00000020 */
+#define USART_ICR_TXFECF                USART_ICR_TXFECF_Msk                    /*!< TX FIFO Empty Clear Flag */
+#define USART_ICR_TCCF_Pos              (6U)
+#define USART_ICR_TCCF_Msk              (0x1UL << USART_ICR_TCCF_Pos)           /*!< 0x00000040 */
+#define USART_ICR_TCCF                  USART_ICR_TCCF_Msk                      /*!< Transmission Complete Clear Flag */
+#define USART_ICR_TCBGTCF_Pos           (7U)
+#define USART_ICR_TCBGTCF_Msk           (0x1UL << USART_ICR_TCBGTCF_Pos)        /*!< 0x00000080 */
+#define USART_ICR_TCBGTCF               USART_ICR_TCBGTCF_Msk                   /*!< Transmission Complete Before Guard Time Clear Flag */
+#define USART_ICR_LBDCF_Pos             (8U)
+#define USART_ICR_LBDCF_Msk             (0x1UL << USART_ICR_LBDCF_Pos)          /*!< 0x00000100 */
+#define USART_ICR_LBDCF                 USART_ICR_LBDCF_Msk                     /*!< LIN Break Detection Clear Flag */
+#define USART_ICR_CTSCF_Pos             (9U)
+#define USART_ICR_CTSCF_Msk             (0x1UL << USART_ICR_CTSCF_Pos)          /*!< 0x00000200 */
+#define USART_ICR_CTSCF                 USART_ICR_CTSCF_Msk                     /*!< CTS Interrupt Clear Flag */
+#define USART_ICR_RTOCF_Pos             (11U)
+#define USART_ICR_RTOCF_Msk             (0x1UL << USART_ICR_RTOCF_Pos)          /*!< 0x00000800 */
+#define USART_ICR_RTOCF                 USART_ICR_RTOCF_Msk                     /*!< Receiver Time Out Clear Flag */
+#define USART_ICR_EOBCF_Pos             (12U)
+#define USART_ICR_EOBCF_Msk             (0x1UL << USART_ICR_EOBCF_Pos)          /*!< 0x00001000 */
+#define USART_ICR_EOBCF                 USART_ICR_EOBCF_Msk                     /*!< End Of Block Clear Flag */
+#define USART_ICR_UDRCF_Pos             (13U)
+#define USART_ICR_UDRCF_Msk             (0x1UL << USART_ICR_UDRCF_Pos)          /*!< 0x00002000 */
+#define USART_ICR_UDRCF                 USART_ICR_UDRCF_Msk                     /*!< SPI Slave Underrun Clear Flag */
+#define USART_ICR_CMCF_Pos              (17U)
+#define USART_ICR_CMCF_Msk              (0x1UL << USART_ICR_CMCF_Pos)           /*!< 0x00020000 */
+#define USART_ICR_CMCF                  USART_ICR_CMCF_Msk                      /*!< Character Match Clear Flag */
+#define USART_ICR_WUCF_Pos              (20U)
+#define USART_ICR_WUCF_Msk              (0x1UL << USART_ICR_WUCF_Pos)           /*!< 0x00100000 */
+#define USART_ICR_WUCF                  USART_ICR_WUCF_Msk                      /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define USART_RDR_RDR_Pos               (0U)
+#define USART_RDR_RDR_Msk               (0x01FFUL << USART_RDR_RDR_Pos)         /*!< 0x000001FF */
+#define USART_RDR_RDR                   USART_RDR_RDR_Msk                       /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define USART_TDR_TDR_Pos               (0U)
+#define USART_TDR_TDR_Msk               (0x01FFUL << USART_TDR_TDR_Pos)         /*!< 0x000001FF */
+#define USART_TDR_TDR                   USART_TDR_TDR_Msk                       /*!< TDR[8:0] bits (Transmit Data value) */
+
+/*******************  Bit definition for USART_PRESC register  ******************/
+#define USART_PRESC_PRESCALER_Pos       (0U)
+#define USART_PRESC_PRESCALER_Msk       (0xFUL << USART_PRESC_PRESCALER_Pos)    /*!< 0x0000000F */
+#define USART_PRESC_PRESCALER           USART_PRESC_PRESCALER_Msk               /*!< PRESCALER[3:0] bits (Clock prescaler) */
+#define USART_PRESC_PRESCALER_0         (0x1U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000001 */
+#define USART_PRESC_PRESCALER_1         (0x2U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000002 */
+#define USART_PRESC_PRESCALER_2         (0x4U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000004 */
+#define USART_PRESC_PRESCALER_3         (0x8U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000008 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                      /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01U << WWDG_CR_T_Pos)                       /*!< 0x00000001 */
+#define WWDG_CR_T_1             (0x02U << WWDG_CR_T_Pos)                       /*!< 0x00000002 */
+#define WWDG_CR_T_2             (0x04U << WWDG_CR_T_Pos)                       /*!< 0x00000004 */
+#define WWDG_CR_T_3             (0x08U << WWDG_CR_T_Pos)                       /*!< 0x00000008 */
+#define WWDG_CR_T_4             (0x10U << WWDG_CR_T_Pos)                       /*!< 0x00000010 */
+#define WWDG_CR_T_5             (0x20U << WWDG_CR_T_Pos)                       /*!< 0x00000020 */
+#define WWDG_CR_T_6             (0x40U << WWDG_CR_T_Pos)                       /*!< 0x00000040 */
+
+#define WWDG_CR_WDGA_Pos        (7U)
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                    /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                     /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01U << WWDG_CFR_W_Pos)                      /*!< 0x00000001 */
+#define WWDG_CFR_W_1            (0x02U << WWDG_CFR_W_Pos)                      /*!< 0x00000002 */
+#define WWDG_CFR_W_2            (0x04U << WWDG_CFR_W_Pos)                      /*!< 0x00000004 */
+#define WWDG_CFR_W_3            (0x08U << WWDG_CFR_W_Pos)                      /*!< 0x00000008 */
+#define WWDG_CFR_W_4            (0x10U << WWDG_CFR_W_Pos)                      /*!< 0x00000010 */
+#define WWDG_CFR_W_5            (0x20U << WWDG_CFR_W_Pos)                      /*!< 0x00000020 */
+#define WWDG_CFR_W_6            (0x40U << WWDG_CFR_W_Pos)                      /*!< 0x00000040 */
+
+#define WWDG_CFR_WDGTB_Pos      (11U)
+#define WWDG_CFR_WDGTB_Msk      (0x7UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00003800 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[2:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00000800 */
+#define WWDG_CFR_WDGTB_1        (0x2U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00001000 */
+#define WWDG_CFR_WDGTB_2        (0x4U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00002000 */
+
+#define WWDG_CFR_EWI_Pos        (9U)
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                    /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                    /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                Debug MCU                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define DBGMCU_IDCODE_DEV_ID_Pos                          (0U)
+#define DBGMCU_IDCODE_DEV_ID_Msk                          (0xFFFUL << DBGMCU_IDCODE_DEV_ID_Pos) /*!< 0x00000FFF */
+#define DBGMCU_IDCODE_DEV_ID                              DBGMCU_IDCODE_DEV_ID_Msk
+#define DBGMCU_IDCODE_REV_ID_Pos                          (16U)
+#define DBGMCU_IDCODE_REV_ID_Msk                          (0xFFFFUL << DBGMCU_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBGMCU_IDCODE_REV_ID                              DBGMCU_IDCODE_REV_ID_Msk
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define DBGMCU_CR_DBG_SLEEP_Pos                           (0U)
+#define DBGMCU_CR_DBG_SLEEP_Msk                           (0x1UL << DBGMCU_CR_DBG_SLEEP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_CR_DBG_SLEEP                               DBGMCU_CR_DBG_SLEEP_Msk
+#define DBGMCU_CR_DBG_STOP_Pos                            (1U)
+#define DBGMCU_CR_DBG_STOP_Msk                            (0x1UL << DBGMCU_CR_DBG_STOP_Pos)   /*!< 0x00000002 */
+#define DBGMCU_CR_DBG_STOP                                DBGMCU_CR_DBG_STOP_Msk
+#define DBGMCU_CR_DBG_STANDBY_Pos                         (2U)
+#define DBGMCU_CR_DBG_STANDBY_Msk                         (0x1UL << DBGMCU_CR_DBG_STANDBY_Pos) /*!< 0x00000004 */
+#define DBGMCU_CR_DBG_STANDBY                             DBGMCU_CR_DBG_STANDBY_Msk
+#define DBGMCU_CR_TRACE_IOEN_Pos                          (5U)
+#define DBGMCU_CR_TRACE_IOEN_Msk                          (0x1UL << DBGMCU_CR_TRACE_IOEN_Pos) /*!< 0x00000020 */
+#define DBGMCU_CR_TRACE_IOEN                              DBGMCU_CR_TRACE_IOEN_Msk
+#define DBGMCU_CR_TRGOEN_Pos                              (28U)
+#define DBGMCU_CR_TRGOEN_Msk                              (0x1UL << DBGMCU_CR_TRGOEN_Pos)      /*!< 0x10000000 */
+#define DBGMCU_CR_TRGOEN                                  DBGMCU_CR_TRGOEN_Msk
+
+/********************  Bit definition for DBGMCU_APB1FZR1 register  ***********/
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP_Pos                 (0U)
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_TIM2_STOP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP                     DBGMCU_APB1FZR1_DBG_TIM2_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP_Pos                  (10U)
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP_Msk                  (0x1UL << DBGMCU_APB1FZR1_DBG_RTC_STOP_Pos)   /*!< 0x00000400 */
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP                      DBGMCU_APB1FZR1_DBG_RTC_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos                 (11U)
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos)  /*!< 0x00000800 */
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP                     DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP_Pos                 (12U)
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_IWDG_STOP_Pos)  /*!< 0x00001000 */
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP                     DBGMCU_APB1FZR1_DBG_IWDG_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP_Pos                 (21U)
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_I2C1_STOP_Pos)  /*!< 0x00200000 */
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP                     DBGMCU_APB1FZR1_DBG_I2C1_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Pos               (31U)
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Msk               (0x1UL << DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP                   DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB1FZR1 register  ***********/
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Pos               (0U)
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP                   DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Pos                (10U)
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Msk                (0x1UL << DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Pos)   /*!< 0x00000400 */
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP                    DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Pos               (12U)
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Pos)  /*!< 0x00001000 */
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP                   DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Pos               (21U)
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Pos)  /*!< 0x00200000 */
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP                   DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Pos             (31U)
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Msk             (0x1UL << DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP                 DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_APB1FZR2 register  ***********/
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Pos               (5U)
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Msk               (0x1UL << DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Pos) /*!< 0x00000020 */
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP                   DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB1FZR2 register  ***********/
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Pos             (5U)
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Msk             (0x1UL << DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Pos) /*!< 0x00000020 */
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP                 DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Msk
+
+/********************  Bit definition for DBGMCU_APB2FZR register  ************/
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP_Pos                  (11U)
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP_Msk                  (0x1UL << DBGMCU_APB2FZR_DBG_TIM1_STOP_Pos) /*!< 0x000000800 */
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP                      DBGMCU_APB2FZR_DBG_TIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB2FZR register  ************/
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Pos                (11U)
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Msk                (0x1UL << DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Pos) /*!< 0x000000800 */
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP                    DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Msk
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+
+/*********************** UART Instances : Asynchronous mode *******************/
+#define IS_UART_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : FIFO mode ***************************/
+#define IS_UART_FIFO_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                         ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : SPI Slave mode **********************/
+#define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** USART Instances : Synchronous mode *******************/
+#define IS_USART_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** USART Instances : Auto Baud Rate detection ***********/
+
+#define IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Half-Duplex mode ********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                 ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : LIN mode ****************************/
+#define IS_UART_LIN_INSTANCE(INSTANCE)    ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Wake-up from Stop mode **************/
+#define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : Hardware Flow control ***************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : Smard card mode *********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Driver Enable ***********************/
+#define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE) (((INSTANCE) == USART1)|| \
+                                                  ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/******************** LPUART Instance *****************************************/
+#define IS_LPUART_INSTANCE(INSTANCE)    ((INSTANCE) == LPUART1)
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+
+/******************************* AES Instances ********************************/
+#define IS_AES_ALL_INSTANCE(INSTANCE) ((INSTANCE) == AES2)
+
+/******************************** COMP Instances ******************************/
+#define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1))
+
+#define IS_COMP_COMMON_INSTANCE(INSTANCE) (0U)
+
+/******************** COMP Instances with window mode capability **************/
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (0U)
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Channel1) || \
+                                       ((INSTANCE) == DMA1_Channel2) || \
+                                       ((INSTANCE) == DMA1_Channel3) || \
+                                       ((INSTANCE) == DMA1_Channel4) || \
+                                       ((INSTANCE) == DMA1_Channel5) || \
+                                       ((INSTANCE) == DMA1_Channel6) || \
+                                       ((INSTANCE) == DMA1_Channel7))
+
+/******************************** DMAMUX Instances ****************************/
+#define IS_DMAMUX_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DMAMUX1)
+
+#define IS_DMAMUX_REQUEST_GEN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMAMUX1_RequestGenerator0) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator1) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator2) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator3))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOE) || \
+                                        ((INSTANCE) == GPIOH))
+
+/******************************* GPIO AF Instances ****************************/
+#define IS_GPIO_AF_INSTANCE(INSTANCE)   IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/**************************** GPIO Lock Instances *****************************/
+#define IS_GPIO_LOCK_INSTANCE(INSTANCE) IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) ((INSTANCE) == I2C1)
+
+/****************** I2C Instances : wakeup capability from stop modes *********/
+#define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
+
+/******************************* SMBUS Instances ******************************/
+#define IS_SMBUS_ALL_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
+
+/******************************* IPCC Instances ********************************/
+#define IS_IPCC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IPCC)
+
+/******************************** HSEM Instances *******************************/
+#define IS_HSEM_ALL_INSTANCE(INSTANCE) ((INSTANCE) == HSEM)
+
+#define HSEM_CPU1_COREID        (0x00000004UL)/* Semaphore Core ID */
+#define HSEM_CPU2_COREID        (0x00000008UL)/* Semaphore Core ID */
+
+#define HSEM_SEMID_MIN     (0U)       /* HSEM ID Min*/
+#define HSEM_SEMID_MAX     (31U)      /* HSEM ID Max */
+
+#define HSEM_PROCESSID_MIN (0U)       /* HSEM Process ID Min */
+#define HSEM_PROCESSID_MAX (255U)     /* HSEM Process ID Max */
+
+#define HSEM_CLEAR_KEY_MIN (0U)       /* HSEM clear Key Min value */
+#define HSEM_CLEAR_KEY_MAX (0xFFFFU)  /* HSEM clear Key Max value */
+
+/******************************** PKA Instances *******************************/
+#define IS_PKA_ALL_INSTANCE(INSTANCE) ((INSTANCE) == PKA)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) ((INSTANCE) == SPI1)
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
+                                         ((INSTANCE) == LPTIM2))
+
+/****************** LPTIM Instances : Encoder mode ****************************/
+#define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) ((INSTANCE) == LPTIM1)
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+/****************** TIM Instances : supporting 32 bits counter ****************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) ((INSTANCE) == TIM2)
+
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/************** TIM Instances : supporting Break source selection *************/
+#define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BKIN2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(INSTANCE)      ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(INSTANCE)      ((INSTANCE) == TIM1)
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.COMDE) *******/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : DMA requests generation (TIMx_DIER.UDE) ***/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/******************* TIM Instances : Timer input selection ********************/
+#define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4))))
+
+/****************** TIM Instances : supporting complementary output(s) ********/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+  (((INSTANCE) == TIM1) &&                    \
+   (((CHANNEL) == TIM_CHANNEL_1) ||           \
+    ((CHANNEL) == TIM_CHANNEL_2) ||           \
+    ((CHANNEL) == TIM_CHANNEL_3)))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
+                                                    ((INSTANCE) == TIM2))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting commutation event generation ***/
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                      ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)  || \
+                                                         ((INSTANCE) == TIM2))
+
+/**************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/************* TIM Instances : supporting ETR source selection ***************/
+#define IS_TIM_ETRSEL_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                             ((INSTANCE) == TIM2))
+
+/****** TIM Instances : Master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/************ TIM Instances : Advanced timers  ********************************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/****************************** TSC Instances *********************************/
+#define IS_TSC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == TSC)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+ */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32WB15xx_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb1mxx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb1mxx.h
@@ -1,0 +1,11029 @@
+/**
+  ******************************************************************************
+  * @file    stm32wb1mxx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS Cortex Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for stm32wb1mxx devices.
+  *
+  *          This file contains:
+  *           - Data structures and the address mapping for all peripherals
+  *           - Peripheral's registers declarations and bits definition
+  *           - Macros to access peripheral's registers hardware
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS_Device
+  * @{
+  */
+
+/** @addtogroup stm32wb1mxx
+  * @{
+  */
+
+#ifndef __STM32WB1Mxx_H
+#define __STM32WB1Mxx_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Configuration_section_for_CMSIS
+  * @{
+  */
+/**
+  * @brief Configuration of the Cortex-M4 Processor and Core Peripherals
+  */
+#define __CM4_REV                 1U /*!< Core Revision r0p1                            */
+#define __MPU_PRESENT             1U /*!< M4 provides an MPU                            */
+#define __VTOR_PRESENT            1U /*!< Vector Table Register supported               */
+#define __NVIC_PRIO_BITS          4U /*!< STM32WBxx uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig    0U /*!< Set to 1 if different SysTick Config is used  */
+#define __FPU_PRESENT             1U /*!< FPU present                                   */
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_interrupt_number_definition
+  * @{
+  */
+
+/**
+  * @brief stm32wb1mxx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
+/*!< Interrupt Number Definition for M4 */
+typedef enum
+{
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
+  HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
+  MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
+  BusFault_IRQn                       = -11,    /*!< Cortex-M4 Bus Fault Interrupt                                     */
+  UsageFault_IRQn                     = -10,    /*!< Cortex-M4 Usage Fault Interrupt                                   */
+  SVCall_IRQn                         = -5,     /*!< Cortex-M4 SV Call Interrupt                                       */
+  DebugMonitor_IRQn                   = -4,     /*!< Cortex-M4 Debug Monitor Interrupt                                 */
+  PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
+  SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
+
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
+  TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
+  RTC_WKUP_IRQn                       = 3,      /*!< RTC Wakeup Interrupt                                              */
+  FLASH_IRQn                          = 4,      /*!< FLASH (CFI)  global Interrupt                                     */
+  RCC_IRQn                            = 5,      /*!< RCC Interrupt                                                     */
+  EXTI0_IRQn                          = 6,      /*!< EXTI Line 0 Interrupt                                             */
+  EXTI1_IRQn                          = 7,      /*!< EXTI Line 1 Interrupt                                             */
+  EXTI2_IRQn                          = 8,      /*!< EXTI Line 2 Interrupt                                             */
+  EXTI3_IRQn                          = 9,      /*!< EXTI Line 3 Interrupt                                             */
+  EXTI4_IRQn                          = 10,     /*!< EXTI Line 4 Interrupt                                             */
+  DMA1_Channel1_IRQn                  = 11,     /*!< DMA1 Channel 1 Interrupt                                          */
+  DMA1_Channel2_IRQn                  = 12,     /*!< DMA1 Channel 2 Interrupt                                          */
+  DMA1_Channel3_IRQn                  = 13,     /*!< DMA1 Channel 3 Interrupt                                          */
+  DMA1_Channel4_IRQn                  = 14,     /*!< DMA1 Channel 4 Interrupt                                          */
+  DMA1_Channel5_IRQn                  = 15,     /*!< DMA1 Channel 5 Interrupt                                          */
+  DMA1_Channel6_IRQn                  = 16,     /*!< DMA1 Channel 6 Interrupt                                          */
+  DMA1_Channel7_IRQn                  = 17,     /*!< DMA1 Channel 7 Interrupt                                          */
+  ADC1_IRQn                           = 18,     /*!< ADC1 Interrupt                                                    */
+  C2SEV_PWR_C2H_IRQn                  = 21,     /*!< CPU2 SEV Interrupt                                                */
+  COMP_IRQn                           = 22,     /*!< COMP1 Interrupt                                                   */
+  EXTI9_5_IRQn                        = 23,     /*!< EXTI Lines [9:5] Interrupt                                        */
+  TIM1_BRK_IRQn                       = 24,     /*!< TIM1 Break Interrupt                                              */
+  TIM1_UP_IRQn                        = 25,     /*!< TIM1 Update Interrupt                                             */
+  TIM1_TRG_COM_IRQn                   = 26,     /*!< TIM1 Trigger and Communication Interrupts                         */
+  TIM1_CC_IRQn                        = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                           = 28,     /*!< TIM2 Global Interrupt                                             */
+  PKA_IRQn                            = 29,     /*!< PKA Interrupt                                                     */
+  I2C1_EV_IRQn                        = 30,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                        = 31,     /*!< I2C1 Error Interrupt                                              */
+  SPI1_IRQn                           = 34,     /*!< SPI1 Interrupt                                                    */
+  USART1_IRQn                         = 36,     /*!< USART1 Interrupt                                                  */
+  LPUART1_IRQn                        = 37,     /*!< LPUART1 Interrupt                                                 */
+  TSC_IRQn                            = 39,     /*!< TSC Interrupt                                                     */
+  EXTI15_10_IRQn                      = 40,     /*!< EXTI Lines1[15:10 ]Interrupts                                     */
+  RTC_Alarm_IRQn                      = 41,     /*!< RTC Alarms (A and B) Interrupt                                    */
+  PWR_SOTF_BLEACT_RFPHASE_IRQn        = 43,     /*!< PWR switching on the fly interrupt
+                                                     PWR end of BLE activity interrupt
+                                                     PWR end of critical radio phase interrupt                         */
+  IPCC_C1_RX_IRQn                     = 44,     /*!< IPCC RX Occupied Interrupt                                        */
+  IPCC_C1_TX_IRQn                     = 45,     /*!< IPCC TX Free Interrupt                                            */
+  HSEM_IRQn                           = 46,     /*!< HSEM Interrupt                                                    */
+  LPTIM1_IRQn                         = 47,     /*!< LPTIM1 Interrupt                                                  */
+  LPTIM2_IRQn                         = 48,     /*!< LPTIM2 Interrupt                                                  */
+  AES2_IRQn                           = 52,     /*!< AES2 Interrupt                                                    */
+  RNG_IRQn                            = 53,     /*!< RNG Interrupt                                                     */
+  FPU_IRQn                            = 54,     /*!< FPU Interrupt                                                     */
+  DMAMUX1_OVR_IRQn                    = 62      /*!< DMAMUX1 overrun Interrupt                                         */
+} IRQn_Type;
+/**
+  * @}
+  */
+
+#include "core_cm4.h"                /* Cortex-M4 processor and core peripherals */
+#include "system_stm32wbxx.h"
+#include <stdint.h>
+
+/** @addtogroup Peripheral_registers_structures
+  * @{
+  */
+
+/**
+  * @brief Analog to Digital Converter
+  */
+typedef struct
+{
+  __IO uint32_t ISR;          /*!< ADC interrupt and status register,             Address offset: 0x00 */
+  __IO uint32_t IER;          /*!< ADC interrupt enable register,                 Address offset: 0x04 */
+  __IO uint32_t CR;           /*!< ADC control register,                          Address offset: 0x08 */
+  __IO uint32_t CFGR1;        /*!< ADC configuration register 1,                  Address offset: 0x0C */
+  __IO uint32_t CFGR2;        /*!< ADC configuration register 2,                  Address offset: 0x10 */
+  __IO uint32_t SMPR;         /*!< ADC sampling time register,                    Address offset: 0x14 */
+       uint32_t RESERVED1;    /*!< Reserved,                                                      0x18 */
+       uint32_t RESERVED2;    /*!< Reserved,                                                      0x1C */
+  __IO uint32_t TR;           /*!< ADC analog watchdog 1 threshold register,      Address offset: 0x20 */
+  __IO uint32_t RESERVED3;    /*!< Reserved,                                                      0x24 */
+  __IO uint32_t CHSELR;       /*!< ADC group regular sequencer register,          Address offset: 0x28 */
+  __IO uint32_t RESERVED4;    /*!< Reserved,                                                      0x2C */
+       uint32_t RESERVED5[4]; /*!< Reserved,                                               0x30 - 0x3C */
+  __IO uint32_t DR;           /*!< ADC group regular data register,               Address offset: 0x40 */
+       uint32_t RESERVED6[23];/*!< Reserved,                                               0x44 - 0x9C */
+  __IO uint32_t RESERVED7;    /*!< Reserved,                                                      0xA0 */
+  __IO uint32_t RESERVED8;    /*!< Reserved,                                                      0xA4 */
+       uint32_t RESERVED9[3]; /*!< Reserved,                                               0xA8 - 0xB0 */
+  __IO uint32_t CALFACT;      /*!< ADC Calibration factor register,               Address offset: 0xB4 */
+} ADC_TypeDef;
+
+/* Legacy registers naming */
+#define TR1     TR
+
+
+typedef struct
+{
+  uint32_t      RESERVED1;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x300 */
+  uint32_t      RESERVED2;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x304 */
+  __IO uint32_t CCR;          /*!< ADC common configuration register,             Address offset: ADC1 base address + 0x308 */
+  uint32_t      RESERVED3;    /*!< Reserved,                                      Address offset: ADC1 base address + 0x30C */
+} ADC_Common_TypeDef;
+
+/**
+  * @brief Comparator
+  */
+typedef struct
+{
+  __IO uint32_t CSR;         /*!< COMP control and status register,               Address offset: 0x00 */
+} COMP_TypeDef;
+
+/**
+  * @brief CRC calculation unit
+  */
+typedef struct
+{
+  __IO uint32_t DR;          /*!< CRC Data register,                           Address offset: 0x00 */
+  __IO uint32_t IDR;         /*!< CRC Independent data register,               Address offset: 0x04 */
+  __IO uint32_t CR;          /*!< CRC Control register,                        Address offset: 0x08 */
+       uint32_t RESERVED2;   /*!< Reserved,                                                    0x0C */
+  __IO uint32_t INIT;        /*!< Initial CRC value register,                  Address offset: 0x10 */
+  __IO uint32_t POL;         /*!< CRC polynomial register,                     Address offset: 0x14 */
+} CRC_TypeDef;
+
+/**
+  * @brief Debug MCU
+  */
+typedef struct
+{
+  __IO uint32_t IDCODE;      /*!< MCU device ID code,                          Address offset: 0x00 */
+  __IO uint32_t CR;          /*!< Debug MCU configuration register,            Address offset: 0x04 */
+  uint32_t RESERVED1[13];    /*!< Reserved,                                               0x08-0x38 */
+  __IO uint32_t APB1FZR1;    /*!< Debug MCU CPU1 APB1 freeze register,         Address offset: 0x3C */
+  __IO uint32_t C2APB1FZR1;  /*!< Debug MCU CPU2 APB1 freeze register,         Address offset: 0x40 */
+  __IO uint32_t APB1FZR2;    /*!< Debug MCU CPU1 APB1 freeze register,         Address offset: 0x44 */
+  __IO uint32_t C2APB1FZR2;  /*!< Debug MCU CPU2 APB1 freeze register,         Address offset: 0x48 */
+  __IO uint32_t APB2FZR;     /*!< Debug MCU CPU1 APB2 freeze register,         Address offset: 0x4C */
+  __IO uint32_t C2APB2FZR;   /*!< Debug MCU CPU2 APB2 freeze register,         Address offset: 0x50 */
+} DBGMCU_TypeDef;
+
+/**
+  * @brief DMA Controller
+  */
+typedef struct
+{
+  __IO uint32_t CCR;         /*!< DMA channel x configuration register        0x00 */
+  __IO uint32_t CNDTR;       /*!< DMA channel x number of data register       0x04 */
+  __IO uint32_t CPAR;        /*!< DMA channel x peripheral address register   0x08 */
+  __IO uint32_t CMAR;        /*!< DMA channel x memory address register       0x0C */
+  uint32_t RESERVED;         /*!< Reserved,                                   0x10 */
+} DMA_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< DMA interrupt status register,                 Address offset: 0x00 */
+  __IO uint32_t IFCR;        /*!< DMA interrupt flag clear register,             Address offset: 0x04 */
+} DMA_TypeDef;
+
+/**
+  * @brief DMA Multiplexer
+  */
+typedef struct
+{
+  __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
+} DMAMUX_Channel_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
+  __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
+} DMAMUX_ChannelStatus_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
+} DMAMUX_RequestGen_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
+  __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
+} DMAMUX_RequestGenStatus_TypeDef;
+
+/**
+  * @brief FLASH Registers
+  */
+typedef struct
+{
+  __IO uint32_t ACR;           /*!< FLASH Access control register,                      Address offset: 0x00      */
+  __IO uint32_t RESERVED;      /*!< Reserved,                                           Address offset: 0x04      */
+  __IO uint32_t KEYR;          /*!< FLASH Key register,                                 Address offset: 0x08      */
+  __IO uint32_t OPTKEYR;       /*!< FLASH Option Key register,                          Address offset: 0x0C      */
+  __IO uint32_t SR;            /*!< FLASH Status register,                              Address offset: 0x10      */
+  __IO uint32_t CR;            /*!< FLASH Control register,                             Address offset: 0x14      */
+  __IO uint32_t ECCR;          /*!< FLASH ECC register,                                 Address offset: 0x18      */
+  uint32_t RESERVED1;          /*!< Reserved,                                           Address offset: 0x1C      */
+  __IO uint32_t OPTR;          /*!< FLASH Option register,                              Address offset: 0x20      */
+  __IO uint32_t PCROP1ASR;     /*!< FLASH Bank 1 PCROP area A Start address register,   Address offset: 0x24      */
+  __IO uint32_t PCROP1AER;     /*!< FLASH Bank 1 PCROP area A End address register,     Address offset: 0x28      */
+  __IO uint32_t WRP1AR;        /*!< FLASH Bank 1 WRP area A address register,           Address offset: 0x2C      */
+  __IO uint32_t WRP1BR;        /*!< FLASH Bank 1 WRP area B address register,           Address offset: 0x30      */
+  __IO uint32_t PCROP1BSR;     /*!< FLASH Bank 1 PCROP area B Start address register,   Address offset: 0x34      */
+  __IO uint32_t PCROP1BER;     /*!< FLASH Bank 1 PCROP area B End address register,     Address offset: 0x38      */
+  __IO uint32_t IPCCBR;        /*!< FLASH IPCC data buffer address,                     Address offset: 0x3C      */
+  uint32_t RESERVED2[7];       /*!< Reserved,                                           Address offset: 0x40-0x58 */
+  __IO uint32_t C2ACR;         /*!< FLASH Core MO+ Access Control Register ,            Address offset: 0x5C      */
+  __IO uint32_t C2SR;          /*!< FLASH Core MO+ Status Register,                     Address offset: 0x60      */
+  __IO uint32_t C2CR;          /*!< FLASH Core MO+ Control register,                    Address offset: 0x64      */
+  uint32_t RESERVED3[6];       /*!< Reserved,                                           Address offset: 0x68-0x7C */
+  __IO uint32_t SFR;           /*!< FLASH secure start address,                         Address offset: 0x80      */
+  __IO uint32_t SRRVR;         /*!< FlASH secure SRAM2 start addr and CPU2 reset vector Address offset: 0x84      */
+} FLASH_TypeDef;
+
+/**
+  * @brief General Purpose I/O
+  */
+typedef struct
+{
+  __IO uint32_t MODER;       /*!< GPIO port mode register,               Address offset: 0x00      */
+  __IO uint32_t OTYPER;      /*!< GPIO port output type register,        Address offset: 0x04      */
+  __IO uint32_t OSPEEDR;     /*!< GPIO port output speed register,       Address offset: 0x08      */
+  __IO uint32_t PUPDR;       /*!< GPIO port pull-up/pull-down register,  Address offset: 0x0C      */
+  __IO uint32_t IDR;         /*!< GPIO port input data register,         Address offset: 0x10      */
+  __IO uint32_t ODR;         /*!< GPIO port output data register,        Address offset: 0x14      */
+  __IO uint32_t BSRR;        /*!< GPIO port bit set/reset  register,     Address offset: 0x18      */
+  __IO uint32_t LCKR;        /*!< GPIO port configuration lock register, Address offset: 0x1C      */
+  __IO uint32_t AFR[2];      /*!< GPIO alternate function registers,     Address offset: 0x20-0x24 */
+  __IO uint32_t BRR;         /*!< GPIO Bit Reset register,               Address offset: 0x28      */
+} GPIO_TypeDef;
+
+/**
+  * @brief Inter-integrated Circuit Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< I2C Control register 1,            Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< I2C Control register 2,            Address offset: 0x04 */
+  __IO uint32_t OAR1;        /*!< I2C Own address 1 register,        Address offset: 0x08 */
+  __IO uint32_t OAR2;        /*!< I2C Own address 2 register,        Address offset: 0x0C */
+  __IO uint32_t TIMINGR;     /*!< I2C Timing register,               Address offset: 0x10 */
+  __IO uint32_t TIMEOUTR;    /*!< I2C Timeout register,              Address offset: 0x14 */
+  __IO uint32_t ISR;         /*!< I2C Interrupt and status register, Address offset: 0x18 */
+  __IO uint32_t ICR;         /*!< I2C Interrupt clear register,      Address offset: 0x1C */
+  __IO uint32_t PECR;        /*!< I2C PEC register,                  Address offset: 0x20 */
+  __IO uint32_t RXDR;        /*!< I2C Receive data register,         Address offset: 0x24 */
+  __IO uint32_t TXDR;        /*!< I2C Transmit data register,        Address offset: 0x28 */
+} I2C_TypeDef;
+
+/**
+  * @brief Independent WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t KR;          /*!< IWDG Key register,       Address offset: 0x00 */
+  __IO uint32_t PR;          /*!< IWDG Prescaler register, Address offset: 0x04 */
+  __IO uint32_t RLR;         /*!< IWDG Reload register,    Address offset: 0x08 */
+  __IO uint32_t SR;          /*!< IWDG Status register,    Address offset: 0x0C */
+  __IO uint32_t WINR;        /*!< IWDG Window register,    Address offset: 0x10 */
+} IWDG_TypeDef;
+
+/**
+  * @brief LPTIMER
+  */
+typedef struct
+{
+  __IO uint32_t ISR;         /*!< LPTIM Interrupt and Status register,                Address offset: 0x00 */
+  __IO uint32_t ICR;         /*!< LPTIM Interrupt Clear register,                     Address offset: 0x04 */
+  __IO uint32_t IER;         /*!< LPTIM Interrupt Enable register,                    Address offset: 0x08 */
+  __IO uint32_t CFGR;        /*!< LPTIM Configuration register,                       Address offset: 0x0C */
+  __IO uint32_t CR;          /*!< LPTIM Control register,                             Address offset: 0x10 */
+  __IO uint32_t CMP;         /*!< LPTIM Compare register,                             Address offset: 0x14 */
+  __IO uint32_t ARR;         /*!< LPTIM Autoreload register,                          Address offset: 0x18 */
+  __IO uint32_t CNT;         /*!< LPTIM Counter register,                             Address offset: 0x1C */
+  __IO uint32_t OR;          /*!< LPTIM Option register,                              Address offset: 0x20 */
+} LPTIM_TypeDef;
+
+/**
+  * @brief Power Control
+  */
+typedef struct
+{
+  __IO uint32_t CR1;          /*!< PWR Power Control Register 1,                     Address offset: 0x00 */
+  __IO uint32_t CR2;          /*!< PWR Power Control Register 2,                     Address offset: 0x04 */
+  __IO uint32_t CR3;          /*!< PWR Power Control Register 3,                     Address offset: 0x08 */
+  __IO uint32_t CR4;          /*!< PWR Power Control Register 4,                     Address offset: 0x0C */
+  __IO uint32_t SR1;          /*!< PWR Power Status Register 1,                      Address offset: 0x10 */
+  __IO uint32_t SR2;          /*!< PWR Power Status Register 2,                      Address offset: 0x14 */
+  __IO uint32_t SCR;          /*!< PWR Power Status Reset Register,                  Address offset: 0x18 */
+  __IO uint32_t CR5;          /*!< PWR Power Control Register 5,                     Address offset: 0x1C */
+  __IO uint32_t PUCRA;        /*!< PWR Pull-Up Control Register of port A,           Address offset: 0x20 */
+  __IO uint32_t PDCRA;        /*!< PWR Pull-Down Control Register of port A,         Address offset: 0x24 */
+  __IO uint32_t PUCRB;        /*!< PWR Pull-Up Control Register of port B,           Address offset: 0x28 */
+  __IO uint32_t PDCRB;        /*!< PWR Pull-Down Control Register of port B,         Address offset: 0x2C */
+  __IO uint32_t PUCRC;        /*!< PWR Pull-Up Control Register of port C,           Address offset: 0x30 */
+  __IO uint32_t PDCRC;        /*!< PWR Pull-Down Control Register of port C,         Address offset: 0x34 */
+       uint32_t RESERVED2[2]; /*!< Reserved,                                         Address offset: 0x38-0x3C */
+  __IO uint32_t PUCRE;        /*!< PWR Pull-Up Control Register of port E,           Address offset: 0x40 */
+  __IO uint32_t PDCRE;        /*!< PWR Pull-Down Control Register of port E,         Address offset: 0x44 */
+       uint32_t RESERVED0[4]; /*!< Reserved,                                         Address offset: 0x48-0x54 */
+  __IO uint32_t PUCRH;        /*!< PWR Pull-Up Control Register of port H,           Address offset: 0x58 */
+  __IO uint32_t PDCRH;        /*!< PWR Pull-Down Control Register of port H,         Address offset: 0x5C */
+       uint32_t RESERVED1[8]; /*!< Reserved,                                         Address offset: 0x60-0x7C */
+  __IO uint32_t C2CR1;        /*!< PWR Power Control Register 1 for CPU2,            Address offset: 0x80 */
+  __IO uint32_t C2CR3;        /*!< PWR Power Control Register 3 for CPU2,            Address offset: 0x84 */
+  __IO uint32_t EXTSCR;       /*!< PWR Power Status Reset Register for CPU2,         Address offset: 0x88 */
+} PWR_TypeDef;
+
+/**
+  * @brief Reset and Clock Control
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< RCC clock  Control Register,                                                    Address offset: 0x00 */
+  __IO uint32_t ICSCR;         /*!< RCC Internal Clock Sources Calibration Register,                                Address offset: 0x04 */
+  __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
+  __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
+       uint32_t RESERVED0[2];  /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
+  __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
+  __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
+  __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
+  __IO uint32_t SMPSCR;        /*!< RCC SMPS step-down converter control register,                                  Address offset: 0x24 */
+  __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
+  __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
+  __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
+  __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
+  __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
+  __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
+  __IO uint32_t APB3RSTR;      /*!< RCC APB3 peripheral reset register,                                             Address offset: 0x44 */
+  __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
+  __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
+  __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
+  __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
+  __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
+  __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
+  __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
+  __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
+  __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
+  __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
+  __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
+  __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
+  __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
+  __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
+  __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
+  __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
+  __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+  __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
+  __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
+  __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
+  __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
+  __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
+  __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
+  __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
+  __IO uint32_t C2APB3ENR;     /*!< RCC APB3 peripheral CPU2 clocks enable register 1,                              Address offset: 0x164 */
+  __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
+  __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
+  __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
+  __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
+  __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
+  __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
+  __IO uint32_t C2APB3SMENR;   /*!< RCC APB3 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x184 */
+} RCC_TypeDef;
+
+
+
+/**
+  * @brief Real-Time Clock
+  */
+typedef struct
+{
+  __IO uint32_t TR;         /*!< RTC time register,                                         Address offset: 0x00 */
+  __IO uint32_t DR;         /*!< RTC date register,                                         Address offset: 0x04 */
+  __IO uint32_t CR;         /*!< RTC control register,                                      Address offset: 0x08 */
+  __IO uint32_t ISR;        /*!< RTC initialization and status register,                    Address offset: 0x0C */
+  __IO uint32_t PRER;       /*!< RTC prescaler register,                                    Address offset: 0x10 */
+  __IO uint32_t WUTR;       /*!< RTC wakeup timer register,                                 Address offset: 0x14 */
+       uint32_t RESERVED;   /*!< Reserved,                                                  Address offset: 0x18 */
+  __IO uint32_t ALRMAR;     /*!< RTC alarm A register,                                      Address offset: 0x1C */
+  __IO uint32_t ALRMBR;     /*!< RTC alarm B register,                                      Address offset: 0x20 */
+  __IO uint32_t WPR;        /*!< RTC write protection register,                             Address offset: 0x24 */
+  __IO uint32_t SSR;        /*!< RTC sub second register,                                   Address offset: 0x28 */
+  __IO uint32_t SHIFTR;     /*!< RTC shift control register,                                Address offset: 0x2C */
+  __IO uint32_t TSTR;       /*!< RTC time stamp time register,                              Address offset: 0x30 */
+  __IO uint32_t TSDR;       /*!< RTC time stamp date register,                              Address offset: 0x34 */
+  __IO uint32_t TSSSR;      /*!< RTC time-stamp sub second register,                        Address offset: 0x38 */
+  __IO uint32_t CALR;       /*!< RTC calibration register,                                  Address offset: 0x3C */
+  __IO uint32_t TAMPCR;     /*!< RTC tamper configuration register,                         Address offset: 0x40 */
+  __IO uint32_t ALRMASSR;   /*!< RTC alarm A sub second register,                           Address offset: 0x44 */
+  __IO uint32_t ALRMBSSR;   /*!< RTC alarm B sub second register,                           Address offset: 0x48 */
+  __IO uint32_t OR;         /*!< RTC option register,                                       Address offset  0x4C */
+  __IO uint32_t BKP0R;      /*!< RTC backup register 0,                                     Address offset: 0x50 */
+  __IO uint32_t BKP1R;      /*!< RTC backup register 1,                                     Address offset: 0x54 */
+  __IO uint32_t BKP2R;      /*!< RTC backup register 2,                                     Address offset: 0x58 */
+  __IO uint32_t BKP3R;      /*!< RTC backup register 3,                                     Address offset: 0x5C */
+  __IO uint32_t BKP4R;      /*!< RTC backup register 4,                                     Address offset: 0x60 */
+  __IO uint32_t BKP5R;      /*!< RTC backup register 5,                                     Address offset: 0x64 */
+  __IO uint32_t BKP6R;      /*!< RTC backup register 6,                                     Address offset: 0x68 */
+  __IO uint32_t BKP7R;      /*!< RTC backup register 7,                                     Address offset: 0x6C */
+  __IO uint32_t BKP8R;      /*!< RTC backup register 8,                                     Address offset: 0x70 */
+  __IO uint32_t BKP9R;      /*!< RTC backup register 9,                                     Address offset: 0x74 */
+  __IO uint32_t BKP10R;     /*!< RTC backup register 10,                                    Address offset: 0x78 */
+  __IO uint32_t BKP11R;     /*!< RTC backup register 11,                                    Address offset: 0x7C */
+  __IO uint32_t BKP12R;     /*!< RTC backup register 12,                                    Address offset: 0x80 */
+  __IO uint32_t BKP13R;     /*!< RTC backup register 13,                                    Address offset: 0x84 */
+  __IO uint32_t BKP14R;     /*!< RTC backup register 14,                                    Address offset: 0x88 */
+  __IO uint32_t BKP15R;     /*!< RTC backup register 15,                                    Address offset: 0x8C */
+  __IO uint32_t BKP16R;     /*!< RTC backup register 16,                                    Address offset: 0x90 */
+  __IO uint32_t BKP17R;     /*!< RTC backup register 17,                                    Address offset: 0x94 */
+  __IO uint32_t BKP18R;     /*!< RTC backup register 18,                                    Address offset: 0x98 */
+  __IO uint32_t BKP19R;     /*!< RTC backup register 19,                                    Address offset: 0x9C */
+} RTC_TypeDef;
+
+
+
+
+/**
+  * @brief Serial Peripheral Interface
+  */
+typedef struct
+{
+  __IO uint32_t CR1;      /*!< SPI Control register 1,       Address offset: 0x00 */
+  __IO uint32_t CR2;      /*!< SPI Control register 2,       Address offset: 0x04 */
+  __IO uint32_t SR;       /*!< SPI Status register,          Address offset: 0x08 */
+  __IO uint32_t DR;       /*!< SPI data register,            Address offset: 0x0C */
+  __IO uint32_t CRCPR;    /*!< SPI CRC polynomial register,  Address offset: 0x10 */
+  __IO uint32_t RXCRCR;   /*!< SPI Rx CRC register,          Address offset: 0x14 */
+  __IO uint32_t TXCRCR;   /*!< SPI Tx CRC register,          Address offset: 0x18 */
+} SPI_TypeDef;
+
+/**
+  * @brief System configuration controller
+  */
+typedef struct
+{
+  __IO uint32_t MEMRMP;            /*!< SYSCFG memory remap register                                            Address offset: 0x00       */
+  __IO uint32_t CFGR1;             /*!< SYSCFG configuration register 1,                                        Address offset: 0x04       */
+  __IO uint32_t EXTICR[4];         /*!< SYSCFG external interrupt configuration registers,                      Address offset: 0x08-0x14  */
+  __IO uint32_t SCSR;              /*!< SYSCFG SRAM2 control and status register,                               Address offset: 0x18       */
+  __IO uint32_t CFGR2;             /*!< SYSCFG configuration register 2,                                        Address offset: 0x1C       */
+  __IO uint32_t SWPR1;             /*!< SYSCFG SRAM2 write protection register part 1,                          Address offset: 0x20       */
+  __IO uint32_t SKR;               /*!< SYSCFG SRAM2 key register,                                              Address offset: 0x24       */
+  __IO uint32_t SWPR2;             /*!< SYSCFG write protection register part 2,                                Address offset: 0x28       */
+       uint32_t RESERVED1[53];     /*!< Reserved,                                                               Address offset: 0x2C-0xFC  */
+  __IO uint32_t IMR1;              /*!< SYSCFG CPU1 (CORTEX M4) interrupt masks control-status register part 1, Address offset: 0x100      */
+  __IO uint32_t IMR2;              /*!< SYSCFG CPU1 (CORTEX M4) interrupt masks control-status register part 2, Address offset: 0x104      */
+  __IO uint32_t C2IMR1;            /*!< SYSCFG CPU2 (CORTEX M0) interrupt masks control-status register part 1, Address offset: 0x108      */
+  __IO uint32_t C2IMR2;            /*!< SYSCFG CPU2 (CORTEX M0) interrupt masks control-status register part 2, Address offset: 0x10C      */
+  __IO uint32_t SIPCR;             /*!< SYSCFG secure IP control register,                                      Address offset: 0x110      */
+
+} SYSCFG_TypeDef;
+
+/**
+  * @brief TIM
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< TIM control register 1,                   Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< TIM control register 2,                   Address offset: 0x04 */
+  __IO uint32_t SMCR;        /*!< TIM slave mode control register,          Address offset: 0x08 */
+  __IO uint32_t DIER;        /*!< TIM DMA/interrupt enable register,        Address offset: 0x0C */
+  __IO uint32_t SR;          /*!< TIM status register,                      Address offset: 0x10 */
+  __IO uint32_t EGR;         /*!< TIM event generation register,            Address offset: 0x14 */
+  __IO uint32_t CCMR1;       /*!< TIM capture/compare mode register 1,      Address offset: 0x18 */
+  __IO uint32_t CCMR2;       /*!< TIM capture/compare mode register 2,      Address offset: 0x1C */
+  __IO uint32_t CCER;        /*!< TIM capture/compare enable register,      Address offset: 0x20 */
+  __IO uint32_t CNT;         /*!< TIM counter register,                     Address offset: 0x24 */
+  __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
+  __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
+  __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
+  __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
+  __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
+  __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */
+  __IO uint32_t OR;          /*!< TIM option register                       Address offset: 0x50 */
+  __IO uint32_t CCMR3;       /*!< TIM capture/compare mode register 3,      Address offset: 0x54 */
+  __IO uint32_t CCR5;        /*!< TIM capture/compare register5,            Address offset: 0x58 */
+  __IO uint32_t CCR6;        /*!< TIM capture/compare register6,            Address offset: 0x5C */
+  __IO uint32_t AF1;         /*!< TIM Alternate function option register 1, Address offset: 0x60 */
+  __IO uint32_t AF2;         /*!< TIM Alternate function option register 2, Address offset: 0x64 */
+} TIM_TypeDef;
+
+/**
+  * @brief Universal Synchronous Asynchronous Receiver Transmitter
+  */
+typedef struct
+{
+  __IO uint32_t CR1;         /*!< USART Control register 1,                 Address offset: 0x00 */
+  __IO uint32_t CR2;         /*!< USART Control register 2,                 Address offset: 0x04 */
+  __IO uint32_t CR3;         /*!< USART Control register 3,                 Address offset: 0x08 */
+  __IO uint32_t BRR;         /*!< USART Baud rate register,                 Address offset: 0x0C */
+  __IO uint32_t GTPR;        /*!< USART Guard time and prescaler register,  Address offset: 0x10 */
+  __IO uint32_t RTOR;        /*!< USART Receiver Time Out register,         Address offset: 0x14 */
+  __IO uint32_t RQR;         /*!< USART Request register,                   Address offset: 0x18 */
+  __IO uint32_t ISR;         /*!< USART Interrupt and status register,      Address offset: 0x1C */
+  __IO uint32_t ICR;         /*!< USART Interrupt flag Clear register,      Address offset: 0x20 */
+  __IO uint32_t RDR;         /*!< USART Receive Data register,              Address offset: 0x24 */
+  __IO uint32_t TDR;         /*!< USART Transmit Data register,             Address offset: 0x28 */
+  __IO uint32_t PRESC;       /*!< USART Prescaler register,                 Address offset: 0x2C */
+} USART_TypeDef;
+
+
+/**
+  * @brief Window WATCHDOG
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< WWDG Control register,       Address offset: 0x00 */
+  __IO uint32_t CFR;         /*!< WWDG Configuration register, Address offset: 0x04 */
+  __IO uint32_t SR;          /*!< WWDG Status register,        Address offset: 0x08 */
+} WWDG_TypeDef;
+
+
+/**
+  * @brief AES hardware accelerator
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< AES control register,                        Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< AES status register,                         Address offset: 0x04 */
+  __IO uint32_t DINR;        /*!< AES data input register,                     Address offset: 0x08 */
+  __IO uint32_t DOUTR;       /*!< AES data output register,                    Address offset: 0x0C */
+  __IO uint32_t KEYR0;       /*!< AES key register 0,                          Address offset: 0x10 */
+  __IO uint32_t KEYR1;       /*!< AES key register 1,                          Address offset: 0x14 */
+  __IO uint32_t KEYR2;       /*!< AES key register 2,                          Address offset: 0x18 */
+  __IO uint32_t KEYR3;       /*!< AES key register 3,                          Address offset: 0x1C */
+  __IO uint32_t IVR0;        /*!< AES initialization vector register 0,        Address offset: 0x20 */
+  __IO uint32_t IVR1;        /*!< AES initialization vector register 1,        Address offset: 0x24 */
+  __IO uint32_t IVR2;        /*!< AES initialization vector register 2,        Address offset: 0x28 */
+  __IO uint32_t IVR3;        /*!< AES initialization vector register 3,        Address offset: 0x2C */
+  __IO uint32_t KEYR4;       /*!< AES key register 4,                          Address offset: 0x30 */
+  __IO uint32_t KEYR5;       /*!< AES key register 5,                          Address offset: 0x34 */
+  __IO uint32_t KEYR6;       /*!< AES key register 6,                          Address offset: 0x38 */
+  __IO uint32_t KEYR7;       /*!< AES key register 7,                          Address offset: 0x3C */
+  __IO uint32_t SUSP0R;      /*!< AES Suspend register 0,                      Address offset: 0x40 */
+  __IO uint32_t SUSP1R;      /*!< AES Suspend register 1,                      Address offset: 0x44 */
+  __IO uint32_t SUSP2R;      /*!< AES Suspend register 2,                      Address offset: 0x48 */
+  __IO uint32_t SUSP3R;      /*!< AES Suspend register 3,                      Address offset: 0x4C */
+  __IO uint32_t SUSP4R;      /*!< AES Suspend register 4,                      Address offset: 0x50 */
+  __IO uint32_t SUSP5R;      /*!< AES Suspend register 5,                      Address offset: 0x54 */
+  __IO uint32_t SUSP6R;      /*!< AES Suspend register 6,                      Address offset: 0x58 */
+  __IO uint32_t SUSP7R;      /*!< AES Suspend register 7,                      Address offset: 0x6C */
+} AES_TypeDef;
+
+/**
+  * @brief RNG
+  */
+typedef struct
+{
+  __IO uint32_t CR;  /*!< RNG control register, Address offset: 0x00 */
+  __IO uint32_t SR;  /*!< RNG status register,  Address offset: 0x04 */
+  __IO uint32_t DR;  /*!< RNG data register,    Address offset: 0x08 */
+} RNG_TypeDef;
+
+/**
+  * @brief Touch Sensing Controller (TSC)
+  */
+typedef struct
+{
+  __IO uint32_t CR;            /*!< TSC control register,                     Address offset: 0x00 */
+  __IO uint32_t IER;           /*!< TSC interrupt enable register,            Address offset: 0x04 */
+  __IO uint32_t ICR;           /*!< TSC interrupt clear register,             Address offset: 0x08 */
+  __IO uint32_t ISR;           /*!< TSC interrupt status register,            Address offset: 0x0C */
+  __IO uint32_t IOHCR;         /*!< TSC I/O hysteresis control register,      Address offset: 0x10 */
+  uint32_t      RESERVED1;     /*!< Reserved,                                 Address offset: 0x14 */
+  __IO uint32_t IOASCR;        /*!< TSC I/O analog switch control register,   Address offset: 0x18 */
+  uint32_t      RESERVED2;     /*!< Reserved,                                 Address offset: 0x1C */
+  __IO uint32_t IOSCR;         /*!< TSC I/O sampling control register,        Address offset: 0x20 */
+  uint32_t      RESERVED3;     /*!< Reserved,                                 Address offset: 0x24 */
+  __IO uint32_t IOCCR;         /*!< TSC I/O channel control register,         Address offset: 0x28 */
+  uint32_t      RESERVED4;     /*!< Reserved,                                 Address offset: 0x2C */
+  __IO uint32_t IOGCSR;        /*!< TSC I/O group control status register,    Address offset: 0x30 */
+  __IO uint32_t IOGXCR[7];     /*!< TSC I/O group x counter register,         Address offset: 0x34-4C */
+} TSC_TypeDef;
+
+/**
+  * @brief Inter-Processor Communication
+  */
+typedef struct
+{
+  __IO uint32_t C1CR;             /*!< Inter-Processor Communication: C1 control register,                  Address offset: 0x000 */
+  __IO uint32_t C1MR ;            /*!< Inter-Processor Communication: C1 mask register,                     Address offset: 0x004 */
+  __IO uint32_t C1SCR;            /*!< Inter-Processor Communication: C1 status set clear register,         Address offset: 0x008 */
+  __IO uint32_t C1TOC2SR;         /*!< Inter-Processor Communication: C1 to processor M4  status register,  Address offset: 0x00C */
+  __IO uint32_t C2CR;             /*!< Inter-Processor Communication: C2 control register,                  Address offset: 0x010 */
+  __IO uint32_t C2MR ;            /*!< Inter-Processor Communication: C2 mask register,                     Address offset: 0x014 */
+  __IO uint32_t C2SCR;            /*!< Inter-Processor Communication: C2 status set clear register,         Address offset: 0x018 */
+  __IO uint32_t C2TOC1SR;         /*!< Inter-Processor Communication: C2 to processor M4 status register,   Address offset: 0x01C */
+} IPCC_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t CR;               /*!< Control register,                                                    Address offset: 0x000 */
+  __IO uint32_t MR;               /*!< Mask register,                                                       Address offset: 0x004 */
+  __IO uint32_t SCR;              /*!< Status set clear register,                                           Address offset: 0x008 */
+  __IO uint32_t SR;               /*!< Status register,                                                     Address offset: 0x00C */
+} IPCC_CommonTypeDef;
+
+/**
+  * @brief Async Interrupts and Events Controller
+  */
+typedef struct
+{
+  __IO uint32_t RTSR1;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x08 */
+  __IO uint32_t PR1;            /*!< EXTI pending register [31:0],                             Address offset: 0x0C */
+  __IO uint32_t RESERVED1[4];   /*!< Reserved,                                                 Address offset: 0x10 - 0x1C */
+  __IO uint32_t RTSR2;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x20 */
+  __IO uint32_t FTSR2;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x24 */
+  __IO uint32_t SWIER2;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x28 */
+  __IO uint32_t PR2;            /*!< EXTI pending register [31:0],                             Address offset: 0x2C */
+  __IO uint32_t RESERVED2[4];   /*!< Reserved,                                                 Address offset: 0x30 - 0x3C */
+  __IO uint32_t RESERVED3[8];   /*!< Reserved,                                                 Address offset: 0x40 - 0x5C */
+  __IO uint32_t RESERVED4[8];   /*!< Reserved,                                                 Address offset: 0x60 - 0x7C */
+  __IO uint32_t IMR1;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x84 */
+  __IO uint32_t RESERVED5[2];   /*!< Reserved,                                                 Address offset: 0x88 - 0x8C */
+  __IO uint32_t IMR2;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x90 */
+  __IO uint32_t EMR2;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x94 */
+  __IO uint32_t RESERVED8[10];  /*!< Reserved,                                                 Address offset: 0x98 - 0xBC */
+  __IO uint32_t C2IMR1;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xC0 */
+  __IO uint32_t C2EMR1;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xC4 */
+  __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
+  __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
+  __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
+} EXTI_TypeDef;
+
+/**
+  * @brief Public Key Accelerator (PKA)
+  */
+typedef struct
+{
+  __IO uint32_t CR;          /*!< PKA control register,                 Address offset: 0x00 */
+  __IO uint32_t SR;          /*!< PKA status register,                  Address offset: 0x04 */
+  __IO uint32_t CLRFR;       /*!< PKA clear flag register,              Address offset: 0x08 */
+  uint32_t  Reserved1[253];  /*!< Reserved                              Address offset: 0x000C-0x03FC*/
+  __IO uint32_t RAM[894];    /*!< PKA RAM,                              Address offset: 0x0400-0x11F4 */
+} PKA_TypeDef;
+
+/**
+  * @brief HW Semaphore HSEM
+  */
+typedef struct
+{
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+} HSEM_TypeDef;
+
+typedef struct
+{
+  __IO uint32_t IER;        /*!< HSEM interrupt enable register ,                Address offset:   0h     */
+  __IO uint32_t ICR;        /*!< HSEM interrupt clear register ,                 Address offset:   4h     */
+  __IO uint32_t ISR;        /*!< HSEM interrupt status register ,                Address offset:   8h     */
+  __IO uint32_t MISR;       /*!< HSEM masked interrupt status register ,         Address offset:   Ch     */
+} HSEM_Common_TypeDef;
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+
+/*!< Boundary memory map */
+#define FLASH_BASE             (0x08000000UL)/*!< FLASH(up to 320KB) base address */
+#define SRAM_BASE              (0x20000000UL)/*!< SRAM(up to 12 KB) base address */
+#define PERIPH_BASE            (0x40000000UL)/*!< Peripheral base address */
+
+/*!< Memory, OTP and Option bytes */
+
+/* Base addresses */
+#define SYSTEM_MEMORY_BASE     (0x1FFF0000UL)  /*!< System Memory : 28Kb (0x1FFF0000 - 0x1FFF6FFF) */
+#define OTP_AREA_BASE          (0x1FFF7000UL)  /*!< OTP area : 1kB (0x1FFF7000 - 0x1FFF73FF)       */
+#define OPTION_BYTE_BASE       (0x1FFF7800UL)  /*!< Option Bytes : 128B (0x1FFF7800 - 0x1FFF787F)   */
+#define ENGI_BYTE_BASE         (0x1FFF7400UL)  /*!< Engi Bytes : 3kB (0x1FFF7400 - 0x1FFF7FFF)     */
+
+#define SRAM1_BASE             SRAM_BASE                 /*!< SRAM1(up to 12 KB) base address */
+#define SRAM2A_BASE            (SRAM_BASE + 0x00030000UL)/*!< SRAM2A(32 KB) base address      */
+#define SRAM2B_BASE            (SRAM_BASE + 0x00038000UL)/*!< SRAM2B(4 KB) base address       */
+
+/* Memory Size */
+#define FLASH_SIZE              (((uint32_t)(*((uint16_t *)FLASHSIZE_BASE)) & (0x07FFUL)) << 10U)
+#define SRAM1_SIZE              0x00003000UL   /*!< SRAM1 default size  : 12 KB */
+#define SRAM2A_SIZE             0x00008000UL   /*!< SRAM2a default size : 32 KB */
+#define SRAM2B_SIZE             0x00001000UL   /*!< SRAM2b default size :  4 KB */
+
+/* End addresses */
+#define SRAM1_END_ADDR         (0x20002FFFUL)  /*!< SRAM1               :  12KB (0x20000000 - 0x20002FFF) */
+#define SRAM2A_END_ADDR        (0x20037FFFUL)  /*!< SRAM2a (backup)     :  32KB (0x20030000 - 0x20037FFF) */
+#define SRAM2B_END_ADDR        (0x20038FFFUL)  /*!< SRAM2b (backup)     :   4KB (0x20038000 - 0x20038FFF) */
+
+#define SYSTEM_MEMORY_END_ADDR (0x1FFF6FFFUL)  /*!< System Memory : 28KB (0x1FFF0000 - 0x1FFF6FFF)  */
+#define OTP_AREA_END_ADDR      (0x1FFF73FFUL)  /*!< OTP area : 1KB (0x1FFF7000 - 0x1FFF73FF)        */
+#define OPTION_BYTE_END_ADDR   (0x1FFF8FFFUL)  /*!< Option Bytes : 4KB (0x1FFF8000 - 0x1FFF8FFF)    */
+#define ENGI_BYTE_END_ADDR     (0x1FFF7FFFUL)  /*!< Engi Bytes : 3kB (0x1FFF7400 - 0x1FFF7FFF)      */
+
+/*!< Peripheral memory map */
+#define APB1PERIPH_BASE       PERIPH_BASE
+#define APB2PERIPH_BASE       (PERIPH_BASE + 0x00010000UL)
+#define AHB1PERIPH_BASE       (PERIPH_BASE + 0x00020000UL)
+#define AHB2PERIPH_BASE       (PERIPH_BASE + 0x08000000UL)
+#define AHB4PERIPH_BASE       (PERIPH_BASE + 0x18000000UL)
+#define APB3PERIPH_BASE       (PERIPH_BASE + 0x20000000UL)
+
+/*!< APB1 peripherals */
+#define TIM2_BASE             (APB1PERIPH_BASE + 0x00000000UL)
+#define RTC_BASE              (APB1PERIPH_BASE + 0x00002800UL)
+#define WWDG_BASE             (APB1PERIPH_BASE + 0x00002C00UL)
+#define IWDG_BASE             (APB1PERIPH_BASE + 0x00003000UL)
+#define I2C1_BASE             (APB1PERIPH_BASE + 0x00005400UL)
+#define LPTIM1_BASE           (APB1PERIPH_BASE + 0x00007C00UL)
+#define LPUART1_BASE          (APB1PERIPH_BASE + 0x00008000UL)
+#define LPTIM2_BASE           (APB1PERIPH_BASE + 0x00009400UL)
+
+/*!< APB2 peripherals */
+#define SYSCFG_BASE           (APB2PERIPH_BASE + 0x00000000UL)
+#define COMP1_BASE            (APB2PERIPH_BASE + 0x00000200UL)
+#define ADC1_BASE             (APB2PERIPH_BASE + 0x00002400UL)
+#define ADC1_COMMON_BASE      (APB2PERIPH_BASE + 0x00002700UL)
+
+#define TIM1_BASE             (APB2PERIPH_BASE + 0x00002C00UL)
+#define SPI1_BASE             (APB2PERIPH_BASE + 0x00003000UL)
+#define USART1_BASE           (APB2PERIPH_BASE + 0x00003800UL)
+
+/*!< AHB1 peripherals */
+#define DMA1_BASE                (AHB1PERIPH_BASE + 0x00000000UL)
+#define DMAMUX1_BASE             (AHB1PERIPH_BASE + 0x00000800UL)
+#define CRC_BASE                 (AHB1PERIPH_BASE + 0x00003000UL)
+#define TSC_BASE                 (AHB1PERIPH_BASE + 0x00004000UL)
+
+#define DMA1_Channel1_BASE       (DMA1_BASE + 0x00000008UL)
+#define DMA1_Channel2_BASE       (DMA1_BASE + 0x0000001CUL)
+#define DMA1_Channel3_BASE       (DMA1_BASE + 0x00000030UL)
+#define DMA1_Channel4_BASE       (DMA1_BASE + 0x00000044UL)
+#define DMA1_Channel5_BASE       (DMA1_BASE + 0x00000058UL)
+#define DMA1_Channel6_BASE       (DMA1_BASE + 0x0000006CUL)
+#define DMA1_Channel7_BASE       (DMA1_BASE + 0x00000080UL)
+
+#define DMAMUX1_Channel0_BASE    (DMAMUX1_BASE)
+#define DMAMUX1_Channel1_BASE    (DMAMUX1_BASE + 0x00000004UL)
+#define DMAMUX1_Channel2_BASE    (DMAMUX1_BASE + 0x00000008UL)
+#define DMAMUX1_Channel3_BASE    (DMAMUX1_BASE + 0x0000000CUL)
+#define DMAMUX1_Channel4_BASE    (DMAMUX1_BASE + 0x00000010UL)
+#define DMAMUX1_Channel5_BASE    (DMAMUX1_BASE + 0x00000014UL)
+#define DMAMUX1_Channel6_BASE    (DMAMUX1_BASE + 0x00000018UL)
+
+#define DMAMUX1_RequestGenerator0_BASE  (DMAMUX1_BASE + 0x00000100UL)
+#define DMAMUX1_RequestGenerator1_BASE  (DMAMUX1_BASE + 0x00000104UL)
+#define DMAMUX1_RequestGenerator2_BASE  (DMAMUX1_BASE + 0x00000108UL)
+#define DMAMUX1_RequestGenerator3_BASE  (DMAMUX1_BASE + 0x0000010CUL)
+
+#define DMAMUX1_ChannelStatus_BASE      (DMAMUX1_BASE + 0x00000080UL)
+#define DMAMUX1_RequestGenStatus_BASE   (DMAMUX1_BASE + 0x00000140UL)
+
+/*!< AHB2 peripherals */
+#define IOPORT_BASE         (AHB2PERIPH_BASE + 0x00000000UL)
+#define GPIOA_BASE          (IOPORT_BASE + 0x00000000UL)
+#define GPIOB_BASE          (IOPORT_BASE + 0x00000400UL)
+#define GPIOC_BASE          (IOPORT_BASE + 0x00000800UL)
+#define GPIOE_BASE          (IOPORT_BASE + 0x00001000UL)
+#define GPIOH_BASE          (IOPORT_BASE + 0x00001C00UL)
+
+/*!< AHB Shared peripherals */
+#define RCC_BASE              (AHB4PERIPH_BASE + 0x00000000UL)
+#define PWR_BASE              (AHB4PERIPH_BASE + 0x00000400UL)
+#define EXTI_BASE             (AHB4PERIPH_BASE + 0x00000800UL)
+#define IPCC_BASE             (AHB4PERIPH_BASE + 0x00000C00UL)
+#define RNG_BASE              (AHB4PERIPH_BASE + 0x00001000UL)
+#define HSEM_BASE             (AHB4PERIPH_BASE + 0x00001400UL)
+#define AES2_BASE             (AHB4PERIPH_BASE + 0x00001800UL)
+#define PKA_BASE              (AHB4PERIPH_BASE + 0x00002000UL)
+#define FLASH_REG_BASE        (AHB4PERIPH_BASE + 0x00004000UL)
+
+/* Debug MCU registers base address */
+#define DBGMCU_BASE           (0xE0042000UL)
+
+
+/*!< AHB3 peripherals */
+
+/*!< Device Electronic Signature */
+#define PACKAGE_BASE          ((uint32_t)0x1FFF7500UL)       /*!< Package data register base address     */
+#define UID64_BASE            ((uint32_t)0x1FFF7580UL)       /*!< 64-bit Unique device Identification    */
+#define UID_BASE              ((uint32_t)0x1FFF7590UL)       /*!< Unique device ID register base address */
+#define FLASHSIZE_BASE        ((uint32_t)0x1FFF75E0UL)       /*!< Flash size data register base address  */
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_declaration
+  * @{
+  */
+
+/* Peripherals available on APB1 bus */
+#define TIM2                ((TIM_TypeDef *) TIM2_BASE)
+#define RTC                 ((RTC_TypeDef *) RTC_BASE)
+#define WWDG                ((WWDG_TypeDef *) WWDG_BASE)
+#define IWDG                ((IWDG_TypeDef *) IWDG_BASE)
+#define I2C1                ((I2C_TypeDef *) I2C1_BASE)
+#define LPTIM1              ((LPTIM_TypeDef *) LPTIM1_BASE)
+#define LPUART1             ((USART_TypeDef *) LPUART1_BASE)
+#define LPTIM2              ((LPTIM_TypeDef *) LPTIM2_BASE)
+
+/* Peripherals available on APB2 bus */
+#define SYSCFG              ((SYSCFG_TypeDef *) SYSCFG_BASE)
+#define COMP1               ((COMP_TypeDef *) COMP1_BASE)
+#define COMP1_COMMON        ((COMP_Common_TypeDef *) COMP1_BASE)
+#define TIM1                ((TIM_TypeDef *) TIM1_BASE)
+#define SPI1                ((SPI_TypeDef *) SPI1_BASE)
+#define USART1              ((USART_TypeDef *) USART1_BASE)
+
+/* Peripherals available on AHB1 bus */
+#define DMA1                ((DMA_TypeDef *) DMA1_BASE)
+#define DMA1_Channel1       ((DMA_Channel_TypeDef *) DMA1_Channel1_BASE)
+#define DMA1_Channel2       ((DMA_Channel_TypeDef *) DMA1_Channel2_BASE)
+#define DMA1_Channel3       ((DMA_Channel_TypeDef *) DMA1_Channel3_BASE)
+#define DMA1_Channel4       ((DMA_Channel_TypeDef *) DMA1_Channel4_BASE)
+#define DMA1_Channel5       ((DMA_Channel_TypeDef *) DMA1_Channel5_BASE)
+#define DMA1_Channel6       ((DMA_Channel_TypeDef *) DMA1_Channel6_BASE)
+#define DMA1_Channel7       ((DMA_Channel_TypeDef *) DMA1_Channel7_BASE)
+
+#define DMAMUX1             ((DMAMUX_Channel_TypeDef *) DMAMUX1_BASE)
+#define DMAMUX1_Channel0    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel0_BASE)
+#define DMAMUX1_Channel1    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel1_BASE)
+#define DMAMUX1_Channel2    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel2_BASE)
+#define DMAMUX1_Channel3    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel3_BASE)
+#define DMAMUX1_Channel4    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel4_BASE)
+#define DMAMUX1_Channel5    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel5_BASE)
+#define DMAMUX1_Channel6    ((DMAMUX_Channel_TypeDef *) DMAMUX1_Channel6_BASE)
+
+#define DMAMUX1_RequestGenerator0  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator0_BASE)
+#define DMAMUX1_RequestGenerator1  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator1_BASE)
+#define DMAMUX1_RequestGenerator2  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator2_BASE)
+#define DMAMUX1_RequestGenerator3  ((DMAMUX_RequestGen_TypeDef *) DMAMUX1_RequestGenerator3_BASE)
+
+#define DMAMUX1_ChannelStatus      ((DMAMUX_ChannelStatus_TypeDef *) DMAMUX1_ChannelStatus_BASE)
+#define DMAMUX1_RequestGenStatus   ((DMAMUX_RequestGenStatus_TypeDef *) DMAMUX1_RequestGenStatus_BASE)
+
+#define CRC                 ((CRC_TypeDef *) CRC_BASE)
+#define TSC                 ((TSC_TypeDef *) TSC_BASE)
+
+/* Peripherals available on AHB2 bus */
+#define GPIOA               ((GPIO_TypeDef *) GPIOA_BASE)
+#define GPIOB               ((GPIO_TypeDef *) GPIOB_BASE)
+#define GPIOC               ((GPIO_TypeDef *) GPIOC_BASE)
+#define GPIOE               ((GPIO_TypeDef *) GPIOE_BASE)
+#define GPIOH               ((GPIO_TypeDef *) GPIOH_BASE)
+
+#define ADC1                ((ADC_TypeDef *) ADC1_BASE)
+#define ADC1_COMMON         ((ADC_Common_TypeDef *) ADC1_COMMON_BASE)
+
+
+/* Peripherals available on AHB shared bus */
+#define RCC                 ((RCC_TypeDef *) RCC_BASE)
+#define PWR                 ((PWR_TypeDef *) PWR_BASE)
+#define EXTI                ((EXTI_TypeDef *) EXTI_BASE)
+#define IPCC                ((IPCC_TypeDef *) IPCC_BASE)
+#define IPCC_C1             ((IPCC_CommonTypeDef *) IPCC_BASE)
+#define IPCC_C2             ((IPCC_CommonTypeDef *) (IPCC_BASE + 0x10U))
+#define RNG                 ((RNG_TypeDef *) RNG_BASE)
+#define HSEM                ((HSEM_TypeDef *) HSEM_BASE)
+#define HSEM_COMMON         ((HSEM_Common_TypeDef *) (HSEM_BASE + 0x100U))
+#define AES2                ((AES_TypeDef *) AES2_BASE)
+#define PKA                 ((PKA_TypeDef *) PKA_BASE)
+#define FLASH               ((FLASH_TypeDef *) FLASH_REG_BASE)
+
+/* Peripherals available on AHB3 bus */
+
+#define DBGMCU              ((DBGMCU_TypeDef *) DBGMCU_BASE)
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_constants
+  * @{
+  */
+
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Peripheral_Registers_Bits_Definition
+  * @{
+  */
+
+/******************************************************************************/
+/*                         Peripheral Registers Bits Definition               */
+/******************************************************************************/
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog to Digital Converter (ADC)                     */
+/*                                                                            */
+/******************************************************************************/
+
+#define ADC_SUPPORT_2_5_MSPS /* ADC sampling rate 2.5 Msamples/sec */
+
+/********************  Bit definition for ADC_ISR register  *******************/
+#define ADC_ISR_ADRDY_Pos              (0U)
+#define ADC_ISR_ADRDY_Msk              (0x1UL << ADC_ISR_ADRDY_Pos)            /*!< 0x00000001 */
+#define ADC_ISR_ADRDY                  ADC_ISR_ADRDY_Msk                       /*!< ADC ready flag */
+#define ADC_ISR_EOSMP_Pos              (1U)
+#define ADC_ISR_EOSMP_Msk              (0x1UL << ADC_ISR_EOSMP_Pos)            /*!< 0x00000002 */
+#define ADC_ISR_EOSMP                  ADC_ISR_EOSMP_Msk                       /*!< ADC group regular end of sampling flag */
+#define ADC_ISR_EOC_Pos                (2U)
+#define ADC_ISR_EOC_Msk                (0x1UL << ADC_ISR_EOC_Pos)              /*!< 0x00000004 */
+#define ADC_ISR_EOC                    ADC_ISR_EOC_Msk                         /*!< ADC group regular end of unitary conversion flag */
+#define ADC_ISR_EOS_Pos                (3U)
+#define ADC_ISR_EOS_Msk                (0x1UL << ADC_ISR_EOS_Pos)              /*!< 0x00000008 */
+#define ADC_ISR_EOS                    ADC_ISR_EOS_Msk                         /*!< ADC group regular end of sequence conversions flag */
+#define ADC_ISR_OVR_Pos                (4U)
+#define ADC_ISR_OVR_Msk                (0x1UL << ADC_ISR_OVR_Pos)              /*!< 0x00000010 */
+#define ADC_ISR_OVR                    ADC_ISR_OVR_Msk                         /*!< ADC group regular overrun flag */
+#define ADC_ISR_AWD1_Pos               (7U)
+#define ADC_ISR_AWD1_Msk               (0x1UL << ADC_ISR_AWD1_Pos)             /*!< 0x00000080 */
+#define ADC_ISR_AWD1                   ADC_ISR_AWD1_Msk                        /*!< ADC analog watchdog 1 flag */
+#define ADC_ISR_AWD2_Pos               (8U)
+#define ADC_ISR_AWD2_Msk               (0x1UL << ADC_ISR_AWD2_Pos)             /*!< 0x00000100 */
+#define ADC_ISR_AWD2                   ADC_ISR_AWD2_Msk                        /*!< ADC analog watchdog 2 flag */
+#define ADC_ISR_AWD3_Pos               (9U)
+#define ADC_ISR_AWD3_Msk               (0x1UL << ADC_ISR_AWD3_Pos)             /*!< 0x00000200 */
+#define ADC_ISR_AWD3                   ADC_ISR_AWD3_Msk                        /*!< ADC analog watchdog 3 flag */
+#define ADC_ISR_EOCAL_Pos              (11U)
+#define ADC_ISR_EOCAL_Msk              (0x1UL << ADC_ISR_EOCAL_Pos)            /*!< 0x00000800 */
+#define ADC_ISR_EOCAL                  ADC_ISR_EOCAL_Msk                       /*!< ADC end of calibration flag */
+#define ADC_ISR_CCRDY_Pos              (13U)
+#define ADC_ISR_CCRDY_Msk              (0x1UL << ADC_ISR_CCRDY_Pos)            /*!< 0x00002000 */
+#define ADC_ISR_CCRDY                  ADC_ISR_CCRDY_Msk                       /*!< ADC channel configuration ready flag */
+
+/********************  Bit definition for ADC_IER register  *******************/
+#define ADC_IER_ADRDYIE_Pos            (0U)
+#define ADC_IER_ADRDYIE_Msk            (0x1UL << ADC_IER_ADRDYIE_Pos)          /*!< 0x00000001 */
+#define ADC_IER_ADRDYIE                ADC_IER_ADRDYIE_Msk                     /*!< ADC ready interrupt */
+#define ADC_IER_EOSMPIE_Pos            (1U)
+#define ADC_IER_EOSMPIE_Msk            (0x1UL << ADC_IER_EOSMPIE_Pos)          /*!< 0x00000002 */
+#define ADC_IER_EOSMPIE                ADC_IER_EOSMPIE_Msk                     /*!< ADC group regular end of sampling interrupt */
+#define ADC_IER_EOCIE_Pos              (2U)
+#define ADC_IER_EOCIE_Msk              (0x1UL << ADC_IER_EOCIE_Pos)            /*!< 0x00000004 */
+#define ADC_IER_EOCIE                  ADC_IER_EOCIE_Msk                       /*!< ADC group regular end of unitary conversion interrupt */
+#define ADC_IER_EOSIE_Pos              (3U)
+#define ADC_IER_EOSIE_Msk              (0x1UL << ADC_IER_EOSIE_Pos)            /*!< 0x00000008 */
+#define ADC_IER_EOSIE                  ADC_IER_EOSIE_Msk                       /*!< ADC group regular end of sequence conversions interrupt */
+#define ADC_IER_OVRIE_Pos              (4U)
+#define ADC_IER_OVRIE_Msk              (0x1UL << ADC_IER_OVRIE_Pos)            /*!< 0x00000010 */
+#define ADC_IER_OVRIE                  ADC_IER_OVRIE_Msk                       /*!< ADC group regular overrun interrupt */
+#define ADC_IER_AWD1IE_Pos             (7U)
+#define ADC_IER_AWD1IE_Msk             (0x1UL << ADC_IER_AWD1IE_Pos)           /*!< 0x00000080 */
+#define ADC_IER_AWD1IE                 ADC_IER_AWD1IE_Msk                      /*!< ADC analog watchdog 1 interrupt */
+#define ADC_IER_AWD2IE_Pos             (8U)
+#define ADC_IER_AWD2IE_Msk             (0x1UL << ADC_IER_AWD2IE_Pos)           /*!< 0x00000100 */
+#define ADC_IER_AWD2IE                 ADC_IER_AWD2IE_Msk                      /*!< ADC analog watchdog 2 interrupt */
+#define ADC_IER_AWD3IE_Pos             (9U)
+#define ADC_IER_AWD3IE_Msk             (0x1UL << ADC_IER_AWD3IE_Pos)           /*!< 0x00000200 */
+#define ADC_IER_AWD3IE                 ADC_IER_AWD3IE_Msk                      /*!< ADC analog watchdog 3 interrupt */
+#define ADC_IER_EOCALIE_Pos            (11U)
+#define ADC_IER_EOCALIE_Msk            (0x1UL << ADC_IER_EOCALIE_Pos)          /*!< 0x00000800 */
+#define ADC_IER_EOCALIE                ADC_IER_EOCALIE_Msk                     /*!< ADC end of calibration interrupt */
+#define ADC_IER_CCRDYIE_Pos            (13U)
+#define ADC_IER_CCRDYIE_Msk            (0x1UL << ADC_IER_CCRDYIE_Pos)          /*!< 0x00002000 */
+#define ADC_IER_CCRDYIE                ADC_IER_CCRDYIE_Msk                     /*!< ADC channel configuration ready interrupt */
+
+/********************  Bit definition for ADC_CR register  ********************/
+#define ADC_CR_ADEN_Pos                (0U)
+#define ADC_CR_ADEN_Msk                (0x1UL << ADC_CR_ADEN_Pos)              /*!< 0x00000001 */
+#define ADC_CR_ADEN                    ADC_CR_ADEN_Msk                         /*!< ADC enable */
+#define ADC_CR_ADDIS_Pos               (1U)
+#define ADC_CR_ADDIS_Msk               (0x1UL << ADC_CR_ADDIS_Pos)             /*!< 0x00000002 */
+#define ADC_CR_ADDIS                   ADC_CR_ADDIS_Msk                        /*!< ADC disable */
+#define ADC_CR_ADSTART_Pos             (2U)
+#define ADC_CR_ADSTART_Msk             (0x1UL << ADC_CR_ADSTART_Pos)           /*!< 0x00000004 */
+#define ADC_CR_ADSTART                 ADC_CR_ADSTART_Msk                      /*!< ADC group regular conversion start */
+#define ADC_CR_ADSTP_Pos               (4U)
+#define ADC_CR_ADSTP_Msk               (0x1UL << ADC_CR_ADSTP_Pos)             /*!< 0x00000010 */
+#define ADC_CR_ADSTP                   ADC_CR_ADSTP_Msk                        /*!< ADC group regular conversion stop */
+#define ADC_CR_ADVREGEN_Pos            (28U)
+#define ADC_CR_ADVREGEN_Msk            (0x1UL << ADC_CR_ADVREGEN_Pos)          /*!< 0x10000000 */
+#define ADC_CR_ADVREGEN                ADC_CR_ADVREGEN_Msk                     /*!< ADC voltage regulator enable */
+#define ADC_CR_ADCAL_Pos               (31U)
+#define ADC_CR_ADCAL_Msk               (0x1UL << ADC_CR_ADCAL_Pos)             /*!< 0x80000000 */
+#define ADC_CR_ADCAL                   ADC_CR_ADCAL_Msk                        /*!< ADC calibration */
+
+/********************  Bit definition for ADC_CFGR1 register  *****************/
+#define ADC_CFGR1_DMAEN_Pos            (0U)
+#define ADC_CFGR1_DMAEN_Msk            (0x1UL << ADC_CFGR1_DMAEN_Pos)          /*!< 0x00000001 */
+#define ADC_CFGR1_DMAEN                ADC_CFGR1_DMAEN_Msk                     /*!< ADC DMA transfer enable */
+#define ADC_CFGR1_DMACFG_Pos           (1U)
+#define ADC_CFGR1_DMACFG_Msk           (0x1UL << ADC_CFGR1_DMACFG_Pos)         /*!< 0x00000002 */
+#define ADC_CFGR1_DMACFG               ADC_CFGR1_DMACFG_Msk                    /*!< ADC DMA transfer configuration */
+
+#define ADC_CFGR1_SCANDIR_Pos          (2U)
+#define ADC_CFGR1_SCANDIR_Msk          (0x1UL << ADC_CFGR1_SCANDIR_Pos)        /*!< 0x00000004 */
+#define ADC_CFGR1_SCANDIR              ADC_CFGR1_SCANDIR_Msk                   /*!< ADC group regular sequencer scan direction */
+
+#define ADC_CFGR1_RES_Pos              (3U)
+#define ADC_CFGR1_RES_Msk              (0x3UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000018 */
+#define ADC_CFGR1_RES                  ADC_CFGR1_RES_Msk                       /*!< ADC data resolution */
+#define ADC_CFGR1_RES_0                (0x1UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000008 */
+#define ADC_CFGR1_RES_1                (0x2UL << ADC_CFGR1_RES_Pos)            /*!< 0x00000010 */
+
+#define ADC_CFGR1_ALIGN_Pos            (5U)
+#define ADC_CFGR1_ALIGN_Msk            (0x1UL << ADC_CFGR1_ALIGN_Pos)          /*!< 0x00000020 */
+#define ADC_CFGR1_ALIGN                ADC_CFGR1_ALIGN_Msk                     /*!< ADC data alignment */
+
+#define ADC_CFGR1_EXTSEL_Pos           (6U)
+#define ADC_CFGR1_EXTSEL_Msk           (0x7UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x000001C0 */
+#define ADC_CFGR1_EXTSEL               ADC_CFGR1_EXTSEL_Msk                    /*!< ADC group regular external trigger source */
+#define ADC_CFGR1_EXTSEL_0             (0x1UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000040 */
+#define ADC_CFGR1_EXTSEL_1             (0x2UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000080 */
+#define ADC_CFGR1_EXTSEL_2             (0x4UL << ADC_CFGR1_EXTSEL_Pos)         /*!< 0x00000100 */
+
+#define ADC_CFGR1_EXTEN_Pos            (10U)
+#define ADC_CFGR1_EXTEN_Msk            (0x3UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000C00 */
+#define ADC_CFGR1_EXTEN                ADC_CFGR1_EXTEN_Msk                     /*!< ADC group regular external trigger polarity */
+#define ADC_CFGR1_EXTEN_0              (0x1UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000400 */
+#define ADC_CFGR1_EXTEN_1              (0x2UL << ADC_CFGR1_EXTEN_Pos)          /*!< 0x00000800 */
+
+#define ADC_CFGR1_OVRMOD_Pos           (12U)
+#define ADC_CFGR1_OVRMOD_Msk           (0x1UL << ADC_CFGR1_OVRMOD_Pos)         /*!< 0x00001000 */
+#define ADC_CFGR1_OVRMOD               ADC_CFGR1_OVRMOD_Msk                    /*!< ADC group regular overrun configuration */
+#define ADC_CFGR1_CONT_Pos             (13U)
+#define ADC_CFGR1_CONT_Msk             (0x1UL << ADC_CFGR1_CONT_Pos)           /*!< 0x00002000 */
+#define ADC_CFGR1_CONT                 ADC_CFGR1_CONT_Msk                      /*!< ADC group regular continuous conversion mode */
+#define ADC_CFGR1_WAIT_Pos             (14U)
+#define ADC_CFGR1_WAIT_Msk             (0x1UL << ADC_CFGR1_WAIT_Pos)           /*!< 0x00004000 */
+#define ADC_CFGR1_WAIT                 ADC_CFGR1_WAIT_Msk                      /*!< ADC low power auto wait */
+#define ADC_CFGR1_AUTOFF_Pos           (15U)
+#define ADC_CFGR1_AUTOFF_Msk           (0x1UL << ADC_CFGR1_AUTOFF_Pos)         /*!< 0x00008000 */
+#define ADC_CFGR1_AUTOFF               ADC_CFGR1_AUTOFF_Msk                    /*!< ADC low power auto power off */
+#define ADC_CFGR1_DISCEN_Pos           (16U)
+#define ADC_CFGR1_DISCEN_Msk           (0x1UL << ADC_CFGR1_DISCEN_Pos)         /*!< 0x00010000 */
+#define ADC_CFGR1_DISCEN               ADC_CFGR1_DISCEN_Msk                    /*!< ADC group regular sequencer discontinuous mode */
+#define ADC_CFGR1_CHSELRMOD_Pos        (21U)
+#define ADC_CFGR1_CHSELRMOD_Msk        (0x1UL << ADC_CFGR1_CHSELRMOD_Pos)      /*!< 0x00200000 */
+#define ADC_CFGR1_CHSELRMOD            ADC_CFGR1_CHSELRMOD_Msk                 /*!< ADC group regular sequencer mode */
+
+#define ADC_CFGR1_AWD1SGL_Pos          (22U)
+#define ADC_CFGR1_AWD1SGL_Msk          (0x1UL << ADC_CFGR1_AWD1SGL_Pos)        /*!< 0x00400000 */
+#define ADC_CFGR1_AWD1SGL              ADC_CFGR1_AWD1SGL_Msk                   /*!< ADC analog watchdog 1 monitoring a single channel or all channels */
+#define ADC_CFGR1_AWD1EN_Pos           (23U)
+#define ADC_CFGR1_AWD1EN_Msk           (0x1UL << ADC_CFGR1_AWD1EN_Pos)         /*!< 0x00800000 */
+#define ADC_CFGR1_AWD1EN               ADC_CFGR1_AWD1EN_Msk                    /*!< ADC analog watchdog 1 enable on scope ADC group regular */
+
+#define ADC_CFGR1_AWD1CH_Pos           (26U)
+#define ADC_CFGR1_AWD1CH_Msk           (0x1FUL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x7C000000 */
+#define ADC_CFGR1_AWD1CH               ADC_CFGR1_AWD1CH_Msk                    /*!< ADC analog watchdog 1 monitored channel selection */
+#define ADC_CFGR1_AWD1CH_0             (0x01UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x04000000 */
+#define ADC_CFGR1_AWD1CH_1             (0x02UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x08000000 */
+#define ADC_CFGR1_AWD1CH_2             (0x04UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x10000000 */
+#define ADC_CFGR1_AWD1CH_3             (0x08UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x20000000 */
+#define ADC_CFGR1_AWD1CH_4             (0x10UL << ADC_CFGR1_AWD1CH_Pos)        /*!< 0x40000000 */
+
+/* Definitions for cohabitation of ADC peripherals 2.5Ms/sec and 5Ms/sec across STM32WB series */
+#define ADC_CFGR_DMAEN_Pos             ADC_CFGR1_DMAEN_Pos
+#define ADC_CFGR_DMAEN_Msk             ADC_CFGR1_DMAEN_Msk
+#define ADC_CFGR_DMAEN                 ADC_CFGR1_DMAEN
+#define ADC_CFGR_DMACFG_Pos            ADC_CFGR1_DMACFG_Pos
+#define ADC_CFGR_DMACFG_Msk            ADC_CFGR1_DMACFG_Msk
+#define ADC_CFGR_DMACFG                ADC_CFGR1_DMACFG
+
+#define ADC_CFGR_SCANDIR_Pos           ADC_CFGR1_SCANDIR_Pos
+#define ADC_CFGR_SCANDIR_Msk           ADC_CFGR1_SCANDIR_Msk
+#define ADC_CFGR_SCANDIR               ADC_CFGR1_SCANDIR
+
+#define ADC_CFGR_RES_Pos               ADC_CFGR1_RES_Pos
+#define ADC_CFGR_RES_Msk               ADC_CFGR1_RES_Msk
+#define ADC_CFGR_RES                   ADC_CFGR1_RES
+#define ADC_CFGR_RES_0                 ADC_CFGR1_RES_0
+#define ADC_CFGR_RES_1                 ADC_CFGR1_RES_1
+
+#define ADC_CFGR_ALIGN_Pos             ADC_CFGR1_ALIGN_Pos
+#define ADC_CFGR_ALIGN_Msk             ADC_CFGR1_ALIGN_Msk
+#define ADC_CFGR_ALIGN                 ADC_CFGR1_ALIGN
+
+#define ADC_CFGR_EXTSEL_Pos            ADC_CFGR1_EXTSEL_Pos
+#define ADC_CFGR_EXTSEL_Msk            ADC_CFGR1_EXTSEL_Msk
+#define ADC_CFGR_EXTSEL                ADC_CFGR1_EXTSEL
+#define ADC_CFGR_EXTSEL_0              ADC_CFGR1_EXTSEL_0
+#define ADC_CFGR_EXTSEL_1              ADC_CFGR1_EXTSEL_1
+#define ADC_CFGR_EXTSEL_2              ADC_CFGR1_EXTSEL_2
+
+#define ADC_CFGR_EXTEN_Pos             ADC_CFGR1_EXTEN_Pos
+#define ADC_CFGR_EXTEN_Msk             ADC_CFGR1_EXTEN_Msk
+#define ADC_CFGR_EXTEN                 ADC_CFGR1_EXTEN
+#define ADC_CFGR_EXTEN_0               ADC_CFGR1_EXTEN_0
+#define ADC_CFGR_EXTEN_1               ADC_CFGR1_EXTEN_1
+
+#define ADC_CFGR_OVRMOD_Pos            ADC_CFGR1_OVRMOD_Pos
+#define ADC_CFGR_OVRMOD_Msk            ADC_CFGR1_OVRMOD_Msk
+#define ADC_CFGR_OVRMOD                ADC_CFGR1_OVRMOD
+#define ADC_CFGR_CONT_Pos              ADC_CFGR1_CONT_Pos
+#define ADC_CFGR_CONT_Msk              ADC_CFGR1_CONT_Msk
+#define ADC_CFGR_CONT                  ADC_CFGR1_CONT
+#define ADC_CFGR_AUTDLY_Pos            ADC_CFGR1_WAIT_Pos
+#define ADC_CFGR_AUTDLY_Msk            ADC_CFGR1_WAIT_Msk
+#define ADC_CFGR_AUTDLY                ADC_CFGR1_WAIT
+#define ADC_CFGR_AUTOFF_Pos            ADC_CFGR1_AUTOFF_Pos
+#define ADC_CFGR_AUTOFF_Msk            ADC_CFGR1_AUTOFF_Msk
+#define ADC_CFGR_AUTOFF                ADC_CFGR1_AUTOFF
+#define ADC_CFGR_DISCEN_Pos            ADC_CFGR1_DISCEN_Pos
+#define ADC_CFGR_DISCEN_Msk            ADC_CFGR1_DISCEN_Msk
+#define ADC_CFGR_DISCEN                ADC_CFGR1_DISCEN
+#define ADC_CFGR_CHSELRMOD_Pos         ADC_CFGR1_CHSELRMOD_Pos
+#define ADC_CFGR_CHSELRMOD_Msk         ADC_CFGR1_CHSELRMOD_Msk
+#define ADC_CFGR_CHSELRMOD             ADC_CFGR1_CHSELRMOD
+
+#define ADC_CFGR_AWD1SGL_Pos           ADC_CFGR1_AWD1SGL_Pos
+#define ADC_CFGR_AWD1SGL_Msk           ADC_CFGR1_AWD1SGL_Msk
+#define ADC_CFGR_AWD1SGL               ADC_CFGR1_AWD1SGL
+#define ADC_CFGR_AWD1EN_Pos            ADC_CFGR1_AWD1EN_Pos
+#define ADC_CFGR_AWD1EN_Msk            ADC_CFGR1_AWD1EN_Msk
+#define ADC_CFGR_AWD1EN                ADC_CFGR1_AWD1EN
+
+#define ADC_CFGR_AWD1CH_Pos            ADC_CFGR1_AWD1CH_Pos
+#define ADC_CFGR_AWD1CH_Msk            ADC_CFGR1_AWD1CH_Msk
+#define ADC_CFGR_AWD1CH                ADC_CFGR1_AWD1CH
+#define ADC_CFGR_AWD1CH_0              ADC_CFGR1_AWD1CH_0
+#define ADC_CFGR_AWD1CH_1              ADC_CFGR1_AWD1CH_1
+#define ADC_CFGR_AWD1CH_2              ADC_CFGR1_AWD1CH_2
+#define ADC_CFGR_AWD1CH_3              ADC_CFGR1_AWD1CH_3
+#define ADC_CFGR_AWD1CH_4              ADC_CFGR1_AWD1CH_4
+
+/********************  Bit definition for ADC_CFGR2 register  *****************/
+#define ADC_CFGR2_LFTRIG_Pos           (29U)
+#define ADC_CFGR2_LFTRIG_Msk           (0x1UL << ADC_CFGR2_LFTRIG_Pos)         /*!< 0x20000000 */
+#define ADC_CFGR2_LFTRIG               ADC_CFGR2_LFTRIG_Msk                    /*!< ADC low frequency trigger mode */
+
+#define ADC_CFGR2_CKMODE_Pos           (30U)
+#define ADC_CFGR2_CKMODE_Msk           (0x3UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0xC0000000 */
+#define ADC_CFGR2_CKMODE               ADC_CFGR2_CKMODE_Msk                    /*!< ADC clock source and prescaler (prescaler only for clock source synchronous) */
+#define ADC_CFGR2_CKMODE_1             (0x2UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x80000000 */
+#define ADC_CFGR2_CKMODE_0             (0x1UL << ADC_CFGR2_CKMODE_Pos)         /*!< 0x40000000 */
+
+/********************  Bit definition for ADC_SMPR register  ******************/
+#define ADC_SMPR_SMP1_Pos              (0U)
+#define ADC_SMPR_SMP1_Msk              (0x7UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000007 */
+#define ADC_SMPR_SMP1                  ADC_SMPR_SMP1_Msk                       /*!< ADC group of channels sampling time 1 */
+#define ADC_SMPR_SMP1_0                (0x1UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000001 */
+#define ADC_SMPR_SMP1_1                (0x2UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000002 */
+#define ADC_SMPR_SMP1_2                (0x4UL << ADC_SMPR_SMP1_Pos)            /*!< 0x00000004 */
+
+#define ADC_SMPR_SMP2_Pos              (4U)
+#define ADC_SMPR_SMP2_Msk              (0x7UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000070 */
+#define ADC_SMPR_SMP2                  ADC_SMPR_SMP2_Msk                       /*!< ADC group of channels sampling time 2 */
+#define ADC_SMPR_SMP2_0                (0x1UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000010 */
+#define ADC_SMPR_SMP2_1                (0x2UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000020 */
+#define ADC_SMPR_SMP2_2                (0x4UL << ADC_SMPR_SMP2_Pos)            /*!< 0x00000040 */
+
+#define ADC_SMPR_SMPSEL_Pos            (8U)
+#define ADC_SMPR_SMPSEL_Msk            (0x7FFFFUL << ADC_SMPR_SMPSEL_Pos)      /*!< 0x07FFFF00 */
+#define ADC_SMPR_SMPSEL                ADC_SMPR_SMPSEL_Msk                     /*!< ADC all channels sampling time selection */
+#define ADC_SMPR_SMPSEL0_Pos           (8U)
+#define ADC_SMPR_SMPSEL0_Msk           (0x1UL << ADC_SMPR_SMPSEL0_Pos)         /*!< 0x00000100 */
+#define ADC_SMPR_SMPSEL0               ADC_SMPR_SMPSEL0_Msk                    /*!< ADC channel 0 sampling time selection */
+#define ADC_SMPR_SMPSEL1_Pos           (9U)
+#define ADC_SMPR_SMPSEL1_Msk           (0x1UL << ADC_SMPR_SMPSEL1_Pos)         /*!< 0x00000200 */
+#define ADC_SMPR_SMPSEL1               ADC_SMPR_SMPSEL1_Msk                    /*!< ADC channel 1 sampling time selection */
+#define ADC_SMPR_SMPSEL2_Pos           (10U)
+#define ADC_SMPR_SMPSEL2_Msk           (0x1UL << ADC_SMPR_SMPSEL2_Pos)         /*!< 0x00000400 */
+#define ADC_SMPR_SMPSEL2               ADC_SMPR_SMPSEL2_Msk                    /*!< ADC channel 2 sampling time selection */
+#define ADC_SMPR_SMPSEL3_Pos           (11U)
+#define ADC_SMPR_SMPSEL3_Msk           (0x1UL << ADC_SMPR_SMPSEL3_Pos)         /*!< 0x00000800 */
+#define ADC_SMPR_SMPSEL3               ADC_SMPR_SMPSEL3_Msk                    /*!< ADC channel 3 sampling time selection */
+#define ADC_SMPR_SMPSEL4_Pos           (12U)
+#define ADC_SMPR_SMPSEL4_Msk           (0x1UL << ADC_SMPR_SMPSEL4_Pos)         /*!< 0x00001000 */
+#define ADC_SMPR_SMPSEL4               ADC_SMPR_SMPSEL4_Msk                    /*!< ADC channel 4 sampling time selection */
+#define ADC_SMPR_SMPSEL5_Pos           (13U)
+#define ADC_SMPR_SMPSEL5_Msk           (0x1UL << ADC_SMPR_SMPSEL5_Pos)         /*!< 0x00002000 */
+#define ADC_SMPR_SMPSEL5               ADC_SMPR_SMPSEL5_Msk                    /*!< ADC channel 5 sampling time selection */
+#define ADC_SMPR_SMPSEL6_Pos           (14U)
+#define ADC_SMPR_SMPSEL6_Msk           (0x1UL << ADC_SMPR_SMPSEL6_Pos)         /*!< 0x00004000 */
+#define ADC_SMPR_SMPSEL6               ADC_SMPR_SMPSEL6_Msk                    /*!< ADC channel 6 sampling time selection */
+#define ADC_SMPR_SMPSEL7_Pos           (15U)
+#define ADC_SMPR_SMPSEL7_Msk           (0x1UL << ADC_SMPR_SMPSEL7_Pos)         /*!< 0x00008000 */
+#define ADC_SMPR_SMPSEL7               ADC_SMPR_SMPSEL7_Msk                    /*!< ADC channel 7 sampling time selection */
+#define ADC_SMPR_SMPSEL8_Pos           (16U)
+#define ADC_SMPR_SMPSEL8_Msk           (0x1UL << ADC_SMPR_SMPSEL8_Pos)         /*!< 0x00010000 */
+#define ADC_SMPR_SMPSEL8               ADC_SMPR_SMPSEL8_Msk                    /*!< ADC channel 8 sampling time selection */
+#define ADC_SMPR_SMPSEL9_Pos           (17U)
+#define ADC_SMPR_SMPSEL9_Msk           (0x1UL << ADC_SMPR_SMPSEL9_Pos)         /*!< 0x00020000 */
+#define ADC_SMPR_SMPSEL9               ADC_SMPR_SMPSEL9_Msk                    /*!< ADC channel 9 sampling time selection */
+#define ADC_SMPR_SMPSEL10_Pos          (18U)
+#define ADC_SMPR_SMPSEL10_Msk          (0x1UL << ADC_SMPR_SMPSEL10_Pos)        /*!< 0x00040000 */
+#define ADC_SMPR_SMPSEL10              ADC_SMPR_SMPSEL10_Msk                   /*!< ADC channel 10 sampling time selection */
+#define ADC_SMPR_SMPSEL11_Pos          (19U)
+#define ADC_SMPR_SMPSEL11_Msk          (0x1UL << ADC_SMPR_SMPSEL11_Pos)        /*!< 0x00080000 */
+#define ADC_SMPR_SMPSEL11              ADC_SMPR_SMPSEL11_Msk                   /*!< ADC channel 11 sampling time selection */
+#define ADC_SMPR_SMPSEL12_Pos          (20U)
+#define ADC_SMPR_SMPSEL12_Msk          (0x1UL << ADC_SMPR_SMPSEL12_Pos)        /*!< 0x00100000 */
+#define ADC_SMPR_SMPSEL12              ADC_SMPR_SMPSEL12_Msk                   /*!< ADC channel 12 sampling time selection */
+#define ADC_SMPR_SMPSEL13_Pos          (21U)
+#define ADC_SMPR_SMPSEL13_Msk          (0x1UL << ADC_SMPR_SMPSEL13_Pos)        /*!< 0x00200000 */
+#define ADC_SMPR_SMPSEL13              ADC_SMPR_SMPSEL13_Msk                   /*!< ADC channel 13 sampling time selection */
+#define ADC_SMPR_SMPSEL14_Pos          (22U)
+#define ADC_SMPR_SMPSEL14_Msk          (0x1UL << ADC_SMPR_SMPSEL14_Pos)        /*!< 0x00400000 */
+#define ADC_SMPR_SMPSEL14              ADC_SMPR_SMPSEL14_Msk                   /*!< ADC channel 14 sampling time selection */
+#define ADC_SMPR_SMPSEL15_Pos          (23U)
+#define ADC_SMPR_SMPSEL15_Msk          (0x1UL << ADC_SMPR_SMPSEL15_Pos)        /*!< 0x00800000 */
+#define ADC_SMPR_SMPSEL15              ADC_SMPR_SMPSEL15_Msk                   /*!< ADC channel 15 sampling time selection */
+#define ADC_SMPR_SMPSEL16_Pos          (24U)
+#define ADC_SMPR_SMPSEL16_Msk          (0x1UL << ADC_SMPR_SMPSEL16_Pos)        /*!< 0x01000000 */
+#define ADC_SMPR_SMPSEL16              ADC_SMPR_SMPSEL16_Msk                   /*!< ADC channel 16 sampling time selection */
+#define ADC_SMPR_SMPSEL17_Pos          (25U)
+#define ADC_SMPR_SMPSEL17_Msk          (0x1UL << ADC_SMPR_SMPSEL17_Pos)        /*!< 0x02000000 */
+#define ADC_SMPR_SMPSEL17              ADC_SMPR_SMPSEL17_Msk                   /*!< ADC channel 17 sampling time selection */
+#define ADC_SMPR_SMPSEL18_Pos          (25U)
+#define ADC_SMPR_SMPSEL18_Msk          (0x1UL << ADC_SMPR_SMPSEL18_Pos)        /*!< 0x04000000 */
+#define ADC_SMPR_SMPSEL18              ADC_SMPR_SMPSEL18_Msk                   /*!< ADC channel 18 sampling time selection */
+
+/********************  Bit definition for ADC_TR register  *******************/
+#define ADC_TR_LT_Pos             (0U)
+#define ADC_TR_LT_Msk             (0xFFFUL << ADC_TR_LT_Pos)         /*!< 0x00000FFF */
+#define ADC_TR_LT                 ADC_TR_LT_Msk                      /*!< ADC analog watchdog 1 threshold low */
+#define ADC_TR_LT_0               (0x001UL << ADC_TR_LT_Pos)         /*!< 0x00000001 */
+#define ADC_TR_LT_1               (0x002UL << ADC_TR_LT_Pos)         /*!< 0x00000002 */
+#define ADC_TR_LT_2               (0x004UL << ADC_TR_LT_Pos)         /*!< 0x00000004 */
+#define ADC_TR_LT_3               (0x008UL << ADC_TR_LT_Pos)         /*!< 0x00000008 */
+#define ADC_TR_LT_4               (0x010UL << ADC_TR_LT_Pos)         /*!< 0x00000010 */
+#define ADC_TR_LT_5               (0x020UL << ADC_TR_LT_Pos)         /*!< 0x00000020 */
+#define ADC_TR_LT_6               (0x040UL << ADC_TR_LT_Pos)         /*!< 0x00000040 */
+#define ADC_TR_LT_7               (0x080UL << ADC_TR_LT_Pos)         /*!< 0x00000080 */
+#define ADC_TR_LT_8               (0x100UL << ADC_TR_LT_Pos)         /*!< 0x00000100 */
+#define ADC_TR_LT_9               (0x200UL << ADC_TR_LT_Pos)         /*!< 0x00000200 */
+#define ADC_TR_LT_10              (0x400UL << ADC_TR_LT_Pos)         /*!< 0x00000400 */
+#define ADC_TR_LT_11              (0x800UL << ADC_TR_LT_Pos)         /*!< 0x00000800 */
+
+#define ADC_TR_HT_Pos             (16U)
+#define ADC_TR_HT_Msk             (0xFFFUL << ADC_TR_HT_Pos)         /*!< 0x0FFF0000 */
+#define ADC_TR_HT                 ADC_TR_HT_Msk                      /*!< ADC Analog watchdog 1 threshold high */
+#define ADC_TR_HT_0               (0x001UL << ADC_TR_HT_Pos)         /*!< 0x00010000 */
+#define ADC_TR_HT_1               (0x002UL << ADC_TR_HT_Pos)         /*!< 0x00020000 */
+#define ADC_TR_HT_2               (0x004UL << ADC_TR_HT_Pos)         /*!< 0x00040000 */
+#define ADC_TR_HT_3               (0x008UL << ADC_TR_HT_Pos)         /*!< 0x00080000 */
+#define ADC_TR_HT_4               (0x010UL << ADC_TR_HT_Pos)         /*!< 0x00100000 */
+#define ADC_TR_HT_5               (0x020UL << ADC_TR_HT_Pos)         /*!< 0x00200000 */
+#define ADC_TR_HT_6               (0x040UL << ADC_TR_HT_Pos)         /*!< 0x00400000 */
+#define ADC_TR_HT_7               (0x080UL << ADC_TR_HT_Pos)         /*!< 0x00800000 */
+#define ADC_TR_HT_8               (0x100UL << ADC_TR_HT_Pos)         /*!< 0x01000000 */
+#define ADC_TR_HT_9               (0x200UL << ADC_TR_HT_Pos)         /*!< 0x02000000 */
+#define ADC_TR_HT_10              (0x400UL << ADC_TR_HT_Pos)         /*!< 0x04000000 */
+#define ADC_TR_HT_11              (0x800UL << ADC_TR_HT_Pos)         /*!< 0x08000000 */
+
+/* Legacy definitions */
+#define ADC_TR1_LT1             ADC_TR_LT
+#define ADC_TR1_LT1_0           ADC_TR_LT_0
+#define ADC_TR1_LT1_1           ADC_TR_LT_1
+#define ADC_TR1_LT1_2           ADC_TR_LT_2
+#define ADC_TR1_LT1_3           ADC_TR_LT_3
+#define ADC_TR1_LT1_4           ADC_TR_LT_4
+#define ADC_TR1_LT1_5           ADC_TR_LT_5
+#define ADC_TR1_LT1_6           ADC_TR_LT_6
+#define ADC_TR1_LT1_7           ADC_TR_LT_7
+#define ADC_TR1_LT1_8           ADC_TR_LT_8
+#define ADC_TR1_LT1_9           ADC_TR_LT_9
+#define ADC_TR1_LT1_10          ADC_TR_LT_10
+#define ADC_TR1_LT1_11          ADC_TR_LT_11
+
+#define ADC_TR1_HT1             ADC_TR_HT
+#define ADC_TR1_HT1_0           ADC_TR_HT_0
+#define ADC_TR1_HT1_1           ADC_TR_HT_1
+#define ADC_TR1_HT1_2           ADC_TR_HT_2
+#define ADC_TR1_HT1_3           ADC_TR_HT_3
+#define ADC_TR1_HT1_4           ADC_TR_HT_4
+#define ADC_TR1_HT1_5           ADC_TR_HT_5
+#define ADC_TR1_HT1_6           ADC_TR_HT_6
+#define ADC_TR1_HT1_7           ADC_TR_HT_7
+#define ADC_TR1_HT1_8           ADC_TR_HT_8
+#define ADC_TR1_HT1_9           ADC_TR_HT_9
+#define ADC_TR1_HT1_10          ADC_TR_HT_10
+#define ADC_TR1_HT1_11          ADC_TR_HT_11
+
+/********************  Bit definition for ADC_CHSELR register  ****************/
+#define ADC_CHSELR_CHSEL_Pos           (0U)
+#define ADC_CHSELR_CHSEL_Msk           (0x7FFFFUL << ADC_CHSELR_CHSEL_Pos)     /*!< 0x0007FFFF */
+#define ADC_CHSELR_CHSEL               ADC_CHSELR_CHSEL_Msk                    /*!< ADC group regular sequencer channels, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL18_Pos         (18U)
+#define ADC_CHSELR_CHSEL18_Msk         (0x1UL << ADC_CHSELR_CHSEL18_Pos)       /*!< 0x00040000 */
+#define ADC_CHSELR_CHSEL18             ADC_CHSELR_CHSEL18_Msk                  /*!< ADC group regular sequencer channel 18, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL17_Pos         (17U)
+#define ADC_CHSELR_CHSEL17_Msk         (0x1UL << ADC_CHSELR_CHSEL17_Pos)       /*!< 0x00020000 */
+#define ADC_CHSELR_CHSEL17             ADC_CHSELR_CHSEL17_Msk                  /*!< ADC group regular sequencer channel 17, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL16_Pos         (16U)
+#define ADC_CHSELR_CHSEL16_Msk         (0x1UL << ADC_CHSELR_CHSEL16_Pos)       /*!< 0x00010000 */
+#define ADC_CHSELR_CHSEL16             ADC_CHSELR_CHSEL16_Msk                  /*!< ADC group regular sequencer channel 16, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL15_Pos         (15U)
+#define ADC_CHSELR_CHSEL15_Msk         (0x1UL << ADC_CHSELR_CHSEL15_Pos)       /*!< 0x00008000 */
+#define ADC_CHSELR_CHSEL15             ADC_CHSELR_CHSEL15_Msk                  /*!< ADC group regular sequencer channel 15, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL14_Pos         (14U)
+#define ADC_CHSELR_CHSEL14_Msk         (0x1UL << ADC_CHSELR_CHSEL14_Pos)       /*!< 0x00004000 */
+#define ADC_CHSELR_CHSEL14             ADC_CHSELR_CHSEL14_Msk                  /*!< ADC group regular sequencer channel 14, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL13_Pos         (13U)
+#define ADC_CHSELR_CHSEL13_Msk         (0x1UL << ADC_CHSELR_CHSEL13_Pos)       /*!< 0x00002000 */
+#define ADC_CHSELR_CHSEL13             ADC_CHSELR_CHSEL13_Msk                  /*!< ADC group regular sequencer channel 13, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL12_Pos         (12U)
+#define ADC_CHSELR_CHSEL12_Msk         (0x1UL << ADC_CHSELR_CHSEL12_Pos)       /*!< 0x00001000 */
+#define ADC_CHSELR_CHSEL12             ADC_CHSELR_CHSEL12_Msk                  /*!< ADC group regular sequencer channel 12, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL11_Pos         (11U)
+#define ADC_CHSELR_CHSEL11_Msk         (0x1UL << ADC_CHSELR_CHSEL11_Pos)       /*!< 0x00000800 */
+#define ADC_CHSELR_CHSEL11             ADC_CHSELR_CHSEL11_Msk                  /*!< ADC group regular sequencer channel 11, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL10_Pos         (10U)
+#define ADC_CHSELR_CHSEL10_Msk         (0x1UL << ADC_CHSELR_CHSEL10_Pos)       /*!< 0x00000400 */
+#define ADC_CHSELR_CHSEL10             ADC_CHSELR_CHSEL10_Msk                  /*!< ADC group regular sequencer channel 10, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL9_Pos          (9U)
+#define ADC_CHSELR_CHSEL9_Msk          (0x1UL << ADC_CHSELR_CHSEL9_Pos)        /*!< 0x00000200 */
+#define ADC_CHSELR_CHSEL9              ADC_CHSELR_CHSEL9_Msk                   /*!< ADC group regular sequencer channel 9, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL8_Pos          (8U)
+#define ADC_CHSELR_CHSEL8_Msk          (0x1UL << ADC_CHSELR_CHSEL8_Pos)        /*!< 0x00000100 */
+#define ADC_CHSELR_CHSEL8              ADC_CHSELR_CHSEL8_Msk                   /*!< ADC group regular sequencer channel 8, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL7_Pos          (7U)
+#define ADC_CHSELR_CHSEL7_Msk          (0x1UL << ADC_CHSELR_CHSEL7_Pos)        /*!< 0x00000080 */
+#define ADC_CHSELR_CHSEL7              ADC_CHSELR_CHSEL7_Msk                   /*!< ADC group regular sequencer channel 7, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL6_Pos          (6U)
+#define ADC_CHSELR_CHSEL6_Msk          (0x1UL << ADC_CHSELR_CHSEL6_Pos)        /*!< 0x00000040 */
+#define ADC_CHSELR_CHSEL6              ADC_CHSELR_CHSEL6_Msk                   /*!< ADC group regular sequencer channel 6, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL5_Pos          (5U)
+#define ADC_CHSELR_CHSEL5_Msk          (0x1UL << ADC_CHSELR_CHSEL5_Pos)        /*!< 0x00000020 */
+#define ADC_CHSELR_CHSEL5              ADC_CHSELR_CHSEL5_Msk                   /*!< ADC group regular sequencer channel 5, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL4_Pos          (4U)
+#define ADC_CHSELR_CHSEL4_Msk          (0x1UL << ADC_CHSELR_CHSEL4_Pos)        /*!< 0x00000010 */
+#define ADC_CHSELR_CHSEL4              ADC_CHSELR_CHSEL4_Msk                   /*!< ADC group regular sequencer channel 4, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL3_Pos          (3U)
+#define ADC_CHSELR_CHSEL3_Msk          (0x1UL << ADC_CHSELR_CHSEL3_Pos)        /*!< 0x00000008 */
+#define ADC_CHSELR_CHSEL3              ADC_CHSELR_CHSEL3_Msk                   /*!< ADC group regular sequencer channel 3, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL2_Pos          (2U)
+#define ADC_CHSELR_CHSEL2_Msk          (0x1UL << ADC_CHSELR_CHSEL2_Pos)        /*!< 0x00000004 */
+#define ADC_CHSELR_CHSEL2              ADC_CHSELR_CHSEL2_Msk                   /*!< ADC group regular sequencer channel 2, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL1_Pos          (1U)
+#define ADC_CHSELR_CHSEL1_Msk          (0x1UL << ADC_CHSELR_CHSEL1_Pos)        /*!< 0x00000002 */
+#define ADC_CHSELR_CHSEL1              ADC_CHSELR_CHSEL1_Msk                   /*!< ADC group regular sequencer channel 1, available when ADC_CFGR1_CHSELRMOD is reset */
+#define ADC_CHSELR_CHSEL0_Pos          (0U)
+#define ADC_CHSELR_CHSEL0_Msk          (0x1UL << ADC_CHSELR_CHSEL0_Pos)        /*!< 0x00000001 */
+#define ADC_CHSELR_CHSEL0              ADC_CHSELR_CHSEL0_Msk                   /*!< ADC group regular sequencer channel 0, available when ADC_CFGR1_CHSELRMOD is reset */
+
+#define ADC_CHSELR_SQ_ALL_Pos          (0U)
+#define ADC_CHSELR_SQ_ALL_Msk          (0xFFFFFFFFUL << ADC_CHSELR_SQ_ALL_Pos) /*!< 0xFFFFFFFF */
+#define ADC_CHSELR_SQ_ALL              ADC_CHSELR_SQ_ALL_Msk                   /*!< ADC group regular sequencer all ranks, available when ADC_CFGR1_CHSELRMOD is set */
+
+#define ADC_CHSELR_SQ8_Pos             (28U)
+#define ADC_CHSELR_SQ8_Msk             (0xFUL << ADC_CHSELR_SQ8_Pos)           /*!< 0xF0000000 */
+#define ADC_CHSELR_SQ8                 ADC_CHSELR_SQ8_Msk                      /*!< ADC group regular sequencer rank 8, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ8_0               (0x1UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x10000000 */
+#define ADC_CHSELR_SQ8_1               (0x2UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x20000000 */
+#define ADC_CHSELR_SQ8_2               (0x4UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x40000000 */
+#define ADC_CHSELR_SQ8_3               (0x8UL << ADC_CHSELR_SQ8_Pos)           /*!< 0x80000000 */
+
+#define ADC_CHSELR_SQ7_Pos             (24U)
+#define ADC_CHSELR_SQ7_Msk             (0xFUL << ADC_CHSELR_SQ7_Pos)           /*!< 0x0F000000 */
+#define ADC_CHSELR_SQ7                 ADC_CHSELR_SQ7_Msk                      /*!< ADC group regular sequencer rank 7, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ7_0               (0x1UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x01000000 */
+#define ADC_CHSELR_SQ7_1               (0x2UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x02000000 */
+#define ADC_CHSELR_SQ7_2               (0x4UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x04000000 */
+#define ADC_CHSELR_SQ7_3               (0x8UL << ADC_CHSELR_SQ7_Pos)           /*!< 0x08000000 */
+
+#define ADC_CHSELR_SQ6_Pos             (20U)
+#define ADC_CHSELR_SQ6_Msk             (0xFUL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00F00000 */
+#define ADC_CHSELR_SQ6                 ADC_CHSELR_SQ6_Msk                      /*!< ADC group regular sequencer rank 6, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ6_0               (0x1UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00100000 */
+#define ADC_CHSELR_SQ6_1               (0x2UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00200000 */
+#define ADC_CHSELR_SQ6_2               (0x4UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00400000 */
+#define ADC_CHSELR_SQ6_3               (0x8UL << ADC_CHSELR_SQ6_Pos)           /*!< 0x00800000 */
+
+#define ADC_CHSELR_SQ5_Pos             (16U)
+#define ADC_CHSELR_SQ5_Msk             (0xFUL << ADC_CHSELR_SQ5_Pos)           /*!< 0x000F0000 */
+#define ADC_CHSELR_SQ5                 ADC_CHSELR_SQ5_Msk                      /*!< ADC group regular sequencer rank 5, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ5_0               (0x1UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00010000 */
+#define ADC_CHSELR_SQ5_1               (0x2UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00020000 */
+#define ADC_CHSELR_SQ5_2               (0x4UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00040000 */
+#define ADC_CHSELR_SQ5_3               (0x8UL << ADC_CHSELR_SQ5_Pos)           /*!< 0x00080000 */
+
+#define ADC_CHSELR_SQ4_Pos             (12U)
+#define ADC_CHSELR_SQ4_Msk             (0xFUL << ADC_CHSELR_SQ4_Pos)           /*!< 0x0000F000 */
+#define ADC_CHSELR_SQ4                 ADC_CHSELR_SQ4_Msk                      /*!< ADC group regular sequencer rank 4, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ4_0               (0x1UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00001000 */
+#define ADC_CHSELR_SQ4_1               (0x2UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00002000 */
+#define ADC_CHSELR_SQ4_2               (0x4UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00004000 */
+#define ADC_CHSELR_SQ4_3               (0x8UL << ADC_CHSELR_SQ4_Pos)           /*!< 0x00008000 */
+
+#define ADC_CHSELR_SQ3_Pos             (8U)
+#define ADC_CHSELR_SQ3_Msk             (0xFUL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000F00 */
+#define ADC_CHSELR_SQ3                 ADC_CHSELR_SQ3_Msk                      /*!< ADC group regular sequencer rank 3, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ3_0               (0x1UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000100 */
+#define ADC_CHSELR_SQ3_1               (0x2UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000200 */
+#define ADC_CHSELR_SQ3_2               (0x4UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000400 */
+#define ADC_CHSELR_SQ3_3               (0x8UL << ADC_CHSELR_SQ3_Pos)           /*!< 0x00000800 */
+
+#define ADC_CHSELR_SQ2_Pos             (4U)
+#define ADC_CHSELR_SQ2_Msk             (0xFUL << ADC_CHSELR_SQ2_Pos)           /*!< 0x000000F0 */
+#define ADC_CHSELR_SQ2                 ADC_CHSELR_SQ2_Msk                      /*!< ADC group regular sequencer rank 2, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ2_0               (0x1UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000010 */
+#define ADC_CHSELR_SQ2_1               (0x2UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000020 */
+#define ADC_CHSELR_SQ2_2               (0x4UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000040 */
+#define ADC_CHSELR_SQ2_3               (0x8UL << ADC_CHSELR_SQ2_Pos)           /*!< 0x00000080 */
+
+#define ADC_CHSELR_SQ1_Pos             (0U)
+#define ADC_CHSELR_SQ1_Msk             (0xFUL << ADC_CHSELR_SQ1_Pos)           /*!< 0x0000000F */
+#define ADC_CHSELR_SQ1                 ADC_CHSELR_SQ1_Msk                      /*!< ADC group regular sequencer rank 1, available when ADC_CFGR1_CHSELRMOD is set */
+#define ADC_CHSELR_SQ1_0               (0x1UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000001 */
+#define ADC_CHSELR_SQ1_1               (0x2UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000002 */
+#define ADC_CHSELR_SQ1_2               (0x4UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000004 */
+#define ADC_CHSELR_SQ1_3               (0x8UL << ADC_CHSELR_SQ1_Pos)           /*!< 0x00000008 */
+
+/********************  Bit definition for ADC_DR register  ********************/
+#define ADC_DR_DATA_Pos                (0U)
+#define ADC_DR_DATA_Msk                (0xFFFFUL << ADC_DR_DATA_Pos)           /*!< 0x0000FFFF */
+#define ADC_DR_DATA                    ADC_DR_DATA_Msk                         /*!< ADC group regular conversion data */
+#define ADC_DR_DATA_0                  (0x0001UL << ADC_DR_DATA_Pos)           /*!< 0x00000001 */
+#define ADC_DR_DATA_1                  (0x0002UL << ADC_DR_DATA_Pos)           /*!< 0x00000002 */
+#define ADC_DR_DATA_2                  (0x0004UL << ADC_DR_DATA_Pos)           /*!< 0x00000004 */
+#define ADC_DR_DATA_3                  (0x0008UL << ADC_DR_DATA_Pos)           /*!< 0x00000008 */
+#define ADC_DR_DATA_4                  (0x0010UL << ADC_DR_DATA_Pos)           /*!< 0x00000010 */
+#define ADC_DR_DATA_5                  (0x0020UL << ADC_DR_DATA_Pos)           /*!< 0x00000020 */
+#define ADC_DR_DATA_6                  (0x0040UL << ADC_DR_DATA_Pos)           /*!< 0x00000040 */
+#define ADC_DR_DATA_7                  (0x0080UL << ADC_DR_DATA_Pos)           /*!< 0x00000080 */
+#define ADC_DR_DATA_8                  (0x0100UL << ADC_DR_DATA_Pos)           /*!< 0x00000100 */
+#define ADC_DR_DATA_9                  (0x0200UL << ADC_DR_DATA_Pos)           /*!< 0x00000200 */
+#define ADC_DR_DATA_10                 (0x0400UL << ADC_DR_DATA_Pos)           /*!< 0x00000400 */
+#define ADC_DR_DATA_11                 (0x0800UL << ADC_DR_DATA_Pos)           /*!< 0x00000800 */
+#define ADC_DR_DATA_12                 (0x1000UL << ADC_DR_DATA_Pos)           /*!< 0x00001000 */
+#define ADC_DR_DATA_13                 (0x2000UL << ADC_DR_DATA_Pos)           /*!< 0x00002000 */
+#define ADC_DR_DATA_14                 (0x4000UL << ADC_DR_DATA_Pos)           /*!< 0x00004000 */
+#define ADC_DR_DATA_15                 (0x8000UL << ADC_DR_DATA_Pos)           /*!< 0x00008000 */
+
+/* Definitions for cohabitation of ADC peripherals 2.5Ms/sec and 5Ms/sec across STM32WB series */
+#define ADC_DR_RDATA_Pos               ADC_DR_DATA_Pos
+#define ADC_DR_RDATA_Msk               ADC_DR_DATA_Msk
+#define ADC_DR_RDATA                   ADC_DR_DATA
+
+/********************  Bit definition for ADC_CALFACT register  ***************/
+#define ADC_CALFACT_CALFACT_Pos        (0U)
+#define ADC_CALFACT_CALFACT_Msk        (0x7FUL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x0000007F */
+#define ADC_CALFACT_CALFACT            ADC_CALFACT_CALFACT_Msk                 /*!< ADC calibration factor in single-ended mode */
+#define ADC_CALFACT_CALFACT_0          (0x01UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000001 */
+#define ADC_CALFACT_CALFACT_1          (0x02UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000002 */
+#define ADC_CALFACT_CALFACT_2          (0x04UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000004 */
+#define ADC_CALFACT_CALFACT_3          (0x08UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000008 */
+#define ADC_CALFACT_CALFACT_4          (0x10UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000010 */
+#define ADC_CALFACT_CALFACT_5          (0x20UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000020 */
+#define ADC_CALFACT_CALFACT_6          (0x40UL << ADC_CALFACT_CALFACT_Pos)     /*!< 0x00000040 */
+
+/*************************  ADC Common registers  *****************************/
+/********************  Bit definition for ADC_CCR register  *******************/
+#define ADC_CCR_PRESC_Pos              (18U)
+#define ADC_CCR_PRESC_Msk              (0xFUL << ADC_CCR_PRESC_Pos)            /*!< 0x003C0000 */
+#define ADC_CCR_PRESC                  ADC_CCR_PRESC_Msk                       /*!< ADC common clock prescaler, only for clock source asynchronous */
+#define ADC_CCR_PRESC_0                (0x1UL << ADC_CCR_PRESC_Pos)            /*!< 0x00040000 */
+#define ADC_CCR_PRESC_1                (0x2UL << ADC_CCR_PRESC_Pos)            /*!< 0x00080000 */
+#define ADC_CCR_PRESC_2                (0x4UL << ADC_CCR_PRESC_Pos)            /*!< 0x00100000 */
+#define ADC_CCR_PRESC_3                (0x8UL << ADC_CCR_PRESC_Pos)            /*!< 0x00200000 */
+
+#define ADC_CCR_VREFEN_Pos             (22U)
+#define ADC_CCR_VREFEN_Msk             (0x1UL << ADC_CCR_VREFEN_Pos)           /*!< 0x00400000 */
+#define ADC_CCR_VREFEN                 ADC_CCR_VREFEN_Msk                      /*!< ADC internal path to VrefInt enable */
+#define ADC_CCR_TSEN_Pos               (23U)
+#define ADC_CCR_TSEN_Msk               (0x1UL << ADC_CCR_TSEN_Pos)             /*!< 0x00800000 */
+#define ADC_CCR_TSEN                   ADC_CCR_TSEN_Msk                        /*!< ADC internal path to temperature sensor enable */
+#define ADC_CCR_VBATEN_Pos             (24U)
+#define ADC_CCR_VBATEN_Msk             (0x1UL << ADC_CCR_VBATEN_Pos)           /*!< 0x01000000 */
+#define ADC_CCR_VBATEN                 ADC_CCR_VBATEN_Msk                      /*!< ADC internal path to battery voltage enable */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Analog Comparators (COMP)                             */
+/*                                                                            */
+/******************************************************************************/
+/**********************  Bit definition for COMP_CSR register  ***************/
+#define COMP_CSR_EN_Pos            (0U)
+#define COMP_CSR_EN_Msk            (0x1UL << COMP_CSR_EN_Pos)                  /*!< 0x00000001 */
+#define COMP_CSR_EN                COMP_CSR_EN_Msk                             /*!< Comparator enable */
+#define COMP_CSR_PWRMODE_Pos       (2U)
+#define COMP_CSR_PWRMODE_Msk       (0x3UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x0000000C */
+#define COMP_CSR_PWRMODE           COMP_CSR_PWRMODE_Msk                        /*!< Comparator power mode */
+#define COMP_CSR_PWRMODE_0         (0x1UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00000004 */
+#define COMP_CSR_PWRMODE_1         (0x2UL << COMP_CSR_PWRMODE_Pos)             /*!< 0x00000008 */
+#define COMP_CSR_INMSEL_Pos        (4U)
+#define COMP_CSR_INMSEL_Msk        (0x7UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000070 */
+#define COMP_CSR_INMSEL            COMP_CSR_INMSEL_Msk                         /*!< Comparator input minus selection */
+#define COMP_CSR_INMSEL_0          (0x1UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000010 */
+#define COMP_CSR_INMSEL_1          (0x2UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000020 */
+#define COMP_CSR_INMSEL_2          (0x4UL << COMP_CSR_INMSEL_Pos)              /*!< 0x00000040 */
+#define COMP_CSR_INPSEL_Pos        (7U)
+#define COMP_CSR_INPSEL_Msk        (0x3UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000180 */
+#define COMP_CSR_INPSEL            COMP_CSR_INPSEL_Msk                         /*!< Comparator input plus selection */
+#define COMP_CSR_INPSEL_0          (0x1UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000080 */
+#define COMP_CSR_INPSEL_1          (0x2UL << COMP_CSR_INPSEL_Pos)              /*!< 0x00000100 */
+#define COMP_CSR_POLARITY_Pos      (15U)
+#define COMP_CSR_POLARITY_Msk      (0x1UL << COMP_CSR_POLARITY_Pos)            /*!< 0x00008000 */
+#define COMP_CSR_POLARITY          COMP_CSR_POLARITY_Msk                       /*!< Comparator output polarity */
+#define COMP_CSR_HYST_Pos          (16U)
+#define COMP_CSR_HYST_Msk          (0x3UL << COMP_CSR_HYST_Pos)                /*!< 0x00030000 */
+#define COMP_CSR_HYST              COMP_CSR_HYST_Msk                           /*!< Comparator hysteresis */
+#define COMP_CSR_HYST_0            (0x1UL << COMP_CSR_HYST_Pos)                /*!< 0x00010000 */
+#define COMP_CSR_HYST_1            (0x2UL << COMP_CSR_HYST_Pos)                /*!< 0x00020000 */
+#define COMP_CSR_BLANKING_Pos      (18U)
+#define COMP_CSR_BLANKING_Msk      (0x7UL << COMP_CSR_BLANKING_Pos)            /*!< 0x001C0000 */
+#define COMP_CSR_BLANKING          COMP_CSR_BLANKING_Msk                       /*!< Comparator blanking source */
+#define COMP_CSR_BLANKING_0        (0x1UL << COMP_CSR_BLANKING_Pos)            /*!< 0x00040000 */
+#define COMP_CSR_BLANKING_1        (0x2UL << COMP_CSR_BLANKING_Pos)            /*!< 0x00080000 */
+#define COMP_CSR_BLANKING_2        (0x4UL << COMP_CSR_BLANKING_Pos)            /*!< 0x00100000 */
+#define COMP_CSR_BRGEN_Pos         (22U)
+#define COMP_CSR_BRGEN_Msk         (0x1UL << COMP_CSR_BRGEN_Pos)               /*!< 0x00400000 */
+#define COMP_CSR_BRGEN             COMP_CSR_BRGEN_Msk                          /*!< Comparator voltage scaler enable */
+#define COMP_CSR_SCALEN_Pos        (23U)
+#define COMP_CSR_SCALEN_Msk        (0x1UL << COMP_CSR_SCALEN_Pos)              /*!< 0x00800000 */
+#define COMP_CSR_SCALEN            COMP_CSR_SCALEN_Msk                         /*!< Comparator scaler bridge enable */
+#define COMP_CSR_INMESEL_Pos       (25U)
+#define COMP_CSR_INMESEL_Msk       (0x3UL << COMP_CSR_INMESEL_Pos)             /*!< 0x06000000 */
+#define COMP_CSR_INMESEL           COMP_CSR_INMESEL_Msk                        /*!< Comparator input minus extended selection */
+#define COMP_CSR_INMESEL_0         (0x1UL << COMP_CSR_INMESEL_Pos)             /*!< 0x02000000 */
+#define COMP_CSR_INMESEL_1         (0x2UL << COMP_CSR_INMESEL_Pos)             /*!< 0x04000000 */
+#define COMP_CSR_VALUE_Pos         (30U)
+#define COMP_CSR_VALUE_Msk         (0x1UL << COMP_CSR_VALUE_Pos)               /*!< 0x40000000 */
+#define COMP_CSR_VALUE             COMP_CSR_VALUE_Msk                          /*!< Comparator output level */
+#define COMP_CSR_LOCK_Pos          (31U)
+#define COMP_CSR_LOCK_Msk          (0x1UL << COMP_CSR_LOCK_Pos)                /*!< 0x80000000 */
+#define COMP_CSR_LOCK              COMP_CSR_LOCK_Msk                           /*!< Comparator lock */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          CRC calculation unit                              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for CRC_DR register  *********************/
+#define CRC_DR_DR_Pos            (0U)
+#define CRC_DR_DR_Msk            (0xFFFFFFFFUL << CRC_DR_DR_Pos)               /*!< 0xFFFFFFFF */
+#define CRC_DR_DR                CRC_DR_DR_Msk                                 /*!< Data register bits */
+
+/*******************  Bit definition for CRC_IDR register  ********************/
+#define CRC_IDR_IDR_Pos          (0U)
+#define CRC_IDR_IDR_Msk          (0xFFFFFFFFUL << CRC_IDR_IDR_Pos)                   /*!< 0x000000FF */
+#define CRC_IDR_IDR              CRC_IDR_IDR_Msk                               /*!< General-purpose 8-bits data register bits */
+
+/********************  Bit definition for CRC_CR register  ********************/
+#define CRC_CR_RESET_Pos         (0U)
+#define CRC_CR_RESET_Msk         (0x1UL << CRC_CR_RESET_Pos)                   /*!< 0x00000001 */
+#define CRC_CR_RESET             CRC_CR_RESET_Msk                              /*!< RESET the CRC computation unit bit */
+#define CRC_CR_POLYSIZE_Pos      (3U)
+#define CRC_CR_POLYSIZE_Msk      (0x3UL << CRC_CR_POLYSIZE_Pos)                /*!< 0x00000018 */
+#define CRC_CR_POLYSIZE          CRC_CR_POLYSIZE_Msk                           /*!< Polynomial size bits */
+#define CRC_CR_POLYSIZE_0        (0x1U << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000008 */
+#define CRC_CR_POLYSIZE_1        (0x2U << CRC_CR_POLYSIZE_Pos)                 /*!< 0x00000010 */
+#define CRC_CR_REV_IN_Pos        (5U)
+#define CRC_CR_REV_IN_Msk        (0x3UL << CRC_CR_REV_IN_Pos)                  /*!< 0x00000060 */
+#define CRC_CR_REV_IN            CRC_CR_REV_IN_Msk                             /*!< REV_IN Reverse Input Data bits */
+#define CRC_CR_REV_IN_0          (0x1U << CRC_CR_REV_IN_Pos)                   /*!< 0x00000020 */
+#define CRC_CR_REV_IN_1          (0x2U << CRC_CR_REV_IN_Pos)                   /*!< 0x00000040 */
+#define CRC_CR_REV_OUT_Pos       (7U)
+#define CRC_CR_REV_OUT_Msk       (0x1UL << CRC_CR_REV_OUT_Pos)                 /*!< 0x00000080 */
+#define CRC_CR_REV_OUT           CRC_CR_REV_OUT_Msk                            /*!< REV_OUT Reverse Output Data bits */
+
+/*******************  Bit definition for CRC_INIT register  *******************/
+#define CRC_INIT_INIT_Pos        (0U)
+#define CRC_INIT_INIT_Msk        (0xFFFFFFFFUL << CRC_INIT_INIT_Pos)           /*!< 0xFFFFFFFF */
+#define CRC_INIT_INIT            CRC_INIT_INIT_Msk                             /*!< Initial CRC value bits */
+
+/*******************  Bit definition for CRC_POL register  ********************/
+#define CRC_POL_POL_Pos          (0U)
+#define CRC_POL_POL_Msk          (0xFFFFFFFFUL << CRC_POL_POL_Pos)             /*!< 0xFFFFFFFF */
+#define CRC_POL_POL              CRC_POL_POL_Msk                               /*!< Coefficients of the polynomial */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Advanced Encryption Standard (AES)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for AES_CR register  *********************/
+#define AES_CR_EN_Pos            (0U)
+#define AES_CR_EN_Msk            (0x1UL << AES_CR_EN_Pos)                      /*!< 0x00000001 */
+#define AES_CR_EN                AES_CR_EN_Msk                                 /*!< AES Enable */
+#define AES_CR_DATATYPE_Pos      (1U)
+#define AES_CR_DATATYPE_Msk      (0x3UL << AES_CR_DATATYPE_Pos)                /*!< 0x00000006 */
+#define AES_CR_DATATYPE          AES_CR_DATATYPE_Msk                           /*!< Data type selection */
+#define AES_CR_DATATYPE_0        (0x1U << AES_CR_DATATYPE_Pos)                 /*!< 0x00000002 */
+#define AES_CR_DATATYPE_1        (0x2U << AES_CR_DATATYPE_Pos)                 /*!< 0x00000004 */
+
+#define AES_CR_MODE_Pos          (3U)
+#define AES_CR_MODE_Msk          (0x3UL << AES_CR_MODE_Pos)                    /*!< 0x00000018 */
+#define AES_CR_MODE              AES_CR_MODE_Msk                               /*!< AES Mode Of Operation */
+#define AES_CR_MODE_0            (0x1U << AES_CR_MODE_Pos)                     /*!< 0x00000008 */
+#define AES_CR_MODE_1            (0x2U << AES_CR_MODE_Pos)                     /*!< 0x00000010 */
+
+#define AES_CR_CHMOD_Pos         (5U)
+#define AES_CR_CHMOD_Msk         (0x803UL << AES_CR_CHMOD_Pos)                 /*!< 0x00010060 */
+#define AES_CR_CHMOD             AES_CR_CHMOD_Msk                              /*!< AES Chaining Mode */
+#define AES_CR_CHMOD_0           (0x001U << AES_CR_CHMOD_Pos)                  /*!< 0x00000020 */
+#define AES_CR_CHMOD_1           (0x002U << AES_CR_CHMOD_Pos)                  /*!< 0x00000040 */
+#define AES_CR_CHMOD_2           (0x800U << AES_CR_CHMOD_Pos)                  /*!< 0x00010000 */
+
+#define AES_CR_CCFC_Pos          (7U)
+#define AES_CR_CCFC_Msk          (0x1UL << AES_CR_CCFC_Pos)                    /*!< 0x00000080 */
+#define AES_CR_CCFC              AES_CR_CCFC_Msk                               /*!< Computation Complete Flag Clear */
+#define AES_CR_ERRC_Pos          (8U)
+#define AES_CR_ERRC_Msk          (0x1UL << AES_CR_ERRC_Pos)                    /*!< 0x00000100 */
+#define AES_CR_ERRC              AES_CR_ERRC_Msk                               /*!< Error Clear */
+#define AES_CR_CCFIE_Pos         (9U)
+#define AES_CR_CCFIE_Msk         (0x1UL << AES_CR_CCFIE_Pos)                   /*!< 0x00000200 */
+#define AES_CR_CCFIE             AES_CR_CCFIE_Msk                              /*!< Computation Complete Flag Interrupt Enable */
+#define AES_CR_ERRIE_Pos         (10U)
+#define AES_CR_ERRIE_Msk         (0x1UL << AES_CR_ERRIE_Pos)                   /*!< 0x00000400 */
+#define AES_CR_ERRIE             AES_CR_ERRIE_Msk                              /*!< Error Interrupt Enable */
+#define AES_CR_DMAINEN_Pos       (11U)
+#define AES_CR_DMAINEN_Msk       (0x1UL << AES_CR_DMAINEN_Pos)                 /*!< 0x00000800 */
+#define AES_CR_DMAINEN           AES_CR_DMAINEN_Msk                            /*!< Enable data input phase DMA management  */
+#define AES_CR_DMAOUTEN_Pos      (12U)
+#define AES_CR_DMAOUTEN_Msk      (0x1UL << AES_CR_DMAOUTEN_Pos)                /*!< 0x00001000 */
+#define AES_CR_DMAOUTEN          AES_CR_DMAOUTEN_Msk                           /*!< Enable data output phase DMA management */
+
+#define AES_CR_GCMPH_Pos         (13U)
+#define AES_CR_GCMPH_Msk         (0x3UL << AES_CR_GCMPH_Pos)                   /*!< 0x00006000 */
+#define AES_CR_GCMPH             AES_CR_GCMPH_Msk                              /*!< GCM Phase */
+#define AES_CR_GCMPH_0           (0x1U << AES_CR_GCMPH_Pos)                    /*!< 0x00002000 */
+#define AES_CR_GCMPH_1           (0x2U << AES_CR_GCMPH_Pos)                    /*!< 0x00004000 */
+
+#define AES_CR_KEYSIZE_Pos       (18U)
+#define AES_CR_KEYSIZE_Msk       (0x1UL << AES_CR_KEYSIZE_Pos)                 /*!< 0x00040000 */
+#define AES_CR_KEYSIZE           AES_CR_KEYSIZE_Msk                            /*!< Key size selection */
+
+#define AES_CR_NPBLB_Pos         (20U)
+#define AES_CR_NPBLB_Msk         (0xFUL << AES_CR_NPBLB_Pos)                   /*!< 0x00F00000 */
+#define AES_CR_NPBLB             AES_CR_NPBLB_Msk                              /*!< Number of padding bytes in last payload block */
+#define AES_CR_NPBLB_0           (0x1U << AES_CR_NPBLB_Pos)                    /*!< 0x00100000 */
+#define AES_CR_NPBLB_1           (0x2U << AES_CR_NPBLB_Pos)                    /*!< 0x00200000 */
+#define AES_CR_NPBLB_2           (0x4U << AES_CR_NPBLB_Pos)                    /*!< 0x00400000 */
+#define AES_CR_NPBLB_3           (0x8U << AES_CR_NPBLB_Pos)                    /*!< 0x00800000 */
+
+/*******************  Bit definition for AES_SR register  *********************/
+#define AES_SR_CCF_Pos           (0U)
+#define AES_SR_CCF_Msk           (0x1UL << AES_SR_CCF_Pos)                     /*!< 0x00000001 */
+#define AES_SR_CCF               AES_SR_CCF_Msk                                /*!< Computation Complete Flag */
+#define AES_SR_RDERR_Pos         (1U)
+#define AES_SR_RDERR_Msk         (0x1UL << AES_SR_RDERR_Pos)                   /*!< 0x00000002 */
+#define AES_SR_RDERR             AES_SR_RDERR_Msk                              /*!< Read Error Flag */
+#define AES_SR_WRERR_Pos         (2U)
+#define AES_SR_WRERR_Msk         (0x1UL << AES_SR_WRERR_Pos)                   /*!< 0x00000004 */
+#define AES_SR_WRERR             AES_SR_WRERR_Msk                              /*!< Write Error Flag */
+#define AES_SR_BUSY_Pos          (3U)
+#define AES_SR_BUSY_Msk          (0x1UL << AES_SR_BUSY_Pos)                    /*!< 0x00000008 */
+#define AES_SR_BUSY              AES_SR_BUSY_Msk                               /*!< Busy Flag */
+
+/*******************  Bit definition for AES_DINR register  *******************/
+#define AES_DINR_Pos             (0U)
+#define AES_DINR_Msk             (0xFFFFFFFFUL << AES_DINR_Pos)                /*!< 0xFFFFFFFF */
+#define AES_DINR                 AES_DINR_Msk                                  /*!< AES Data Input Register */
+
+/*******************  Bit definition for AES_DOUTR register  ******************/
+#define AES_DOUTR_Pos            (0U)
+#define AES_DOUTR_Msk            (0xFFFFFFFFUL << AES_DOUTR_Pos)               /*!< 0xFFFFFFFF */
+#define AES_DOUTR                AES_DOUTR_Msk                                 /*!< AES Data Output Register */
+
+/*******************  Bit definition for AES_KEYR0 register  ******************/
+#define AES_KEYR0_Pos            (0U)
+#define AES_KEYR0_Msk            (0xFFFFFFFFUL << AES_KEYR0_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR0                AES_KEYR0_Msk                                 /*!< AES Key Register 0 */
+
+/*******************  Bit definition for AES_KEYR1 register  ******************/
+#define AES_KEYR1_Pos            (0U)
+#define AES_KEYR1_Msk            (0xFFFFFFFFUL << AES_KEYR1_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR1                AES_KEYR1_Msk                                 /*!< AES Key Register 1 */
+
+/*******************  Bit definition for AES_KEYR2 register  ******************/
+#define AES_KEYR2_Pos            (0U)
+#define AES_KEYR2_Msk            (0xFFFFFFFFUL << AES_KEYR2_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR2                AES_KEYR2_Msk                                 /*!< AES Key Register 2 */
+
+/*******************  Bit definition for AES_KEYR3 register  ******************/
+#define AES_KEYR3_Pos            (0U)
+#define AES_KEYR3_Msk            (0xFFFFFFFFUL << AES_KEYR3_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR3                AES_KEYR3_Msk                                 /*!< AES Key Register 3 */
+
+/*******************  Bit definition for AES_KEYR4 register  ******************/
+#define AES_KEYR4_Pos            (0U)
+#define AES_KEYR4_Msk            (0xFFFFFFFFUL << AES_KEYR4_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR4                AES_KEYR4_Msk                                 /*!< AES Key Register 4 */
+
+/*******************  Bit definition for AES_KEYR5 register  ******************/
+#define AES_KEYR5_Pos            (0U)
+#define AES_KEYR5_Msk            (0xFFFFFFFFUL << AES_KEYR5_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR5                AES_KEYR5_Msk                                 /*!< AES Key Register 5 */
+
+/*******************  Bit definition for AES_KEYR6 register  ******************/
+#define AES_KEYR6_Pos            (0U)
+#define AES_KEYR6_Msk            (0xFFFFFFFFUL << AES_KEYR6_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR6                AES_KEYR6_Msk                                 /*!< AES Key Register 6 */
+
+/*******************  Bit definition for AES_KEYR7 register  ******************/
+#define AES_KEYR7_Pos            (0U)
+#define AES_KEYR7_Msk            (0xFFFFFFFFUL << AES_KEYR7_Pos)               /*!< 0xFFFFFFFF */
+#define AES_KEYR7                AES_KEYR7_Msk                                 /*!< AES Key Register 7 */
+
+/*******************  Bit definition for AES_IVR0 register   ******************/
+#define AES_IVR0_Pos             (0U)
+#define AES_IVR0_Msk             (0xFFFFFFFFUL << AES_IVR0_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR0                 AES_IVR0_Msk                                  /*!< AES Initialization Vector Register 0 */
+
+/*******************  Bit definition for AES_IVR1 register   ******************/
+#define AES_IVR1_Pos             (0U)
+#define AES_IVR1_Msk             (0xFFFFFFFFUL << AES_IVR1_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR1                 AES_IVR1_Msk                                  /*!< AES Initialization Vector Register 1 */
+
+/*******************  Bit definition for AES_IVR2 register   ******************/
+#define AES_IVR2_Pos             (0U)
+#define AES_IVR2_Msk             (0xFFFFFFFFUL << AES_IVR2_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR2                 AES_IVR2_Msk                                  /*!< AES Initialization Vector Register 2 */
+
+/*******************  Bit definition for AES_IVR3 register   ******************/
+#define AES_IVR3_Pos             (0U)
+#define AES_IVR3_Msk             (0xFFFFFFFFUL << AES_IVR3_Pos)                /*!< 0xFFFFFFFF */
+#define AES_IVR3                 AES_IVR3_Msk                                  /*!< AES Initialization Vector Register 3 */
+
+/*******************  Bit definition for AES_SUSP0R register  ******************/
+#define AES_SUSP0R_Pos           (0U)
+#define AES_SUSP0R_Msk           (0xFFFFFFFFUL << AES_SUSP0R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP0R               AES_SUSP0R_Msk                                /*!< AES Suspend registers 0 */
+
+/*******************  Bit definition for AES_SUSP1R register  ******************/
+#define AES_SUSP1R_Pos           (0U)
+#define AES_SUSP1R_Msk           (0xFFFFFFFFUL << AES_SUSP1R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP1R               AES_SUSP1R_Msk                                /*!< AES Suspend registers 1 */
+
+/*******************  Bit definition for AES_SUSP2R register  ******************/
+#define AES_SUSP2R_Pos           (0U)
+#define AES_SUSP2R_Msk           (0xFFFFFFFFUL << AES_SUSP2R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP2R               AES_SUSP2R_Msk                                /*!< AES Suspend registers 2 */
+
+/*******************  Bit definition for AES_SUSP3R register  ******************/
+#define AES_SUSP3R_Pos           (0U)
+#define AES_SUSP3R_Msk           (0xFFFFFFFFUL << AES_SUSP3R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP3R               AES_SUSP3R_Msk                                /*!< AES Suspend registers 3 */
+
+/*******************  Bit definition for AES_SUSP4R register  ******************/
+#define AES_SUSP4R_Pos           (0U)
+#define AES_SUSP4R_Msk           (0xFFFFFFFFUL << AES_SUSP4R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP4R               AES_SUSP4R_Msk                                /*!< AES Suspend registers 4 */
+
+/*******************  Bit definition for AES_SUSP5R register  ******************/
+#define AES_SUSP5R_Pos           (0U)
+#define AES_SUSP5R_Msk           (0xFFFFFFFFUL << AES_SUSP5R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP5R               AES_SUSP5R_Msk                                /*!< AES Suspend registers 5 */
+
+/*******************  Bit definition for AES_SUSP6R register  ******************/
+#define AES_SUSP6R_Pos           (0U)
+#define AES_SUSP6R_Msk           (0xFFFFFFFFUL << AES_SUSP6R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP6R               AES_SUSP6R_Msk                                /*!< AES Suspend registers 6 */
+
+/*******************  Bit definition for AES_SUSP7R register  ******************/
+#define AES_SUSP7R_Pos           (0U)
+#define AES_SUSP7R_Msk           (0xFFFFFFFFUL << AES_SUSP7R_Pos)              /*!< 0xFFFFFFFF */
+#define AES_SUSP7R               AES_SUSP7R_Msk                                /*!< AES Suspend registers 7 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                           DMA Controller (DMA)                             */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bit definition for DMA_ISR register  ********************/
+#define DMA_ISR_GIF1_Pos       (0U)
+#define DMA_ISR_GIF1_Msk       (0x1UL << DMA_ISR_GIF1_Pos)                     /*!< 0x00000001 */
+#define DMA_ISR_GIF1           DMA_ISR_GIF1_Msk                                /*!< Channel 1 Global interrupt flag */
+#define DMA_ISR_TCIF1_Pos      (1U)
+#define DMA_ISR_TCIF1_Msk      (0x1UL << DMA_ISR_TCIF1_Pos)                    /*!< 0x00000002 */
+#define DMA_ISR_TCIF1          DMA_ISR_TCIF1_Msk                               /*!< Channel 1 Transfer Complete flag */
+#define DMA_ISR_HTIF1_Pos      (2U)
+#define DMA_ISR_HTIF1_Msk      (0x1UL << DMA_ISR_HTIF1_Pos)                    /*!< 0x00000004 */
+#define DMA_ISR_HTIF1          DMA_ISR_HTIF1_Msk                               /*!< Channel 1 Half Transfer flag */
+#define DMA_ISR_TEIF1_Pos      (3U)
+#define DMA_ISR_TEIF1_Msk      (0x1UL << DMA_ISR_TEIF1_Pos)                    /*!< 0x00000008 */
+#define DMA_ISR_TEIF1          DMA_ISR_TEIF1_Msk                               /*!< Channel 1 Transfer Error flag */
+#define DMA_ISR_GIF2_Pos       (4U)
+#define DMA_ISR_GIF2_Msk       (0x1UL << DMA_ISR_GIF2_Pos)                     /*!< 0x00000010 */
+#define DMA_ISR_GIF2           DMA_ISR_GIF2_Msk                                /*!< Channel 2 Global interrupt flag */
+#define DMA_ISR_TCIF2_Pos      (5U)
+#define DMA_ISR_TCIF2_Msk      (0x1UL << DMA_ISR_TCIF2_Pos)                    /*!< 0x00000020 */
+#define DMA_ISR_TCIF2          DMA_ISR_TCIF2_Msk                               /*!< Channel 2 Transfer Complete flag */
+#define DMA_ISR_HTIF2_Pos      (6U)
+#define DMA_ISR_HTIF2_Msk      (0x1UL << DMA_ISR_HTIF2_Pos)                    /*!< 0x00000040 */
+#define DMA_ISR_HTIF2          DMA_ISR_HTIF2_Msk                               /*!< Channel 2 Half Transfer flag */
+#define DMA_ISR_TEIF2_Pos      (7U)
+#define DMA_ISR_TEIF2_Msk      (0x1UL << DMA_ISR_TEIF2_Pos)                    /*!< 0x00000080 */
+#define DMA_ISR_TEIF2          DMA_ISR_TEIF2_Msk                               /*!< Channel 2 Transfer Error flag */
+#define DMA_ISR_GIF3_Pos       (8U)
+#define DMA_ISR_GIF3_Msk       (0x1UL << DMA_ISR_GIF3_Pos)                     /*!< 0x00000100 */
+#define DMA_ISR_GIF3           DMA_ISR_GIF3_Msk                                /*!< Channel 3 Global interrupt flag */
+#define DMA_ISR_TCIF3_Pos      (9U)
+#define DMA_ISR_TCIF3_Msk      (0x1UL << DMA_ISR_TCIF3_Pos)                    /*!< 0x00000200 */
+#define DMA_ISR_TCIF3          DMA_ISR_TCIF3_Msk                               /*!< Channel 3 Transfer Complete flag */
+#define DMA_ISR_HTIF3_Pos      (10U)
+#define DMA_ISR_HTIF3_Msk      (0x1UL << DMA_ISR_HTIF3_Pos)                    /*!< 0x00000400 */
+#define DMA_ISR_HTIF3          DMA_ISR_HTIF3_Msk                               /*!< Channel 3 Half Transfer flag */
+#define DMA_ISR_TEIF3_Pos      (11U)
+#define DMA_ISR_TEIF3_Msk      (0x1UL << DMA_ISR_TEIF3_Pos)                    /*!< 0x00000800 */
+#define DMA_ISR_TEIF3          DMA_ISR_TEIF3_Msk                               /*!< Channel 3 Transfer Error flag */
+#define DMA_ISR_GIF4_Pos       (12U)
+#define DMA_ISR_GIF4_Msk       (0x1UL << DMA_ISR_GIF4_Pos)                     /*!< 0x00001000 */
+#define DMA_ISR_GIF4           DMA_ISR_GIF4_Msk                                /*!< Channel 4 Global interrupt flag */
+#define DMA_ISR_TCIF4_Pos      (13U)
+#define DMA_ISR_TCIF4_Msk      (0x1UL << DMA_ISR_TCIF4_Pos)                    /*!< 0x00002000 */
+#define DMA_ISR_TCIF4          DMA_ISR_TCIF4_Msk                               /*!< Channel 4 Transfer Complete flag */
+#define DMA_ISR_HTIF4_Pos      (14U)
+#define DMA_ISR_HTIF4_Msk      (0x1UL << DMA_ISR_HTIF4_Pos)                    /*!< 0x00004000 */
+#define DMA_ISR_HTIF4          DMA_ISR_HTIF4_Msk                               /*!< Channel 4 Half Transfer flag */
+#define DMA_ISR_TEIF4_Pos      (15U)
+#define DMA_ISR_TEIF4_Msk      (0x1UL << DMA_ISR_TEIF4_Pos)                    /*!< 0x00008000 */
+#define DMA_ISR_TEIF4          DMA_ISR_TEIF4_Msk                               /*!< Channel 4 Transfer Error flag */
+#define DMA_ISR_GIF5_Pos       (16U)
+#define DMA_ISR_GIF5_Msk       (0x1UL << DMA_ISR_GIF5_Pos)                     /*!< 0x00010000 */
+#define DMA_ISR_GIF5           DMA_ISR_GIF5_Msk                                /*!< Channel 5 Global interrupt flag */
+#define DMA_ISR_TCIF5_Pos      (17U)
+#define DMA_ISR_TCIF5_Msk      (0x1UL << DMA_ISR_TCIF5_Pos)                    /*!< 0x00020000 */
+#define DMA_ISR_TCIF5          DMA_ISR_TCIF5_Msk                               /*!< Channel 5 Transfer Complete flag */
+#define DMA_ISR_HTIF5_Pos      (18U)
+#define DMA_ISR_HTIF5_Msk      (0x1UL << DMA_ISR_HTIF5_Pos)                    /*!< 0x00040000 */
+#define DMA_ISR_HTIF5          DMA_ISR_HTIF5_Msk                               /*!< Channel 5 Half Transfer flag */
+#define DMA_ISR_TEIF5_Pos      (19U)
+#define DMA_ISR_TEIF5_Msk      (0x1UL << DMA_ISR_TEIF5_Pos)                    /*!< 0x00080000 */
+#define DMA_ISR_TEIF5          DMA_ISR_TEIF5_Msk                               /*!< Channel 5 Transfer Error flag */
+#define DMA_ISR_GIF6_Pos       (20U)
+#define DMA_ISR_GIF6_Msk       (0x1UL << DMA_ISR_GIF6_Pos)                     /*!< 0x00100000 */
+#define DMA_ISR_GIF6           DMA_ISR_GIF6_Msk                                /*!< Channel 6 Global interrupt flag */
+#define DMA_ISR_TCIF6_Pos      (21U)
+#define DMA_ISR_TCIF6_Msk      (0x1UL << DMA_ISR_TCIF6_Pos)                    /*!< 0x00200000 */
+#define DMA_ISR_TCIF6          DMA_ISR_TCIF6_Msk                               /*!< Channel 6 Transfer Complete flag */
+#define DMA_ISR_HTIF6_Pos      (22U)
+#define DMA_ISR_HTIF6_Msk      (0x1UL << DMA_ISR_HTIF6_Pos)                    /*!< 0x00400000 */
+#define DMA_ISR_HTIF6          DMA_ISR_HTIF6_Msk                               /*!< Channel 6 Half Transfer flag */
+#define DMA_ISR_TEIF6_Pos      (23U)
+#define DMA_ISR_TEIF6_Msk      (0x1UL << DMA_ISR_TEIF6_Pos)                    /*!< 0x00800000 */
+#define DMA_ISR_TEIF6          DMA_ISR_TEIF6_Msk                               /*!< Channel 6 Transfer Error flag */
+#define DMA_ISR_GIF7_Pos       (24U)
+#define DMA_ISR_GIF7_Msk       (0x1UL << DMA_ISR_GIF7_Pos)                     /*!< 0x01000000 */
+#define DMA_ISR_GIF7           DMA_ISR_GIF7_Msk                                /*!< Channel 7 Global interrupt flag */
+#define DMA_ISR_TCIF7_Pos      (25U)
+#define DMA_ISR_TCIF7_Msk      (0x1UL << DMA_ISR_TCIF7_Pos)                    /*!< 0x02000000 */
+#define DMA_ISR_TCIF7          DMA_ISR_TCIF7_Msk                               /*!< Channel 7 Transfer Complete flag */
+#define DMA_ISR_HTIF7_Pos      (26U)
+#define DMA_ISR_HTIF7_Msk      (0x1UL << DMA_ISR_HTIF7_Pos)                    /*!< 0x04000000 */
+#define DMA_ISR_HTIF7          DMA_ISR_HTIF7_Msk                               /*!< Channel 7 Half Transfer flag */
+#define DMA_ISR_TEIF7_Pos      (27U)
+#define DMA_ISR_TEIF7_Msk      (0x1UL << DMA_ISR_TEIF7_Pos)                    /*!< 0x08000000 */
+#define DMA_ISR_TEIF7          DMA_ISR_TEIF7_Msk                               /*!< Channel 7 Transfer Error flag */
+
+/*******************  Bit definition for DMA_IFCR register  *******************/
+#define DMA_IFCR_CGIF1_Pos     (0U)
+#define DMA_IFCR_CGIF1_Msk     (0x1UL << DMA_IFCR_CGIF1_Pos)                   /*!< 0x00000001 */
+#define DMA_IFCR_CGIF1         DMA_IFCR_CGIF1_Msk                              /*!< Channel 1 Global interrupt clear */
+#define DMA_IFCR_CTCIF1_Pos    (1U)
+#define DMA_IFCR_CTCIF1_Msk    (0x1UL << DMA_IFCR_CTCIF1_Pos)                  /*!< 0x00000002 */
+#define DMA_IFCR_CTCIF1        DMA_IFCR_CTCIF1_Msk                             /*!< Channel 1 Transfer Complete clear */
+#define DMA_IFCR_CHTIF1_Pos    (2U)
+#define DMA_IFCR_CHTIF1_Msk    (0x1UL << DMA_IFCR_CHTIF1_Pos)                  /*!< 0x00000004 */
+#define DMA_IFCR_CHTIF1        DMA_IFCR_CHTIF1_Msk                             /*!< Channel 1 Half Transfer clear */
+#define DMA_IFCR_CTEIF1_Pos    (3U)
+#define DMA_IFCR_CTEIF1_Msk    (0x1UL << DMA_IFCR_CTEIF1_Pos)                  /*!< 0x00000008 */
+#define DMA_IFCR_CTEIF1        DMA_IFCR_CTEIF1_Msk                             /*!< Channel 1 Transfer Error clear */
+#define DMA_IFCR_CGIF2_Pos     (4U)
+#define DMA_IFCR_CGIF2_Msk     (0x1UL << DMA_IFCR_CGIF2_Pos)                   /*!< 0x00000010 */
+#define DMA_IFCR_CGIF2         DMA_IFCR_CGIF2_Msk                              /*!< Channel 2 Global interrupt clear */
+#define DMA_IFCR_CTCIF2_Pos    (5U)
+#define DMA_IFCR_CTCIF2_Msk    (0x1UL << DMA_IFCR_CTCIF2_Pos)                  /*!< 0x00000020 */
+#define DMA_IFCR_CTCIF2        DMA_IFCR_CTCIF2_Msk                             /*!< Channel 2 Transfer Complete clear */
+#define DMA_IFCR_CHTIF2_Pos    (6U)
+#define DMA_IFCR_CHTIF2_Msk    (0x1UL << DMA_IFCR_CHTIF2_Pos)                  /*!< 0x00000040 */
+#define DMA_IFCR_CHTIF2        DMA_IFCR_CHTIF2_Msk                             /*!< Channel 2 Half Transfer clear */
+#define DMA_IFCR_CTEIF2_Pos    (7U)
+#define DMA_IFCR_CTEIF2_Msk    (0x1UL << DMA_IFCR_CTEIF2_Pos)                  /*!< 0x00000080 */
+#define DMA_IFCR_CTEIF2        DMA_IFCR_CTEIF2_Msk                             /*!< Channel 2 Transfer Error clear */
+#define DMA_IFCR_CGIF3_Pos     (8U)
+#define DMA_IFCR_CGIF3_Msk     (0x1UL << DMA_IFCR_CGIF3_Pos)                   /*!< 0x00000100 */
+#define DMA_IFCR_CGIF3         DMA_IFCR_CGIF3_Msk                              /*!< Channel 3 Global interrupt clear */
+#define DMA_IFCR_CTCIF3_Pos    (9U)
+#define DMA_IFCR_CTCIF3_Msk    (0x1UL << DMA_IFCR_CTCIF3_Pos)                  /*!< 0x00000200 */
+#define DMA_IFCR_CTCIF3        DMA_IFCR_CTCIF3_Msk                             /*!< Channel 3 Transfer Complete clear */
+#define DMA_IFCR_CHTIF3_Pos    (10U)
+#define DMA_IFCR_CHTIF3_Msk    (0x1UL << DMA_IFCR_CHTIF3_Pos)                  /*!< 0x00000400 */
+#define DMA_IFCR_CHTIF3        DMA_IFCR_CHTIF3_Msk                             /*!< Channel 3 Half Transfer clear */
+#define DMA_IFCR_CTEIF3_Pos    (11U)
+#define DMA_IFCR_CTEIF3_Msk    (0x1UL << DMA_IFCR_CTEIF3_Pos)                  /*!< 0x00000800 */
+#define DMA_IFCR_CTEIF3        DMA_IFCR_CTEIF3_Msk                             /*!< Channel 3 Transfer Error clear */
+#define DMA_IFCR_CGIF4_Pos     (12U)
+#define DMA_IFCR_CGIF4_Msk     (0x1UL << DMA_IFCR_CGIF4_Pos)                   /*!< 0x00001000 */
+#define DMA_IFCR_CGIF4         DMA_IFCR_CGIF4_Msk                              /*!< Channel 4 Global interrupt clear */
+#define DMA_IFCR_CTCIF4_Pos    (13U)
+#define DMA_IFCR_CTCIF4_Msk    (0x1UL << DMA_IFCR_CTCIF4_Pos)                  /*!< 0x00002000 */
+#define DMA_IFCR_CTCIF4        DMA_IFCR_CTCIF4_Msk                             /*!< Channel 4 Transfer Complete clear */
+#define DMA_IFCR_CHTIF4_Pos    (14U)
+#define DMA_IFCR_CHTIF4_Msk    (0x1UL << DMA_IFCR_CHTIF4_Pos)                  /*!< 0x00004000 */
+#define DMA_IFCR_CHTIF4        DMA_IFCR_CHTIF4_Msk                             /*!< Channel 4 Half Transfer clear */
+#define DMA_IFCR_CTEIF4_Pos    (15U)
+#define DMA_IFCR_CTEIF4_Msk    (0x1UL << DMA_IFCR_CTEIF4_Pos)                  /*!< 0x00008000 */
+#define DMA_IFCR_CTEIF4        DMA_IFCR_CTEIF4_Msk                             /*!< Channel 4 Transfer Error clear */
+#define DMA_IFCR_CGIF5_Pos     (16U)
+#define DMA_IFCR_CGIF5_Msk     (0x1UL << DMA_IFCR_CGIF5_Pos)                   /*!< 0x00010000 */
+#define DMA_IFCR_CGIF5         DMA_IFCR_CGIF5_Msk                              /*!< Channel 5 Global interrupt clear */
+#define DMA_IFCR_CTCIF5_Pos    (17U)
+#define DMA_IFCR_CTCIF5_Msk    (0x1UL << DMA_IFCR_CTCIF5_Pos)                  /*!< 0x00020000 */
+#define DMA_IFCR_CTCIF5        DMA_IFCR_CTCIF5_Msk                             /*!< Channel 5 Transfer Complete clear */
+#define DMA_IFCR_CHTIF5_Pos    (18U)
+#define DMA_IFCR_CHTIF5_Msk    (0x1UL << DMA_IFCR_CHTIF5_Pos)                  /*!< 0x00040000 */
+#define DMA_IFCR_CHTIF5        DMA_IFCR_CHTIF5_Msk                             /*!< Channel 5 Half Transfer clear */
+#define DMA_IFCR_CTEIF5_Pos    (19U)
+#define DMA_IFCR_CTEIF5_Msk    (0x1UL << DMA_IFCR_CTEIF5_Pos)                  /*!< 0x00080000 */
+#define DMA_IFCR_CTEIF5        DMA_IFCR_CTEIF5_Msk                             /*!< Channel 5 Transfer Error clear */
+#define DMA_IFCR_CGIF6_Pos     (20U)
+#define DMA_IFCR_CGIF6_Msk     (0x1UL << DMA_IFCR_CGIF6_Pos)                   /*!< 0x00100000 */
+#define DMA_IFCR_CGIF6         DMA_IFCR_CGIF6_Msk                              /*!< Channel 6 Global interrupt clear */
+#define DMA_IFCR_CTCIF6_Pos    (21U)
+#define DMA_IFCR_CTCIF6_Msk    (0x1UL << DMA_IFCR_CTCIF6_Pos)                  /*!< 0x00200000 */
+#define DMA_IFCR_CTCIF6        DMA_IFCR_CTCIF6_Msk                             /*!< Channel 6 Transfer Complete clear */
+#define DMA_IFCR_CHTIF6_Pos    (22U)
+#define DMA_IFCR_CHTIF6_Msk    (0x1UL << DMA_IFCR_CHTIF6_Pos)                  /*!< 0x00400000 */
+#define DMA_IFCR_CHTIF6        DMA_IFCR_CHTIF6_Msk                             /*!< Channel 6 Half Transfer clear */
+#define DMA_IFCR_CTEIF6_Pos    (23U)
+#define DMA_IFCR_CTEIF6_Msk    (0x1UL << DMA_IFCR_CTEIF6_Pos)                  /*!< 0x00800000 */
+#define DMA_IFCR_CTEIF6        DMA_IFCR_CTEIF6_Msk                             /*!< Channel 6 Transfer Error clear */
+#define DMA_IFCR_CGIF7_Pos     (24U)
+#define DMA_IFCR_CGIF7_Msk     (0x1UL << DMA_IFCR_CGIF7_Pos)                   /*!< 0x01000000 */
+#define DMA_IFCR_CGIF7         DMA_IFCR_CGIF7_Msk                              /*!< Channel 7 Global interrupt clear */
+#define DMA_IFCR_CTCIF7_Pos    (25U)
+#define DMA_IFCR_CTCIF7_Msk    (0x1UL << DMA_IFCR_CTCIF7_Pos)                  /*!< 0x02000000 */
+#define DMA_IFCR_CTCIF7        DMA_IFCR_CTCIF7_Msk                             /*!< Channel 7 Transfer Complete clear */
+#define DMA_IFCR_CHTIF7_Pos    (26U)
+#define DMA_IFCR_CHTIF7_Msk    (0x1UL << DMA_IFCR_CHTIF7_Pos)                  /*!< 0x04000000 */
+#define DMA_IFCR_CHTIF7        DMA_IFCR_CHTIF7_Msk                             /*!< Channel 7 Half Transfer clear */
+#define DMA_IFCR_CTEIF7_Pos    (27U)
+#define DMA_IFCR_CTEIF7_Msk    (0x1UL << DMA_IFCR_CTEIF7_Pos)                  /*!< 0x08000000 */
+#define DMA_IFCR_CTEIF7        DMA_IFCR_CTEIF7_Msk                             /*!< Channel 7 Transfer Error clear */
+
+/*******************  Bit definition for DMA_CCR register  ********************/
+#define DMA_CCR_EN_Pos         (0U)
+#define DMA_CCR_EN_Msk         (0x1UL << DMA_CCR_EN_Pos)                       /*!< 0x00000001 */
+#define DMA_CCR_EN             DMA_CCR_EN_Msk                                  /*!< Channel enable                      */
+#define DMA_CCR_TCIE_Pos       (1U)
+#define DMA_CCR_TCIE_Msk       (0x1UL << DMA_CCR_TCIE_Pos)                     /*!< 0x00000002 */
+#define DMA_CCR_TCIE           DMA_CCR_TCIE_Msk                                /*!< Transfer complete interrupt enable  */
+#define DMA_CCR_HTIE_Pos       (2U)
+#define DMA_CCR_HTIE_Msk       (0x1UL << DMA_CCR_HTIE_Pos)                     /*!< 0x00000004 */
+#define DMA_CCR_HTIE           DMA_CCR_HTIE_Msk                                /*!< Half Transfer interrupt enable      */
+#define DMA_CCR_TEIE_Pos       (3U)
+#define DMA_CCR_TEIE_Msk       (0x1UL << DMA_CCR_TEIE_Pos)                     /*!< 0x00000008 */
+#define DMA_CCR_TEIE           DMA_CCR_TEIE_Msk                                /*!< Transfer error interrupt enable     */
+#define DMA_CCR_DIR_Pos        (4U)
+#define DMA_CCR_DIR_Msk        (0x1UL << DMA_CCR_DIR_Pos)                      /*!< 0x00000010 */
+#define DMA_CCR_DIR            DMA_CCR_DIR_Msk                                 /*!< Data transfer direction             */
+#define DMA_CCR_CIRC_Pos       (5U)
+#define DMA_CCR_CIRC_Msk       (0x1UL << DMA_CCR_CIRC_Pos)                     /*!< 0x00000020 */
+#define DMA_CCR_CIRC           DMA_CCR_CIRC_Msk                                /*!< Circular mode                       */
+#define DMA_CCR_PINC_Pos       (6U)
+#define DMA_CCR_PINC_Msk       (0x1UL << DMA_CCR_PINC_Pos)                     /*!< 0x00000040 */
+#define DMA_CCR_PINC           DMA_CCR_PINC_Msk                                /*!< Peripheral increment mode           */
+#define DMA_CCR_MINC_Pos       (7U)
+#define DMA_CCR_MINC_Msk       (0x1UL << DMA_CCR_MINC_Pos)                     /*!< 0x00000080 */
+#define DMA_CCR_MINC           DMA_CCR_MINC_Msk                                /*!< Memory increment mode               */
+
+#define DMA_CCR_PSIZE_Pos      (8U)
+#define DMA_CCR_PSIZE_Msk      (0x3UL << DMA_CCR_PSIZE_Pos)                    /*!< 0x00000300 */
+#define DMA_CCR_PSIZE          DMA_CCR_PSIZE_Msk                               /*!< PSIZE[1:0] bits (Peripheral size)   */
+#define DMA_CCR_PSIZE_0        (0x1U << DMA_CCR_PSIZE_Pos)                     /*!< 0x00000100 */
+#define DMA_CCR_PSIZE_1        (0x2U << DMA_CCR_PSIZE_Pos)                     /*!< 0x00000200 */
+
+#define DMA_CCR_MSIZE_Pos      (10U)
+#define DMA_CCR_MSIZE_Msk      (0x3UL << DMA_CCR_MSIZE_Pos)                    /*!< 0x00000C00 */
+#define DMA_CCR_MSIZE          DMA_CCR_MSIZE_Msk                               /*!< MSIZE[1:0] bits (Memory size)       */
+#define DMA_CCR_MSIZE_0        (0x1U << DMA_CCR_MSIZE_Pos)                     /*!< 0x00000400 */
+#define DMA_CCR_MSIZE_1        (0x2U << DMA_CCR_MSIZE_Pos)                     /*!< 0x00000800 */
+
+#define DMA_CCR_PL_Pos         (12U)
+#define DMA_CCR_PL_Msk         (0x3UL << DMA_CCR_PL_Pos)                       /*!< 0x00003000 */
+#define DMA_CCR_PL             DMA_CCR_PL_Msk                                  /*!< PL[1:0] bits(Channel Priority level)*/
+#define DMA_CCR_PL_0           (0x1U << DMA_CCR_PL_Pos)                        /*!< 0x00001000 */
+#define DMA_CCR_PL_1           (0x2U << DMA_CCR_PL_Pos)                        /*!< 0x00002000 */
+
+#define DMA_CCR_MEM2MEM_Pos    (14U)
+#define DMA_CCR_MEM2MEM_Msk    (0x1UL << DMA_CCR_MEM2MEM_Pos)                  /*!< 0x00004000 */
+#define DMA_CCR_MEM2MEM        DMA_CCR_MEM2MEM_Msk                             /*!< Memory to memory mode               */
+
+/******************  Bit definition for DMA_CNDTR register  *******************/
+#define DMA_CNDTR_NDT_Pos      (0U)
+#define DMA_CNDTR_NDT_Msk      (0xFFFFUL << DMA_CNDTR_NDT_Pos)                 /*!< 0x0000FFFF */
+#define DMA_CNDTR_NDT          DMA_CNDTR_NDT_Msk                               /*!< Number of data to Transfer          */
+
+/******************  Bit definition for DMA_CPAR register  ********************/
+#define DMA_CPAR_PA_Pos        (0U)
+#define DMA_CPAR_PA_Msk        (0xFFFFFFFFUL << DMA_CPAR_PA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CPAR_PA            DMA_CPAR_PA_Msk                                 /*!< Peripheral Address                  */
+
+/******************  Bit definition for DMA_CMAR register  ********************/
+#define DMA_CMAR_MA_Pos        (0U)
+#define DMA_CMAR_MA_Msk        (0xFFFFFFFFUL << DMA_CMAR_MA_Pos)               /*!< 0xFFFFFFFF */
+#define DMA_CMAR_MA            DMA_CMAR_MA_Msk                                 /*!< Memory Address                      */
+
+/******************************************************************************/
+/*                                                                            */
+/*                             DMAMUX Controller                              */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for DMAMUX_CxCR register  **************/
+#define DMAMUX_CxCR_DMAREQ_ID_Pos              (0U)
+#define DMAMUX_CxCR_DMAREQ_ID_Msk              (0x3FUL << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x0000003F */
+#define DMAMUX_CxCR_DMAREQ_ID                  DMAMUX_CxCR_DMAREQ_ID_Msk       /*!< DMA Request ID                       */
+#define DMAMUX_CxCR_DMAREQ_ID_0                (0x01U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_CxCR_DMAREQ_ID_1                (0x02U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_CxCR_DMAREQ_ID_2                (0x04U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_CxCR_DMAREQ_ID_3                (0x08U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_CxCR_DMAREQ_ID_4                (0x10U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_CxCR_DMAREQ_ID_5                (0x20U << DMAMUX_CxCR_DMAREQ_ID_Pos) /*!< 0x00000020 */
+#define DMAMUX_CxCR_SOIE_Pos                   (8U)
+#define DMAMUX_CxCR_SOIE_Msk                   (0x1UL << DMAMUX_CxCR_SOIE_Pos) /*!< 0x00000100 */
+#define DMAMUX_CxCR_SOIE                       DMAMUX_CxCR_SOIE_Msk            /*!< Synchro overrun interrupt enable     */
+#define DMAMUX_CxCR_EGE_Pos                    (9U)
+#define DMAMUX_CxCR_EGE_Msk                    (0x1UL << DMAMUX_CxCR_EGE_Pos)  /*!< 0x00000200 */
+#define DMAMUX_CxCR_EGE                        DMAMUX_CxCR_EGE_Msk             /*!< Event generation interrupt enable    */
+#define DMAMUX_CxCR_SE_Pos                     (16U)
+#define DMAMUX_CxCR_SE_Msk                     (0x1UL << DMAMUX_CxCR_SE_Pos)   /*!< 0x00010000 */
+#define DMAMUX_CxCR_SE                         DMAMUX_CxCR_SE_Msk              /*!< Synchronization enable               */
+#define DMAMUX_CxCR_SPOL_Pos                   (17U)
+#define DMAMUX_CxCR_SPOL_Msk                   (0x3UL << DMAMUX_CxCR_SPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_CxCR_SPOL                       DMAMUX_CxCR_SPOL_Msk            /*!< Synchronization polarity             */
+#define DMAMUX_CxCR_SPOL_0                     (0x1U << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00020000 */
+#define DMAMUX_CxCR_SPOL_1                     (0x2U << DMAMUX_CxCR_SPOL_Pos)  /*!< 0x00040000 */
+#define DMAMUX_CxCR_NBREQ_Pos                  (19U)
+#define DMAMUX_CxCR_NBREQ_Msk                  (0x1FUL << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_CxCR_NBREQ                      DMAMUX_CxCR_NBREQ_Msk           /*!< Number of request                    */
+#define DMAMUX_CxCR_NBREQ_0                    (0x01U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_CxCR_NBREQ_1                    (0x02U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_CxCR_NBREQ_2                    (0x04U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_CxCR_NBREQ_3                    (0x08U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_CxCR_NBREQ_4                    (0x10U << DMAMUX_CxCR_NBREQ_Pos) /*!< 0x00800000 */
+#define DMAMUX_CxCR_SYNC_ID_Pos                (24U)
+#define DMAMUX_CxCR_SYNC_ID_Msk                (0x1FUL << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x1F000000 */
+#define DMAMUX_CxCR_SYNC_ID                    DMAMUX_CxCR_SYNC_ID_Msk         /*!< Synchronization ID                   */
+#define DMAMUX_CxCR_SYNC_ID_0                  (0x01U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x01000000 */
+#define DMAMUX_CxCR_SYNC_ID_1                  (0x02U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x02000000 */
+#define DMAMUX_CxCR_SYNC_ID_2                  (0x04U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x04000000 */
+#define DMAMUX_CxCR_SYNC_ID_3                  (0x08U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x08000000 */
+#define DMAMUX_CxCR_SYNC_ID_4                  (0x10U << DMAMUX_CxCR_SYNC_ID_Pos) /*!< 0x10000000 */
+
+/*******************  Bits definition for DMAMUX_CSR register  **************/
+#define DMAMUX_CSR_SOF0_Pos                    (0U)
+#define DMAMUX_CSR_SOF0_Msk                    (0x1UL << DMAMUX_CSR_SOF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_CSR_SOF0                        DMAMUX_CSR_SOF0_Msk             /*!< Synchronization Overrun Flag 0       */
+#define DMAMUX_CSR_SOF1_Pos                    (1U)
+#define DMAMUX_CSR_SOF1_Msk                    (0x1UL << DMAMUX_CSR_SOF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_CSR_SOF1                        DMAMUX_CSR_SOF1_Msk             /*!< Synchronization Overrun Flag 1       */
+#define DMAMUX_CSR_SOF2_Pos                    (2U)
+#define DMAMUX_CSR_SOF2_Msk                    (0x1UL << DMAMUX_CSR_SOF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_CSR_SOF2                        DMAMUX_CSR_SOF2_Msk             /*!< Synchronization Overrun Flag 2       */
+#define DMAMUX_CSR_SOF3_Pos                    (3U)
+#define DMAMUX_CSR_SOF3_Msk                    (0x1UL << DMAMUX_CSR_SOF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_CSR_SOF3                        DMAMUX_CSR_SOF3_Msk             /*!< Synchronization Overrun Flag 3       */
+#define DMAMUX_CSR_SOF4_Pos                    (4U)
+#define DMAMUX_CSR_SOF4_Msk                    (0x1UL << DMAMUX_CSR_SOF4_Pos)  /*!< 0x00000010 */
+#define DMAMUX_CSR_SOF4                        DMAMUX_CSR_SOF4_Msk             /*!< Synchronization Overrun Flag 4       */
+#define DMAMUX_CSR_SOF5_Pos                    (5U)
+#define DMAMUX_CSR_SOF5_Msk                    (0x1UL << DMAMUX_CSR_SOF5_Pos)  /*!< 0x00000020 */
+#define DMAMUX_CSR_SOF5                        DMAMUX_CSR_SOF5_Msk             /*!< Synchronization Overrun Flag 5       */
+#define DMAMUX_CSR_SOF6_Pos                    (6U)
+#define DMAMUX_CSR_SOF6_Msk                    (0x1UL << DMAMUX_CSR_SOF6_Pos)  /*!< 0x00000040 */
+#define DMAMUX_CSR_SOF6                        DMAMUX_CSR_SOF6_Msk             /*!< Synchronization Overrun Flag 6       */
+
+/********************  Bits definition for DMAMUX_CFR register  **************/
+#define DMAMUX_CFR_CSOF0_Pos                   (0U)
+#define DMAMUX_CFR_CSOF0_Msk                   (0x1UL << DMAMUX_CFR_CSOF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_CFR_CSOF0                       DMAMUX_CFR_CSOF0_Msk            /*!< Clear Overrun Flag 0                 */
+#define DMAMUX_CFR_CSOF1_Pos                   (1U)
+#define DMAMUX_CFR_CSOF1_Msk                   (0x1UL << DMAMUX_CFR_CSOF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_CFR_CSOF1                       DMAMUX_CFR_CSOF1_Msk            /*!< Clear Overrun Flag 1                 */
+#define DMAMUX_CFR_CSOF2_Pos                   (2U)
+#define DMAMUX_CFR_CSOF2_Msk                   (0x1UL << DMAMUX_CFR_CSOF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_CFR_CSOF2                       DMAMUX_CFR_CSOF2_Msk            /*!< Clear Overrun Flag 2                 */
+#define DMAMUX_CFR_CSOF3_Pos                   (3U)
+#define DMAMUX_CFR_CSOF3_Msk                   (0x1UL << DMAMUX_CFR_CSOF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_CFR_CSOF3                       DMAMUX_CFR_CSOF3_Msk            /*!< Clear Overrun Flag 3                 */
+#define DMAMUX_CFR_CSOF4_Pos                   (4U)
+#define DMAMUX_CFR_CSOF4_Msk                   (0x1UL << DMAMUX_CFR_CSOF4_Pos) /*!< 0x00000010 */
+#define DMAMUX_CFR_CSOF4                       DMAMUX_CFR_CSOF4_Msk            /*!< Clear Overrun Flag 4                 */
+#define DMAMUX_CFR_CSOF5_Pos                   (5U)
+#define DMAMUX_CFR_CSOF5_Msk                   (0x1UL << DMAMUX_CFR_CSOF5_Pos) /*!< 0x00000020 */
+#define DMAMUX_CFR_CSOF5                       DMAMUX_CFR_CSOF5_Msk            /*!< Clear Overrun Flag 5                 */
+#define DMAMUX_CFR_CSOF6_Pos                   (6U)
+#define DMAMUX_CFR_CSOF6_Msk                   (0x1UL << DMAMUX_CFR_CSOF6_Pos) /*!< 0x00000040 */
+#define DMAMUX_CFR_CSOF6                       DMAMUX_CFR_CSOF6_Msk            /*!< Clear Overrun Flag 6                 */
+
+/********************  Bits definition for DMAMUX_RGxCR register  ************/
+#define DMAMUX_RGxCR_SIG_ID_Pos                (0U)
+#define DMAMUX_RGxCR_SIG_ID_Msk                (0x1FUL << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x0000001F */
+#define DMAMUX_RGxCR_SIG_ID                    DMAMUX_RGxCR_SIG_ID_Msk         /*!< Signal ID                            */
+#define DMAMUX_RGxCR_SIG_ID_0                  (0x01U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGxCR_SIG_ID_1                  (0x02U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGxCR_SIG_ID_2                  (0x04U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGxCR_SIG_ID_3                  (0x08U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGxCR_SIG_ID_4                  (0x10U << DMAMUX_RGxCR_SIG_ID_Pos) /*!< 0x00000010 */
+#define DMAMUX_RGxCR_OIE_Pos                   (8U)
+#define DMAMUX_RGxCR_OIE_Msk                   (0x1UL << DMAMUX_RGxCR_OIE_Pos) /*!< 0x00000100 */
+#define DMAMUX_RGxCR_OIE                       DMAMUX_RGxCR_OIE_Msk            /*!< Overrun interrupt enable             */
+#define DMAMUX_RGxCR_GE_Pos                    (16U)
+#define DMAMUX_RGxCR_GE_Msk                    (0x1UL << DMAMUX_RGxCR_GE_Pos)  /*!< 0x00010000 */
+#define DMAMUX_RGxCR_GE                        DMAMUX_RGxCR_GE_Msk             /*!< Generation enable                    */
+#define DMAMUX_RGxCR_GPOL_Pos                  (17U)
+#define DMAMUX_RGxCR_GPOL_Msk                  (0x3UL << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00060000 */
+#define DMAMUX_RGxCR_GPOL                      DMAMUX_RGxCR_GPOL_Msk           /*!< Generation polarity                  */
+#define DMAMUX_RGxCR_GPOL_0                    (0x1U << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00020000 */
+#define DMAMUX_RGxCR_GPOL_1                    (0x2U << DMAMUX_RGxCR_GPOL_Pos) /*!< 0x00040000 */
+#define DMAMUX_RGxCR_GNBREQ_Pos                (19U)
+#define DMAMUX_RGxCR_GNBREQ_Msk                (0x1FUL << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00F80000 */
+#define DMAMUX_RGxCR_GNBREQ                    DMAMUX_RGxCR_GNBREQ_Msk          /*!< Number of request                    */
+#define DMAMUX_RGxCR_GNBREQ_0                  (0x01U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00080000 */
+#define DMAMUX_RGxCR_GNBREQ_1                  (0x02U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00100000 */
+#define DMAMUX_RGxCR_GNBREQ_2                  (0x04U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00200000 */
+#define DMAMUX_RGxCR_GNBREQ_3                  (0x08U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00400000 */
+#define DMAMUX_RGxCR_GNBREQ_4                  (0x10U << DMAMUX_RGxCR_GNBREQ_Pos) /*!< 0x00800000 */
+
+/********************  Bits definition for DMAMUX_RGSR register  **************/
+#define DMAMUX_RGSR_OF0_Pos                    (0U)
+#define DMAMUX_RGSR_OF0_Msk                    (0x1UL << DMAMUX_RGSR_OF0_Pos)  /*!< 0x00000001 */
+#define DMAMUX_RGSR_OF0                        DMAMUX_RGSR_OF0_Msk             /*!< Overrun flag 0                       */
+#define DMAMUX_RGSR_OF1_Pos                    (1U)
+#define DMAMUX_RGSR_OF1_Msk                    (0x1UL << DMAMUX_RGSR_OF1_Pos)  /*!< 0x00000002 */
+#define DMAMUX_RGSR_OF1                        DMAMUX_RGSR_OF1_Msk             /*!< Overrun flag 1                       */
+#define DMAMUX_RGSR_OF2_Pos                    (2U)
+#define DMAMUX_RGSR_OF2_Msk                    (0x1UL << DMAMUX_RGSR_OF2_Pos)  /*!< 0x00000004 */
+#define DMAMUX_RGSR_OF2                        DMAMUX_RGSR_OF2_Msk             /*!< Overrun flag 2                       */
+#define DMAMUX_RGSR_OF3_Pos                    (3U)
+#define DMAMUX_RGSR_OF3_Msk                    (0x1UL << DMAMUX_RGSR_OF3_Pos)  /*!< 0x00000008 */
+#define DMAMUX_RGSR_OF3                        DMAMUX_RGSR_OF3_Msk             /*!< Overrun flag 3                       */
+
+/********************  Bits definition for DMAMUX_RGCFR register  **************/
+#define DMAMUX_RGCFR_COF0_Pos                  (0U)
+#define DMAMUX_RGCFR_COF0_Msk                  (0x1UL << DMAMUX_RGCFR_COF0_Pos) /*!< 0x00000001 */
+#define DMAMUX_RGCFR_COF0                      DMAMUX_RGCFR_COF0_Msk           /*!< Clear Overrun flag 0                 */
+#define DMAMUX_RGCFR_COF1_Pos                  (1U)
+#define DMAMUX_RGCFR_COF1_Msk                  (0x1UL << DMAMUX_RGCFR_COF1_Pos) /*!< 0x00000002 */
+#define DMAMUX_RGCFR_COF1                      DMAMUX_RGCFR_COF1_Msk           /*!< Clear Overrun flag 1                 */
+#define DMAMUX_RGCFR_COF2_Pos                  (2U)
+#define DMAMUX_RGCFR_COF2_Msk                  (0x1UL << DMAMUX_RGCFR_COF2_Pos) /*!< 0x00000004 */
+#define DMAMUX_RGCFR_COF2                      DMAMUX_RGCFR_COF2_Msk           /*!< Clear Overrun flag 2                 */
+#define DMAMUX_RGCFR_COF3_Pos                  (3U)
+#define DMAMUX_RGCFR_COF3_Msk                  (0x1UL << DMAMUX_RGCFR_COF3_Pos) /*!< 0x00000008 */
+#define DMAMUX_RGCFR_COF3                      DMAMUX_RGCFR_COF3_Msk           /*!< Clear Overrun flag 3                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                    External Interrupt/Event Controller                     */
+/*                                                                            */
+/******************************************************************************/
+
+/******************  Bit definition for EXTI_RTSR1 register  ******************/
+#define EXTI_RTSR1_RT_Pos        (0U)
+#define EXTI_RTSR1_RT_Msk        (0x803FFFFFUL << EXTI_RTSR1_RT_Pos)           /*!< 0x803FFFFF */
+#define EXTI_RTSR1_RT            EXTI_RTSR1_RT_Msk                             /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR1_RT0_Pos       (0U)
+#define EXTI_RTSR1_RT0_Msk       (0x1UL << EXTI_RTSR1_RT0_Pos)                 /*!< 0x00000001 */
+#define EXTI_RTSR1_RT0           EXTI_RTSR1_RT0_Msk                            /*!< Rising trigger event configuration bit of line 0 */
+#define EXTI_RTSR1_RT1_Pos       (1U)
+#define EXTI_RTSR1_RT1_Msk       (0x1UL << EXTI_RTSR1_RT1_Pos)                 /*!< 0x00000002 */
+#define EXTI_RTSR1_RT1           EXTI_RTSR1_RT1_Msk                            /*!< Rising trigger event configuration bit of line 1 */
+#define EXTI_RTSR1_RT2_Pos       (2U)
+#define EXTI_RTSR1_RT2_Msk       (0x1UL << EXTI_RTSR1_RT2_Pos)                 /*!< 0x00000004 */
+#define EXTI_RTSR1_RT2           EXTI_RTSR1_RT2_Msk                            /*!< Rising trigger event configuration bit of line 2 */
+#define EXTI_RTSR1_RT3_Pos       (3U)
+#define EXTI_RTSR1_RT3_Msk       (0x1UL << EXTI_RTSR1_RT3_Pos)                 /*!< 0x00000008 */
+#define EXTI_RTSR1_RT3           EXTI_RTSR1_RT3_Msk                            /*!< Rising trigger event configuration bit of line 3 */
+#define EXTI_RTSR1_RT4_Pos       (4U)
+#define EXTI_RTSR1_RT4_Msk       (0x1UL << EXTI_RTSR1_RT4_Pos)                 /*!< 0x00000010 */
+#define EXTI_RTSR1_RT4           EXTI_RTSR1_RT4_Msk                            /*!< Rising trigger event configuration bit of line 4 */
+#define EXTI_RTSR1_RT5_Pos       (5U)
+#define EXTI_RTSR1_RT5_Msk       (0x1UL << EXTI_RTSR1_RT5_Pos)                 /*!< 0x00000020 */
+#define EXTI_RTSR1_RT5           EXTI_RTSR1_RT5_Msk                            /*!< Rising trigger event configuration bit of line 5 */
+#define EXTI_RTSR1_RT6_Pos       (6U)
+#define EXTI_RTSR1_RT6_Msk       (0x1UL << EXTI_RTSR1_RT6_Pos)                 /*!< 0x00000040 */
+#define EXTI_RTSR1_RT6           EXTI_RTSR1_RT6_Msk                            /*!< Rising trigger event configuration bit of line 6 */
+#define EXTI_RTSR1_RT7_Pos       (7U)
+#define EXTI_RTSR1_RT7_Msk       (0x1UL << EXTI_RTSR1_RT7_Pos)                 /*!< 0x00000080 */
+#define EXTI_RTSR1_RT7           EXTI_RTSR1_RT7_Msk                            /*!< Rising trigger event configuration bit of line 7 */
+#define EXTI_RTSR1_RT8_Pos       (8U)
+#define EXTI_RTSR1_RT8_Msk       (0x1UL << EXTI_RTSR1_RT8_Pos)                 /*!< 0x00000100 */
+#define EXTI_RTSR1_RT8           EXTI_RTSR1_RT8_Msk                            /*!< Rising trigger event configuration bit of line 8 */
+#define EXTI_RTSR1_RT9_Pos       (9U)
+#define EXTI_RTSR1_RT9_Msk       (0x1UL << EXTI_RTSR1_RT9_Pos)                 /*!< 0x00000200 */
+#define EXTI_RTSR1_RT9           EXTI_RTSR1_RT9_Msk                            /*!< Rising trigger event configuration bit of line 9 */
+#define EXTI_RTSR1_RT10_Pos      (10U)
+#define EXTI_RTSR1_RT10_Msk      (0x1UL << EXTI_RTSR1_RT10_Pos)                /*!< 0x00000400 */
+#define EXTI_RTSR1_RT10          EXTI_RTSR1_RT10_Msk                           /*!< Rising trigger event configuration bit of line 10 */
+#define EXTI_RTSR1_RT11_Pos      (11U)
+#define EXTI_RTSR1_RT11_Msk      (0x1UL << EXTI_RTSR1_RT11_Pos)                /*!< 0x00000800 */
+#define EXTI_RTSR1_RT11          EXTI_RTSR1_RT11_Msk                           /*!< Rising trigger event configuration bit of line 11 */
+#define EXTI_RTSR1_RT12_Pos      (12U)
+#define EXTI_RTSR1_RT12_Msk      (0x1UL << EXTI_RTSR1_RT12_Pos)                /*!< 0x00001000 */
+#define EXTI_RTSR1_RT12          EXTI_RTSR1_RT12_Msk                           /*!< Rising trigger event configuration bit of line 12 */
+#define EXTI_RTSR1_RT13_Pos      (13U)
+#define EXTI_RTSR1_RT13_Msk      (0x1UL << EXTI_RTSR1_RT13_Pos)                /*!< 0x00002000 */
+#define EXTI_RTSR1_RT13          EXTI_RTSR1_RT13_Msk                           /*!< Rising trigger event configuration bit of line 13 */
+#define EXTI_RTSR1_RT14_Pos      (14U)
+#define EXTI_RTSR1_RT14_Msk      (0x1UL << EXTI_RTSR1_RT14_Pos)                /*!< 0x00004000 */
+#define EXTI_RTSR1_RT14          EXTI_RTSR1_RT14_Msk                           /*!< Rising trigger event configuration bit of line 14 */
+#define EXTI_RTSR1_RT15_Pos      (15U)
+#define EXTI_RTSR1_RT15_Msk      (0x1UL << EXTI_RTSR1_RT15_Pos)                /*!< 0x00008000 */
+#define EXTI_RTSR1_RT15          EXTI_RTSR1_RT15_Msk                           /*!< Rising trigger event configuration bit of line 15 */
+#define EXTI_RTSR1_RT16_Pos      (16U)
+#define EXTI_RTSR1_RT16_Msk      (0x1UL << EXTI_RTSR1_RT16_Pos)                /*!< 0x00010000 */
+#define EXTI_RTSR1_RT16          EXTI_RTSR1_RT16_Msk                           /*!< Rising trigger event configuration bit of line 16 */
+#define EXTI_RTSR1_RT17_Pos      (17U)
+#define EXTI_RTSR1_RT17_Msk      (0x1UL << EXTI_RTSR1_RT17_Pos)                /*!< 0x00020000 */
+#define EXTI_RTSR1_RT17          EXTI_RTSR1_RT17_Msk                           /*!< Rising trigger event configuration bit of line 17 */
+#define EXTI_RTSR1_RT18_Pos      (18U)
+#define EXTI_RTSR1_RT18_Msk      (0x1UL << EXTI_RTSR1_RT18_Pos)                /*!< 0x00040000 */
+#define EXTI_RTSR1_RT18          EXTI_RTSR1_RT18_Msk                           /*!< Rising trigger event configuration bit of line 18 */
+#define EXTI_RTSR1_RT19_Pos      (19U)
+#define EXTI_RTSR1_RT19_Msk      (0x1UL << EXTI_RTSR1_RT19_Pos)                /*!< 0x00080000 */
+#define EXTI_RTSR1_RT19          EXTI_RTSR1_RT19_Msk                           /*!< Rising trigger event configuration bit of line 19 */
+#define EXTI_RTSR1_RT20_Pos      (20U)
+#define EXTI_RTSR1_RT20_Msk      (0x1UL << EXTI_RTSR1_RT20_Pos)                /*!< 0x00100000 */
+#define EXTI_RTSR1_RT20          EXTI_RTSR1_RT20_Msk                           /*!< Rising trigger event configuration bit of line 20 */
+#define EXTI_RTSR1_RT31_Pos      (31U)
+#define EXTI_RTSR1_RT31_Msk      (0x1UL << EXTI_RTSR1_RT31_Pos)                /*!< 0x80000000 */
+#define EXTI_RTSR1_RT31          EXTI_RTSR1_RT31_Msk                           /*!< Rising trigger event configuration bit of line 31 */
+
+/******************  Bit definition for EXTI_FTSR1 register  ******************/
+#define EXTI_FTSR1_FT_Pos        (0U)
+#define EXTI_FTSR1_FT_Msk        (0x803FFFFFUL << EXTI_FTSR1_FT_Pos)           /*!< 0x803FFFFF */
+#define EXTI_FTSR1_FT            EXTI_FTSR1_FT_Msk                             /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR1_FT0_Pos       (0U)
+#define EXTI_FTSR1_FT0_Msk       (0x1UL << EXTI_FTSR1_FT0_Pos)                 /*!< 0x00000001 */
+#define EXTI_FTSR1_FT0           EXTI_FTSR1_FT0_Msk                            /*!< Falling trigger event configuration bit of line 0 */
+#define EXTI_FTSR1_FT1_Pos       (1U)
+#define EXTI_FTSR1_FT1_Msk       (0x1UL << EXTI_FTSR1_FT1_Pos)                 /*!< 0x00000002 */
+#define EXTI_FTSR1_FT1           EXTI_FTSR1_FT1_Msk                            /*!< Falling trigger event configuration bit of line 1 */
+#define EXTI_FTSR1_FT2_Pos       (2U)
+#define EXTI_FTSR1_FT2_Msk       (0x1UL << EXTI_FTSR1_FT2_Pos)                 /*!< 0x00000004 */
+#define EXTI_FTSR1_FT2           EXTI_FTSR1_FT2_Msk                            /*!< Falling trigger event configuration bit of line 2 */
+#define EXTI_FTSR1_FT3_Pos       (3U)
+#define EXTI_FTSR1_FT3_Msk       (0x1UL << EXTI_FTSR1_FT3_Pos)                 /*!< 0x00000008 */
+#define EXTI_FTSR1_FT3           EXTI_FTSR1_FT3_Msk                            /*!< Falling trigger event configuration bit of line 3 */
+#define EXTI_FTSR1_FT4_Pos       (4U)
+#define EXTI_FTSR1_FT4_Msk       (0x1UL << EXTI_FTSR1_FT4_Pos)                 /*!< 0x00000010 */
+#define EXTI_FTSR1_FT4           EXTI_FTSR1_FT4_Msk                            /*!< Falling trigger event configuration bit of line 4 */
+#define EXTI_FTSR1_FT5_Pos       (5U)
+#define EXTI_FTSR1_FT5_Msk       (0x1UL << EXTI_FTSR1_FT5_Pos)                 /*!< 0x00000020 */
+#define EXTI_FTSR1_FT5           EXTI_FTSR1_FT5_Msk                            /*!< Falling trigger event configuration bit of line 5 */
+#define EXTI_FTSR1_FT6_Pos       (6U)
+#define EXTI_FTSR1_FT6_Msk       (0x1UL << EXTI_FTSR1_FT6_Pos)                 /*!< 0x00000040 */
+#define EXTI_FTSR1_FT6           EXTI_FTSR1_FT6_Msk                            /*!< Falling trigger event configuration bit of line 6 */
+#define EXTI_FTSR1_FT7_Pos       (7U)
+#define EXTI_FTSR1_FT7_Msk       (0x1UL << EXTI_FTSR1_FT7_Pos)                 /*!< 0x00000080 */
+#define EXTI_FTSR1_FT7           EXTI_FTSR1_FT7_Msk                            /*!< Falling trigger event configuration bit of line 7 */
+#define EXTI_FTSR1_FT8_Pos       (8U)
+#define EXTI_FTSR1_FT8_Msk       (0x1UL << EXTI_FTSR1_FT8_Pos)                 /*!< 0x00000100 */
+#define EXTI_FTSR1_FT8           EXTI_FTSR1_FT8_Msk                            /*!< Falling trigger event configuration bit of line 8 */
+#define EXTI_FTSR1_FT9_Pos       (9U)
+#define EXTI_FTSR1_FT9_Msk       (0x1UL << EXTI_FTSR1_FT9_Pos)                 /*!< 0x00000200 */
+#define EXTI_FTSR1_FT9           EXTI_FTSR1_FT9_Msk                            /*!< Falling trigger event configuration bit of line 9 */
+#define EXTI_FTSR1_FT10_Pos      (10U)
+#define EXTI_FTSR1_FT10_Msk      (0x1UL << EXTI_FTSR1_FT10_Pos)                /*!< 0x00000400 */
+#define EXTI_FTSR1_FT10          EXTI_FTSR1_FT10_Msk                           /*!< Falling trigger event configuration bit of line 10 */
+#define EXTI_FTSR1_FT11_Pos      (11U)
+#define EXTI_FTSR1_FT11_Msk      (0x1UL << EXTI_FTSR1_FT11_Pos)                /*!< 0x00000800 */
+#define EXTI_FTSR1_FT11          EXTI_FTSR1_FT11_Msk                           /*!< Falling trigger event configuration bit of line 11 */
+#define EXTI_FTSR1_FT12_Pos      (12U)
+#define EXTI_FTSR1_FT12_Msk      (0x1UL << EXTI_FTSR1_FT12_Pos)                /*!< 0x00001000 */
+#define EXTI_FTSR1_FT12          EXTI_FTSR1_FT12_Msk                           /*!< Falling trigger event configuration bit of line 12 */
+#define EXTI_FTSR1_FT13_Pos      (13U)
+#define EXTI_FTSR1_FT13_Msk      (0x1UL << EXTI_FTSR1_FT13_Pos)                /*!< 0x00002000 */
+#define EXTI_FTSR1_FT13          EXTI_FTSR1_FT13_Msk                           /*!< Falling trigger event configuration bit of line 13 */
+#define EXTI_FTSR1_FT14_Pos      (14U)
+#define EXTI_FTSR1_FT14_Msk      (0x1UL << EXTI_FTSR1_FT14_Pos)                /*!< 0x00004000 */
+#define EXTI_FTSR1_FT14          EXTI_FTSR1_FT14_Msk                           /*!< Falling trigger event configuration bit of line 14 */
+#define EXTI_FTSR1_FT15_Pos      (15U)
+#define EXTI_FTSR1_FT15_Msk      (0x1UL << EXTI_FTSR1_FT15_Pos)                /*!< 0x00008000 */
+#define EXTI_FTSR1_FT15          EXTI_FTSR1_FT15_Msk                           /*!< Falling trigger event configuration bit of line 15 */
+#define EXTI_FTSR1_FT16_Pos      (16U)
+#define EXTI_FTSR1_FT16_Msk      (0x1UL << EXTI_FTSR1_FT16_Pos)                /*!< 0x00010000 */
+#define EXTI_FTSR1_FT16          EXTI_FTSR1_FT16_Msk                           /*!< Falling trigger event configuration bit of line 16 */
+#define EXTI_FTSR1_FT17_Pos      (17U)
+#define EXTI_FTSR1_FT17_Msk      (0x1UL << EXTI_FTSR1_FT17_Pos)                /*!< 0x00020000 */
+#define EXTI_FTSR1_FT17          EXTI_FTSR1_FT17_Msk                           /*!< Falling trigger event configuration bit of line 17 */
+#define EXTI_FTSR1_FT18_Pos      (18U)
+#define EXTI_FTSR1_FT18_Msk      (0x1UL << EXTI_FTSR1_FT18_Pos)                /*!< 0x00040000 */
+#define EXTI_FTSR1_FT18          EXTI_FTSR1_FT18_Msk                           /*!< Falling trigger event configuration bit of line 18 */
+#define EXTI_FTSR1_FT19_Pos      (19U)
+#define EXTI_FTSR1_FT19_Msk      (0x1UL << EXTI_FTSR1_FT19_Pos)                /*!< 0x00080000 */
+#define EXTI_FTSR1_FT19          EXTI_FTSR1_FT19_Msk                           /*!< Falling trigger event configuration bit of line 19 */
+#define EXTI_FTSR1_FT20_Pos      (20U)
+#define EXTI_FTSR1_FT20_Msk      (0x1UL << EXTI_FTSR1_FT20_Pos)                /*!< 0x00100000 */
+#define EXTI_FTSR1_FT20          EXTI_FTSR1_FT20_Msk                           /*!< Falling trigger event configuration bit of line 20 */
+#define EXTI_FTSR1_FT31_Pos      (31U)
+#define EXTI_FTSR1_FT31_Msk      (0x1UL << EXTI_FTSR1_FT31_Pos)                /*!< 0x80000000 */
+#define EXTI_FTSR1_FT31          EXTI_FTSR1_FT31_Msk                           /*!< Falling trigger event configuration bit of line 31 */
+
+/******************  Bit definition for EXTI_SWIER1 register  *****************/
+#define EXTI_SWIER1_SWI_Pos      (0U)
+#define EXTI_SWIER1_SWI_Msk      (0x803FFFFFUL << EXTI_SWIER1_SWI_Pos)         /*!< 0x803FFFFF */
+#define EXTI_SWIER1_SWI          EXTI_SWIER1_SWI_Msk                           /*!< Software interrupt */
+#define EXTI_SWIER1_SWI0_Pos     (0U)
+#define EXTI_SWIER1_SWI0_Msk     (0x1UL << EXTI_SWIER1_SWI0_Pos)               /*!< 0x00000001 */
+#define EXTI_SWIER1_SWI0         EXTI_SWIER1_SWI0_Msk                          /*!< Software Interrupt on line 0 */
+#define EXTI_SWIER1_SWI1_Pos     (1U)
+#define EXTI_SWIER1_SWI1_Msk     (0x1UL << EXTI_SWIER1_SWI1_Pos)               /*!< 0x00000002 */
+#define EXTI_SWIER1_SWI1         EXTI_SWIER1_SWI1_Msk                          /*!< Software Interrupt on line 1 */
+#define EXTI_SWIER1_SWI2_Pos     (2U)
+#define EXTI_SWIER1_SWI2_Msk     (0x1UL << EXTI_SWIER1_SWI2_Pos)               /*!< 0x00000004 */
+#define EXTI_SWIER1_SWI2         EXTI_SWIER1_SWI2_Msk                          /*!< Software Interrupt on line 2 */
+#define EXTI_SWIER1_SWI3_Pos     (3U)
+#define EXTI_SWIER1_SWI3_Msk     (0x1UL << EXTI_SWIER1_SWI3_Pos)               /*!< 0x00000008 */
+#define EXTI_SWIER1_SWI3         EXTI_SWIER1_SWI3_Msk                          /*!< Software Interrupt on line 3 */
+#define EXTI_SWIER1_SWI4_Pos     (4U)
+#define EXTI_SWIER1_SWI4_Msk     (0x1UL << EXTI_SWIER1_SWI4_Pos)               /*!< 0x00000010 */
+#define EXTI_SWIER1_SWI4         EXTI_SWIER1_SWI4_Msk                          /*!< Software Interrupt on line 4 */
+#define EXTI_SWIER1_SWI5_Pos     (5U)
+#define EXTI_SWIER1_SWI5_Msk     (0x1UL << EXTI_SWIER1_SWI5_Pos)               /*!< 0x00000020 */
+#define EXTI_SWIER1_SWI5         EXTI_SWIER1_SWI5_Msk                          /*!< Software Interrupt on line 5 */
+#define EXTI_SWIER1_SWI6_Pos     (6U)
+#define EXTI_SWIER1_SWI6_Msk     (0x1UL << EXTI_SWIER1_SWI6_Pos)               /*!< 0x00000040 */
+#define EXTI_SWIER1_SWI6         EXTI_SWIER1_SWI6_Msk                          /*!< Software Interrupt on line 6 */
+#define EXTI_SWIER1_SWI7_Pos     (7U)
+#define EXTI_SWIER1_SWI7_Msk     (0x1UL << EXTI_SWIER1_SWI7_Pos)               /*!< 0x00000080 */
+#define EXTI_SWIER1_SWI7         EXTI_SWIER1_SWI7_Msk                          /*!< Software Interrupt on line 7 */
+#define EXTI_SWIER1_SWI8_Pos     (8U)
+#define EXTI_SWIER1_SWI8_Msk     (0x1UL << EXTI_SWIER1_SWI8_Pos)               /*!< 0x00000100 */
+#define EXTI_SWIER1_SWI8         EXTI_SWIER1_SWI8_Msk                          /*!< Software Interrupt on line 8 */
+#define EXTI_SWIER1_SWI9_Pos     (9U)
+#define EXTI_SWIER1_SWI9_Msk     (0x1UL << EXTI_SWIER1_SWI9_Pos)               /*!< 0x00000200 */
+#define EXTI_SWIER1_SWI9         EXTI_SWIER1_SWI9_Msk                          /*!< Software Interrupt on line 9 */
+#define EXTI_SWIER1_SWI10_Pos    (10U)
+#define EXTI_SWIER1_SWI10_Msk    (0x1UL << EXTI_SWIER1_SWI10_Pos)              /*!< 0x00000400 */
+#define EXTI_SWIER1_SWI10        EXTI_SWIER1_SWI10_Msk                         /*!< Software Interrupt on line 10 */
+#define EXTI_SWIER1_SWI11_Pos    (11U)
+#define EXTI_SWIER1_SWI11_Msk    (0x1UL << EXTI_SWIER1_SWI11_Pos)              /*!< 0x00000800 */
+#define EXTI_SWIER1_SWI11        EXTI_SWIER1_SWI11_Msk                         /*!< Software Interrupt on line 11 */
+#define EXTI_SWIER1_SWI12_Pos    (12U)
+#define EXTI_SWIER1_SWI12_Msk    (0x1UL << EXTI_SWIER1_SWI12_Pos)              /*!< 0x00001000 */
+#define EXTI_SWIER1_SWI12        EXTI_SWIER1_SWI12_Msk                         /*!< Software Interrupt on line 12 */
+#define EXTI_SWIER1_SWI13_Pos    (13U)
+#define EXTI_SWIER1_SWI13_Msk    (0x1UL << EXTI_SWIER1_SWI13_Pos)              /*!< 0x00002000 */
+#define EXTI_SWIER1_SWI13        EXTI_SWIER1_SWI13_Msk                         /*!< Software Interrupt on line 13 */
+#define EXTI_SWIER1_SWI14_Pos    (14U)
+#define EXTI_SWIER1_SWI14_Msk    (0x1UL << EXTI_SWIER1_SWI14_Pos)              /*!< 0x00004000 */
+#define EXTI_SWIER1_SWI14        EXTI_SWIER1_SWI14_Msk                         /*!< Software Interrupt on line 14 */
+#define EXTI_SWIER1_SWI15_Pos    (15U)
+#define EXTI_SWIER1_SWI15_Msk    (0x1UL << EXTI_SWIER1_SWI15_Pos)              /*!< 0x00008000 */
+#define EXTI_SWIER1_SWI15        EXTI_SWIER1_SWI15_Msk                         /*!< Software Interrupt on line 15 */
+#define EXTI_SWIER1_SWI16_Pos    (16U)
+#define EXTI_SWIER1_SWI16_Msk    (0x1UL << EXTI_SWIER1_SWI16_Pos)              /*!< 0x00010000 */
+#define EXTI_SWIER1_SWI16        EXTI_SWIER1_SWI16_Msk                         /*!< Software Interrupt on line 16 */
+#define EXTI_SWIER1_SWI17_Pos    (17U)
+#define EXTI_SWIER1_SWI17_Msk    (0x1UL << EXTI_SWIER1_SWI17_Pos)              /*!< 0x00020000 */
+#define EXTI_SWIER1_SWI17        EXTI_SWIER1_SWI17_Msk                         /*!< Software Interrupt on line 17 */
+#define EXTI_SWIER1_SWI18_Pos    (18U)
+#define EXTI_SWIER1_SWI18_Msk    (0x1UL << EXTI_SWIER1_SWI18_Pos)              /*!< 0x00040000 */
+#define EXTI_SWIER1_SWI18        EXTI_SWIER1_SWI18_Msk                         /*!< Software Interrupt on line 18 */
+#define EXTI_SWIER1_SWI19_Pos    (19U)
+#define EXTI_SWIER1_SWI19_Msk    (0x1UL << EXTI_SWIER1_SWI19_Pos)              /*!< 0x00080000 */
+#define EXTI_SWIER1_SWI19        EXTI_SWIER1_SWI19_Msk                         /*!< Software Interrupt on line 19 */
+#define EXTI_SWIER1_SWI20_Pos    (20U)
+#define EXTI_SWIER1_SWI20_Msk    (0x1UL << EXTI_SWIER1_SWI20_Pos)              /*!< 0x00100000 */
+#define EXTI_SWIER1_SWI20        EXTI_SWIER1_SWI20_Msk                         /*!< Software Interrupt on line 20 */
+#define EXTI_SWIER1_SWI31_Pos    (31U)
+#define EXTI_SWIER1_SWI31_Msk    (0x1UL << EXTI_SWIER1_SWI31_Pos)              /*!< 0x80000000 */
+#define EXTI_SWIER1_SWI31         EXTI_SWIER1_SWI31_Msk                        /*!< Software Interrupt on line 31 */
+
+/*******************  Bit definition for EXTI_PR1 register  *******************/
+#define EXTI_PR1_PIF_Pos         (0U)
+#define EXTI_PR1_PIF_Msk         (0x803FFFFFUL << EXTI_PR1_PIF_Pos)            /*!< 0x803FFFFF */
+#define EXTI_PR1_PIF             EXTI_PR1_PIF_Msk                              /*!< Pending bit */
+#define EXTI_PR1_PIF0_Pos        (0U)
+#define EXTI_PR1_PIF0_Msk        (0x1UL << EXTI_PR1_PIF0_Pos)                  /*!< 0x00000001 */
+#define EXTI_PR1_PIF0            EXTI_PR1_PIF0_Msk                             /*!< Pending bit for line 0 */
+#define EXTI_PR1_PIF1_Pos        (1U)
+#define EXTI_PR1_PIF1_Msk        (0x1UL << EXTI_PR1_PIF1_Pos)                  /*!< 0x00000002 */
+#define EXTI_PR1_PIF1            EXTI_PR1_PIF1_Msk                             /*!< Pending bit for line 1 */
+#define EXTI_PR1_PIF2_Pos        (2U)
+#define EXTI_PR1_PIF2_Msk        (0x1UL << EXTI_PR1_PIF2_Pos)                  /*!< 0x00000004 */
+#define EXTI_PR1_PIF2            EXTI_PR1_PIF2_Msk                             /*!< Pending bit for line 2 */
+#define EXTI_PR1_PIF3_Pos        (3U)
+#define EXTI_PR1_PIF3_Msk        (0x1UL << EXTI_PR1_PIF3_Pos)                  /*!< 0x00000008 */
+#define EXTI_PR1_PIF3            EXTI_PR1_PIF3_Msk                             /*!< Pending bit for line 3 */
+#define EXTI_PR1_PIF4_Pos        (4U)
+#define EXTI_PR1_PIF4_Msk        (0x1UL << EXTI_PR1_PIF4_Pos)                  /*!< 0x00000010 */
+#define EXTI_PR1_PIF4            EXTI_PR1_PIF4_Msk                             /*!< Pending bit for line 4 */
+#define EXTI_PR1_PIF5_Pos        (5U)
+#define EXTI_PR1_PIF5_Msk        (0x1UL << EXTI_PR1_PIF5_Pos)                  /*!< 0x00000020 */
+#define EXTI_PR1_PIF5            EXTI_PR1_PIF5_Msk                             /*!< Pending bit for line 5 */
+#define EXTI_PR1_PIF6_Pos        (6U)
+#define EXTI_PR1_PIF6_Msk        (0x1UL << EXTI_PR1_PIF6_Pos)                  /*!< 0x00000040 */
+#define EXTI_PR1_PIF6            EXTI_PR1_PIF6_Msk                             /*!< Pending bit for line 6 */
+#define EXTI_PR1_PIF7_Pos        (7U)
+#define EXTI_PR1_PIF7_Msk        (0x1UL << EXTI_PR1_PIF7_Pos)                  /*!< 0x00000080 */
+#define EXTI_PR1_PIF7            EXTI_PR1_PIF7_Msk                             /*!< Pending bit for line 7 */
+#define EXTI_PR1_PIF8_Pos        (8U)
+#define EXTI_PR1_PIF8_Msk        (0x1UL << EXTI_PR1_PIF8_Pos)                  /*!< 0x00000100 */
+#define EXTI_PR1_PIF8            EXTI_PR1_PIF8_Msk                             /*!< Pending bit for line 8 */
+#define EXTI_PR1_PIF9_Pos        (9U)
+#define EXTI_PR1_PIF9_Msk        (0x1UL << EXTI_PR1_PIF9_Pos)                  /*!< 0x00000200 */
+#define EXTI_PR1_PIF9            EXTI_PR1_PIF9_Msk                             /*!< Pending bit for line 9 */
+#define EXTI_PR1_PIF10_Pos       (10U)
+#define EXTI_PR1_PIF10_Msk       (0x1UL << EXTI_PR1_PIF10_Pos)                 /*!< 0x00000400 */
+#define EXTI_PR1_PIF10           EXTI_PR1_PIF10_Msk                            /*!< Pending bit for line 10 */
+#define EXTI_PR1_PIF11_Pos       (11U)
+#define EXTI_PR1_PIF11_Msk       (0x1UL << EXTI_PR1_PIF11_Pos)                 /*!< 0x00000800 */
+#define EXTI_PR1_PIF11           EXTI_PR1_PIF11_Msk                            /*!< Pending bit for line 11 */
+#define EXTI_PR1_PIF12_Pos       (12U)
+#define EXTI_PR1_PIF12_Msk       (0x1UL << EXTI_PR1_PIF12_Pos)                 /*!< 0x00001000 */
+#define EXTI_PR1_PIF12           EXTI_PR1_PIF12_Msk                            /*!< Pending bit for line 12 */
+#define EXTI_PR1_PIF13_Pos       (13U)
+#define EXTI_PR1_PIF13_Msk       (0x1UL << EXTI_PR1_PIF13_Pos)                 /*!< 0x00002000 */
+#define EXTI_PR1_PIF13           EXTI_PR1_PIF13_Msk                            /*!< Pending bit for line 13 */
+#define EXTI_PR1_PIF14_Pos       (14U)
+#define EXTI_PR1_PIF14_Msk       (0x1UL << EXTI_PR1_PIF14_Pos)                 /*!< 0x00004000 */
+#define EXTI_PR1_PIF14           EXTI_PR1_PIF14_Msk                            /*!< Pending bit for line 14 */
+#define EXTI_PR1_PIF15_Pos       (15U)
+#define EXTI_PR1_PIF15_Msk       (0x1UL << EXTI_PR1_PIF15_Pos)                 /*!< 0x00008000 */
+#define EXTI_PR1_PIF15           EXTI_PR1_PIF15_Msk                            /*!< Pending bit for line 15 */
+#define EXTI_PR1_PIF16_Pos       (16U)
+#define EXTI_PR1_PIF16_Msk       (0x1UL << EXTI_PR1_PIF16_Pos)                 /*!< 0x00010000 */
+#define EXTI_PR1_PIF16           EXTI_PR1_PIF16_Msk                            /*!< Pending bit for line 16 */
+#define EXTI_PR1_PIF17_Pos       (17U)
+#define EXTI_PR1_PIF17_Msk       (0x1UL << EXTI_PR1_PIF17_Pos)                 /*!< 0x00020000 */
+#define EXTI_PR1_PIF17           EXTI_PR1_PIF17_Msk                            /*!< Pending bit for line 17 */
+#define EXTI_PR1_PIF18_Pos       (18U)
+#define EXTI_PR1_PIF18_Msk       (0x1UL << EXTI_PR1_PIF18_Pos)                 /*!< 0x00040000 */
+#define EXTI_PR1_PIF18           EXTI_PR1_PIF18_Msk                            /*!< Pending bit for line 18 */
+#define EXTI_PR1_PIF19_Pos       (19U)
+#define EXTI_PR1_PIF19_Msk       (0x1UL << EXTI_PR1_PIF19_Pos)                 /*!< 0x00080000 */
+#define EXTI_PR1_PIF19           EXTI_PR1_PIF19_Msk                            /*!< Pending bit for line 19 */
+#define EXTI_PR1_PIF20_Pos       (20U)
+#define EXTI_PR1_PIF20_Msk       (0x1UL << EXTI_PR1_PIF20_Pos)                 /*!< 0x00100000 */
+#define EXTI_PR1_PIF20           EXTI_PR1_PIF20_Msk                            /*!< Pending bit for line 20 */
+#define EXTI_PR1_PIF31_Pos       (31U)
+#define EXTI_PR1_PIF31_Msk       (0x1UL << EXTI_PR1_PIF31_Pos)                 /*!< 0x80000000 */
+#define EXTI_PR1_PIF31           EXTI_PR1_PIF31_Msk                            /*!< Pending bit for line 31 */
+
+/******************  Bit definition for EXTI_RTSR2 register  ******************/
+#define EXTI_RTSR2_RT_Pos        (0U)
+#define EXTI_RTSR2_RT_Msk        (0x302UL << EXTI_RTSR2_RT_Pos)                /*!< 0x00000302 */
+#define EXTI_RTSR2_RT            EXTI_RTSR2_RT_Msk                             /*!< Rising trigger event configuration bit */
+#define EXTI_RTSR2_RT33_Pos      (1U)
+#define EXTI_RTSR2_RT33_Msk      (0x1UL << EXTI_RTSR2_RT33_Pos)                /*!< 0x00000002 */
+#define EXTI_RTSR2_RT33          EXTI_RTSR2_RT33_Msk                           /*!< Rising trigger event configuration bit of line 33 */
+#define EXTI_RTSR2_RT40_Pos      (8U)
+#define EXTI_RTSR2_RT40_Msk      (0x1UL << EXTI_RTSR2_RT40_Pos)                /*!< 0x00000100 */
+#define EXTI_RTSR2_RT40          EXTI_RTSR2_RT40_Msk                           /*!< Rising trigger event configuration bit of line 40 */
+#define EXTI_RTSR2_RT41_Pos      (9U)
+#define EXTI_RTSR2_RT41_Msk      (0x1UL << EXTI_RTSR2_RT41_Pos)                /*!< 0x00000200 */
+#define EXTI_RTSR2_RT41          EXTI_RTSR2_RT41_Msk                           /*!< Rising trigger event configuration bit of line 41 */
+
+/******************  Bit definition for EXTI_FTSR2 register  ******************/
+#define EXTI_FTSR2_FT_Pos        (0U)
+#define EXTI_FTSR2_FT_Msk        (0x302UL << EXTI_FTSR2_FT_Pos)                /*!< 0x00000302 */
+#define EXTI_FTSR2_FT            EXTI_FTSR2_FT_Msk                             /*!< Falling trigger event configuration bit */
+#define EXTI_FTSR2_FT33_Pos      (1U)
+#define EXTI_FTSR2_FT33_Msk      (0x1UL << EXTI_FTSR2_FT33_Pos)                /*!< 0x00000002 */
+#define EXTI_FTSR2_FT33          EXTI_FTSR2_FT33_Msk                           /*!< Falling trigger event configuration bit of line 33 */
+#define EXTI_FTSR2_FT40_Pos      (8U)
+#define EXTI_FTSR2_FT40_Msk      (0x1UL << EXTI_FTSR2_FT40_Pos)                /*!< 0x00000100 */
+#define EXTI_FTSR2_FT40          EXTI_FTSR2_FT40_Msk                           /*!< Falling trigger event configuration bit of line 40 */
+#define EXTI_FTSR2_FT41_Pos      (9U)
+#define EXTI_FTSR2_FT41_Msk      (0x1UL << EXTI_FTSR2_FT41_Pos)                /*!< 0x00000200 */
+#define EXTI_FTSR2_FT41          EXTI_FTSR2_FT41_Msk                           /*!< Falling trigger event configuration bit of line 41 */
+
+/******************  Bit definition for EXTI_SWIER2 register  *****************/
+#define EXTI_SWIER2_SWI_Pos      (0U)
+#define EXTI_SWIER2_SWI_Msk      (0x302UL << EXTI_SWIER2_SWI_Pos)              /*!< 0x00000302 */
+#define EXTI_SWIER2_SWI          EXTI_SWIER2_SWI_Msk                           /*!< Falling trigger event configuration bit */
+#define EXTI_SWIER2_SWI33_Pos    (1U)
+#define EXTI_SWIER2_SWI33_Msk    (0x1UL << EXTI_SWIER2_SWI33_Pos)                /*!< 0x00000002 */
+#define EXTI_SWIER2_SWI33        EXTI_SWIER2_SWI33_Msk                           /*!< Software Interrupt on line 33 */
+#define EXTI_SWIER2_SWI40_Pos    (8U)
+#define EXTI_SWIER2_SWI40_Msk    (0x1UL << EXTI_SWIER2_SWI40_Pos)                /*!< 0x00000100 */
+#define EXTI_SWIER2_SWI40        EXTI_SWIER2_SWI40_Msk                           /*!< Software Interrupt on line 40 */
+#define EXTI_SWIER2_SWI41_Pos    (9U)
+#define EXTI_SWIER2_SWI41_Msk    (0x1UL << EXTI_SWIER2_SWI41_Pos)                /*!< 0x00000200 */
+#define EXTI_SWIER2_SWI41        EXTI_SWIER2_SWI41_Msk                           /*!< Software Interrupt on line 41 */
+
+/*******************  Bit definition for EXTI_PR2 register  *******************/
+#define EXTI_PR2_PIF_Pos         (0U)
+#define EXTI_PR2_PIF_Msk         (0x302UL << EXTI_PR2_PIF_Pos)                 /*!< 0x00000302 */
+#define EXTI_PR2_PIF             EXTI_PR2_PIF_Msk                              /*!< Pending bit */
+#define EXTI_PR2_PIF33_Pos       (1U)
+#define EXTI_PR2_PIF33_Msk       (0x1UL << EXTI_PR2_PIF33_Pos)                 /*!< 0x00000002 */
+#define EXTI_PR2_PIF33           EXTI_PR2_PIF33_Msk                            /*!< Pending bit for line 33 */
+#define EXTI_PR2_PIF40_Pos       (8U)
+#define EXTI_PR2_PIF40_Msk       (0x1UL << EXTI_PR2_PIF40_Pos)                 /*!< 0x00000100 */
+#define EXTI_PR2_PIF40           EXTI_PR2_PIF40_Msk                            /*!< Pending bit for line 40 */
+#define EXTI_PR2_PIF41_Pos       (9U)
+#define EXTI_PR2_PIF41_Msk       (0x1UL << EXTI_PR2_PIF41_Pos)                 /*!< 0x00000200 */
+#define EXTI_PR2_PIF41           EXTI_PR2_PIF41_Msk                            /*!< Pending bit for line 41 */
+
+/********************  Bits definition for EXTI_IMR1 register  ****************/
+#define EXTI_IMR1_Pos            (0U)
+#define EXTI_IMR1_Msk            (0xFFFFFFFFUL << EXTI_IMR1_Pos)               /*!< 0xFFFFFFFF */
+#define EXTI_IMR1_IM             EXTI_IMR1_Msk                                 /*!< CPU1 wakeup with interrupt Mask on Event */
+#define EXTI_IMR1_IM0_Pos        (0U)
+#define EXTI_IMR1_IM0_Msk        (0x1UL << EXTI_IMR1_IM0_Pos)                  /*!< 0x00000001 */
+#define EXTI_IMR1_IM0            EXTI_IMR1_IM0_Msk                             /*!< CPU1 Interrupt Mask on line 0 */
+#define EXTI_IMR1_IM1_Pos        (1U)
+#define EXTI_IMR1_IM1_Msk        (0x1UL << EXTI_IMR1_IM1_Pos)                  /*!< 0x00000002 */
+#define EXTI_IMR1_IM1            EXTI_IMR1_IM1_Msk                             /*!< CPU1 Interrupt Mask on line 1 */
+#define EXTI_IMR1_IM2_Pos        (2U)
+#define EXTI_IMR1_IM2_Msk        (0x1UL << EXTI_IMR1_IM2_Pos)                  /*!< 0x00000004 */
+#define EXTI_IMR1_IM2            EXTI_IMR1_IM2_Msk                             /*!< CPU1 Interrupt Mask on line 2 */
+#define EXTI_IMR1_IM3_Pos        (3U)
+#define EXTI_IMR1_IM3_Msk        (0x1UL << EXTI_IMR1_IM3_Pos)                  /*!< 0x00000008 */
+#define EXTI_IMR1_IM3            EXTI_IMR1_IM3_Msk                             /*!< CPU1 Interrupt Mask on line 3 */
+#define EXTI_IMR1_IM4_Pos        (4U)
+#define EXTI_IMR1_IM4_Msk        (0x1UL << EXTI_IMR1_IM4_Pos)                  /*!< 0x00000010 */
+#define EXTI_IMR1_IM4            EXTI_IMR1_IM4_Msk                             /*!< CPU1 Interrupt Mask on line 4 */
+#define EXTI_IMR1_IM5_Pos        (5U)
+#define EXTI_IMR1_IM5_Msk        (0x1UL << EXTI_IMR1_IM5_Pos)                  /*!< 0x00000020 */
+#define EXTI_IMR1_IM5            EXTI_IMR1_IM5_Msk                             /*!< CPU1 Interrupt Mask on line 5 */
+#define EXTI_IMR1_IM6_Pos        (6U)
+#define EXTI_IMR1_IM6_Msk        (0x1UL << EXTI_IMR1_IM6_Pos)                  /*!< 0x00000040 */
+#define EXTI_IMR1_IM6            EXTI_IMR1_IM6_Msk                             /*!< CPU1 Interrupt Mask on line 6 */
+#define EXTI_IMR1_IM7_Pos        (7U)
+#define EXTI_IMR1_IM7_Msk        (0x1UL << EXTI_IMR1_IM7_Pos)                  /*!< 0x00000080 */
+#define EXTI_IMR1_IM7            EXTI_IMR1_IM7_Msk                             /*!< CPU1 Interrupt Mask on line 7 */
+#define EXTI_IMR1_IM8_Pos        (8U)
+#define EXTI_IMR1_IM8_Msk        (0x1UL << EXTI_IMR1_IM8_Pos)                  /*!< 0x00000100 */
+#define EXTI_IMR1_IM8            EXTI_IMR1_IM8_Msk                             /*!< CPU1 Interrupt Mask on line 8 */
+#define EXTI_IMR1_IM9_Pos        (9U)
+#define EXTI_IMR1_IM9_Msk        (0x1UL << EXTI_IMR1_IM9_Pos)                  /*!< 0x00000200 */
+#define EXTI_IMR1_IM9            EXTI_IMR1_IM9_Msk                             /*!< CPU1 Interrupt Mask on line 9 */
+#define EXTI_IMR1_IM10_Pos       (10U)
+#define EXTI_IMR1_IM10_Msk       (0x1UL << EXTI_IMR1_IM10_Pos)                 /*!< 0x00000400 */
+#define EXTI_IMR1_IM10           EXTI_IMR1_IM10_Msk                            /*!< CPU1 Interrupt Mask on line 10 */
+#define EXTI_IMR1_IM11_Pos       (11U)
+#define EXTI_IMR1_IM11_Msk       (0x1UL << EXTI_IMR1_IM11_Pos)                 /*!< 0x00000800 */
+#define EXTI_IMR1_IM11           EXTI_IMR1_IM11_Msk                            /*!< CPU1 Interrupt Mask on line 11 */
+#define EXTI_IMR1_IM12_Pos       (12U)
+#define EXTI_IMR1_IM12_Msk       (0x1UL << EXTI_IMR1_IM12_Pos)                 /*!< 0x00001000 */
+#define EXTI_IMR1_IM12           EXTI_IMR1_IM12_Msk                            /*!< CPU1 Interrupt Mask on line 12 */
+#define EXTI_IMR1_IM13_Pos       (13U)
+#define EXTI_IMR1_IM13_Msk       (0x1UL << EXTI_IMR1_IM13_Pos)                 /*!< 0x00002000 */
+#define EXTI_IMR1_IM13           EXTI_IMR1_IM13_Msk                            /*!< CPU1 Interrupt Mask on line 13 */
+#define EXTI_IMR1_IM14_Pos       (14U)
+#define EXTI_IMR1_IM14_Msk       (0x1UL << EXTI_IMR1_IM14_Pos)                 /*!< 0x00004000 */
+#define EXTI_IMR1_IM14           EXTI_IMR1_IM14_Msk                            /*!< CPU1 Interrupt Mask on line 14 */
+#define EXTI_IMR1_IM15_Pos       (15U)
+#define EXTI_IMR1_IM15_Msk       (0x1UL << EXTI_IMR1_IM15_Pos)                 /*!< 0x00008000 */
+#define EXTI_IMR1_IM15           EXTI_IMR1_IM15_Msk                            /*!< CPU1 Interrupt Mask on line 15 */
+#define EXTI_IMR1_IM16_Pos       (16U)
+#define EXTI_IMR1_IM16_Msk       (0x1UL << EXTI_IMR1_IM16_Pos)                 /*!< 0x00010000 */
+#define EXTI_IMR1_IM16           EXTI_IMR1_IM16_Msk                            /*!< CPU1 Interrupt Mask on line 16 */
+#define EXTI_IMR1_IM17_Pos       (17U)
+#define EXTI_IMR1_IM17_Msk       (0x1UL << EXTI_IMR1_IM17_Pos)                 /*!< 0x00020000 */
+#define EXTI_IMR1_IM17           EXTI_IMR1_IM17_Msk                            /*!< CPU1 Interrupt Mask on line 17 */
+#define EXTI_IMR1_IM18_Pos       (18U)
+#define EXTI_IMR1_IM18_Msk       (0x1UL << EXTI_IMR1_IM18_Pos)                 /*!< 0x00040000 */
+#define EXTI_IMR1_IM18           EXTI_IMR1_IM18_Msk                            /*!< CPU1 Interrupt Mask on line 18 */
+#define EXTI_IMR1_IM19_Pos       (19U)
+#define EXTI_IMR1_IM19_Msk       (0x1UL << EXTI_IMR1_IM19_Pos)                 /*!< 0x00080000 */
+#define EXTI_IMR1_IM19           EXTI_IMR1_IM19_Msk                            /*!< CPU1 Interrupt Mask on line 19 */
+#define EXTI_IMR1_IM20_Pos       (20U)
+#define EXTI_IMR1_IM20_Msk       (0x1UL << EXTI_IMR1_IM20_Pos)                 /*!< 0x00100000 */
+#define EXTI_IMR1_IM20           EXTI_IMR1_IM20_Msk                            /*!< CPU1 Interrupt Mask on line 20 */
+#define EXTI_IMR1_IM22_Pos       (22U)
+#define EXTI_IMR1_IM22_Msk       (0x1UL << EXTI_IMR1_IM22_Pos)                 /*!< 0x00400000 */
+#define EXTI_IMR1_IM22           EXTI_IMR1_IM22_Msk                            /*!< CPU1 Interrupt Mask on line 22 */
+#define EXTI_IMR1_IM24_Pos       (24U)
+#define EXTI_IMR1_IM24_Msk       (0x1UL << EXTI_IMR1_IM24_Pos)                 /*!< 0x01000000 */
+#define EXTI_IMR1_IM24           EXTI_IMR1_IM24_Msk                            /*!< CPU1 Interrupt Mask on line 24 */
+#define EXTI_IMR1_IM25_Pos       (25U)
+#define EXTI_IMR1_IM25_Msk       (0x1UL << EXTI_IMR1_IM25_Pos)                 /*!< 0x02000000 */
+#define EXTI_IMR1_IM25           EXTI_IMR1_IM25_Msk                            /*!< CPU1 Interrupt Mask on line 25 */
+#define EXTI_IMR1_IM29_Pos       (29U)
+#define EXTI_IMR1_IM29_Msk       (0x1UL << EXTI_IMR1_IM29_Pos)                 /*!< 0x20000000 */
+#define EXTI_IMR1_IM29           EXTI_IMR1_IM29_Msk                            /*!< CPU1 Interrupt Mask on line 29 */
+#define EXTI_IMR1_IM30_Pos       (30U)
+#define EXTI_IMR1_IM30_Msk       (0x1UL << EXTI_IMR1_IM30_Pos)                 /*!< 0x40000000 */
+#define EXTI_IMR1_IM30           EXTI_IMR1_IM30_Msk                            /*!< CPU1 Interrupt Mask on line 30 */
+#define EXTI_IMR1_IM31_Pos       (31U)
+#define EXTI_IMR1_IM31_Msk       (0x1UL << EXTI_IMR1_IM31_Pos)                 /*!< 0x80000000 */
+#define EXTI_IMR1_IM31           EXTI_IMR1_IM31_Msk                            /*!< CPU1 Interrupt Mask on line 31 */
+
+/********************  Bits definition for EXTI_EMR1 register  ****************/
+#define EXTI_EMR1_Pos            (0U)
+#define EXTI_EMR1_Msk            (0x003EFFFFUL << EXTI_EMR1_Pos)               /*!< 0xFFFFFFFF */
+#define EXTI_EMR1_EM             EXTI_EMR1_Msk                                 /*!< CPU1 Event Mask */
+#define EXTI_EMR1_EM0_Pos        (0U)
+#define EXTI_EMR1_EM0_Msk        (0x1UL << EXTI_EMR1_EM0_Pos)                  /*!< 0x00000001 */
+#define EXTI_EMR1_EM0            EXTI_EMR1_EM0_Msk                             /*!< CPU1 Event Mask on line 0 */
+#define EXTI_EMR1_EM1_Pos        (1U)
+#define EXTI_EMR1_EM1_Msk        (0x1UL << EXTI_EMR1_EM1_Pos)                  /*!< 0x00000002 */
+#define EXTI_EMR1_EM1            EXTI_EMR1_EM1_Msk                             /*!< CPU1 Event Mask on line 1 */
+#define EXTI_EMR1_EM2_Pos        (2U)
+#define EXTI_EMR1_EM2_Msk        (0x1UL << EXTI_EMR1_EM2_Pos)                  /*!< 0x00000004 */
+#define EXTI_EMR1_EM2            EXTI_EMR1_EM2_Msk                             /*!< CPU1 Event Mask on line 2 */
+#define EXTI_EMR1_EM3_Pos        (3U)
+#define EXTI_EMR1_EM3_Msk        (0x1UL << EXTI_EMR1_EM3_Pos)                  /*!< 0x00000008 */
+#define EXTI_EMR1_EM3            EXTI_EMR1_EM3_Msk                             /*!< CPU1 Event Mask on line 3 */
+#define EXTI_EMR1_EM4_Pos        (4U)
+#define EXTI_EMR1_EM4_Msk        (0x1UL << EXTI_EMR1_EM4_Pos)                  /*!< 0x00000010 */
+#define EXTI_EMR1_EM4            EXTI_EMR1_EM4_Msk                             /*!< CPU1 Event Mask on line 4 */
+#define EXTI_EMR1_EM5_Pos        (5U)
+#define EXTI_EMR1_EM5_Msk        (0x1UL << EXTI_EMR1_EM5_Pos)                  /*!< 0x00000020 */
+#define EXTI_EMR1_EM5            EXTI_EMR1_EM5_Msk                             /*!< CPU1 Event Mask on line 5 */
+#define EXTI_EMR1_EM6_Pos        (6U)
+#define EXTI_EMR1_EM6_Msk        (0x1UL << EXTI_EMR1_EM6_Pos)                  /*!< 0x00000040 */
+#define EXTI_EMR1_EM6            EXTI_EMR1_EM6_Msk                             /*!< CPU1 Event Mask on line 6 */
+#define EXTI_EMR1_EM7_Pos        (7U)
+#define EXTI_EMR1_EM7_Msk        (0x1UL << EXTI_EMR1_EM7_Pos)                  /*!< 0x00000080 */
+#define EXTI_EMR1_EM7            EXTI_EMR1_EM7_Msk                             /*!< CPU1 Event Mask on line 7 */
+#define EXTI_EMR1_EM8_Pos        (8U)
+#define EXTI_EMR1_EM8_Msk        (0x1UL << EXTI_EMR1_EM8_Pos)                  /*!< 0x00000100 */
+#define EXTI_EMR1_EM8            EXTI_EMR1_EM8_Msk                             /*!< CPU1 Event Mask on line 8 */
+#define EXTI_EMR1_EM9_Pos        (9U)
+#define EXTI_EMR1_EM9_Msk        (0x1UL << EXTI_EMR1_EM9_Pos)                  /*!< 0x00000200 */
+#define EXTI_EMR1_EM9            EXTI_EMR1_EM9_Msk                             /*!< CPU1 Event Mask on line 9 */
+#define EXTI_EMR1_EM10_Pos       (10U)
+#define EXTI_EMR1_EM10_Msk       (0x1UL << EXTI_EMR1_EM10_Pos)                 /*!< 0x00000400 */
+#define EXTI_EMR1_EM10           EXTI_EMR1_EM10_Msk                            /*!< CPU1 Event Mask on line 10 */
+#define EXTI_EMR1_EM11_Pos       (11U)
+#define EXTI_EMR1_EM11_Msk       (0x1UL << EXTI_EMR1_EM11_Pos)                 /*!< 0x00000800 */
+#define EXTI_EMR1_EM11           EXTI_EMR1_EM11_Msk                            /*!< CPU1 Event Mask on line 11 */
+#define EXTI_EMR1_EM12_Pos       (12U)
+#define EXTI_EMR1_EM12_Msk       (0x1UL << EXTI_EMR1_EM12_Pos)                 /*!< 0x00001000 */
+#define EXTI_EMR1_EM12           EXTI_EMR1_EM12_Msk                            /*!< CPU1 Event Mask on line 12 */
+#define EXTI_EMR1_EM13_Pos       (13U)
+#define EXTI_EMR1_EM13_Msk       (0x1UL << EXTI_EMR1_EM13_Pos)                 /*!< 0x00002000 */
+#define EXTI_EMR1_EM13           EXTI_EMR1_EM13_Msk                            /*!< CPU1 Event Mask on line 13 */
+#define EXTI_EMR1_EM14_Pos       (14U)
+#define EXTI_EMR1_EM14_Msk       (0x1UL << EXTI_EMR1_EM14_Pos)                 /*!< 0x00004000 */
+#define EXTI_EMR1_EM14           EXTI_EMR1_EM14_Msk                            /*!< CPU1 Event Mask on line 14 */
+#define EXTI_EMR1_EM15_Pos       (15U)
+#define EXTI_EMR1_EM15_Msk       (0x1UL << EXTI_EMR1_EM15_Pos)                 /*!< 0x00008000 */
+#define EXTI_EMR1_EM15           EXTI_EMR1_EM15_Msk                            /*!< CPU1 Event Mask on line 15 */
+#define EXTI_EMR1_EM17_Pos       (17U)
+#define EXTI_EMR1_EM17_Msk       (0x1UL << EXTI_EMR1_EM17_Pos)                 /*!< 0x00020000 */
+#define EXTI_EMR1_EM17           EXTI_EMR1_EM17_Msk                            /*!< CPU1 Event Mask on line 17 */
+#define EXTI_EMR1_EM18_Pos       (18U)
+#define EXTI_EMR1_EM18_Msk       (0x1UL << EXTI_EMR1_EM18_Pos)                 /*!< 0x00040000 */
+#define EXTI_EMR1_EM18           EXTI_EMR1_EM18_Msk                            /*!< CPU1 Event Mask on line 18 */
+#define EXTI_EMR1_EM19_Pos       (19U)
+#define EXTI_EMR1_EM19_Msk       (0x1UL << EXTI_EMR1_EM19_Pos)                 /*!< 0x00080000 */
+#define EXTI_EMR1_EM19           EXTI_EMR1_EM19_Msk                            /*!< CPU1 Event Mask on line 19 */
+#define EXTI_EMR1_EM20_Pos       (20U)
+#define EXTI_EMR1_EM20_Msk       (0x1UL << EXTI_EMR1_EM20_Pos)                 /*!< 0x00100000 */
+#define EXTI_EMR1_EM20           EXTI_EMR1_EM20_Msk                            /*!< CPU1 Event Mask on line 20 */
+
+/********************  Bits definition for EXTI_IMR2 register  ****************/
+#define EXTI_IMR2_Pos            (0U)
+#define EXTI_IMR2_Msk            (0x0001FFFFUL << EXTI_IMR2_Pos)               /*!< 0x0001FFFF */
+#define EXTI_IMR2_IM             EXTI_IMR2_Msk                                 /*!< CPU1 Interrupt Mask  */
+#define EXTI_IMR2_IM33_Pos       (1U)
+#define EXTI_IMR2_IM33_Msk       (0x1UL << EXTI_IMR2_IM33_Pos)                 /*!< 0x00000002 */
+#define EXTI_IMR2_IM33           EXTI_IMR2_IM33_Msk                            /*!< CPU1 Interrupt Mask on line 33 */
+#define EXTI_IMR2_IM36_Pos       (4U)
+#define EXTI_IMR2_IM36_Msk       (0x1UL << EXTI_IMR2_IM36_Pos)                 /*!< 0x00000010 */
+#define EXTI_IMR2_IM36           EXTI_IMR2_IM36_Msk                            /*!< CPU1 Interrupt Mask on line 36 */
+#define EXTI_IMR2_IM37_Pos       (5U)
+#define EXTI_IMR2_IM37_Msk       (0x1UL << EXTI_IMR2_IM37_Pos)                 /*!< 0x00000020 */
+#define EXTI_IMR2_IM37           EXTI_IMR2_IM37_Msk                            /*!< CPU1 Interrupt Mask on line 37 */
+#define EXTI_IMR2_IM38_Pos       (6U)
+#define EXTI_IMR2_IM38_Msk       (0x1UL << EXTI_IMR2_IM38_Pos)                 /*!< 0x00000040 */
+#define EXTI_IMR2_IM38           EXTI_IMR2_IM38_Msk                            /*!< CPU1 Interrupt Mask on line 38 */
+#define EXTI_IMR2_IM39_Pos       (7U)
+#define EXTI_IMR2_IM39_Msk       (0x1UL << EXTI_IMR2_IM39_Pos)                 /*!< 0x00000080 */
+#define EXTI_IMR2_IM39           EXTI_IMR2_IM39_Msk                            /*!< CPU1 Interrupt Mask on line 39 */
+#define EXTI_IMR2_IM40_Pos       (8U)
+#define EXTI_IMR2_IM40_Msk       (0x1UL << EXTI_IMR2_IM40_Pos)                 /*!< 0x00000100 */
+#define EXTI_IMR2_IM40           EXTI_IMR2_IM40_Msk                            /*!< CPU1 Interrupt Mask on line 40 */
+#define EXTI_IMR2_IM41_Pos       (9U)
+#define EXTI_IMR2_IM41_Msk       (0x1UL << EXTI_IMR2_IM41_Pos)                 /*!< 0x00000200 */
+#define EXTI_IMR2_IM41           EXTI_IMR2_IM41_Msk                            /*!< CPU1 Interrupt Mask on line 41 */
+#define EXTI_IMR2_IM42_Pos       (10U)
+#define EXTI_IMR2_IM42_Msk       (0x1UL << EXTI_IMR2_IM42_Pos)                 /*!< 0x00000400 */
+#define EXTI_IMR2_IM42           EXTI_IMR2_IM42_Msk                            /*!< CPU1 Interrupt Mask on line 42 */
+#define EXTI_IMR2_IM44_Pos       (12U)
+#define EXTI_IMR2_IM44_Msk       (0x1UL << EXTI_IMR2_IM44_Pos)                 /*!< 0x00001000 */
+#define EXTI_IMR2_IM44           EXTI_IMR2_IM44_Msk                            /*!< CPU1 Interrupt Mask on line 44 */
+#define EXTI_IMR2_IM45_Pos       (13U)
+#define EXTI_IMR2_IM45_Msk       (0x1UL << EXTI_IMR2_IM45_Pos)                 /*!< 0x00002000 */
+#define EXTI_IMR2_IM45           EXTI_IMR2_IM45_Msk                            /*!< CPU1 Interrupt Mask on line 45 */
+#define EXTI_IMR2_IM48_Pos       (16U)
+#define EXTI_IMR2_IM48_Msk       (0x1UL << EXTI_IMR2_IM48_Pos)                 /*!< 0x00010000 */
+#define EXTI_IMR2_IM48           EXTI_IMR2_IM48_Msk                            /*!< CPU1 Interrupt Mask on line 48 */
+
+/********************  Bits definition for EXTI_EMR2 register  ****************/
+#define EXTI_EMR2_Pos            (0U)
+#define EXTI_EMR2_Msk            (0x00000300UL << EXTI_EMR2_Pos)               /*!< 0x000003000 */
+#define EXTI_EMR2_EM             EXTI_EMR2_Msk                                 /*!< CPU1 Interrupt Mask  */
+#define EXTI_EMR2_EM40_Pos       (8U)
+#define EXTI_EMR2_EM40_Msk       (0x1UL << EXTI_EMR2_EM40_Pos)                 /*!< 0x00000100 */
+#define EXTI_EMR2_EM40           EXTI_EMR2_EM40_Msk                            /*!< CPU1 Event Mask on line 40 */
+#define EXTI_EMR2_EM41_Pos       (9U)
+#define EXTI_EMR2_EM41_Msk       (0x1UL << EXTI_EMR2_EM41_Pos)                 /*!< 0x00000200 */
+#define EXTI_EMR2_EM41           EXTI_EMR2_EM41_Msk                            /*!< CPU1 Event Mask on line 41 */
+
+/********************  Bits definition for EXTI_C2IMR1 register  **************/
+#define EXTI_C2IMR1_Pos          (0U)
+#define EXTI_C2IMR1_Msk          (0xFFFFFFFFUL << EXTI_C2IMR1_Pos)             /*!< 0xFFFFFFFF */
+#define EXTI_C2IMR1_IM           EXTI_C2IMR1_Msk                               /*!< CPU2 wakeup with interrupt Mask on Event */
+#define EXTI_C2IMR1_IM0_Pos      (0U)
+#define EXTI_C2IMR1_IM0_Msk      (0x1UL << EXTI_C2IMR1_IM0_Pos)                /*!< 0x00000001 */
+#define EXTI_C2IMR1_IM0          EXTI_C2IMR1_IM0_Msk                           /*!< CPU2 Interrupt Mask on line 0 */
+#define EXTI_C2IMR1_IM1_Pos      (1U)
+#define EXTI_C2IMR1_IM1_Msk      (0x1UL << EXTI_C2IMR1_IM1_Pos)                /*!< 0x00000002 */
+#define EXTI_C2IMR1_IM1          EXTI_C2IMR1_IM1_Msk                           /*!< CPU2 Interrupt Mask on line 1 */
+#define EXTI_C2IMR1_IM2_Pos      (2U)
+#define EXTI_C2IMR1_IM2_Msk      (0x1UL << EXTI_C2IMR1_IM2_Pos)                /*!< 0x00000004 */
+#define EXTI_C2IMR1_IM2          EXTI_C2IMR1_IM2_Msk                           /*!< CPU2 Interrupt Mask on line 2 */
+#define EXTI_C2IMR1_IM3_Pos      (3U)
+#define EXTI_C2IMR1_IM3_Msk      (0x1UL << EXTI_C2IMR1_IM3_Pos)                /*!< 0x00000008 */
+#define EXTI_C2IMR1_IM3          EXTI_C2IMR1_IM3_Msk                           /*!< CPU2 Interrupt Mask on line 3 */
+#define EXTI_C2IMR1_IM4_Pos      (4U)
+#define EXTI_C2IMR1_IM4_Msk      (0x1UL << EXTI_C2IMR1_IM4_Pos)                /*!< 0x00000010 */
+#define EXTI_C2IMR1_IM4          EXTI_C2IMR1_IM4_Msk                           /*!< CPU2 Interrupt Mask on line 4 */
+#define EXTI_C2IMR1_IM5_Pos      (5U)
+#define EXTI_C2IMR1_IM5_Msk      (0x1UL << EXTI_C2IMR1_IM5_Pos)                /*!< 0x00000020 */
+#define EXTI_C2IMR1_IM5          EXTI_C2IMR1_IM5_Msk                           /*!< CPU2 Interrupt Mask on line 5 */
+#define EXTI_C2IMR1_IM6_Pos      (6U)
+#define EXTI_C2IMR1_IM6_Msk      (0x1UL << EXTI_C2IMR1_IM6_Pos)                /*!< 0x00000040 */
+#define EXTI_C2IMR1_IM6          EXTI_C2IMR1_IM6_Msk                           /*!< CPU2 Interrupt Mask on line 6 */
+#define EXTI_C2IMR1_IM7_Pos      (7U)
+#define EXTI_C2IMR1_IM7_Msk      (0x1UL << EXTI_C2IMR1_IM7_Pos)                /*!< 0x00000080 */
+#define EXTI_C2IMR1_IM7          EXTI_C2IMR1_IM7_Msk                           /*!< CPU2 Interrupt Mask on line 7 */
+#define EXTI_C2IMR1_IM8_Pos      (8U)
+#define EXTI_C2IMR1_IM8_Msk      (0x1UL << EXTI_C2IMR1_IM8_Pos)                /*!< 0x00000100 */
+#define EXTI_C2IMR1_IM8          EXTI_C2IMR1_IM8_Msk                           /*!< CPU2 Interrupt Mask on line 8 */
+#define EXTI_C2IMR1_IM9_Pos      (9U)
+#define EXTI_C2IMR1_IM9_Msk      (0x1UL << EXTI_C2IMR1_IM9_Pos)                /*!< 0x00000200 */
+#define EXTI_C2IMR1_IM9          EXTI_C2IMR1_IM9_Msk                           /*!< CPU2 Interrupt Mask on line 9 */
+#define EXTI_C2IMR1_IM10_Pos     (10U)
+#define EXTI_C2IMR1_IM10_Msk     (0x1UL << EXTI_C2IMR1_IM10_Pos)               /*!< 0x00000400 */
+#define EXTI_C2IMR1_IM10         EXTI_C2IMR1_IM10_Msk                          /*!< CPU2 Interrupt Mask on line 10 */
+#define EXTI_C2IMR1_IM11_Pos     (11U)
+#define EXTI_C2IMR1_IM11_Msk     (0x1UL << EXTI_C2IMR1_IM11_Pos)               /*!< 0x00000800 */
+#define EXTI_C2IMR1_IM11         EXTI_C2IMR1_IM11_Msk                          /*!< CPU2 Interrupt Mask on line 11 */
+#define EXTI_C2IMR1_IM12_Pos     (12U)
+#define EXTI_C2IMR1_IM12_Msk     (0x1UL << EXTI_C2IMR1_IM12_Pos)               /*!< 0x00001000 */
+#define EXTI_C2IMR1_IM12         EXTI_C2IMR1_IM12_Msk                          /*!< CPU2 Interrupt Mask on line 12 */
+#define EXTI_C2IMR1_IM13_Pos     (13U)
+#define EXTI_C2IMR1_IM13_Msk     (0x1UL << EXTI_C2IMR1_IM13_Pos)               /*!< 0x00002000 */
+#define EXTI_C2IMR1_IM13         EXTI_C2IMR1_IM13_Msk                          /*!< CPU2 Interrupt Mask on line 13 */
+#define EXTI_C2IMR1_IM14_Pos     (14U)
+#define EXTI_C2IMR1_IM14_Msk     (0x1UL << EXTI_C2IMR1_IM14_Pos)               /*!< 0x00004000 */
+#define EXTI_C2IMR1_IM14         EXTI_C2IMR1_IM14_Msk                          /*!< CPU2 Interrupt Mask on line 14 */
+#define EXTI_C2IMR1_IM15_Pos     (15U)
+#define EXTI_C2IMR1_IM15_Msk     (0x1UL << EXTI_C2IMR1_IM15_Pos)               /*!< 0x00008000 */
+#define EXTI_C2IMR1_IM15         EXTI_C2IMR1_IM15_Msk                          /*!< CPU2 Interrupt Mask on line 15 */
+#define EXTI_C2IMR1_IM16_Pos     (16U)
+#define EXTI_C2IMR1_IM16_Msk     (0x1UL << EXTI_C2IMR1_IM16_Pos)               /*!< 0x00010000 */
+#define EXTI_C2IMR1_IM16         EXTI_C2IMR1_IM16_Msk                          /*!< CPU2 Interrupt Mask on line 16 */
+#define EXTI_C2IMR1_IM17_Pos     (17U)
+#define EXTI_C2IMR1_IM17_Msk     (0x1UL << EXTI_C2IMR1_IM17_Pos)               /*!< 0x00020000 */
+#define EXTI_C2IMR1_IM17         EXTI_C2IMR1_IM17_Msk                          /*!< CPU2 Interrupt Mask on line 17 */
+#define EXTI_C2IMR1_IM18_Pos     (18U)
+#define EXTI_C2IMR1_IM18_Msk     (0x1UL << EXTI_C2IMR1_IM18_Pos)               /*!< 0x00040000 */
+#define EXTI_C2IMR1_IM18         EXTI_C2IMR1_IM18_Msk                          /*!< CPU2 Interrupt Mask on line 18 */
+#define EXTI_C2IMR1_IM19_Pos     (19U)
+#define EXTI_C2IMR1_IM19_Msk     (0x1UL << EXTI_C2IMR1_IM19_Pos)               /*!< 0x00080000 */
+#define EXTI_C2IMR1_IM19         EXTI_C2IMR1_IM19_Msk                          /*!< CPU2 Interrupt Mask on line 19 */
+#define EXTI_C2IMR1_IM20_Pos     (20U)
+#define EXTI_C2IMR1_IM20_Msk     (0x1UL << EXTI_C2IMR1_IM20_Pos)               /*!< 0x00100000 */
+#define EXTI_C2IMR1_IM20         EXTI_C2IMR1_IM20_Msk                          /*!< CPU2 Interrupt Mask on line 20 */
+#define EXTI_C2IMR1_IM22_Pos     (22U)
+#define EXTI_C2IMR1_IM22_Msk     (0x1UL << EXTI_C2IMR1_IM22_Pos)               /*!< 0x00400000 */
+#define EXTI_C2IMR1_IM22         EXTI_C2IMR1_IM22_Msk                          /*!< CPU2 Interrupt Mask on line 22 */
+#define EXTI_C2IMR1_IM24_Pos     (24U)
+#define EXTI_C2IMR1_IM24_Msk     (0x1UL << EXTI_C2IMR1_IM24_Pos)               /*!< 0x01000000 */
+#define EXTI_C2IMR1_IM24         EXTI_C2IMR1_IM24_Msk                          /*!< CPU2 Interrupt Mask on line 24 */
+#define EXTI_C2IMR1_IM25_Pos     (25U)
+#define EXTI_C2IMR1_IM25_Msk     (0x1UL << EXTI_C2IMR1_IM25_Pos)               /*!< 0x02000000 */
+#define EXTI_C2IMR1_IM25         EXTI_C2IMR1_IM25_Msk                          /*!< CPU2 Interrupt Mask on line 25 */
+#define EXTI_C2IMR1_IM29_Pos     (29U)
+#define EXTI_C2IMR1_IM29_Msk     (0x1UL << EXTI_C2IMR1_IM29_Pos)               /*!< 0x20000000 */
+#define EXTI_C2IMR1_IM29         EXTI_C2IMR1_IM29_Msk                          /*!< CPU2 Interrupt Mask on line 29 */
+#define EXTI_C2IMR1_IM30_Pos     (30U)
+#define EXTI_C2IMR1_IM30_Msk     (0x1UL << EXTI_C2IMR1_IM30_Pos)               /*!< 0x40000000 */
+#define EXTI_C2IMR1_IM30         EXTI_C2IMR1_IM30_Msk                          /*!< CPU2 Interrupt Mask on line 30 */
+#define EXTI_C2IMR1_IM31_Pos     (31U)
+#define EXTI_C2IMR1_IM31_Msk     (0x1UL << EXTI_C2IMR1_IM31_Pos)               /*!< 0x80000000 */
+#define EXTI_C2IMR1_IM31         EXTI_C2IMR1_IM31_Msk                          /*!< CPU2 Interrupt Mask on line 31 */
+
+/********************  Bits definition for EXTI_C2EMR1 register  **************/
+#define EXTI_C2EMR1_Pos          (0U)
+#define EXTI_C2EMR1_Msk          (0x003EFFFFUL << EXTI_C2EMR1_Pos)             /*!< 0xFFFFFFFF */
+#define EXTI_C2EMR1_EM           EXTI_C2EMR1_Msk                               /*!< CPU2 Event Mask */
+#define EXTI_C2EMR1_EM0_Pos      (0U)
+#define EXTI_C2EMR1_EM0_Msk      (0x1UL << EXTI_C2EMR1_EM0_Pos)                /*!< 0x00000001 */
+#define EXTI_C2EMR1_EM0          EXTI_C2EMR1_EM0_Msk                           /*!< CPU2 Event Mask on line 0 */
+#define EXTI_C2EMR1_EM1_Pos      (1U)
+#define EXTI_C2EMR1_EM1_Msk      (0x1UL << EXTI_C2EMR1_EM1_Pos)                /*!< 0x00000002 */
+#define EXTI_C2EMR1_EM1          EXTI_C2EMR1_EM1_Msk                           /*!< CPU2 Event Mask on line 1 */
+#define EXTI_C2EMR1_EM2_Pos      (2U)
+#define EXTI_C2EMR1_EM2_Msk      (0x1UL << EXTI_C2EMR1_EM2_Pos)                /*!< 0x00000004 */
+#define EXTI_C2EMR1_EM2          EXTI_C2EMR1_EM2_Msk                           /*!< CPU2 Event Mask on line 2 */
+#define EXTI_C2EMR1_EM3_Pos      (3U)
+#define EXTI_C2EMR1_EM3_Msk      (0x1UL << EXTI_C2EMR1_EM3_Pos)                /*!< 0x00000008 */
+#define EXTI_C2EMR1_EM3          EXTI_C2EMR1_EM3_Msk                           /*!< CPU2 Event Mask on line 3 */
+#define EXTI_C2EMR1_EM4_Pos      (4U)
+#define EXTI_C2EMR1_EM4_Msk      (0x1UL << EXTI_C2EMR1_EM4_Pos)                /*!< 0x00000010 */
+#define EXTI_C2EMR1_EM4          EXTI_C2EMR1_EM4_Msk                           /*!< CPU2 Event Mask on line 4 */
+#define EXTI_C2EMR1_EM5_Pos      (5U)
+#define EXTI_C2EMR1_EM5_Msk      (0x1UL << EXTI_C2EMR1_EM5_Pos)                /*!< 0x00000020 */
+#define EXTI_C2EMR1_EM5          EXTI_C2EMR1_EM5_Msk                           /*!< CPU2 Event Mask on line 5 */
+#define EXTI_C2EMR1_EM6_Pos      (6U)
+#define EXTI_C2EMR1_EM6_Msk      (0x1UL << EXTI_C2EMR1_EM6_Pos)                /*!< 0x00000040 */
+#define EXTI_C2EMR1_EM6          EXTI_C2EMR1_EM6_Msk                           /*!< CPU2 Event Mask on line 6 */
+#define EXTI_C2EMR1_EM7_Pos      (7U)
+#define EXTI_C2EMR1_EM7_Msk      (0x1UL << EXTI_C2EMR1_EM7_Pos)                /*!< 0x00000080 */
+#define EXTI_C2EMR1_EM7          EXTI_C2EMR1_EM7_Msk                           /*!< CPU2 Event Mask on line 7 */
+#define EXTI_C2EMR1_EM8_Pos      (8U)
+#define EXTI_C2EMR1_EM8_Msk      (0x1UL << EXTI_C2EMR1_EM8_Pos)                /*!< 0x00000100 */
+#define EXTI_C2EMR1_EM8          EXTI_C2EMR1_EM8_Msk                           /*!< CPU2 Event Mask on line 8 */
+#define EXTI_C2EMR1_EM9_Pos      (9U)
+#define EXTI_C2EMR1_EM9_Msk      (0x1UL << EXTI_C2EMR1_EM9_Pos)                /*!< 0x00000200 */
+#define EXTI_C2EMR1_EM9          EXTI_C2EMR1_EM9_Msk                           /*!< CPU2 Event Mask on line 9 */
+#define EXTI_C2EMR1_EM10_Pos     (10U)
+#define EXTI_C2EMR1_EM10_Msk     (0x1UL << EXTI_C2EMR1_EM10_Pos)               /*!< 0x00000400 */
+#define EXTI_C2EMR1_EM10         EXTI_C2EMR1_EM10_Msk                          /*!< CPU2 Event Mask on line 10 */
+#define EXTI_C2EMR1_EM11_Pos     (11U)
+#define EXTI_C2EMR1_EM11_Msk     (0x1UL << EXTI_C2EMR1_EM11_Pos)               /*!< 0x00000800 */
+#define EXTI_C2EMR1_EM11         EXTI_C2EMR1_EM11_Msk                          /*!< CPU2 Event Mask on line 11 */
+#define EXTI_C2EMR1_EM12_Pos     (12U)
+#define EXTI_C2EMR1_EM12_Msk     (0x1UL << EXTI_C2EMR1_EM12_Pos)               /*!< 0x00001000 */
+#define EXTI_C2EMR1_EM12         EXTI_C2EMR1_EM12_Msk                          /*!< CPU2 Event Mask on line 12 */
+#define EXTI_C2EMR1_EM13_Pos     (13U)
+#define EXTI_C2EMR1_EM13_Msk     (0x1UL << EXTI_C2EMR1_EM13_Pos)               /*!< 0x00002000 */
+#define EXTI_C2EMR1_EM13         EXTI_C2EMR1_EM13_Msk                          /*!< CPU2 Event Mask on line 13 */
+#define EXTI_C2EMR1_EM14_Pos     (14U)
+#define EXTI_C2EMR1_EM14_Msk     (0x1UL << EXTI_C2EMR1_EM14_Pos)               /*!< 0x00004000 */
+#define EXTI_C2EMR1_EM14         EXTI_C2EMR1_EM14_Msk                          /*!< CPU2 Event Mask on line 14 */
+#define EXTI_C2EMR1_EM15_Pos     (15U)
+#define EXTI_C2EMR1_EM15_Msk     (0x1UL << EXTI_C2EMR1_EM15_Pos)               /*!< 0x00008000 */
+#define EXTI_C2EMR1_EM15         EXTI_C2EMR1_EM15_Msk                          /*!< CPU2 Event Mask on line 15 */
+#define EXTI_C2EMR1_EM17_Pos     (17U)
+#define EXTI_C2EMR1_EM17_Msk     (0x1UL << EXTI_C2EMR1_EM17_Pos)               /*!< 0x00020000 */
+#define EXTI_C2EMR1_EM17         EXTI_C2EMR1_EM17_Msk                          /*!< CPU2 Event Mask on line 17 */
+#define EXTI_C2EMR1_EM18_Pos     (18U)
+#define EXTI_C2EMR1_EM18_Msk     (0x1UL << EXTI_C2EMR1_EM18_Pos)               /*!< 0x00040000 */
+#define EXTI_C2EMR1_EM18         EXTI_C2EMR1_EM18_Msk                          /*!< CPU2 Event Mask on line 18 */
+#define EXTI_C2EMR1_EM19_Pos     (19U)
+#define EXTI_C2EMR1_EM19_Msk     (0x1UL << EXTI_C2EMR1_EM19_Pos)               /*!< 0x00080000 */
+#define EXTI_C2EMR1_EM19         EXTI_C2EMR1_EM19_Msk                          /*!< CPU2 Event Mask on line 19 */
+#define EXTI_C2EMR1_EM20_Pos     (20U)
+#define EXTI_C2EMR1_EM20_Msk     (0x1UL << EXTI_C2EMR1_EM20_Pos)               /*!< 0x00100000 */
+#define EXTI_C2EMR1_EM20         EXTI_C2EMR1_EM20_Msk                          /*!< CPU2 Event Mask on line 20 */
+
+/********************  Bits definition for EXTI_C2IMR2 register  **************/
+#define EXTI_C2IMR2_Pos          (0U)
+#define EXTI_C2IMR2_Msk          (0x0001FFFFUL << EXTI_C2IMR2_Pos)             /*!< 0x0001FFFF */
+#define EXTI_C2IMR2_IM           EXTI_C2IMR2_Msk                               /*!< CPU2 Interrupt Mask  */
+#define EXTI_C2IMR2_IM33_Pos     (1U)
+#define EXTI_C2IMR2_IM33_Msk     (0x1UL << EXTI_C2IMR2_IM33_Pos)               /*!< 0x00000002 */
+#define EXTI_C2IMR2_IM33         EXTI_C2IMR2_IM33_Msk                          /*!< CPU2 Interrupt Mask on line 33 */
+#define EXTI_C2IMR2_IM36_Pos     (4U)
+#define EXTI_C2IMR2_IM36_Msk     (0x1UL << EXTI_C2IMR2_IM36_Pos)               /*!< 0x00000010 */
+#define EXTI_C2IMR2_IM36         EXTI_C2IMR2_IM36_Msk                          /*!< CPU2 Interrupt Mask on line 36 */
+#define EXTI_C2IMR2_IM37_Pos     (5U)
+#define EXTI_C2IMR2_IM37_Msk     (0x1UL << EXTI_C2IMR2_IM37_Pos)               /*!< 0x00000020 */
+#define EXTI_C2IMR2_IM37         EXTI_C2IMR2_IM37_Msk                          /*!< CPU2 Interrupt Mask on line 37 */
+#define EXTI_C2IMR2_IM38_Pos     (6U)
+#define EXTI_C2IMR2_IM38_Msk     (0x1UL << EXTI_C2IMR2_IM38_Pos)               /*!< 0x00000040 */
+#define EXTI_C2IMR2_IM38         EXTI_C2IMR2_IM38_Msk                          /*!< CPU2 Interrupt Mask on line 38 */
+#define EXTI_C2IMR2_IM39_Pos     (7U)
+#define EXTI_C2IMR2_IM39_Msk     (0x1UL << EXTI_C2IMR2_IM39_Pos)               /*!< 0x00000080 */
+#define EXTI_C2IMR2_IM39         EXTI_C2IMR2_IM39_Msk                          /*!< CPU2 Interrupt Mask on line 39 */
+#define EXTI_C2IMR2_IM40_Pos     (8U)
+#define EXTI_C2IMR2_IM40_Msk     (0x1UL << EXTI_C2IMR2_IM40_Pos)               /*!< 0x00000100 */
+#define EXTI_C2IMR2_IM40         EXTI_C2IMR2_IM40_Msk                          /*!< CPU2 Interrupt Mask on line 40 */
+#define EXTI_C2IMR2_IM41_Pos     (9U)
+#define EXTI_C2IMR2_IM41_Msk     (0x1UL << EXTI_C2IMR2_IM41_Pos)               /*!< 0x00000200 */
+#define EXTI_C2IMR2_IM41         EXTI_C2IMR2_IM41_Msk                          /*!< CPU2 Interrupt Mask on line 41 */
+#define EXTI_C2IMR2_IM42_Pos     (10U)
+#define EXTI_C2IMR2_IM42_Msk     (0x1UL << EXTI_C2IMR2_IM42_Pos)               /*!< 0x00000400 */
+#define EXTI_C2IMR2_IM42         EXTI_C2IMR2_IM42_Msk                          /*!< CPU2 Interrupt Mask on line 42 */
+#define EXTI_C2IMR2_IM44_Pos     (12U)
+#define EXTI_C2IMR2_IM44_Msk     (0x1UL << EXTI_C2IMR2_IM44_Pos)               /*!< 0x00001000 */
+#define EXTI_C2IMR2_IM44         EXTI_C2IMR2_IM44_Msk                          /*!< CPU2 Interrupt Mask on line 44 */
+#define EXTI_C2IMR2_IM45_Pos     (13U)
+#define EXTI_C2IMR2_IM45_Msk     (0x1UL << EXTI_C2IMR2_IM45_Pos)               /*!< 0x00002000 */
+#define EXTI_C2IMR2_IM45         EXTI_C2IMR2_IM45_Msk                          /*!< CPU2 Interrupt Mask on line 45 */
+#define EXTI_C2IMR2_IM48_Pos     (16U)
+#define EXTI_C2IMR2_IM48_Msk     (0x1UL << EXTI_C2IMR2_IM48_Pos)               /*!< 0x00010000 */
+#define EXTI_C2IMR2_IM48         EXTI_C2IMR2_IM48_Msk                          /*!< CPU2 Interrupt Mask on line 48 */
+
+/********************  Bits definition for EXTI_C2EMR2 register  **************/
+#define EXTI_C2EMR2_Pos          (8U)
+#define EXTI_C2EMR2_Msk          (0x00000300UL << EXTI_C2EMR2_Pos)             /*!< 0x000003000 */
+#define EXTI_C2EMR2_EM           EXTI_C2EMR2_Msk                               /*!< CPU2 Interrupt Mask  */
+#define EXTI_C2EMR2_EM40_Pos     (8U)
+#define EXTI_C2EMR2_EM40_Msk     (0x1UL << EXTI_C2EMR2_EM40_Pos)               /*!< 0x00000100 */
+#define EXTI_C2EMR2_EM40         EXTI_C2EMR2_EM40_Msk                          /*!< CPU2 Event Mask on line 40 */
+#define EXTI_C2EMR2_EM41_Pos     (9U)
+#define EXTI_C2EMR2_EM41_Msk     (0x1UL << EXTI_C2EMR2_EM41_Pos)               /*!< 0x00000200 */
+#define EXTI_C2EMR2_EM41         EXTI_C2EMR2_EM41_Msk                          /*!< CPU2 Event Mask on line 41 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                       Public Key Accelerator (PKA)                         */
+/*                                                                            */
+/******************************************************************************/
+
+/*******************  Bits definition for PKA_CR register  **************/
+#define PKA_CR_EN_Pos              (0U)
+#define PKA_CR_EN_Msk              (0x1UL << PKA_CR_EN_Pos)                /*!< 0x00000001 */
+#define PKA_CR_EN                  PKA_CR_EN_Msk                           /*!< PKA enable */
+#define PKA_CR_START_Pos           (1U)
+#define PKA_CR_START_Msk           (0x1UL << PKA_CR_START_Pos)             /*!< 0x00000002 */
+#define PKA_CR_START               PKA_CR_START_Msk                        /*!< Start operation */
+#define PKA_CR_MODE_Pos            (8U)
+#define PKA_CR_MODE_Msk            (0x3FUL << PKA_CR_MODE_Pos)             /*!< 0x00003F00 */
+#define PKA_CR_MODE                PKA_CR_MODE_Msk                         /*!< MODE[5:0] PKA operation code */
+#define PKA_CR_MODE_0              (0x01U << PKA_CR_MODE_Pos)              /*!< 0x00000100 */
+#define PKA_CR_MODE_1              (0x02U << PKA_CR_MODE_Pos)              /*!< 0x00000200 */
+#define PKA_CR_MODE_2              (0x04U << PKA_CR_MODE_Pos)              /*!< 0x00000400 */
+#define PKA_CR_MODE_3              (0x08U << PKA_CR_MODE_Pos)              /*!< 0x00000800 */
+#define PKA_CR_MODE_4              (0x10U << PKA_CR_MODE_Pos)              /*!< 0x00001000 */
+#define PKA_CR_MODE_5              (0x20U << PKA_CR_MODE_Pos)              /*!< 0x00002000 */
+#define PKA_CR_PROCENDIE_Pos       (17U)
+#define PKA_CR_PROCENDIE_Msk       (0x1UL << PKA_CR_PROCENDIE_Pos)         /*!< 0x00020000 */
+#define PKA_CR_PROCENDIE           PKA_CR_PROCENDIE_Msk                    /*!< End of operation interrupt enable */
+#define PKA_CR_RAMERRIE_Pos        (19U)
+#define PKA_CR_RAMERRIE_Msk        (0x1UL << PKA_CR_RAMERRIE_Pos)          /*!< 0x00080000 */
+#define PKA_CR_RAMERRIE            PKA_CR_RAMERRIE_Msk                     /*!< RAM error interrupt enable */
+#define PKA_CR_ADDRERRIE_Pos       (20U)
+#define PKA_CR_ADDRERRIE_Msk       (0x1UL << PKA_CR_ADDRERRIE_Pos)         /*!< 0x00100000 */
+#define PKA_CR_ADDRERRIE           PKA_CR_ADDRERRIE_Msk                    /*!< RAM error interrupt enable */
+
+/*******************  Bits definition for PKA_SR register  **************/
+#define PKA_SR_BUSY_Pos            (16U)
+#define PKA_SR_BUSY_Msk            (0x1UL << PKA_SR_BUSY_Pos)              /*!< 0x00010000 */
+#define PKA_SR_BUSY                PKA_SR_BUSY_Msk                         /*!< PKA operation is in progress */
+#define PKA_SR_PROCENDF_Pos        (17U)
+#define PKA_SR_PROCENDF_Msk        (0x1UL << PKA_SR_PROCENDF_Pos)          /*!< 0x00020000 */
+#define PKA_SR_PROCENDF            PKA_SR_PROCENDF_Msk                     /*!< PKA end of operation flag */
+#define PKA_SR_RAMERRF_Pos         (19U)
+#define PKA_SR_RAMERRF_Msk         (0x1UL << PKA_SR_RAMERRF_Pos)           /*!< 0x00080000 */
+#define PKA_SR_RAMERRF             PKA_SR_RAMERRF_Msk                      /*!< PKA RAM error flag */
+#define PKA_SR_ADDRERRF_Pos        (20U)
+#define PKA_SR_ADDRERRF_Msk        (0x1UL << PKA_SR_ADDRERRF_Pos)          /*!< 0x00100000 */
+#define PKA_SR_ADDRERRF            PKA_SR_ADDRERRF_Msk                     /*!< Address error flag */
+
+/*******************  Bits definition for PKA_CLRFR register  **************/
+#define PKA_CLRFR_PROCENDFC_Pos    (17U)
+#define PKA_CLRFR_PROCENDFC_Msk    (0x1UL << PKA_CLRFR_PROCENDFC_Pos)      /*!< 0x00020000 */
+#define PKA_CLRFR_PROCENDFC        PKA_CLRFR_PROCENDFC_Msk                 /*!< Clear PKA end of operation flag */
+#define PKA_CLRFR_RAMERRFC_Pos     (19U)
+#define PKA_CLRFR_RAMERRFC_Msk     (0x1UL << PKA_CLRFR_RAMERRFC_Pos)       /*!< 0x00080000 */
+#define PKA_CLRFR_RAMERRFC         PKA_CLRFR_RAMERRFC_Msk                  /*!< Clear PKA RAM error flag */
+#define PKA_CLRFR_ADDRERRFC_Pos    (20U)
+#define PKA_CLRFR_ADDRERRFC_Msk    (0x1UL << PKA_CLRFR_ADDRERRFC_Pos)      /*!< 0x00100000 */
+#define PKA_CLRFR_ADDRERRFC        PKA_CLRFR_ADDRERRFC_Msk                 /*!< Clear address error flag */
+
+/*******************  Bits definition for PKA RAM  *************************/
+#define PKA_RAM_OFFSET                            0x400U                           /*!< PKA RAM address offset */
+
+/* Compute Montgomery parameter input data */
+#define PKA_MONTGOMERY_PARAM_IN_MOD_NB_BITS       ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_MONTGOMERY_PARAM_IN_MODULUS           ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Compute Montgomery parameter output data */
+#define PKA_MONTGOMERY_PARAM_OUT_PARAMETER        ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Output Montgomery parameter */
+
+/* Compute modular exponentiation input data */
+#define PKA_MODULAR_EXP_IN_EXP_NB_BITS            ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent number of bits */
+#define PKA_MODULAR_EXP_IN_OP_NB_BITS             ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM       ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Input storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_IN_EXPONENT_BASE          ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input base of the exponentiation */
+#define PKA_MODULAR_EXP_IN_EXPONENT               ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent to process */
+#define PKA_MODULAR_EXP_IN_MODULUS                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Compute modular exponentiation output data */
+#define PKA_MODULAR_EXP_OUT_MONTGOMERY_PARAM      ((0x594U - PKA_RAM_OFFSET)>>2)   /*!< Output storage area for Montgomery parameter */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC1          ((0x724U - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 1 */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC2          ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 2 */
+#define PKA_MODULAR_EXP_OUT_EXPONENT_BASE         ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Output base of the exponentiation */
+#define PKA_MODULAR_EXP_OUT_SM_ALGO_ACC3          ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Output SM algorithm accumulator 3 */
+
+/* Compute ECC scalar multiplication input data */
+#define PKA_ECC_SCALAR_MUL_IN_EXP_NB_BITS         ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input exponent number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_OP_NB_BITS          ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF_SIGN        ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_A_COEFF             ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECC_SCALAR_MUL_IN_MOD_GF              ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECC_SCALAR_MUL_IN_MONTGOMERY_PARAM    ((0x4B4U - PKA_RAM_OFFSET)>>2)   /*!< Input storage area for Montgomery parameter */
+#define PKA_ECC_SCALAR_MUL_IN_K                   ((0x508U - PKA_RAM_OFFSET)>>2)   /*!< Input 'k' of KP */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X     ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y     ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+
+/* Compute ECC scalar multiplication output data */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_X           ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Output result X coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_RESULT_Y           ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Output result Y coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_X1     ((0xDE8U - PKA_RAM_OFFSET)>>2)   /*!< Output last double X1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_Y1     ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Output last double Y1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_LAST_DOUBLE_Z1     ((0xE90U - PKA_RAM_OFFSET)>>2)   /*!< Output last double Z1 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_X2     ((0xEE4U - PKA_RAM_OFFSET)>>2)   /*!< Output check point X2 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_Y2     ((0xF38U - PKA_RAM_OFFSET)>>2)   /*!< Output check point Y2 coordinate */
+#define PKA_ECC_SCALAR_MUL_OUT_CHECK_POINT_Z2     ((0xF8CU - PKA_RAM_OFFSET)>>2)   /*!< Output check point Z2 coordinate */
+
+/* Point check input data */
+#define PKA_POINT_CHECK_IN_MOD_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_POINT_CHECK_IN_A_COEFF_SIGN           ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_POINT_CHECK_IN_A_COEFF                ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_POINT_CHECK_IN_B_COEFF                ((0x7FCU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'b' coefficient */
+#define PKA_POINT_CHECK_IN_MOD_GF                 ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_X        ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_POINT_CHECK_IN_INITIAL_POINT_Y        ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+
+/* Point check output data */
+#define PKA_POINT_CHECK_OUT_ERROR                 ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Output error */
+
+/* ECDSA signature input data */
+#define PKA_ECDSA_SIGN_IN_ORDER_NB_BITS           ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input order number of bits */
+#define PKA_ECDSA_SIGN_IN_MOD_NB_BITS             ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_ECDSA_SIGN_IN_A_COEFF_SIGN            ((0x408U - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_A_COEFF                 ((0x40CU - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_SIGN_IN_MOD_GF                  ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECDSA_SIGN_IN_K                       ((0x508U - PKA_RAM_OFFSET)>>2)   /*!< Input k value of the ECDSA */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_X         ((0x55CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_SIGN_IN_INITIAL_POINT_Y         ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_SIGN_IN_HASH_E                  ((0xDE8U - PKA_RAM_OFFSET)>>2)   /*!< Input e, hash of the message */
+#define PKA_ECDSA_SIGN_IN_PRIVATE_KEY_D           ((0xE3CU - PKA_RAM_OFFSET)>>2)   /*!< Input d, private key */
+#define PKA_ECDSA_SIGN_IN_ORDER_N                 ((0xE94U - PKA_RAM_OFFSET)>>2)   /*!< Input n, order of the curve */
+
+/* ECDSA signature output data */
+#define PKA_ECDSA_SIGN_OUT_ERROR                  ((0xEE8U - PKA_RAM_OFFSET)>>2)   /*!< Output error */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_R            ((0x700U - PKA_RAM_OFFSET)>>2)   /*!< Output signature r */
+#define PKA_ECDSA_SIGN_OUT_SIGNATURE_S            ((0x754U - PKA_RAM_OFFSET)>>2)   /*!< Output signature s */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_X          ((0x103CU - PKA_RAM_OFFSET)>>2)  /*!< Output final point kP X coordinate */
+#define PKA_ECDSA_SIGN_OUT_FINAL_POINT_Y          ((0x1090U - PKA_RAM_OFFSET)>>2)  /*!< Output final point kP Y coordinate */
+
+/* ECDSA verification input data */
+#define PKA_ECDSA_VERIF_IN_ORDER_NB_BITS          ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input order number of bits */
+#define PKA_ECDSA_VERIF_IN_MOD_NB_BITS            ((0x4B4U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus number of bits */
+#define PKA_ECDSA_VERIF_IN_A_COEFF_SIGN           ((0x45CU - PKA_RAM_OFFSET)>>2)   /*!< Input sign of the 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_A_COEFF                ((0x460U - PKA_RAM_OFFSET)>>2)   /*!< Input ECC curve 'a' coefficient */
+#define PKA_ECDSA_VERIF_IN_MOD_GF                 ((0x4B8U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus GF(p) */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_X        ((0x5E8U - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P X coordinate */
+#define PKA_ECDSA_VERIF_IN_INITIAL_POINT_Y        ((0x63CU - PKA_RAM_OFFSET)>>2)   /*!< Input initial point P Y coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X     ((0xF40U - PKA_RAM_OFFSET)>>2)   /*!< Input public key point X coordinate */
+#define PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y     ((0xF94U - PKA_RAM_OFFSET)>>2)   /*!< Input public key point Y coordinate */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_R            ((0x1098U - PKA_RAM_OFFSET)>>2)  /*!< Input r, part of the signature */
+#define PKA_ECDSA_VERIF_IN_SIGNATURE_S            ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input s, part of the signature */
+#define PKA_ECDSA_VERIF_IN_HASH_E                 ((0xFE8U - PKA_RAM_OFFSET)>>2)   /*!< Input e, hash of the message */
+#define PKA_ECDSA_VERIF_IN_ORDER_N                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input n, order of the curve */
+
+/* ECDSA verification output data */
+#define PKA_ECDSA_VERIF_OUT_RESULT                ((0x5B0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* RSA CRT exponentiation input data */
+#define PKA_RSA_CRT_EXP_IN_MOD_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operands number of bits */
+#define PKA_RSA_CRT_EXP_IN_DP_CRT                 ((0x65CU - PKA_RAM_OFFSET)>>2)   /*!< Input Dp CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_DQ_CRT                 ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Input Dq CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_QINV_CRT               ((0x7ECU - PKA_RAM_OFFSET)>>2)   /*!< Input qInv CRT parameter */
+#define PKA_RSA_CRT_EXP_IN_PRIME_P                ((0x97CU - PKA_RAM_OFFSET)>>2)   /*!< Input Prime p */
+#define PKA_RSA_CRT_EXP_IN_PRIME_Q                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input Prime q */
+#define PKA_RSA_CRT_EXP_IN_EXPONENT_BASE          ((0xEECU - PKA_RAM_OFFSET)>>2)   /*!< Input base of the exponentiation */
+
+/* RSA CRT exponentiation output data */
+#define PKA_RSA_CRT_EXP_OUT_RESULT                ((0x724U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular reduction input data */
+#define PKA_MODULAR_REDUC_IN_OP_LENGTH            ((0x400U - PKA_RAM_OFFSET)>>2)   /*!< Input operand length */
+#define PKA_MODULAR_REDUC_IN_OPERAND              ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand */
+#define PKA_MODULAR_REDUC_IN_MOD_LENGTH           ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus length */
+#define PKA_MODULAR_REDUC_IN_MODULUS              ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Modular reduction output data */
+#define PKA_MODULAR_REDUC_OUT_RESULT              ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic addition input data */
+#define PKA_ARITHMETIC_ADD_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ADD_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ADD_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic addition output data */
+#define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic subtraction input data */
+#define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic subtraction output data */
+#define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Arithmetic multiplication input data */
+#define PKA_ARITHMETIC_MUL_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_MUL_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_MUL_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Arithmetic multiplication output data */
+#define PKA_ARITHMETIC_MUL_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Comparison input data */
+#define PKA_COMPARISON_NB_BITS                    ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_COMPARISON_IN_OP1                     ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_COMPARISON_IN_OP2                     ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Comparison output data */
+#define PKA_COMPARISON_OUT_RESULT                 ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular addition input data */
+#define PKA_MODULAR_ADD_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_ADD_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_ADD_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MODULAR_ADD_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 (modulus) */
+
+/* Modular addition output data */
+#define PKA_MODULAR_ADD_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular inversion input data */
+#define PKA_MODULAR_INV_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_INV_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_INV_IN_OP2_MOD                ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 (modulus) */
+
+/* Modular inversion output data */
+#define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Modular subtraction input data */
+#define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
+
+/* Modular subtraction output data */
+#define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Montgomery multiplication input data */
+#define PKA_MONTGOMERY_MUL_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_MONTGOMERY_MUL_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_MONTGOMERY_MUL_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_MONTGOMERY_MUL_IN_OP3_MOD             ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input modulus */
+
+/* Montgomery multiplication output data */
+#define PKA_MONTGOMERY_MUL_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/* Generic Arithmetic input data */
+#define PKA_ARITHMETIC_ALL_OPS_NB_BITS            ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP1             ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP2             ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+#define PKA_ARITHMETIC_ALL_OPS_IN_OP3             ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
+
+/* Generic Arithmetic output data */
+#define PKA_ARITHMETIC_ALL_OPS_OUT_RESULT         ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    FLASH                                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bits definition for FLASH_ACR register  *****************/
+#define FLASH_ACR_LATENCY_Pos               (0U)
+#define FLASH_ACR_LATENCY_Msk               (0x7UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000007 */
+#define FLASH_ACR_LATENCY                   FLASH_ACR_LATENCY_Msk              /*!< Latency                                             */
+#define FLASH_ACR_LATENCY_0                 (0x1UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000001 */
+#define FLASH_ACR_LATENCY_1                 (0x2UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000002 */
+#define FLASH_ACR_LATENCY_2                 (0x4UL << FLASH_ACR_LATENCY_Pos)   /*!< 0x00000004 */
+#define FLASH_ACR_PRFTEN_Pos                (8U)
+#define FLASH_ACR_PRFTEN_Msk                (0x1UL << FLASH_ACR_PRFTEN_Pos)    /*!< 0x00000100 */
+#define FLASH_ACR_PRFTEN                    FLASH_ACR_PRFTEN_Msk               /*!< Prefetch enable                                     */
+#define FLASH_ACR_ICEN_Pos                  (9U)
+#define FLASH_ACR_ICEN_Msk                  (0x1UL << FLASH_ACR_ICEN_Pos)      /*!< 0x00000200 */
+#define FLASH_ACR_ICEN                      FLASH_ACR_ICEN_Msk                 /*!< Instruction cache enable                            */
+#define FLASH_ACR_DCEN_Pos                  (10U)
+#define FLASH_ACR_DCEN_Msk                  (0x1UL << FLASH_ACR_DCEN_Pos)      /*!< 0x00000400 */
+#define FLASH_ACR_DCEN                      FLASH_ACR_DCEN_Msk                 /*!< Data cache enable                                   */
+#define FLASH_ACR_ICRST_Pos                 (11U)
+#define FLASH_ACR_ICRST_Msk                 (0x1UL << FLASH_ACR_ICRST_Pos)     /*!< 0x00000800 */
+#define FLASH_ACR_ICRST                     FLASH_ACR_ICRST_Msk                /*!< Instruction cache reset                             */
+#define FLASH_ACR_DCRST_Pos                 (12U)
+#define FLASH_ACR_DCRST_Msk                 (0x1UL << FLASH_ACR_DCRST_Pos)     /*!< 0x00001000 */
+#define FLASH_ACR_DCRST                     FLASH_ACR_DCRST_Msk                /*!< Data cache reset                                    */
+#define FLASH_ACR_PES_Pos                   (15U)
+#define FLASH_ACR_PES_Msk                   (0x1UL << FLASH_ACR_PES_Pos)       /*!< 0x00008000 */
+#define FLASH_ACR_PES                       FLASH_ACR_PES_Msk                  /*!< Program/erase suspend request                       */
+#define FLASH_ACR_EMPTY_Pos                 (16U)
+#define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
+#define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
+
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
+
+/*******************  Bits definition for FLASH_SR register  ******************/
+#define FLASH_SR_EOP_Pos                    (0U)
+#define FLASH_SR_EOP_Msk                    (0x1UL << FLASH_SR_EOP_Pos)        /*!< 0x00000001 */
+#define FLASH_SR_EOP                        FLASH_SR_EOP_Msk                   /*!< End of Operation                                    */
+#define FLASH_SR_OPERR_Pos                  (1U)
+#define FLASH_SR_OPERR_Msk                  (0x1UL << FLASH_SR_OPERR_Pos)      /*!< 0x00000002 */
+#define FLASH_SR_OPERR                      FLASH_SR_OPERR_Msk                 /*!< Operation error                                     */
+#define FLASH_SR_PROGERR_Pos                (3U)
+#define FLASH_SR_PROGERR_Msk                (0x1UL << FLASH_SR_PROGERR_Pos)    /*!< 0x00000008 */
+#define FLASH_SR_PROGERR                    FLASH_SR_PROGERR_Msk               /*!< Programming error                                   */
+#define FLASH_SR_WRPERR_Pos                 (4U)
+#define FLASH_SR_WRPERR_Msk                 (0x1UL << FLASH_SR_WRPERR_Pos)     /*!< 0x00000010 */
+#define FLASH_SR_WRPERR                     FLASH_SR_WRPERR_Msk                /*!< Write protection error                              */
+#define FLASH_SR_PGAERR_Pos                 (5U)
+#define FLASH_SR_PGAERR_Msk                 (0x1UL << FLASH_SR_PGAERR_Pos)     /*!< 0x00000020 */
+#define FLASH_SR_PGAERR                     FLASH_SR_PGAERR_Msk                /*!< Programming alignment error                         */
+#define FLASH_SR_SIZERR_Pos                 (6U)
+#define FLASH_SR_SIZERR_Msk                 (0x1UL << FLASH_SR_SIZERR_Pos)     /*!< 0x00000040 */
+#define FLASH_SR_SIZERR                     FLASH_SR_SIZERR_Msk                /*!< Size error                                          */
+#define FLASH_SR_PGSERR_Pos                 (7U)
+#define FLASH_SR_PGSERR_Msk                 (0x1UL << FLASH_SR_PGSERR_Pos)     /*!< 0x00000080 */
+#define FLASH_SR_PGSERR                     FLASH_SR_PGSERR_Msk                /*!< Programming sequence error                          */
+#define FLASH_SR_MISERR_Pos                 (8U)
+#define FLASH_SR_MISERR_Msk                 (0x1UL << FLASH_SR_MISERR_Pos)     /*!< 0x00000100 */
+#define FLASH_SR_MISERR                     FLASH_SR_MISERR_Msk                /*!< Fast programming data miss error                    */
+#define FLASH_SR_FASTERR_Pos                (9U)
+#define FLASH_SR_FASTERR_Msk                (0x1UL << FLASH_SR_FASTERR_Pos)    /*!< 0x00000200 */
+#define FLASH_SR_FASTERR                    FLASH_SR_FASTERR_Msk               /*!< Fast programming error                              */
+#define FLASH_SR_OPTNV_Pos                  (13U)
+#define FLASH_SR_OPTNV_Msk                  (0x1UL << FLASH_SR_OPTNV_Pos)     /*!< 0x00002000 */
+#define FLASH_SR_OPTNV                      FLASH_SR_OPTNV_Msk                /*!< User option OPTVAL indication                       */
+#define FLASH_SR_RDERR_Pos                  (14U)
+#define FLASH_SR_RDERR_Msk                  (0x1UL << FLASH_SR_RDERR_Pos)      /*!< 0x00004000 */
+#define FLASH_SR_RDERR                      FLASH_SR_RDERR_Msk                 /*!< PCROP read error                                    */
+#define FLASH_SR_OPTVERR_Pos                (15U)
+#define FLASH_SR_OPTVERR_Msk                (0x1UL << FLASH_SR_OPTVERR_Pos)    /*!< 0x00008000 */
+#define FLASH_SR_OPTVERR                    FLASH_SR_OPTVERR_Msk               /*!< Option validity error                               */
+#define FLASH_SR_BSY_Pos                    (16U)
+#define FLASH_SR_BSY_Msk                    (0x1UL << FLASH_SR_BSY_Pos)        /*!< 0x00010000 */
+#define FLASH_SR_BSY                        FLASH_SR_BSY_Msk                   /*!< Flash Busy                                          */
+#define FLASH_SR_CFGBSY_Pos                 (18U)
+#define FLASH_SR_CFGBSY_Msk                 (0x1UL << FLASH_SR_CFGBSY_Pos)     /*!< 0x00040000 */
+#define FLASH_SR_CFGBSY                     FLASH_SR_CFGBSY_Msk                /*!< Programming or erase configuration busy             */
+#define FLASH_SR_PESD_Pos                   (19U)
+#define FLASH_SR_PESD_Msk                   (0x1UL << FLASH_SR_PESD_Pos)       /*!< 0x00080000 */
+#define FLASH_SR_PESD                       FLASH_SR_PESD_Msk                  /*!< Programming/erase operation suspended               */
+
+/*******************  Bits definition for FLASH_CR register  ******************/
+#define FLASH_CR_PG_Pos                     (0U)
+#define FLASH_CR_PG_Msk                     (0x1UL << FLASH_CR_PG_Pos)         /*!< 0x00000001 */
+#define FLASH_CR_PG                         FLASH_CR_PG_Msk                    /*!< Flash programming                                   */
+#define FLASH_CR_PER_Pos                    (1U)
+#define FLASH_CR_PER_Msk                    (0x1UL << FLASH_CR_PER_Pos)        /*!< 0x00000002 */
+#define FLASH_CR_PER                        FLASH_CR_PER_Msk                   /*!< Page erase                                          */
+#define FLASH_CR_MER_Pos                    (2U)
+#define FLASH_CR_MER_Msk                    (0x1UL << FLASH_CR_MER_Pos)        /*!< 0x00000004 */
+#define FLASH_CR_MER                        FLASH_CR_MER_Msk                   /*!< Mass erase                                          */
+#define FLASH_CR_PNB_Pos                    (3U)
+#define FLASH_CR_PNB_Msk                    (0xFFUL << FLASH_CR_PNB_Pos)       /*!< 0x000007F8 */
+#define FLASH_CR_PNB                        FLASH_CR_PNB_Msk                   /*!< Page number selection mask                          */
+#define FLASH_CR_STRT_Pos                   (16U)
+#define FLASH_CR_STRT_Msk                   (0x1UL << FLASH_CR_STRT_Pos)       /*!< 0x00010000 */
+#define FLASH_CR_STRT                       FLASH_CR_STRT_Msk                  /*!< Start an erase operation                            */
+#define FLASH_CR_OPTSTRT_Pos                (17U)
+#define FLASH_CR_OPTSTRT_Msk                (0x1UL << FLASH_CR_OPTSTRT_Pos)    /*!< 0x00020000 */
+#define FLASH_CR_OPTSTRT                    FLASH_CR_OPTSTRT_Msk               /*!< Options modification start                          */
+#define FLASH_CR_FSTPG_Pos                  (18U)
+#define FLASH_CR_FSTPG_Msk                  (0x1UL << FLASH_CR_FSTPG_Pos)      /*!< 0x00040000 */
+#define FLASH_CR_FSTPG                      FLASH_CR_FSTPG_Msk                 /*!< Fast programming                                    */
+#define FLASH_CR_EOPIE_Pos                  (24U)
+#define FLASH_CR_EOPIE_Msk                  (0x1UL << FLASH_CR_EOPIE_Pos)      /*!< 0x01000000 */
+#define FLASH_CR_EOPIE                      FLASH_CR_EOPIE_Msk                 /*!< End of operation interrupt enable                   */
+#define FLASH_CR_ERRIE_Pos                  (25U)
+#define FLASH_CR_ERRIE_Msk                  (0x1UL << FLASH_CR_ERRIE_Pos)      /*!< 0x02000000 */
+#define FLASH_CR_ERRIE                      FLASH_CR_ERRIE_Msk                 /*!< Error interrupt enable                              */
+#define FLASH_CR_RDERRIE_Pos                (26U)
+#define FLASH_CR_RDERRIE_Msk                (0x1UL << FLASH_CR_RDERRIE_Pos)    /*!< 0x04000000 */
+#define FLASH_CR_RDERRIE                    FLASH_CR_RDERRIE_Msk               /*!< PCROP read error interrupt enable                   */
+#define FLASH_CR_OBL_LAUNCH_Pos             (27U)
+#define FLASH_CR_OBL_LAUNCH_Msk             (0x1UL << FLASH_CR_OBL_LAUNCH_Pos) /*!< 0x08000000 */
+#define FLASH_CR_OBL_LAUNCH                 FLASH_CR_OBL_LAUNCH_Msk            /*!< Force the option byte loading                       */
+#define FLASH_CR_OPTLOCK_Pos                (30U)
+#define FLASH_CR_OPTLOCK_Msk                (0x1UL << FLASH_CR_OPTLOCK_Pos)    /*!< 0x40000000 */
+#define FLASH_CR_OPTLOCK                    FLASH_CR_OPTLOCK_Msk               /*!< Options lock                                        */
+#define FLASH_CR_LOCK_Pos                   (31U)
+#define FLASH_CR_LOCK_Msk                   (0x1UL << FLASH_CR_LOCK_Pos)       /*!< 0x80000000 */
+#define FLASH_CR_LOCK                       FLASH_CR_LOCK_Msk                  /*!< Flash control register lock                         */
+
+/*******************  Bits definition for FLASH_ECCR register  ****************/
+#define FLASH_ECCR_ADDR_ECC_Pos             (0U)
+#define FLASH_ECCR_ADDR_ECC_Msk             (0x1FFFFUL << FLASH_ECCR_ADDR_ECC_Pos) /*!< 0x0001FFFF */
+#define FLASH_ECCR_ADDR_ECC                 FLASH_ECCR_ADDR_ECC_Msk            /*!< double-word address ECC fail                        */
+#define FLASH_ECCR_SYSF_ECC_Pos             (20U)
+#define FLASH_ECCR_SYSF_ECC_Msk             (0x1UL << FLASH_ECCR_SYSF_ECC_Pos) /*!< 0x00100000 */
+#define FLASH_ECCR_SYSF_ECC                 FLASH_ECCR_SYSF_ECC_Msk            /*!< System flash ECC fail                               */
+#define FLASH_ECCR_ECCCIE_Pos               (24U)
+#define FLASH_ECCR_ECCCIE_Msk               (0x1UL << FLASH_ECCR_ECCCIE_Pos)   /*!< 0x01000000 */
+#define FLASH_ECCR_ECCCIE                   FLASH_ECCR_ECCCIE_Msk              /*!< ECC correction interrupt enable                     */
+#define FLASH_ECCR_CPUID_Pos                (26U)
+#define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
+#define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
+#define FLASH_ECCR_ECCC_Pos                 (30U)
+#define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
+#define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
+#define FLASH_ECCR_ECCD_Pos                 (31U)
+#define FLASH_ECCR_ECCD_Msk                 (0x1UL << FLASH_ECCR_ECCD_Pos)     /*!< 0x80000000 */
+#define FLASH_ECCR_ECCD                     FLASH_ECCR_ECCD_Msk                /*!< ECC detection                                       */
+
+/*******************  Bits definition for FLASH_OPTR register  ****************/
+#define FLASH_OPTR_RDP_Pos                  (0U)
+#define FLASH_OPTR_RDP_Msk                  (0xFFUL << FLASH_OPTR_RDP_Pos)     /*!< 0x000000FF */
+#define FLASH_OPTR_RDP                      FLASH_OPTR_RDP_Msk                 /*!< Read protection level                               */
+#define FLASH_OPTR_ESE_Pos                  (8U)
+#define FLASH_OPTR_ESE_Msk                  (0x1UL << FLASH_OPTR_ESE_Pos)      /*!< 0x00000100 */
+#define FLASH_OPTR_ESE                      FLASH_OPTR_ESE_Msk                 /*!< Security enable                                     */
+#define FLASH_OPTR_BOR_LEV_Pos              (9U)
+#define FLASH_OPTR_BOR_LEV_Msk              (0x7UL << FLASH_OPTR_BOR_LEV_Pos)  /*!< 0x00000E00 */
+#define FLASH_OPTR_BOR_LEV                  FLASH_OPTR_BOR_LEV_Msk             /*!< BOR reset level mask                                */
+#define FLASH_OPTR_BOR_LEV_0                (0x1U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000200 */
+#define FLASH_OPTR_BOR_LEV_1                (0x2U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000400 */
+#define FLASH_OPTR_BOR_LEV_2                (0x4U << FLASH_OPTR_BOR_LEV_Pos)   /*!< 0x00000800 */
+#define FLASH_OPTR_nRST_STOP_Pos            (12U)
+#define FLASH_OPTR_nRST_STOP_Msk            (0x1UL << FLASH_OPTR_nRST_STOP_Pos) /*!< 0x00001000 */
+#define FLASH_OPTR_nRST_STOP                FLASH_OPTR_nRST_STOP_Msk           /*!< Reset option in Stop mode                           */
+#define FLASH_OPTR_nRST_STDBY_Pos           (13U)
+#define FLASH_OPTR_nRST_STDBY_Msk           (0x1UL << FLASH_OPTR_nRST_STDBY_Pos) /*!< 0x00002000 */
+#define FLASH_OPTR_nRST_STDBY               FLASH_OPTR_nRST_STDBY_Msk          /*!< Reset option in Standby mode                        */
+#define FLASH_OPTR_nRST_SHDW_Pos            (14U)
+#define FLASH_OPTR_nRST_SHDW_Msk            (0x1UL << FLASH_OPTR_nRST_SHDW_Pos) /*!< 0x00004000 */
+#define FLASH_OPTR_nRST_SHDW                FLASH_OPTR_nRST_SHDW_Msk           /*!< Reset option in Shutdown mode                       */
+#define FLASH_OPTR_IRHEN_Pos                (15U)
+#define FLASH_OPTR_IRHEN_Msk                (0x1UL << FLASH_OPTR_IRHEN_Pos)    /*!< 0x00008000 */
+#define FLASH_OPTR_IRHEN                    FLASH_OPTR_IRHEN_Msk               /*!< Internal reset holder enable bit                    */
+#define FLASH_OPTR_IWDG_SW_Pos              (16U)
+#define FLASH_OPTR_IWDG_SW_Msk              (0x1UL << FLASH_OPTR_IWDG_SW_Pos)  /*!< 0x00010000 */
+#define FLASH_OPTR_IWDG_SW                  FLASH_OPTR_IWDG_SW_Msk             /*!< Independent watchdog selection                      */
+#define FLASH_OPTR_IWDG_STOP_Pos            (17U)
+#define FLASH_OPTR_IWDG_STOP_Msk            (0x1UL << FLASH_OPTR_IWDG_STOP_Pos) /*!< 0x00020000 */
+#define FLASH_OPTR_IWDG_STOP                FLASH_OPTR_IWDG_STOP_Msk           /*!< Independent watchdog counter option in Stop mode    */
+#define FLASH_OPTR_IWDG_STDBY_Pos           (18U)
+#define FLASH_OPTR_IWDG_STDBY_Msk           (0x1UL << FLASH_OPTR_IWDG_STDBY_Pos) /*!< 0x00040000 */
+#define FLASH_OPTR_IWDG_STDBY               FLASH_OPTR_IWDG_STDBY_Msk          /*!< Independent watchdog counter option in Standby mode */
+#define FLASH_OPTR_WWDG_SW_Pos              (19U)
+#define FLASH_OPTR_WWDG_SW_Msk              (0x1UL << FLASH_OPTR_WWDG_SW_Pos)  /*!< 0x00080000 */
+#define FLASH_OPTR_WWDG_SW                  FLASH_OPTR_WWDG_SW_Msk             /*!< Window watchdog selection                           */
+#define FLASH_OPTR_nRST_MODE_1_Pos          (22U)
+#define FLASH_OPTR_nRST_MODE_1_Msk          (0x1UL << FLASH_OPTR_nRST_MODE_1_Pos)  /*!< 0x04000000 */
+#define FLASH_OPTR_nRST_MODE_1              FLASH_OPTR_nRST_MODE_1_Msk         /*!< PB11 GPIO normal mode                               */
+#define FLASH_OPTR_nBOOT1_Pos               (23U)
+#define FLASH_OPTR_nBOOT1_Msk               (0x1UL << FLASH_OPTR_nBOOT1_Pos)   /*!< 0x00800000 */
+#define FLASH_OPTR_nBOOT1                   FLASH_OPTR_nBOOT1_Msk              /*!< Boot Configuration                                  */
+#define FLASH_OPTR_SRAM2PE_Pos              (24U)
+#define FLASH_OPTR_SRAM2PE_Msk              (0x1UL << FLASH_OPTR_SRAM2PE_Pos)  /*!< 0x01000000 */
+#define FLASH_OPTR_SRAM2PE                  FLASH_OPTR_SRAM2PE_Msk             /*!< SRAM2 parity check enable                           */
+#define FLASH_OPTR_SRAM2RST_Pos             (25U)
+#define FLASH_OPTR_SRAM2RST_Msk             (0x1UL << FLASH_OPTR_SRAM2RST_Pos) /*!< 0x02000000 */
+#define FLASH_OPTR_SRAM2RST                 FLASH_OPTR_SRAM2RST_Msk            /*!< SRAM2 erase option when system reset                */
+#define FLASH_OPTR_nSWBOOT0_Pos             (26U)
+#define FLASH_OPTR_nSWBOOT0_Msk             (0x1UL << FLASH_OPTR_nSWBOOT0_Pos) /*!< 0x04000000 */
+#define FLASH_OPTR_nSWBOOT0                 FLASH_OPTR_nSWBOOT0_Msk            /*!< Software BOOT0                                      */
+#define FLASH_OPTR_nBOOT0_Pos               (27U)
+#define FLASH_OPTR_nBOOT0_Msk               (0x1UL << FLASH_OPTR_nBOOT0_Pos)   /*!< 0x08000000 */
+#define FLASH_OPTR_nBOOT0                   FLASH_OPTR_nBOOT0_Msk              /*!< BOOT0 option bit                                    */
+#define FLASH_OPTR_nRST_MODE_0_Pos          (28U)
+#define FLASH_OPTR_nRST_MODE_0_Msk          (0x1UL << FLASH_OPTR_nRST_MODE_0_Pos)  /*!< 0x10000000 */
+#define FLASH_OPTR_nRST_MODE_0              FLASH_OPTR_nRST_MODE_0_Msk         /*!< PB11 reset input mode                               */
+#define FLASH_OPTR_nRST_MODE_Pos            (22U)
+#define FLASH_OPTR_nRST_MODE_Msk            (0x41UL << FLASH_OPTR_nRST_MODE_Pos)  /*!< 0x10400000 */
+#define FLASH_OPTR_nRST_MODE                FLASH_OPTR_nRST_MODE_Msk
+#define FLASH_OPTR_AGC_TRIM_Pos             (29U)
+#define FLASH_OPTR_AGC_TRIM_Msk             (0x7UL << FLASH_OPTR_AGC_TRIM_Pos)  /*!< 0xE0000000 */
+#define FLASH_OPTR_AGC_TRIM                 FLASH_OPTR_AGC_TRIM_Msk             /*!< Automatic Gain Control trimming mask               */
+#define FLASH_OPTR_AGC_TRIM_0               (0x1U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x20000000 */
+#define FLASH_OPTR_AGC_TRIM_1               (0x2U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x40000000 */
+#define FLASH_OPTR_AGC_TRIM_2               (0x4U << FLASH_OPTR_AGC_TRIM_Pos)   /*!< 0x80000000 */
+
+/******************  Bits definition for FLASH_PCROP1ASR register  ************/
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Pos    (0U)
+#define FLASH_PCROP1ASR_PCROP1A_STRT_Msk    (0x1FFUL << FLASH_PCROP1ASR_PCROP1A_STRT_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1ASR_PCROP1A_STRT        FLASH_PCROP1ASR_PCROP1A_STRT_Msk   /*!< PCROP area A start offset                           */
+
+/******************  Bits definition for FLASH_PCROP1AER register  ************/
+#define FLASH_PCROP1AER_PCROP1A_END_Pos     (0U)
+#define FLASH_PCROP1AER_PCROP1A_END_Msk     (0x1FFUL << FLASH_PCROP1AER_PCROP1A_END_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1AER_PCROP1A_END         FLASH_PCROP1AER_PCROP1A_END_Msk    /*!< PCROP area A end offset                             */
+#define FLASH_PCROP1AER_PCROP_RDP_Pos       (31U)
+#define FLASH_PCROP1AER_PCROP_RDP_Msk       (0x1UL << FLASH_PCROP1AER_PCROP_RDP_Pos) /*!< 0x80000000 */
+#define FLASH_PCROP1AER_PCROP_RDP           FLASH_PCROP1AER_PCROP_RDP_Msk      /*!< PCROP area   preserved when RDP level decreased     */
+
+/******************  Bits definition for FLASH_WRP1AR register  ***************/
+#define FLASH_WRP1AR_WRP1A_STRT_Pos         (0U)
+#define FLASH_WRP1AR_WRP1A_STRT_Msk         (0xFFUL << FLASH_WRP1AR_WRP1A_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_WRP1AR_WRP1A_STRT             FLASH_WRP1AR_WRP1A_STRT_Msk        /*!< WRP area A start offset                             */
+#define FLASH_WRP1AR_WRP1A_END_Pos          (16U)
+#define FLASH_WRP1AR_WRP1A_END_Msk          (0xFFUL << FLASH_WRP1AR_WRP1A_END_Pos) /*!< 0x00FF0000 */
+#define FLASH_WRP1AR_WRP1A_END              FLASH_WRP1AR_WRP1A_END_Msk         /*!< WRP area A end offset                               */
+
+/******************  Bits definition for FLASH_WRP1BR register  ***************/
+#define FLASH_WRP1BR_WRP1B_STRT_Pos         (0U)
+#define FLASH_WRP1BR_WRP1B_STRT_Msk         (0xFFUL << FLASH_WRP1BR_WRP1B_STRT_Pos) /*!< 0x000000FF */
+#define FLASH_WRP1BR_WRP1B_STRT             FLASH_WRP1BR_WRP1B_STRT_Msk        /*!< WRP area B start offset                             */
+#define FLASH_WRP1BR_WRP1B_END_Pos          (16U)
+#define FLASH_WRP1BR_WRP1B_END_Msk          (0xFFUL << FLASH_WRP1BR_WRP1B_END_Pos) /*!< 0x00FF0000 */
+#define FLASH_WRP1BR_WRP1B_END              FLASH_WRP1BR_WRP1B_END_Msk         /*!< WRP area B end offset                               */
+
+/******************  Bits definition for FLASH_PCROP1BSR register  ************/
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Pos    (0U)
+#define FLASH_PCROP1BSR_PCROP1B_STRT_Msk    (0x1FFUL << FLASH_PCROP1BSR_PCROP1B_STRT_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1BSR_PCROP1B_STRT        FLASH_PCROP1BSR_PCROP1B_STRT_Msk   /*!< PCROP area B start offset                           */
+
+/******************  Bits definition for FLASH_PCROP1BER register  ************/
+#define FLASH_PCROP1BER_PCROP1B_END_Pos     (0U)
+#define FLASH_PCROP1BER_PCROP1B_END_Msk     (0x1FFUL << FLASH_PCROP1BER_PCROP1B_END_Pos) /*!< 0x000001FF */
+#define FLASH_PCROP1BER_PCROP1B_END         FLASH_PCROP1BER_PCROP1B_END_Msk    /*!< PCROP area B end offset                             */
+
+/******************  Bits definition for FLASH_IPCCBR register  ************/
+#define FLASH_IPCCBR_IPCCDBA_Pos            (0U)
+#define FLASH_IPCCBR_IPCCDBA_Msk            (0x3FFFUL << FLASH_IPCCBR_IPCCDBA_Pos) /*!< 0x00003FFF */
+#define FLASH_IPCCBR_IPCCDBA                FLASH_IPCCBR_IPCCDBA_Msk           /*!< IPCC data buffer base address                       */
+
+/******************  Bits definition for FLASH_SFR register  ************/
+#define FLASH_SFR_SFSA_Pos                  (0U)
+#define FLASH_SFR_SFSA_Msk                  (0xFFUL << FLASH_SFR_SFSA_Pos)     /*!< 0x000000FF */
+#define FLASH_SFR_SFSA                      FLASH_SFR_SFSA_Msk                 /* Secure flash start address                             */
+#define FLASH_SFR_FSD_Pos                   (8U)
+#define FLASH_SFR_FSD_Msk                   (0x1UL << FLASH_SFR_FSD_Pos)       /*!< 0x00000100 */
+#define FLASH_SFR_FSD                       FLASH_SFR_FSD_Msk                  /* Flash mode secure                                      */
+#define FLASH_SFR_DDS_Pos                   (12U)
+#define FLASH_SFR_DDS_Msk                   (0x1UL << FLASH_SFR_DDS_Pos)       /*!< 0x00001000 */
+#define FLASH_SFR_DDS                       FLASH_SFR_DDS_Msk                  /* Enabling and disabling CPU2 Debug access               */
+
+/******************  Bits definition for FLASH_SRRVR register  ************/
+#define FLASH_SRRVR_SBRV_Pos                (0U)
+#define FLASH_SRRVR_SBRV_Msk                (0x1FFFFUL << FLASH_SRRVR_SBRV_Pos) /*!< 0x0001FFFF */
+#define FLASH_SRRVR_SBRV                    FLASH_SRRVR_SBRV_Msk                /* CPU2 boot reset vector memory offset                  */
+
+#define FLASH_SRRVR_SBRSA_A_Pos             (18U)
+#define FLASH_SRRVR_SBRSA_A_Msk             (0x1FUL << FLASH_SRRVR_SBRSA_A_Pos) /*!< 0x007C0000 */
+#define FLASH_SRRVR_SBRSA_A                 FLASH_SRRVR_SBRSA_A_Msk             /* Secure backup SRAM2a start address                    */
+#define FLASH_SRRVR_BRSD_A_Pos              (23U)
+#define FLASH_SRRVR_BRSD_A_Msk              (0x1UL << FLASH_SRRVR_BRSD_A_Pos)   /*!< 0x00800000 */
+#define FLASH_SRRVR_BRSD_A                  FLASH_SRRVR_BRSD_A_Msk              /* Backup SRAM2A secure mode                             */
+
+#define FLASH_SRRVR_SBRSA_B_Pos             (25U)
+#define FLASH_SRRVR_SBRSA_B_Msk             (0x3UL << FLASH_SRRVR_SBRSA_B_Pos)  /*!< 0x06000000 */
+#define FLASH_SRRVR_SBRSA_B                 FLASH_SRRVR_SBRSA_B_Msk             /* Secure backup SRAM2b start address                    */
+#define FLASH_SRRVR_BRSD_B_Pos              (30U)
+#define FLASH_SRRVR_BRSD_B_Msk              (0x1UL << FLASH_SRRVR_BRSD_B_Pos)   /*!< 0x40000000 */
+#define FLASH_SRRVR_BRSD_B                  FLASH_SRRVR_BRSD_B_Msk              /* Backup SRAM2B secure mode                             */
+#define FLASH_SRRVR_C2OPT_Pos               (31U)
+#define FLASH_SRRVR_C2OPT_Msk               (0x1UL << FLASH_SRRVR_C2OPT_Pos)    /*!< 0x80000000 */
+#define FLASH_SRRVR_C2OPT                   FLASH_SRRVR_C2OPT_Msk               /* CPU2 boot reset vector memory selection                */
+
+/******************  Bits definition for FLASH_C2ACR register  ************/
+#define FLASH_C2ACR_PRFTEN_Pos              (8U)
+#define FLASH_C2ACR_PRFTEN_Msk              (0x1UL << FLASH_C2ACR_PRFTEN_Pos) /*!< 0x00000100 */
+#define FLASH_C2ACR_PRFTEN                  FLASH_C2ACR_PRFTEN_Msk            /*!< CPU2 Prefetch enable                                */
+#define FLASH_C2ACR_ICEN_Pos                (9U)
+#define FLASH_C2ACR_ICEN_Msk                (0x1UL << FLASH_C2ACR_ICEN_Pos)   /*!< 0x00000200 */
+#define FLASH_C2ACR_ICEN                    FLASH_C2ACR_ICEN_Msk              /*!< CPU2 Instruction cache enable                       */
+#define FLASH_C2ACR_ICRST_Pos               (11U)
+#define FLASH_C2ACR_ICRST_Msk               (0x1UL << FLASH_C2ACR_ICRST_Pos)  /*!< 0x00000800 */
+#define FLASH_C2ACR_ICRST                   FLASH_C2ACR_ICRST_Msk             /*!< CPU2 Instruction cache reset                        */
+#define FLASH_C2ACR_PES_Pos                 (15U)
+#define FLASH_C2ACR_PES_Msk                 (0x1UL << FLASH_C2ACR_PES_Pos)    /*!< 0x00008000 */
+#define FLASH_C2ACR_PES                     FLASH_C2ACR_PES_Msk               /*!< CPU2 Program/erase suspend request                  */
+
+/******************  Bits definition for FLASH_C2SR register  ************/
+#define FLASH_C2SR_EOP_Pos                  (0U)
+#define FLASH_C2SR_EOP_Msk                  (0x1UL << FLASH_C2SR_EOP_Pos)     /*!< 0x00000001 */
+#define FLASH_C2SR_EOP                      FLASH_C2SR_EOP_Msk                /*!< CPU2 End of operation                            */
+#define FLASH_C2SR_OPERR_Pos                (1U)
+#define FLASH_C2SR_OPERR_Msk                (0x1UL << FLASH_C2SR_OPERR_Pos)   /*!< 0x00000002 */
+#define FLASH_C2SR_OPERR                    FLASH_C2SR_OPERR_Msk              /*!< CPU2 Operation error                             */
+#define FLASH_C2SR_PROGERR_Pos              (3U)
+#define FLASH_C2SR_PROGERR_Msk              (0x1UL << FLASH_C2SR_PROGERR_Pos) /*!< 0x00000008 */
+#define FLASH_C2SR_PROGERR                  FLASH_C2SR_PROGERR_Msk            /*!< CPU2 Programming error                           */
+#define FLASH_C2SR_WRPERR_Pos               (4U)
+#define FLASH_C2SR_WRPERR_Msk               (0x1UL << FLASH_C2SR_WRPERR_Pos)  /*!< 0x00000010 */
+#define FLASH_C2SR_WRPERR                   FLASH_C2SR_WRPERR_Msk             /*!< CPU2 Write protection error                      */
+#define FLASH_C2SR_PGAERR_Pos               (5U)
+#define FLASH_C2SR_PGAERR_Msk               (0x1UL << FLASH_C2SR_PGAERR_Pos)  /*!< 0x00000020 */
+#define FLASH_C2SR_PGAERR                   FLASH_C2SR_PGAERR_Msk             /*!< CPU2 Programming alignment error                 */
+#define FLASH_C2SR_SIZERR_Pos               (6U)
+#define FLASH_C2SR_SIZERR_Msk               (0x1UL << FLASH_C2SR_SIZERR_Pos)  /*!< 0x00000040 */
+#define FLASH_C2SR_SIZERR                   FLASH_C2SR_SIZERR_Msk             /*!< CPU2 Size error                                  */
+#define FLASH_C2SR_PGSERR_Pos               (7U)
+#define FLASH_C2SR_PGSERR_Msk               (0x1UL << FLASH_C2SR_PGSERR_Pos)  /*!< 0x00000080 */
+#define FLASH_C2SR_PGSERR                   FLASH_C2SR_PGSERR_Msk             /*!< CPU2 Programming sequence error                  */
+#define FLASH_C2SR_MISERR_Pos               (8U)
+#define FLASH_C2SR_MISERR_Msk               (0x1UL << FLASH_C2SR_MISERR_Pos)  /*!< 0x00000100 */
+#define FLASH_C2SR_MISERR                   FLASH_C2SR_MISERR_Msk             /*!< CPU2 Fast programming data miss error            */
+#define FLASH_C2SR_FASTERR_Pos              (9U)
+#define FLASH_C2SR_FASTERR_Msk              (0x1UL << FLASH_C2SR_FASTERR_Pos) /*!< 0x00000200 */
+#define FLASH_C2SR_FASTERR                  FLASH_C2SR_FASTERR_Msk            /*!< CPU2 Fast programming error                      */
+#define FLASH_C2SR_RDERR_Pos                (14U)
+#define FLASH_C2SR_RDERR_Msk                (0x1UL << FLASH_C2SR_RDERR_Pos)   /*!< 0x00004000 */
+#define FLASH_C2SR_RDERR                    FLASH_C2SR_RDERR_Msk              /*!< CPU2 PCROP read error                            */
+#define FLASH_C2SR_BSY_Pos                  (16U)
+#define FLASH_C2SR_BSY_Msk                  (0x1UL << FLASH_C2SR_BSY_Pos)     /*!< 0x00010000 */
+#define FLASH_C2SR_BSY                      FLASH_C2SR_BSY_Msk                /*!< CPU2 Flash busy                                  */
+#define FLASH_C2SR_CFGBSY_Pos               (18U)
+#define FLASH_C2SR_CFGBSY_Msk               (0x1UL << FLASH_C2SR_CFGBSY_Pos)  /*!< 0x00040000 */
+#define FLASH_C2SR_CFGBSY                   FLASH_C2SR_CFGBSY_Msk             /*!< CPU2 Programming or erase configuration busy     */
+#define FLASH_C2SR_PESD_Pos                 (19U)
+#define FLASH_C2SR_PESD_Msk                 (0x1UL << FLASH_C2SR_PESD_Pos)   /*!< 0x00080000 */
+#define FLASH_C2SR_PESD                     FLASH_C2SR_PESD_Msk              /*!< CPU2 Programming/erase operation suspended       */
+
+/******************  Bits definition for FLASH_C2CR register  ************/
+#define FLASH_C2CR_PG_Pos                   (0U)
+#define FLASH_C2CR_PG_Msk                   (0x1UL << FLASH_C2CR_PG_Pos)      /*!< 0x00000001 */
+#define FLASH_C2CR_PG                       FLASH_C2CR_PG_Msk                 /*!< CPU2 Flash programming                                   */
+#define FLASH_C2CR_PER_Pos                  (1U)
+#define FLASH_C2CR_PER_Msk                  (0x1UL << FLASH_C2CR_PER_Pos)     /*!< 0x00000002 */
+#define FLASH_C2CR_PER                      FLASH_C2CR_PER_Msk                /*!< CPU2 Page erase                                          */
+#define FLASH_C2CR_MER_Pos                  (2U)
+#define FLASH_C2CR_MER_Msk                  (0x1UL << FLASH_C2CR_MER_Pos)     /*!< 0x00000004 */
+#define FLASH_C2CR_MER                      FLASH_C2CR_MER_Msk                /*!< CPU2 Mass erase                                          */
+#define FLASH_C2CR_PNB_Pos                  (3U)
+#define FLASH_C2CR_PNB_Msk                  (0xFFUL << FLASH_C2CR_PNB_Pos)    /*!< 0x000007F8 */
+#define FLASH_C2CR_PNB                      FLASH_C2CR_PNB_Msk                /*!< CPU2 Page number selection mask                          */
+#define FLASH_C2CR_STRT_Pos                 (16U)
+#define FLASH_C2CR_STRT_Msk                 (0x1UL << FLASH_C2CR_STRT_Pos)    /*!< 0x00010000 */
+#define FLASH_C2CR_STRT                     FLASH_C2CR_STRT_Msk               /*!< CPU2 Start an erase operation                            */
+#define FLASH_C2CR_FSTPG_Pos                (18U)
+#define FLASH_C2CR_FSTPG_Msk                (0x1UL << FLASH_C2CR_FSTPG_Pos)   /*!< 0x00040000 */
+#define FLASH_C2CR_FSTPG                    FLASH_C2CR_FSTPG_Msk              /*!< CPU2 Fast programming                                    */
+#define FLASH_C2CR_EOPIE_Pos                (24U)
+#define FLASH_C2CR_EOPIE_Msk                (0x1UL << FLASH_C2CR_EOPIE_Pos)   /*!< 0x01000000 */
+#define FLASH_C2CR_EOPIE                    FLASH_C2CR_EOPIE_Msk              /*!< CPU2 End of operation interrupt enable                   */
+#define FLASH_C2CR_ERRIE_Pos                (25U)
+#define FLASH_C2CR_ERRIE_Msk                (0x1UL << FLASH_C2CR_ERRIE_Pos)   /*!< 0x02000000 */
+#define FLASH_C2CR_ERRIE                    FLASH_C2CR_ERRIE_Msk              /*!< CPU2 Error interrupt enable                              */
+#define FLASH_C2CR_RDERRIE_Pos              (26U)
+#define FLASH_C2CR_RDERRIE_Msk              (0x1UL << FLASH_C2CR_RDERRIE_Pos) /*!< 0x04000000 */
+#define FLASH_C2CR_RDERRIE                  FLASH_C2CR_RDERRIE_Msk            /*!< CPU2 PCROP read error interrupt enable                   */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            General Purpose I/O                             */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bits definition for GPIO_MODER register  *****************/
+#define GPIO_MODER_MODE0_Pos           (0U)
+#define GPIO_MODER_MODE0_Msk           (0x3UL << GPIO_MODER_MODE0_Pos)         /*!< 0x00000003 */
+#define GPIO_MODER_MODE0               GPIO_MODER_MODE0_Msk
+#define GPIO_MODER_MODE0_0             (0x1U << GPIO_MODER_MODE0_Pos)          /*!< 0x00000001 */
+#define GPIO_MODER_MODE0_1             (0x2U << GPIO_MODER_MODE0_Pos)          /*!< 0x00000002 */
+#define GPIO_MODER_MODE1_Pos           (2U)
+#define GPIO_MODER_MODE1_Msk           (0x3UL << GPIO_MODER_MODE1_Pos)         /*!< 0x0000000C */
+#define GPIO_MODER_MODE1               GPIO_MODER_MODE1_Msk
+#define GPIO_MODER_MODE1_0             (0x1U << GPIO_MODER_MODE1_Pos)          /*!< 0x00000004 */
+#define GPIO_MODER_MODE1_1             (0x2U << GPIO_MODER_MODE1_Pos)          /*!< 0x00000008 */
+#define GPIO_MODER_MODE2_Pos           (4U)
+#define GPIO_MODER_MODE2_Msk           (0x3UL << GPIO_MODER_MODE2_Pos)         /*!< 0x00000030 */
+#define GPIO_MODER_MODE2               GPIO_MODER_MODE2_Msk
+#define GPIO_MODER_MODE2_0             (0x1U << GPIO_MODER_MODE2_Pos)          /*!< 0x00000010 */
+#define GPIO_MODER_MODE2_1             (0x2U << GPIO_MODER_MODE2_Pos)          /*!< 0x00000020 */
+#define GPIO_MODER_MODE3_Pos           (6U)
+#define GPIO_MODER_MODE3_Msk           (0x3UL << GPIO_MODER_MODE3_Pos)         /*!< 0x000000C0 */
+#define GPIO_MODER_MODE3               GPIO_MODER_MODE3_Msk
+#define GPIO_MODER_MODE3_0             (0x1U << GPIO_MODER_MODE3_Pos)          /*!< 0x00000040 */
+#define GPIO_MODER_MODE3_1             (0x2U << GPIO_MODER_MODE3_Pos)          /*!< 0x00000080 */
+#define GPIO_MODER_MODE4_Pos           (8U)
+#define GPIO_MODER_MODE4_Msk           (0x3UL << GPIO_MODER_MODE4_Pos)         /*!< 0x00000300 */
+#define GPIO_MODER_MODE4               GPIO_MODER_MODE4_Msk
+#define GPIO_MODER_MODE4_0             (0x1U << GPIO_MODER_MODE4_Pos)          /*!< 0x00000100 */
+#define GPIO_MODER_MODE4_1             (0x2U << GPIO_MODER_MODE4_Pos)          /*!< 0x00000200 */
+#define GPIO_MODER_MODE5_Pos           (10U)
+#define GPIO_MODER_MODE5_Msk           (0x3UL << GPIO_MODER_MODE5_Pos)         /*!< 0x00000C00 */
+#define GPIO_MODER_MODE5               GPIO_MODER_MODE5_Msk
+#define GPIO_MODER_MODE5_0             (0x1U << GPIO_MODER_MODE5_Pos)          /*!< 0x00000400 */
+#define GPIO_MODER_MODE5_1             (0x2U << GPIO_MODER_MODE5_Pos)          /*!< 0x00000800 */
+#define GPIO_MODER_MODE6_Pos           (12U)
+#define GPIO_MODER_MODE6_Msk           (0x3UL << GPIO_MODER_MODE6_Pos)         /*!< 0x00003000 */
+#define GPIO_MODER_MODE6               GPIO_MODER_MODE6_Msk
+#define GPIO_MODER_MODE6_0             (0x1U << GPIO_MODER_MODE6_Pos)          /*!< 0x00001000 */
+#define GPIO_MODER_MODE6_1             (0x2U << GPIO_MODER_MODE6_Pos)          /*!< 0x00002000 */
+#define GPIO_MODER_MODE7_Pos           (14U)
+#define GPIO_MODER_MODE7_Msk           (0x3UL << GPIO_MODER_MODE7_Pos)         /*!< 0x0000C000 */
+#define GPIO_MODER_MODE7               GPIO_MODER_MODE7_Msk
+#define GPIO_MODER_MODE7_0             (0x1U << GPIO_MODER_MODE7_Pos)          /*!< 0x00004000 */
+#define GPIO_MODER_MODE7_1             (0x2U << GPIO_MODER_MODE7_Pos)          /*!< 0x00008000 */
+#define GPIO_MODER_MODE8_Pos           (16U)
+#define GPIO_MODER_MODE8_Msk           (0x3UL << GPIO_MODER_MODE8_Pos)         /*!< 0x00030000 */
+#define GPIO_MODER_MODE8               GPIO_MODER_MODE8_Msk
+#define GPIO_MODER_MODE8_0             (0x1U << GPIO_MODER_MODE8_Pos)          /*!< 0x00010000 */
+#define GPIO_MODER_MODE8_1             (0x2U << GPIO_MODER_MODE8_Pos)          /*!< 0x00020000 */
+#define GPIO_MODER_MODE9_Pos           (18U)
+#define GPIO_MODER_MODE9_Msk           (0x3UL << GPIO_MODER_MODE9_Pos)         /*!< 0x000C0000 */
+#define GPIO_MODER_MODE9               GPIO_MODER_MODE9_Msk
+#define GPIO_MODER_MODE9_0             (0x1U << GPIO_MODER_MODE9_Pos)          /*!< 0x00040000 */
+#define GPIO_MODER_MODE9_1             (0x2U << GPIO_MODER_MODE9_Pos)          /*!< 0x00080000 */
+#define GPIO_MODER_MODE10_Pos          (20U)
+#define GPIO_MODER_MODE10_Msk          (0x3UL << GPIO_MODER_MODE10_Pos)        /*!< 0x00300000 */
+#define GPIO_MODER_MODE10              GPIO_MODER_MODE10_Msk
+#define GPIO_MODER_MODE10_0            (0x1U << GPIO_MODER_MODE10_Pos)         /*!< 0x00100000 */
+#define GPIO_MODER_MODE10_1            (0x2U << GPIO_MODER_MODE10_Pos)         /*!< 0x00200000 */
+#define GPIO_MODER_MODE11_Pos          (22U)
+#define GPIO_MODER_MODE11_Msk          (0x3UL << GPIO_MODER_MODE11_Pos)        /*!< 0x00C00000 */
+#define GPIO_MODER_MODE11              GPIO_MODER_MODE11_Msk
+#define GPIO_MODER_MODE11_0            (0x1U << GPIO_MODER_MODE11_Pos)         /*!< 0x00400000 */
+#define GPIO_MODER_MODE11_1            (0x2U << GPIO_MODER_MODE11_Pos)         /*!< 0x00800000 */
+#define GPIO_MODER_MODE12_Pos          (24U)
+#define GPIO_MODER_MODE12_Msk          (0x3UL << GPIO_MODER_MODE12_Pos)        /*!< 0x03000000 */
+#define GPIO_MODER_MODE12              GPIO_MODER_MODE12_Msk
+#define GPIO_MODER_MODE12_0            (0x1U << GPIO_MODER_MODE12_Pos)         /*!< 0x01000000 */
+#define GPIO_MODER_MODE12_1            (0x2U << GPIO_MODER_MODE12_Pos)         /*!< 0x02000000 */
+#define GPIO_MODER_MODE13_Pos          (26U)
+#define GPIO_MODER_MODE13_Msk          (0x3UL << GPIO_MODER_MODE13_Pos)        /*!< 0x0C000000 */
+#define GPIO_MODER_MODE13              GPIO_MODER_MODE13_Msk
+#define GPIO_MODER_MODE13_0            (0x1U << GPIO_MODER_MODE13_Pos)         /*!< 0x04000000 */
+#define GPIO_MODER_MODE13_1            (0x2U << GPIO_MODER_MODE13_Pos)         /*!< 0x08000000 */
+#define GPIO_MODER_MODE14_Pos          (28U)
+#define GPIO_MODER_MODE14_Msk          (0x3UL << GPIO_MODER_MODE14_Pos)        /*!< 0x30000000 */
+#define GPIO_MODER_MODE14              GPIO_MODER_MODE14_Msk
+#define GPIO_MODER_MODE14_0            (0x1U << GPIO_MODER_MODE14_Pos)         /*!< 0x10000000 */
+#define GPIO_MODER_MODE14_1            (0x2U << GPIO_MODER_MODE14_Pos)         /*!< 0x20000000 */
+#define GPIO_MODER_MODE15_Pos          (30U)
+#define GPIO_MODER_MODE15_Msk          (0x3UL << GPIO_MODER_MODE15_Pos)        /*!< 0xC0000000 */
+#define GPIO_MODER_MODE15              GPIO_MODER_MODE15_Msk
+#define GPIO_MODER_MODE15_0            (0x1U << GPIO_MODER_MODE15_Pos)         /*!< 0x40000000 */
+#define GPIO_MODER_MODE15_1            (0x2U << GPIO_MODER_MODE15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_OTYPER register  ****************/
+#define GPIO_OTYPER_OT0_Pos            (0U)
+#define GPIO_OTYPER_OT0_Msk            (0x1UL << GPIO_OTYPER_OT0_Pos)          /*!< 0x00000001 */
+#define GPIO_OTYPER_OT0                GPIO_OTYPER_OT0_Msk
+#define GPIO_OTYPER_OT1_Pos            (1U)
+#define GPIO_OTYPER_OT1_Msk            (0x1UL << GPIO_OTYPER_OT1_Pos)          /*!< 0x00000002 */
+#define GPIO_OTYPER_OT1                GPIO_OTYPER_OT1_Msk
+#define GPIO_OTYPER_OT2_Pos            (2U)
+#define GPIO_OTYPER_OT2_Msk            (0x1UL << GPIO_OTYPER_OT2_Pos)          /*!< 0x00000004 */
+#define GPIO_OTYPER_OT2                GPIO_OTYPER_OT2_Msk
+#define GPIO_OTYPER_OT3_Pos            (3U)
+#define GPIO_OTYPER_OT3_Msk            (0x1UL << GPIO_OTYPER_OT3_Pos)          /*!< 0x00000008 */
+#define GPIO_OTYPER_OT3                GPIO_OTYPER_OT3_Msk
+#define GPIO_OTYPER_OT4_Pos            (4U)
+#define GPIO_OTYPER_OT4_Msk            (0x1UL << GPIO_OTYPER_OT4_Pos)          /*!< 0x00000010 */
+#define GPIO_OTYPER_OT4                GPIO_OTYPER_OT4_Msk
+#define GPIO_OTYPER_OT5_Pos            (5U)
+#define GPIO_OTYPER_OT5_Msk            (0x1UL << GPIO_OTYPER_OT5_Pos)          /*!< 0x00000020 */
+#define GPIO_OTYPER_OT5                GPIO_OTYPER_OT5_Msk
+#define GPIO_OTYPER_OT6_Pos            (6U)
+#define GPIO_OTYPER_OT6_Msk            (0x1UL << GPIO_OTYPER_OT6_Pos)          /*!< 0x00000040 */
+#define GPIO_OTYPER_OT6                GPIO_OTYPER_OT6_Msk
+#define GPIO_OTYPER_OT7_Pos            (7U)
+#define GPIO_OTYPER_OT7_Msk            (0x1UL << GPIO_OTYPER_OT7_Pos)          /*!< 0x00000080 */
+#define GPIO_OTYPER_OT7                GPIO_OTYPER_OT7_Msk
+#define GPIO_OTYPER_OT8_Pos            (8U)
+#define GPIO_OTYPER_OT8_Msk            (0x1UL << GPIO_OTYPER_OT8_Pos)          /*!< 0x00000100 */
+#define GPIO_OTYPER_OT8                GPIO_OTYPER_OT8_Msk
+#define GPIO_OTYPER_OT9_Pos            (9U)
+#define GPIO_OTYPER_OT9_Msk            (0x1UL << GPIO_OTYPER_OT9_Pos)          /*!< 0x00000200 */
+#define GPIO_OTYPER_OT9                GPIO_OTYPER_OT9_Msk
+#define GPIO_OTYPER_OT10_Pos           (10U)
+#define GPIO_OTYPER_OT10_Msk           (0x1UL << GPIO_OTYPER_OT10_Pos)         /*!< 0x00000400 */
+#define GPIO_OTYPER_OT10               GPIO_OTYPER_OT10_Msk
+#define GPIO_OTYPER_OT11_Pos           (11U)
+#define GPIO_OTYPER_OT11_Msk           (0x1UL << GPIO_OTYPER_OT11_Pos)         /*!< 0x00000800 */
+#define GPIO_OTYPER_OT11               GPIO_OTYPER_OT11_Msk
+#define GPIO_OTYPER_OT12_Pos           (12U)
+#define GPIO_OTYPER_OT12_Msk           (0x1UL << GPIO_OTYPER_OT12_Pos)         /*!< 0x00001000 */
+#define GPIO_OTYPER_OT12               GPIO_OTYPER_OT12_Msk
+#define GPIO_OTYPER_OT13_Pos           (13U)
+#define GPIO_OTYPER_OT13_Msk           (0x1UL << GPIO_OTYPER_OT13_Pos)         /*!< 0x00002000 */
+#define GPIO_OTYPER_OT13               GPIO_OTYPER_OT13_Msk
+#define GPIO_OTYPER_OT14_Pos           (14U)
+#define GPIO_OTYPER_OT14_Msk           (0x1UL << GPIO_OTYPER_OT14_Pos)         /*!< 0x00004000 */
+#define GPIO_OTYPER_OT14               GPIO_OTYPER_OT14_Msk
+#define GPIO_OTYPER_OT15_Pos           (15U)
+#define GPIO_OTYPER_OT15_Msk           (0x1UL << GPIO_OTYPER_OT15_Pos)         /*!< 0x00008000 */
+#define GPIO_OTYPER_OT15               GPIO_OTYPER_OT15_Msk
+
+/******************  Bits definition for GPIO_OSPEEDR register  ***************/
+#define GPIO_OSPEEDR_OSPEED0_Pos       (0U)
+#define GPIO_OSPEEDR_OSPEED0_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED0_Pos)     /*!< 0x00000003 */
+#define GPIO_OSPEEDR_OSPEED0           GPIO_OSPEEDR_OSPEED0_Msk
+#define GPIO_OSPEEDR_OSPEED0_0         (0x1U << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000001 */
+#define GPIO_OSPEEDR_OSPEED0_1         (0x2U << GPIO_OSPEEDR_OSPEED0_Pos)      /*!< 0x00000002 */
+#define GPIO_OSPEEDR_OSPEED1_Pos       (2U)
+#define GPIO_OSPEEDR_OSPEED1_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED1_Pos)     /*!< 0x0000000C */
+#define GPIO_OSPEEDR_OSPEED1           GPIO_OSPEEDR_OSPEED1_Msk
+#define GPIO_OSPEEDR_OSPEED1_0         (0x1U << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000004 */
+#define GPIO_OSPEEDR_OSPEED1_1         (0x2U << GPIO_OSPEEDR_OSPEED1_Pos)      /*!< 0x00000008 */
+#define GPIO_OSPEEDR_OSPEED2_Pos       (4U)
+#define GPIO_OSPEEDR_OSPEED2_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED2_Pos)     /*!< 0x00000030 */
+#define GPIO_OSPEEDR_OSPEED2           GPIO_OSPEEDR_OSPEED2_Msk
+#define GPIO_OSPEEDR_OSPEED2_0         (0x1U << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000010 */
+#define GPIO_OSPEEDR_OSPEED2_1         (0x2U << GPIO_OSPEEDR_OSPEED2_Pos)      /*!< 0x00000020 */
+#define GPIO_OSPEEDR_OSPEED3_Pos       (6U)
+#define GPIO_OSPEEDR_OSPEED3_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED3_Pos)     /*!< 0x000000C0 */
+#define GPIO_OSPEEDR_OSPEED3           GPIO_OSPEEDR_OSPEED3_Msk
+#define GPIO_OSPEEDR_OSPEED3_0         (0x1U << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000040 */
+#define GPIO_OSPEEDR_OSPEED3_1         (0x2U << GPIO_OSPEEDR_OSPEED3_Pos)      /*!< 0x00000080 */
+#define GPIO_OSPEEDR_OSPEED4_Pos       (8U)
+#define GPIO_OSPEEDR_OSPEED4_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED4_Pos)     /*!< 0x00000300 */
+#define GPIO_OSPEEDR_OSPEED4           GPIO_OSPEEDR_OSPEED4_Msk
+#define GPIO_OSPEEDR_OSPEED4_0         (0x1U << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000100 */
+#define GPIO_OSPEEDR_OSPEED4_1         (0x2U << GPIO_OSPEEDR_OSPEED4_Pos)      /*!< 0x00000200 */
+#define GPIO_OSPEEDR_OSPEED5_Pos       (10U)
+#define GPIO_OSPEEDR_OSPEED5_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED5_Pos)     /*!< 0x00000C00 */
+#define GPIO_OSPEEDR_OSPEED5           GPIO_OSPEEDR_OSPEED5_Msk
+#define GPIO_OSPEEDR_OSPEED5_0         (0x1U << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000400 */
+#define GPIO_OSPEEDR_OSPEED5_1         (0x2U << GPIO_OSPEEDR_OSPEED5_Pos)      /*!< 0x00000800 */
+#define GPIO_OSPEEDR_OSPEED6_Pos       (12U)
+#define GPIO_OSPEEDR_OSPEED6_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED6_Pos)     /*!< 0x00003000 */
+#define GPIO_OSPEEDR_OSPEED6           GPIO_OSPEEDR_OSPEED6_Msk
+#define GPIO_OSPEEDR_OSPEED6_0         (0x1U << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00001000 */
+#define GPIO_OSPEEDR_OSPEED6_1         (0x2U << GPIO_OSPEEDR_OSPEED6_Pos)      /*!< 0x00002000 */
+#define GPIO_OSPEEDR_OSPEED7_Pos       (14U)
+#define GPIO_OSPEEDR_OSPEED7_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED7_Pos)     /*!< 0x0000C000 */
+#define GPIO_OSPEEDR_OSPEED7           GPIO_OSPEEDR_OSPEED7_Msk
+#define GPIO_OSPEEDR_OSPEED7_0         (0x1U << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00004000 */
+#define GPIO_OSPEEDR_OSPEED7_1         (0x2U << GPIO_OSPEEDR_OSPEED7_Pos)      /*!< 0x00008000 */
+#define GPIO_OSPEEDR_OSPEED8_Pos       (16U)
+#define GPIO_OSPEEDR_OSPEED8_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED8_Pos)     /*!< 0x00030000 */
+#define GPIO_OSPEEDR_OSPEED8           GPIO_OSPEEDR_OSPEED8_Msk
+#define GPIO_OSPEEDR_OSPEED8_0         (0x1U << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00010000 */
+#define GPIO_OSPEEDR_OSPEED8_1         (0x2U << GPIO_OSPEEDR_OSPEED8_Pos)      /*!< 0x00020000 */
+#define GPIO_OSPEEDR_OSPEED9_Pos       (18U)
+#define GPIO_OSPEEDR_OSPEED9_Msk       (0x3UL << GPIO_OSPEEDR_OSPEED9_Pos)     /*!< 0x000C0000 */
+#define GPIO_OSPEEDR_OSPEED9           GPIO_OSPEEDR_OSPEED9_Msk
+#define GPIO_OSPEEDR_OSPEED9_0         (0x1U << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00040000 */
+#define GPIO_OSPEEDR_OSPEED9_1         (0x2U << GPIO_OSPEEDR_OSPEED9_Pos)      /*!< 0x00080000 */
+#define GPIO_OSPEEDR_OSPEED10_Pos      (20U)
+#define GPIO_OSPEEDR_OSPEED10_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED10_Pos)    /*!< 0x00300000 */
+#define GPIO_OSPEEDR_OSPEED10          GPIO_OSPEEDR_OSPEED10_Msk
+#define GPIO_OSPEEDR_OSPEED10_0        (0x1U << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00100000 */
+#define GPIO_OSPEEDR_OSPEED10_1        (0x2U << GPIO_OSPEEDR_OSPEED10_Pos)     /*!< 0x00200000 */
+#define GPIO_OSPEEDR_OSPEED11_Pos      (22U)
+#define GPIO_OSPEEDR_OSPEED11_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED11_Pos)    /*!< 0x00C00000 */
+#define GPIO_OSPEEDR_OSPEED11          GPIO_OSPEEDR_OSPEED11_Msk
+#define GPIO_OSPEEDR_OSPEED11_0        (0x1U << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00400000 */
+#define GPIO_OSPEEDR_OSPEED11_1        (0x2U << GPIO_OSPEEDR_OSPEED11_Pos)     /*!< 0x00800000 */
+#define GPIO_OSPEEDR_OSPEED12_Pos      (24U)
+#define GPIO_OSPEEDR_OSPEED12_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED12_Pos)    /*!< 0x03000000 */
+#define GPIO_OSPEEDR_OSPEED12          GPIO_OSPEEDR_OSPEED12_Msk
+#define GPIO_OSPEEDR_OSPEED12_0        (0x1U << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x01000000 */
+#define GPIO_OSPEEDR_OSPEED12_1        (0x2U << GPIO_OSPEEDR_OSPEED12_Pos)     /*!< 0x02000000 */
+#define GPIO_OSPEEDR_OSPEED13_Pos      (26U)
+#define GPIO_OSPEEDR_OSPEED13_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED13_Pos)    /*!< 0x0C000000 */
+#define GPIO_OSPEEDR_OSPEED13          GPIO_OSPEEDR_OSPEED13_Msk
+#define GPIO_OSPEEDR_OSPEED13_0        (0x1U << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x04000000 */
+#define GPIO_OSPEEDR_OSPEED13_1        (0x2U << GPIO_OSPEEDR_OSPEED13_Pos)     /*!< 0x08000000 */
+#define GPIO_OSPEEDR_OSPEED14_Pos      (28U)
+#define GPIO_OSPEEDR_OSPEED14_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED14_Pos)    /*!< 0x30000000 */
+#define GPIO_OSPEEDR_OSPEED14          GPIO_OSPEEDR_OSPEED14_Msk
+#define GPIO_OSPEEDR_OSPEED14_0        (0x1U << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x10000000 */
+#define GPIO_OSPEEDR_OSPEED14_1        (0x2U << GPIO_OSPEEDR_OSPEED14_Pos)     /*!< 0x20000000 */
+#define GPIO_OSPEEDR_OSPEED15_Pos      (30U)
+#define GPIO_OSPEEDR_OSPEED15_Msk      (0x3UL << GPIO_OSPEEDR_OSPEED15_Pos)    /*!< 0xC0000000 */
+#define GPIO_OSPEEDR_OSPEED15          GPIO_OSPEEDR_OSPEED15_Msk
+#define GPIO_OSPEEDR_OSPEED15_0        (0x1U << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x40000000 */
+#define GPIO_OSPEEDR_OSPEED15_1        (0x2U << GPIO_OSPEEDR_OSPEED15_Pos)     /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_PUPDR register  *****************/
+#define GPIO_PUPDR_PUPD0_Pos           (0U)
+#define GPIO_PUPDR_PUPD0_Msk           (0x3UL << GPIO_PUPDR_PUPD0_Pos)         /*!< 0x00000003 */
+#define GPIO_PUPDR_PUPD0               GPIO_PUPDR_PUPD0_Msk
+#define GPIO_PUPDR_PUPD0_0             (0x1U << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000001 */
+#define GPIO_PUPDR_PUPD0_1             (0x2U << GPIO_PUPDR_PUPD0_Pos)          /*!< 0x00000002 */
+#define GPIO_PUPDR_PUPD1_Pos           (2U)
+#define GPIO_PUPDR_PUPD1_Msk           (0x3UL << GPIO_PUPDR_PUPD1_Pos)         /*!< 0x0000000C */
+#define GPIO_PUPDR_PUPD1               GPIO_PUPDR_PUPD1_Msk
+#define GPIO_PUPDR_PUPD1_0             (0x1U << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000004 */
+#define GPIO_PUPDR_PUPD1_1             (0x2U << GPIO_PUPDR_PUPD1_Pos)          /*!< 0x00000008 */
+#define GPIO_PUPDR_PUPD2_Pos           (4U)
+#define GPIO_PUPDR_PUPD2_Msk           (0x3UL << GPIO_PUPDR_PUPD2_Pos)         /*!< 0x00000030 */
+#define GPIO_PUPDR_PUPD2               GPIO_PUPDR_PUPD2_Msk
+#define GPIO_PUPDR_PUPD2_0             (0x1U << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000010 */
+#define GPIO_PUPDR_PUPD2_1             (0x2U << GPIO_PUPDR_PUPD2_Pos)          /*!< 0x00000020 */
+#define GPIO_PUPDR_PUPD3_Pos           (6U)
+#define GPIO_PUPDR_PUPD3_Msk           (0x3UL << GPIO_PUPDR_PUPD3_Pos)         /*!< 0x000000C0 */
+#define GPIO_PUPDR_PUPD3               GPIO_PUPDR_PUPD3_Msk
+#define GPIO_PUPDR_PUPD3_0             (0x1U << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000040 */
+#define GPIO_PUPDR_PUPD3_1             (0x2U << GPIO_PUPDR_PUPD3_Pos)          /*!< 0x00000080 */
+#define GPIO_PUPDR_PUPD4_Pos           (8U)
+#define GPIO_PUPDR_PUPD4_Msk           (0x3UL << GPIO_PUPDR_PUPD4_Pos)         /*!< 0x00000300 */
+#define GPIO_PUPDR_PUPD4               GPIO_PUPDR_PUPD4_Msk
+#define GPIO_PUPDR_PUPD4_0             (0x1U << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000100 */
+#define GPIO_PUPDR_PUPD4_1             (0x2U << GPIO_PUPDR_PUPD4_Pos)          /*!< 0x00000200 */
+#define GPIO_PUPDR_PUPD5_Pos           (10U)
+#define GPIO_PUPDR_PUPD5_Msk           (0x3UL << GPIO_PUPDR_PUPD5_Pos)         /*!< 0x00000C00 */
+#define GPIO_PUPDR_PUPD5               GPIO_PUPDR_PUPD5_Msk
+#define GPIO_PUPDR_PUPD5_0             (0x1U << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000400 */
+#define GPIO_PUPDR_PUPD5_1             (0x2U << GPIO_PUPDR_PUPD5_Pos)          /*!< 0x00000800 */
+#define GPIO_PUPDR_PUPD6_Pos           (12U)
+#define GPIO_PUPDR_PUPD6_Msk           (0x3UL << GPIO_PUPDR_PUPD6_Pos)         /*!< 0x00003000 */
+#define GPIO_PUPDR_PUPD6               GPIO_PUPDR_PUPD6_Msk
+#define GPIO_PUPDR_PUPD6_0             (0x1U << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00001000 */
+#define GPIO_PUPDR_PUPD6_1             (0x2U << GPIO_PUPDR_PUPD6_Pos)          /*!< 0x00002000 */
+#define GPIO_PUPDR_PUPD7_Pos           (14U)
+#define GPIO_PUPDR_PUPD7_Msk           (0x3UL << GPIO_PUPDR_PUPD7_Pos)         /*!< 0x0000C000 */
+#define GPIO_PUPDR_PUPD7               GPIO_PUPDR_PUPD7_Msk
+#define GPIO_PUPDR_PUPD7_0             (0x1U << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00004000 */
+#define GPIO_PUPDR_PUPD7_1             (0x2U << GPIO_PUPDR_PUPD7_Pos)          /*!< 0x00008000 */
+#define GPIO_PUPDR_PUPD8_Pos           (16U)
+#define GPIO_PUPDR_PUPD8_Msk           (0x3UL << GPIO_PUPDR_PUPD8_Pos)         /*!< 0x00030000 */
+#define GPIO_PUPDR_PUPD8               GPIO_PUPDR_PUPD8_Msk
+#define GPIO_PUPDR_PUPD8_0             (0x1U << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00010000 */
+#define GPIO_PUPDR_PUPD8_1             (0x2U << GPIO_PUPDR_PUPD8_Pos)          /*!< 0x00020000 */
+#define GPIO_PUPDR_PUPD9_Pos           (18U)
+#define GPIO_PUPDR_PUPD9_Msk           (0x3UL << GPIO_PUPDR_PUPD9_Pos)         /*!< 0x000C0000 */
+#define GPIO_PUPDR_PUPD9               GPIO_PUPDR_PUPD9_Msk
+#define GPIO_PUPDR_PUPD9_0             (0x1U << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00040000 */
+#define GPIO_PUPDR_PUPD9_1             (0x2U << GPIO_PUPDR_PUPD9_Pos)          /*!< 0x00080000 */
+#define GPIO_PUPDR_PUPD10_Pos          (20U)
+#define GPIO_PUPDR_PUPD10_Msk          (0x3UL << GPIO_PUPDR_PUPD10_Pos)        /*!< 0x00300000 */
+#define GPIO_PUPDR_PUPD10              GPIO_PUPDR_PUPD10_Msk
+#define GPIO_PUPDR_PUPD10_0            (0x1U << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00100000 */
+#define GPIO_PUPDR_PUPD10_1            (0x2U << GPIO_PUPDR_PUPD10_Pos)         /*!< 0x00200000 */
+#define GPIO_PUPDR_PUPD11_Pos          (22U)
+#define GPIO_PUPDR_PUPD11_Msk          (0x3UL << GPIO_PUPDR_PUPD11_Pos)        /*!< 0x00C00000 */
+#define GPIO_PUPDR_PUPD11              GPIO_PUPDR_PUPD11_Msk
+#define GPIO_PUPDR_PUPD11_0            (0x1U << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00400000 */
+#define GPIO_PUPDR_PUPD11_1            (0x2U << GPIO_PUPDR_PUPD11_Pos)         /*!< 0x00800000 */
+#define GPIO_PUPDR_PUPD12_Pos          (24U)
+#define GPIO_PUPDR_PUPD12_Msk          (0x3UL << GPIO_PUPDR_PUPD12_Pos)        /*!< 0x03000000 */
+#define GPIO_PUPDR_PUPD12              GPIO_PUPDR_PUPD12_Msk
+#define GPIO_PUPDR_PUPD12_0            (0x1U << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x01000000 */
+#define GPIO_PUPDR_PUPD12_1            (0x2U << GPIO_PUPDR_PUPD12_Pos)         /*!< 0x02000000 */
+#define GPIO_PUPDR_PUPD13_Pos          (26U)
+#define GPIO_PUPDR_PUPD13_Msk          (0x3UL << GPIO_PUPDR_PUPD13_Pos)        /*!< 0x0C000000 */
+#define GPIO_PUPDR_PUPD13              GPIO_PUPDR_PUPD13_Msk
+#define GPIO_PUPDR_PUPD13_0            (0x1U << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x04000000 */
+#define GPIO_PUPDR_PUPD13_1            (0x2U << GPIO_PUPDR_PUPD13_Pos)         /*!< 0x08000000 */
+#define GPIO_PUPDR_PUPD14_Pos          (28U)
+#define GPIO_PUPDR_PUPD14_Msk          (0x3UL << GPIO_PUPDR_PUPD14_Pos)        /*!< 0x30000000 */
+#define GPIO_PUPDR_PUPD14              GPIO_PUPDR_PUPD14_Msk
+#define GPIO_PUPDR_PUPD14_0            (0x1U << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x10000000 */
+#define GPIO_PUPDR_PUPD14_1            (0x2U << GPIO_PUPDR_PUPD14_Pos)         /*!< 0x20000000 */
+#define GPIO_PUPDR_PUPD15_Pos          (30U)
+#define GPIO_PUPDR_PUPD15_Msk          (0x3UL << GPIO_PUPDR_PUPD15_Pos)        /*!< 0xC0000000 */
+#define GPIO_PUPDR_PUPD15              GPIO_PUPDR_PUPD15_Msk
+#define GPIO_PUPDR_PUPD15_0            (0x1U << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x40000000 */
+#define GPIO_PUPDR_PUPD15_1            (0x2U << GPIO_PUPDR_PUPD15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_IDR register  *******************/
+#define GPIO_IDR_ID0_Pos               (0U)
+#define GPIO_IDR_ID0_Msk               (0x1UL << GPIO_IDR_ID0_Pos)             /*!< 0x00000001 */
+#define GPIO_IDR_ID0                   GPIO_IDR_ID0_Msk
+#define GPIO_IDR_ID1_Pos               (1U)
+#define GPIO_IDR_ID1_Msk               (0x1UL << GPIO_IDR_ID1_Pos)             /*!< 0x00000002 */
+#define GPIO_IDR_ID1                   GPIO_IDR_ID1_Msk
+#define GPIO_IDR_ID2_Pos               (2U)
+#define GPIO_IDR_ID2_Msk               (0x1UL << GPIO_IDR_ID2_Pos)             /*!< 0x00000004 */
+#define GPIO_IDR_ID2                   GPIO_IDR_ID2_Msk
+#define GPIO_IDR_ID3_Pos               (3U)
+#define GPIO_IDR_ID3_Msk               (0x1UL << GPIO_IDR_ID3_Pos)             /*!< 0x00000008 */
+#define GPIO_IDR_ID3                   GPIO_IDR_ID3_Msk
+#define GPIO_IDR_ID4_Pos               (4U)
+#define GPIO_IDR_ID4_Msk               (0x1UL << GPIO_IDR_ID4_Pos)             /*!< 0x00000010 */
+#define GPIO_IDR_ID4                   GPIO_IDR_ID4_Msk
+#define GPIO_IDR_ID5_Pos               (5U)
+#define GPIO_IDR_ID5_Msk               (0x1UL << GPIO_IDR_ID5_Pos)             /*!< 0x00000020 */
+#define GPIO_IDR_ID5                   GPIO_IDR_ID5_Msk
+#define GPIO_IDR_ID6_Pos               (6U)
+#define GPIO_IDR_ID6_Msk               (0x1UL << GPIO_IDR_ID6_Pos)             /*!< 0x00000040 */
+#define GPIO_IDR_ID6                   GPIO_IDR_ID6_Msk
+#define GPIO_IDR_ID7_Pos               (7U)
+#define GPIO_IDR_ID7_Msk               (0x1UL << GPIO_IDR_ID7_Pos)             /*!< 0x00000080 */
+#define GPIO_IDR_ID7                   GPIO_IDR_ID7_Msk
+#define GPIO_IDR_ID8_Pos               (8U)
+#define GPIO_IDR_ID8_Msk               (0x1UL << GPIO_IDR_ID8_Pos)             /*!< 0x00000100 */
+#define GPIO_IDR_ID8                   GPIO_IDR_ID8_Msk
+#define GPIO_IDR_ID9_Pos               (9U)
+#define GPIO_IDR_ID9_Msk               (0x1UL << GPIO_IDR_ID9_Pos)             /*!< 0x00000200 */
+#define GPIO_IDR_ID9                   GPIO_IDR_ID9_Msk
+#define GPIO_IDR_ID10_Pos              (10U)
+#define GPIO_IDR_ID10_Msk              (0x1UL << GPIO_IDR_ID10_Pos)            /*!< 0x00000400 */
+#define GPIO_IDR_ID10                  GPIO_IDR_ID10_Msk
+#define GPIO_IDR_ID11_Pos              (11U)
+#define GPIO_IDR_ID11_Msk              (0x1UL << GPIO_IDR_ID11_Pos)            /*!< 0x00000800 */
+#define GPIO_IDR_ID11                  GPIO_IDR_ID11_Msk
+#define GPIO_IDR_ID12_Pos              (12U)
+#define GPIO_IDR_ID12_Msk              (0x1UL << GPIO_IDR_ID12_Pos)            /*!< 0x00001000 */
+#define GPIO_IDR_ID12                  GPIO_IDR_ID12_Msk
+#define GPIO_IDR_ID13_Pos              (13U)
+#define GPIO_IDR_ID13_Msk              (0x1UL << GPIO_IDR_ID13_Pos)            /*!< 0x00002000 */
+#define GPIO_IDR_ID13                  GPIO_IDR_ID13_Msk
+#define GPIO_IDR_ID14_Pos              (14U)
+#define GPIO_IDR_ID14_Msk              (0x1UL << GPIO_IDR_ID14_Pos)            /*!< 0x00004000 */
+#define GPIO_IDR_ID14                  GPIO_IDR_ID14_Msk
+#define GPIO_IDR_ID15_Pos              (15U)
+#define GPIO_IDR_ID15_Msk              (0x1UL << GPIO_IDR_ID15_Pos)            /*!< 0x00008000 */
+#define GPIO_IDR_ID15                  GPIO_IDR_ID15_Msk
+
+/******************  Bits definition for GPIO_ODR register  *******************/
+#define GPIO_ODR_OD0_Pos               (0U)
+#define GPIO_ODR_OD0_Msk               (0x1UL << GPIO_ODR_OD0_Pos)             /*!< 0x00000001 */
+#define GPIO_ODR_OD0                   GPIO_ODR_OD0_Msk
+#define GPIO_ODR_OD1_Pos               (1U)
+#define GPIO_ODR_OD1_Msk               (0x1UL << GPIO_ODR_OD1_Pos)             /*!< 0x00000002 */
+#define GPIO_ODR_OD1                   GPIO_ODR_OD1_Msk
+#define GPIO_ODR_OD2_Pos               (2U)
+#define GPIO_ODR_OD2_Msk               (0x1UL << GPIO_ODR_OD2_Pos)             /*!< 0x00000004 */
+#define GPIO_ODR_OD2                   GPIO_ODR_OD2_Msk
+#define GPIO_ODR_OD3_Pos               (3U)
+#define GPIO_ODR_OD3_Msk               (0x1UL << GPIO_ODR_OD3_Pos)             /*!< 0x00000008 */
+#define GPIO_ODR_OD3                   GPIO_ODR_OD3_Msk
+#define GPIO_ODR_OD4_Pos               (4U)
+#define GPIO_ODR_OD4_Msk               (0x1UL << GPIO_ODR_OD4_Pos)             /*!< 0x00000010 */
+#define GPIO_ODR_OD4                   GPIO_ODR_OD4_Msk
+#define GPIO_ODR_OD5_Pos               (5U)
+#define GPIO_ODR_OD5_Msk               (0x1UL << GPIO_ODR_OD5_Pos)             /*!< 0x00000020 */
+#define GPIO_ODR_OD5                   GPIO_ODR_OD5_Msk
+#define GPIO_ODR_OD6_Pos               (6U)
+#define GPIO_ODR_OD6_Msk               (0x1UL << GPIO_ODR_OD6_Pos)             /*!< 0x00000040 */
+#define GPIO_ODR_OD6                   GPIO_ODR_OD6_Msk
+#define GPIO_ODR_OD7_Pos               (7U)
+#define GPIO_ODR_OD7_Msk               (0x1UL << GPIO_ODR_OD7_Pos)             /*!< 0x00000080 */
+#define GPIO_ODR_OD7                   GPIO_ODR_OD7_Msk
+#define GPIO_ODR_OD8_Pos               (8U)
+#define GPIO_ODR_OD8_Msk               (0x1UL << GPIO_ODR_OD8_Pos)             /*!< 0x00000100 */
+#define GPIO_ODR_OD8                   GPIO_ODR_OD8_Msk
+#define GPIO_ODR_OD9_Pos               (9U)
+#define GPIO_ODR_OD9_Msk               (0x1UL << GPIO_ODR_OD9_Pos)             /*!< 0x00000200 */
+#define GPIO_ODR_OD9                   GPIO_ODR_OD9_Msk
+#define GPIO_ODR_OD10_Pos              (10U)
+#define GPIO_ODR_OD10_Msk              (0x1UL << GPIO_ODR_OD10_Pos)            /*!< 0x00000400 */
+#define GPIO_ODR_OD10                  GPIO_ODR_OD10_Msk
+#define GPIO_ODR_OD11_Pos              (11U)
+#define GPIO_ODR_OD11_Msk              (0x1UL << GPIO_ODR_OD11_Pos)            /*!< 0x00000800 */
+#define GPIO_ODR_OD11                  GPIO_ODR_OD11_Msk
+#define GPIO_ODR_OD12_Pos              (12U)
+#define GPIO_ODR_OD12_Msk              (0x1UL << GPIO_ODR_OD12_Pos)            /*!< 0x00001000 */
+#define GPIO_ODR_OD12                  GPIO_ODR_OD12_Msk
+#define GPIO_ODR_OD13_Pos              (13U)
+#define GPIO_ODR_OD13_Msk              (0x1UL << GPIO_ODR_OD13_Pos)            /*!< 0x00002000 */
+#define GPIO_ODR_OD13                  GPIO_ODR_OD13_Msk
+#define GPIO_ODR_OD14_Pos              (14U)
+#define GPIO_ODR_OD14_Msk              (0x1UL << GPIO_ODR_OD14_Pos)            /*!< 0x00004000 */
+#define GPIO_ODR_OD14                  GPIO_ODR_OD14_Msk
+#define GPIO_ODR_OD15_Pos              (15U)
+#define GPIO_ODR_OD15_Msk              (0x1UL << GPIO_ODR_OD15_Pos)            /*!< 0x00008000 */
+#define GPIO_ODR_OD15                  GPIO_ODR_OD15_Msk
+
+/******************  Bits definition for GPIO_BSRR register  ******************/
+#define GPIO_BSRR_BS0_Pos              (0U)
+#define GPIO_BSRR_BS0_Msk              (0x1UL << GPIO_BSRR_BS0_Pos)            /*!< 0x00000001 */
+#define GPIO_BSRR_BS0                  GPIO_BSRR_BS0_Msk
+#define GPIO_BSRR_BS1_Pos              (1U)
+#define GPIO_BSRR_BS1_Msk              (0x1UL << GPIO_BSRR_BS1_Pos)            /*!< 0x00000002 */
+#define GPIO_BSRR_BS1                  GPIO_BSRR_BS1_Msk
+#define GPIO_BSRR_BS2_Pos              (2U)
+#define GPIO_BSRR_BS2_Msk              (0x1UL << GPIO_BSRR_BS2_Pos)            /*!< 0x00000004 */
+#define GPIO_BSRR_BS2                  GPIO_BSRR_BS2_Msk
+#define GPIO_BSRR_BS3_Pos              (3U)
+#define GPIO_BSRR_BS3_Msk              (0x1UL << GPIO_BSRR_BS3_Pos)            /*!< 0x00000008 */
+#define GPIO_BSRR_BS3                  GPIO_BSRR_BS3_Msk
+#define GPIO_BSRR_BS4_Pos              (4U)
+#define GPIO_BSRR_BS4_Msk              (0x1UL << GPIO_BSRR_BS4_Pos)            /*!< 0x00000010 */
+#define GPIO_BSRR_BS4                  GPIO_BSRR_BS4_Msk
+#define GPIO_BSRR_BS5_Pos              (5U)
+#define GPIO_BSRR_BS5_Msk              (0x1UL << GPIO_BSRR_BS5_Pos)            /*!< 0x00000020 */
+#define GPIO_BSRR_BS5                  GPIO_BSRR_BS5_Msk
+#define GPIO_BSRR_BS6_Pos              (6U)
+#define GPIO_BSRR_BS6_Msk              (0x1UL << GPIO_BSRR_BS6_Pos)            /*!< 0x00000040 */
+#define GPIO_BSRR_BS6                  GPIO_BSRR_BS6_Msk
+#define GPIO_BSRR_BS7_Pos              (7U)
+#define GPIO_BSRR_BS7_Msk              (0x1UL << GPIO_BSRR_BS7_Pos)            /*!< 0x00000080 */
+#define GPIO_BSRR_BS7                  GPIO_BSRR_BS7_Msk
+#define GPIO_BSRR_BS8_Pos              (8U)
+#define GPIO_BSRR_BS8_Msk              (0x1UL << GPIO_BSRR_BS8_Pos)            /*!< 0x00000100 */
+#define GPIO_BSRR_BS8                  GPIO_BSRR_BS8_Msk
+#define GPIO_BSRR_BS9_Pos              (9U)
+#define GPIO_BSRR_BS9_Msk              (0x1UL << GPIO_BSRR_BS9_Pos)            /*!< 0x00000200 */
+#define GPIO_BSRR_BS9                  GPIO_BSRR_BS9_Msk
+#define GPIO_BSRR_BS10_Pos             (10U)
+#define GPIO_BSRR_BS10_Msk             (0x1UL << GPIO_BSRR_BS10_Pos)           /*!< 0x00000400 */
+#define GPIO_BSRR_BS10                 GPIO_BSRR_BS10_Msk
+#define GPIO_BSRR_BS11_Pos             (11U)
+#define GPIO_BSRR_BS11_Msk             (0x1UL << GPIO_BSRR_BS11_Pos)           /*!< 0x00000800 */
+#define GPIO_BSRR_BS11                 GPIO_BSRR_BS11_Msk
+#define GPIO_BSRR_BS12_Pos             (12U)
+#define GPIO_BSRR_BS12_Msk             (0x1UL << GPIO_BSRR_BS12_Pos)           /*!< 0x00001000 */
+#define GPIO_BSRR_BS12                 GPIO_BSRR_BS12_Msk
+#define GPIO_BSRR_BS13_Pos             (13U)
+#define GPIO_BSRR_BS13_Msk             (0x1UL << GPIO_BSRR_BS13_Pos)           /*!< 0x00002000 */
+#define GPIO_BSRR_BS13                 GPIO_BSRR_BS13_Msk
+#define GPIO_BSRR_BS14_Pos             (14U)
+#define GPIO_BSRR_BS14_Msk             (0x1UL << GPIO_BSRR_BS14_Pos)           /*!< 0x00004000 */
+#define GPIO_BSRR_BS14                 GPIO_BSRR_BS14_Msk
+#define GPIO_BSRR_BS15_Pos             (15U)
+#define GPIO_BSRR_BS15_Msk             (0x1UL << GPIO_BSRR_BS15_Pos)           /*!< 0x00008000 */
+#define GPIO_BSRR_BS15                 GPIO_BSRR_BS15_Msk
+#define GPIO_BSRR_BR0_Pos              (16U)
+#define GPIO_BSRR_BR0_Msk              (0x1UL << GPIO_BSRR_BR0_Pos)            /*!< 0x00010000 */
+#define GPIO_BSRR_BR0                  GPIO_BSRR_BR0_Msk
+#define GPIO_BSRR_BR1_Pos              (17U)
+#define GPIO_BSRR_BR1_Msk              (0x1UL << GPIO_BSRR_BR1_Pos)            /*!< 0x00020000 */
+#define GPIO_BSRR_BR1                  GPIO_BSRR_BR1_Msk
+#define GPIO_BSRR_BR2_Pos              (18U)
+#define GPIO_BSRR_BR2_Msk              (0x1UL << GPIO_BSRR_BR2_Pos)            /*!< 0x00040000 */
+#define GPIO_BSRR_BR2                  GPIO_BSRR_BR2_Msk
+#define GPIO_BSRR_BR3_Pos              (19U)
+#define GPIO_BSRR_BR3_Msk              (0x1UL << GPIO_BSRR_BR3_Pos)            /*!< 0x00080000 */
+#define GPIO_BSRR_BR3                  GPIO_BSRR_BR3_Msk
+#define GPIO_BSRR_BR4_Pos              (20U)
+#define GPIO_BSRR_BR4_Msk              (0x1UL << GPIO_BSRR_BR4_Pos)            /*!< 0x00100000 */
+#define GPIO_BSRR_BR4                  GPIO_BSRR_BR4_Msk
+#define GPIO_BSRR_BR5_Pos              (21U)
+#define GPIO_BSRR_BR5_Msk              (0x1UL << GPIO_BSRR_BR5_Pos)            /*!< 0x00200000 */
+#define GPIO_BSRR_BR5                  GPIO_BSRR_BR5_Msk
+#define GPIO_BSRR_BR6_Pos              (22U)
+#define GPIO_BSRR_BR6_Msk              (0x1UL << GPIO_BSRR_BR6_Pos)            /*!< 0x00400000 */
+#define GPIO_BSRR_BR6                  GPIO_BSRR_BR6_Msk
+#define GPIO_BSRR_BR7_Pos              (23U)
+#define GPIO_BSRR_BR7_Msk              (0x1UL << GPIO_BSRR_BR7_Pos)            /*!< 0x00800000 */
+#define GPIO_BSRR_BR7                  GPIO_BSRR_BR7_Msk
+#define GPIO_BSRR_BR8_Pos              (24U)
+#define GPIO_BSRR_BR8_Msk              (0x1UL << GPIO_BSRR_BR8_Pos)            /*!< 0x01000000 */
+#define GPIO_BSRR_BR8                  GPIO_BSRR_BR8_Msk
+#define GPIO_BSRR_BR9_Pos              (25U)
+#define GPIO_BSRR_BR9_Msk              (0x1UL << GPIO_BSRR_BR9_Pos)            /*!< 0x02000000 */
+#define GPIO_BSRR_BR9                  GPIO_BSRR_BR9_Msk
+#define GPIO_BSRR_BR10_Pos             (26U)
+#define GPIO_BSRR_BR10_Msk             (0x1UL << GPIO_BSRR_BR10_Pos)           /*!< 0x04000000 */
+#define GPIO_BSRR_BR10                 GPIO_BSRR_BR10_Msk
+#define GPIO_BSRR_BR11_Pos             (27U)
+#define GPIO_BSRR_BR11_Msk             (0x1UL << GPIO_BSRR_BR11_Pos)           /*!< 0x08000000 */
+#define GPIO_BSRR_BR11                 GPIO_BSRR_BR11_Msk
+#define GPIO_BSRR_BR12_Pos             (28U)
+#define GPIO_BSRR_BR12_Msk             (0x1UL << GPIO_BSRR_BR12_Pos)           /*!< 0x10000000 */
+#define GPIO_BSRR_BR12                 GPIO_BSRR_BR12_Msk
+#define GPIO_BSRR_BR13_Pos             (29U)
+#define GPIO_BSRR_BR13_Msk             (0x1UL << GPIO_BSRR_BR13_Pos)           /*!< 0x20000000 */
+#define GPIO_BSRR_BR13                 GPIO_BSRR_BR13_Msk
+#define GPIO_BSRR_BR14_Pos             (30U)
+#define GPIO_BSRR_BR14_Msk             (0x1UL << GPIO_BSRR_BR14_Pos)           /*!< 0x40000000 */
+#define GPIO_BSRR_BR14                 GPIO_BSRR_BR14_Msk
+#define GPIO_BSRR_BR15_Pos             (31U)
+#define GPIO_BSRR_BR15_Msk             (0x1UL << GPIO_BSRR_BR15_Pos)           /*!< 0x80000000 */
+#define GPIO_BSRR_BR15                 GPIO_BSRR_BR15_Msk
+
+/****************** Bit definition for GPIO_LCKR register *********************/
+#define GPIO_LCKR_LCK0_Pos             (0U)
+#define GPIO_LCKR_LCK0_Msk             (0x1UL << GPIO_LCKR_LCK0_Pos)           /*!< 0x00000001 */
+#define GPIO_LCKR_LCK0                 GPIO_LCKR_LCK0_Msk
+#define GPIO_LCKR_LCK1_Pos             (1U)
+#define GPIO_LCKR_LCK1_Msk             (0x1UL << GPIO_LCKR_LCK1_Pos)           /*!< 0x00000002 */
+#define GPIO_LCKR_LCK1                 GPIO_LCKR_LCK1_Msk
+#define GPIO_LCKR_LCK2_Pos             (2U)
+#define GPIO_LCKR_LCK2_Msk             (0x1UL << GPIO_LCKR_LCK2_Pos)           /*!< 0x00000004 */
+#define GPIO_LCKR_LCK2                 GPIO_LCKR_LCK2_Msk
+#define GPIO_LCKR_LCK3_Pos             (3U)
+#define GPIO_LCKR_LCK3_Msk             (0x1UL << GPIO_LCKR_LCK3_Pos)           /*!< 0x00000008 */
+#define GPIO_LCKR_LCK3                 GPIO_LCKR_LCK3_Msk
+#define GPIO_LCKR_LCK4_Pos             (4U)
+#define GPIO_LCKR_LCK4_Msk             (0x1UL << GPIO_LCKR_LCK4_Pos)           /*!< 0x00000010 */
+#define GPIO_LCKR_LCK4                 GPIO_LCKR_LCK4_Msk
+#define GPIO_LCKR_LCK5_Pos             (5U)
+#define GPIO_LCKR_LCK5_Msk             (0x1UL << GPIO_LCKR_LCK5_Pos)           /*!< 0x00000020 */
+#define GPIO_LCKR_LCK5                 GPIO_LCKR_LCK5_Msk
+#define GPIO_LCKR_LCK6_Pos             (6U)
+#define GPIO_LCKR_LCK6_Msk             (0x1UL << GPIO_LCKR_LCK6_Pos)           /*!< 0x00000040 */
+#define GPIO_LCKR_LCK6                 GPIO_LCKR_LCK6_Msk
+#define GPIO_LCKR_LCK7_Pos             (7U)
+#define GPIO_LCKR_LCK7_Msk             (0x1UL << GPIO_LCKR_LCK7_Pos)           /*!< 0x00000080 */
+#define GPIO_LCKR_LCK7                 GPIO_LCKR_LCK7_Msk
+#define GPIO_LCKR_LCK8_Pos             (8U)
+#define GPIO_LCKR_LCK8_Msk             (0x1UL << GPIO_LCKR_LCK8_Pos)           /*!< 0x00000100 */
+#define GPIO_LCKR_LCK8                 GPIO_LCKR_LCK8_Msk
+#define GPIO_LCKR_LCK9_Pos             (9U)
+#define GPIO_LCKR_LCK9_Msk             (0x1UL << GPIO_LCKR_LCK9_Pos)           /*!< 0x00000200 */
+#define GPIO_LCKR_LCK9                 GPIO_LCKR_LCK9_Msk
+#define GPIO_LCKR_LCK10_Pos            (10U)
+#define GPIO_LCKR_LCK10_Msk            (0x1UL << GPIO_LCKR_LCK10_Pos)          /*!< 0x00000400 */
+#define GPIO_LCKR_LCK10                GPIO_LCKR_LCK10_Msk
+#define GPIO_LCKR_LCK11_Pos            (11U)
+#define GPIO_LCKR_LCK11_Msk            (0x1UL << GPIO_LCKR_LCK11_Pos)          /*!< 0x00000800 */
+#define GPIO_LCKR_LCK11                GPIO_LCKR_LCK11_Msk
+#define GPIO_LCKR_LCK12_Pos            (12U)
+#define GPIO_LCKR_LCK12_Msk            (0x1UL << GPIO_LCKR_LCK12_Pos)          /*!< 0x00001000 */
+#define GPIO_LCKR_LCK12                GPIO_LCKR_LCK12_Msk
+#define GPIO_LCKR_LCK13_Pos            (13U)
+#define GPIO_LCKR_LCK13_Msk            (0x1UL << GPIO_LCKR_LCK13_Pos)          /*!< 0x00002000 */
+#define GPIO_LCKR_LCK13                GPIO_LCKR_LCK13_Msk
+#define GPIO_LCKR_LCK14_Pos            (14U)
+#define GPIO_LCKR_LCK14_Msk            (0x1UL << GPIO_LCKR_LCK14_Pos)          /*!< 0x00004000 */
+#define GPIO_LCKR_LCK14                GPIO_LCKR_LCK14_Msk
+#define GPIO_LCKR_LCK15_Pos            (15U)
+#define GPIO_LCKR_LCK15_Msk            (0x1UL << GPIO_LCKR_LCK15_Pos)          /*!< 0x00008000 */
+#define GPIO_LCKR_LCK15                GPIO_LCKR_LCK15_Msk
+#define GPIO_LCKR_LCKK_Pos             (16U)
+#define GPIO_LCKR_LCKK_Msk             (0x1UL << GPIO_LCKR_LCKK_Pos)           /*!< 0x00010000 */
+#define GPIO_LCKR_LCKK                 GPIO_LCKR_LCKK_Msk
+
+/****************** Bit definition for GPIO_AFRL register *********************/
+#define GPIO_AFRL_AFSEL0_Pos           (0U)
+#define GPIO_AFRL_AFSEL0_Msk           (0xFUL << GPIO_AFRL_AFSEL0_Pos)         /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0               GPIO_AFRL_AFSEL0_Msk
+#define GPIO_AFRL_AFSEL0_0             (0x1U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRL_AFSEL0_1             (0x2U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRL_AFSEL0_2             (0x4U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRL_AFSEL0_3             (0x8U << GPIO_AFRL_AFSEL0_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRL_AFSEL1_Pos           (4U)
+#define GPIO_AFRL_AFSEL1_Msk           (0xFUL << GPIO_AFRL_AFSEL1_Pos)         /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1               GPIO_AFRL_AFSEL1_Msk
+#define GPIO_AFRL_AFSEL1_0             (0x1U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRL_AFSEL1_1             (0x2U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRL_AFSEL1_2             (0x4U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRL_AFSEL1_3             (0x8U << GPIO_AFRL_AFSEL1_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRL_AFSEL2_Pos           (8U)
+#define GPIO_AFRL_AFSEL2_Msk           (0xFUL << GPIO_AFRL_AFSEL2_Pos)         /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2               GPIO_AFRL_AFSEL2_Msk
+#define GPIO_AFRL_AFSEL2_0             (0x1U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000100 */
+#define GPIO_AFRL_AFSEL2_1             (0x2U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000200 */
+#define GPIO_AFRL_AFSEL2_2             (0x4U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000400 */
+#define GPIO_AFRL_AFSEL2_3             (0x8U << GPIO_AFRL_AFSEL2_Pos)          /*!< 0x00000800 */
+#define GPIO_AFRL_AFSEL3_Pos           (12U)
+#define GPIO_AFRL_AFSEL3_Msk           (0xFUL << GPIO_AFRL_AFSEL3_Pos)         /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3               GPIO_AFRL_AFSEL3_Msk
+#define GPIO_AFRL_AFSEL3_0             (0x1U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00001000 */
+#define GPIO_AFRL_AFSEL3_1             (0x2U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00002000 */
+#define GPIO_AFRL_AFSEL3_2             (0x4U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00004000 */
+#define GPIO_AFRL_AFSEL3_3             (0x8U << GPIO_AFRL_AFSEL3_Pos)          /*!< 0x00008000 */
+#define GPIO_AFRL_AFSEL4_Pos           (16U)
+#define GPIO_AFRL_AFSEL4_Msk           (0xFUL << GPIO_AFRL_AFSEL4_Pos)         /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4               GPIO_AFRL_AFSEL4_Msk
+#define GPIO_AFRL_AFSEL4_0             (0x1U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00010000 */
+#define GPIO_AFRL_AFSEL4_1             (0x2U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00020000 */
+#define GPIO_AFRL_AFSEL4_2             (0x4U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00040000 */
+#define GPIO_AFRL_AFSEL4_3             (0x8U << GPIO_AFRL_AFSEL4_Pos)          /*!< 0x00080000 */
+#define GPIO_AFRL_AFSEL5_Pos           (20U)
+#define GPIO_AFRL_AFSEL5_Msk           (0xFUL << GPIO_AFRL_AFSEL5_Pos)         /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5               GPIO_AFRL_AFSEL5_Msk
+#define GPIO_AFRL_AFSEL5_0             (0x1U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00100000 */
+#define GPIO_AFRL_AFSEL5_1             (0x2U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00200000 */
+#define GPIO_AFRL_AFSEL5_2             (0x4U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00400000 */
+#define GPIO_AFRL_AFSEL5_3             (0x8U << GPIO_AFRL_AFSEL5_Pos)          /*!< 0x00800000 */
+#define GPIO_AFRL_AFSEL6_Pos           (24U)
+#define GPIO_AFRL_AFSEL6_Msk           (0xFUL << GPIO_AFRL_AFSEL6_Pos)         /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6               GPIO_AFRL_AFSEL6_Msk
+#define GPIO_AFRL_AFSEL6_0             (0x1U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x01000000 */
+#define GPIO_AFRL_AFSEL6_1             (0x2U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x02000000 */
+#define GPIO_AFRL_AFSEL6_2             (0x4U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x04000000 */
+#define GPIO_AFRL_AFSEL6_3             (0x8U << GPIO_AFRL_AFSEL6_Pos)          /*!< 0x08000000 */
+#define GPIO_AFRL_AFSEL7_Pos           (28U)
+#define GPIO_AFRL_AFSEL7_Msk           (0xFUL << GPIO_AFRL_AFSEL7_Pos)         /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7               GPIO_AFRL_AFSEL7_Msk
+#define GPIO_AFRL_AFSEL7_0             (0x1U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x10000000 */
+#define GPIO_AFRL_AFSEL7_1             (0x2U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x20000000 */
+#define GPIO_AFRL_AFSEL7_2             (0x4U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x40000000 */
+#define GPIO_AFRL_AFSEL7_3             (0x8U << GPIO_AFRL_AFSEL7_Pos)          /*!< 0x80000000 */
+
+/****************** Bit definition for GPIO_AFRH register *********************/
+#define GPIO_AFRH_AFSEL8_Pos           (0U)
+#define GPIO_AFRH_AFSEL8_Msk           (0xFUL << GPIO_AFRH_AFSEL8_Pos)         /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8               GPIO_AFRH_AFSEL8_Msk
+#define GPIO_AFRH_AFSEL8_0             (0x1U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000001 */
+#define GPIO_AFRH_AFSEL8_1             (0x2U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000002 */
+#define GPIO_AFRH_AFSEL8_2             (0x4U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000004 */
+#define GPIO_AFRH_AFSEL8_3             (0x8U << GPIO_AFRH_AFSEL8_Pos)          /*!< 0x00000008 */
+#define GPIO_AFRH_AFSEL9_Pos           (4U)
+#define GPIO_AFRH_AFSEL9_Msk           (0xFUL << GPIO_AFRH_AFSEL9_Pos)         /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9               GPIO_AFRH_AFSEL9_Msk
+#define GPIO_AFRH_AFSEL9_0             (0x1U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000010 */
+#define GPIO_AFRH_AFSEL9_1             (0x2U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000020 */
+#define GPIO_AFRH_AFSEL9_2             (0x4U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000040 */
+#define GPIO_AFRH_AFSEL9_3             (0x8U << GPIO_AFRH_AFSEL9_Pos)          /*!< 0x00000080 */
+#define GPIO_AFRH_AFSEL10_Pos          (8U)
+#define GPIO_AFRH_AFSEL10_Msk          (0xFUL << GPIO_AFRH_AFSEL10_Pos)        /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10              GPIO_AFRH_AFSEL10_Msk
+#define GPIO_AFRH_AFSEL10_0            (0x1U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000100 */
+#define GPIO_AFRH_AFSEL10_1            (0x2U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000200 */
+#define GPIO_AFRH_AFSEL10_2            (0x4U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000400 */
+#define GPIO_AFRH_AFSEL10_3            (0x8U << GPIO_AFRH_AFSEL10_Pos)         /*!< 0x00000800 */
+#define GPIO_AFRH_AFSEL11_Pos          (12U)
+#define GPIO_AFRH_AFSEL11_Msk          (0xFUL << GPIO_AFRH_AFSEL11_Pos)        /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11              GPIO_AFRH_AFSEL11_Msk
+#define GPIO_AFRH_AFSEL11_0            (0x1U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00001000 */
+#define GPIO_AFRH_AFSEL11_1            (0x2U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00002000 */
+#define GPIO_AFRH_AFSEL11_2            (0x4U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00004000 */
+#define GPIO_AFRH_AFSEL11_3            (0x8U << GPIO_AFRH_AFSEL11_Pos)         /*!< 0x00008000 */
+#define GPIO_AFRH_AFSEL12_Pos          (16U)
+#define GPIO_AFRH_AFSEL12_Msk          (0xFUL << GPIO_AFRH_AFSEL12_Pos)        /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12              GPIO_AFRH_AFSEL12_Msk
+#define GPIO_AFRH_AFSEL12_0            (0x1U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00010000 */
+#define GPIO_AFRH_AFSEL12_1            (0x2U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00020000 */
+#define GPIO_AFRH_AFSEL12_2            (0x4U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00040000 */
+#define GPIO_AFRH_AFSEL12_3            (0x8U << GPIO_AFRH_AFSEL12_Pos)         /*!< 0x00080000 */
+#define GPIO_AFRH_AFSEL13_Pos          (20U)
+#define GPIO_AFRH_AFSEL13_Msk          (0xFUL << GPIO_AFRH_AFSEL13_Pos)        /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13              GPIO_AFRH_AFSEL13_Msk
+#define GPIO_AFRH_AFSEL13_0            (0x1U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00100000 */
+#define GPIO_AFRH_AFSEL13_1            (0x2U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00200000 */
+#define GPIO_AFRH_AFSEL13_2            (0x4U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00400000 */
+#define GPIO_AFRH_AFSEL13_3            (0x8U << GPIO_AFRH_AFSEL13_Pos)         /*!< 0x00800000 */
+#define GPIO_AFRH_AFSEL14_Pos          (24U)
+#define GPIO_AFRH_AFSEL14_Msk          (0xFUL << GPIO_AFRH_AFSEL14_Pos)        /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14              GPIO_AFRH_AFSEL14_Msk
+#define GPIO_AFRH_AFSEL14_0            (0x1U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x01000000 */
+#define GPIO_AFRH_AFSEL14_1            (0x2U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x02000000 */
+#define GPIO_AFRH_AFSEL14_2            (0x4U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x04000000 */
+#define GPIO_AFRH_AFSEL14_3            (0x8U << GPIO_AFRH_AFSEL14_Pos)         /*!< 0x08000000 */
+#define GPIO_AFRH_AFSEL15_Pos          (28U)
+#define GPIO_AFRH_AFSEL15_Msk          (0xFUL << GPIO_AFRH_AFSEL15_Pos)        /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15              GPIO_AFRH_AFSEL15_Msk
+#define GPIO_AFRH_AFSEL15_0            (0x1U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x10000000 */
+#define GPIO_AFRH_AFSEL15_1            (0x2U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x20000000 */
+#define GPIO_AFRH_AFSEL15_2            (0x4U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x40000000 */
+#define GPIO_AFRH_AFSEL15_3            (0x8U << GPIO_AFRH_AFSEL15_Pos)         /*!< 0x80000000 */
+
+/******************  Bits definition for GPIO_BRR register  ******************/
+#define GPIO_BRR_BR0_Pos               (0U)
+#define GPIO_BRR_BR0_Msk               (0x1UL << GPIO_BRR_BR0_Pos)             /*!< 0x00000001 */
+#define GPIO_BRR_BR0                   GPIO_BRR_BR0_Msk
+#define GPIO_BRR_BR1_Pos               (1U)
+#define GPIO_BRR_BR1_Msk               (0x1UL << GPIO_BRR_BR1_Pos)             /*!< 0x00000002 */
+#define GPIO_BRR_BR1                   GPIO_BRR_BR1_Msk
+#define GPIO_BRR_BR2_Pos               (2U)
+#define GPIO_BRR_BR2_Msk               (0x1UL << GPIO_BRR_BR2_Pos)             /*!< 0x00000004 */
+#define GPIO_BRR_BR2                   GPIO_BRR_BR2_Msk
+#define GPIO_BRR_BR3_Pos               (3U)
+#define GPIO_BRR_BR3_Msk               (0x1UL << GPIO_BRR_BR3_Pos)             /*!< 0x00000008 */
+#define GPIO_BRR_BR3                   GPIO_BRR_BR3_Msk
+#define GPIO_BRR_BR4_Pos               (4U)
+#define GPIO_BRR_BR4_Msk               (0x1UL << GPIO_BRR_BR4_Pos)             /*!< 0x00000010 */
+#define GPIO_BRR_BR4                   GPIO_BRR_BR4_Msk
+#define GPIO_BRR_BR5_Pos               (5U)
+#define GPIO_BRR_BR5_Msk               (0x1UL << GPIO_BRR_BR5_Pos)             /*!< 0x00000020 */
+#define GPIO_BRR_BR5                   GPIO_BRR_BR5_Msk
+#define GPIO_BRR_BR6_Pos               (6U)
+#define GPIO_BRR_BR6_Msk               (0x1UL << GPIO_BRR_BR6_Pos)             /*!< 0x00000040 */
+#define GPIO_BRR_BR6                   GPIO_BRR_BR6_Msk
+#define GPIO_BRR_BR7_Pos               (7U)
+#define GPIO_BRR_BR7_Msk               (0x1UL << GPIO_BRR_BR7_Pos)             /*!< 0x00000080 */
+#define GPIO_BRR_BR7                   GPIO_BRR_BR7_Msk
+#define GPIO_BRR_BR8_Pos               (8U)
+#define GPIO_BRR_BR8_Msk               (0x1UL << GPIO_BRR_BR8_Pos)             /*!< 0x00000100 */
+#define GPIO_BRR_BR8                   GPIO_BRR_BR8_Msk
+#define GPIO_BRR_BR9_Pos               (9U)
+#define GPIO_BRR_BR9_Msk               (0x1UL << GPIO_BRR_BR9_Pos)             /*!< 0x00000200 */
+#define GPIO_BRR_BR9                   GPIO_BRR_BR9_Msk
+#define GPIO_BRR_BR10_Pos              (10U)
+#define GPIO_BRR_BR10_Msk              (0x1UL << GPIO_BRR_BR10_Pos)            /*!< 0x00000400 */
+#define GPIO_BRR_BR10                  GPIO_BRR_BR10_Msk
+#define GPIO_BRR_BR11_Pos              (11U)
+#define GPIO_BRR_BR11_Msk              (0x1UL << GPIO_BRR_BR11_Pos)            /*!< 0x00000800 */
+#define GPIO_BRR_BR11                  GPIO_BRR_BR11_Msk
+#define GPIO_BRR_BR12_Pos              (12U)
+#define GPIO_BRR_BR12_Msk              (0x1UL << GPIO_BRR_BR12_Pos)            /*!< 0x00001000 */
+#define GPIO_BRR_BR12                  GPIO_BRR_BR12_Msk
+#define GPIO_BRR_BR13_Pos              (13U)
+#define GPIO_BRR_BR13_Msk              (0x1UL << GPIO_BRR_BR13_Pos)            /*!< 0x00002000 */
+#define GPIO_BRR_BR13                  GPIO_BRR_BR13_Msk
+#define GPIO_BRR_BR14_Pos              (14U)
+#define GPIO_BRR_BR14_Msk              (0x1UL << GPIO_BRR_BR14_Pos)            /*!< 0x00004000 */
+#define GPIO_BRR_BR14                  GPIO_BRR_BR14_Msk
+#define GPIO_BRR_BR15_Pos              (15U)
+#define GPIO_BRR_BR15_Msk              (0x1UL << GPIO_BRR_BR15_Pos)            /*!< 0x00008000 */
+#define GPIO_BRR_BR15                  GPIO_BRR_BR15_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                        HSEM HW Semaphore                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for HSEM_R register  ********************/
+#define HSEM_R_PROCID_Pos        (0U)
+#define HSEM_R_PROCID_Msk        (0xFFUL << HSEM_R_PROCID_Pos)                 /*!< 0x000000FF */
+#define HSEM_R_PROCID            HSEM_R_PROCID_Msk                             /*!<Semaphore ProcessID */
+#define HSEM_R_COREID_Pos        (8U)
+#define HSEM_R_COREID_Msk        (0xFUL << HSEM_R_COREID_Pos)                  /*!< 0x00000F00 */
+#define HSEM_R_COREID            HSEM_R_COREID_Msk                             /*!<Semaphore CoreID. */
+#define HSEM_R_LOCK_Pos          (31U)
+#define HSEM_R_LOCK_Msk          (0x1UL << HSEM_R_LOCK_Pos)                    /*!< 0x80000000 */
+#define HSEM_R_LOCK              HSEM_R_LOCK_Msk                               /*!<Lock indication. */
+
+/********************  Bit definition for HSEM_RLR register  ******************/
+#define HSEM_RLR_PROCID_Pos      (0U)
+#define HSEM_RLR_PROCID_Msk      (0xFFUL << HSEM_RLR_PROCID_Pos)               /*!< 0x000000FF */
+#define HSEM_RLR_PROCID          HSEM_RLR_PROCID_Msk                           /*!<Semaphore ProcessID */
+#define HSEM_RLR_COREID_Pos      (8U)
+#define HSEM_RLR_COREID_Msk      (0xFUL << HSEM_RLR_COREID_Pos)                /*!< 0x00000F00 */
+#define HSEM_RLR_COREID          HSEM_RLR_COREID_Msk                           /*!<Semaphore CoreID. */
+#define HSEM_RLR_LOCK_Pos        (31U)
+#define HSEM_RLR_LOCK_Msk        (0x1UL << HSEM_RLR_LOCK_Pos)                  /*!< 0x80000000 */
+#define HSEM_RLR_LOCK            HSEM_RLR_LOCK_Msk                             /*!<Lock indication. */
+
+/********************  Bit definition for HSEM_C1IER register  ****************/
+#define HSEM_C1IER_ISE0_Pos      (0U)
+#define HSEM_C1IER_ISE0_Msk      (0x1UL << HSEM_C1IER_ISE0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1IER_ISE0          HSEM_C1IER_ISE0_Msk                           /*!<semaphore 0 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE1_Pos      (1U)
+#define HSEM_C1IER_ISE1_Msk      (0x1UL << HSEM_C1IER_ISE1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1IER_ISE1          HSEM_C1IER_ISE1_Msk                           /*!<semaphore 1 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE2_Pos      (2U)
+#define HSEM_C1IER_ISE2_Msk      (0x1UL << HSEM_C1IER_ISE2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1IER_ISE2          HSEM_C1IER_ISE2_Msk                           /*!<semaphore 2 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE3_Pos      (3U)
+#define HSEM_C1IER_ISE3_Msk      (0x1UL << HSEM_C1IER_ISE3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1IER_ISE3          HSEM_C1IER_ISE3_Msk                           /*!<semaphore 3 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE4_Pos      (4U)
+#define HSEM_C1IER_ISE4_Msk      (0x1UL << HSEM_C1IER_ISE4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1IER_ISE4          HSEM_C1IER_ISE4_Msk                           /*!<semaphore 4 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE5_Pos      (5U)
+#define HSEM_C1IER_ISE5_Msk      (0x1UL << HSEM_C1IER_ISE5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1IER_ISE5          HSEM_C1IER_ISE5_Msk                           /*!<semaphore 5 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE6_Pos      (6U)
+#define HSEM_C1IER_ISE6_Msk      (0x1UL << HSEM_C1IER_ISE6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1IER_ISE6          HSEM_C1IER_ISE6_Msk                           /*!<semaphore 6 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE7_Pos      (7U)
+#define HSEM_C1IER_ISE7_Msk      (0x1UL << HSEM_C1IER_ISE7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1IER_ISE7          HSEM_C1IER_ISE7_Msk                           /*!<semaphore 7 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE8_Pos      (8U)
+#define HSEM_C1IER_ISE8_Msk      (0x1UL << HSEM_C1IER_ISE8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1IER_ISE8          HSEM_C1IER_ISE8_Msk                           /*!<semaphore 8 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE9_Pos      (9U)
+#define HSEM_C1IER_ISE9_Msk      (0x1UL << HSEM_C1IER_ISE9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1IER_ISE9          HSEM_C1IER_ISE9_Msk                           /*!<semaphore 9 CPU1 interrupt enable bit.  */
+#define HSEM_C1IER_ISE10_Pos     (10U)
+#define HSEM_C1IER_ISE10_Msk     (0x1UL << HSEM_C1IER_ISE10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1IER_ISE10         HSEM_C1IER_ISE10_Msk                          /*!<semaphore 10 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE11_Pos     (11U)
+#define HSEM_C1IER_ISE11_Msk     (0x1UL << HSEM_C1IER_ISE11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1IER_ISE11         HSEM_C1IER_ISE11_Msk                          /*!<semaphore 11 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE12_Pos     (12U)
+#define HSEM_C1IER_ISE12_Msk     (0x1UL << HSEM_C1IER_ISE12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1IER_ISE12         HSEM_C1IER_ISE12_Msk                          /*!<semaphore 12 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE13_Pos     (13U)
+#define HSEM_C1IER_ISE13_Msk     (0x1UL << HSEM_C1IER_ISE13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1IER_ISE13         HSEM_C1IER_ISE13_Msk                          /*!<semaphore 13 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE14_Pos     (14U)
+#define HSEM_C1IER_ISE14_Msk     (0x1UL << HSEM_C1IER_ISE14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1IER_ISE14         HSEM_C1IER_ISE14_Msk                          /*!<semaphore 14 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE15_Pos     (15U)
+#define HSEM_C1IER_ISE15_Msk     (0x1UL << HSEM_C1IER_ISE15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1IER_ISE15         HSEM_C1IER_ISE15_Msk                          /*!<semaphore 15 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE16_Pos     (16U)
+#define HSEM_C1IER_ISE16_Msk     (0x1UL << HSEM_C1IER_ISE16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1IER_ISE16         HSEM_C1IER_ISE16_Msk                          /*!<semaphore 16 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE17_Pos     (17U)
+#define HSEM_C1IER_ISE17_Msk     (0x1UL << HSEM_C1IER_ISE17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1IER_ISE17         HSEM_C1IER_ISE17_Msk                          /*!<semaphore 17 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE18_Pos     (18U)
+#define HSEM_C1IER_ISE18_Msk     (0x1UL << HSEM_C1IER_ISE18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1IER_ISE18         HSEM_C1IER_ISE18_Msk                          /*!<semaphore 18 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE19_Pos     (19U)
+#define HSEM_C1IER_ISE19_Msk     (0x1UL << HSEM_C1IER_ISE19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1IER_ISE19         HSEM_C1IER_ISE19_Msk                          /*!<semaphore 19 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE20_Pos     (20U)
+#define HSEM_C1IER_ISE20_Msk     (0x1UL << HSEM_C1IER_ISE20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1IER_ISE20         HSEM_C1IER_ISE20_Msk                          /*!<semaphore 20 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE21_Pos     (21U)
+#define HSEM_C1IER_ISE21_Msk     (0x1UL << HSEM_C1IER_ISE21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1IER_ISE21         HSEM_C1IER_ISE21_Msk                          /*!<semaphore 21 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE22_Pos     (22U)
+#define HSEM_C1IER_ISE22_Msk     (0x1UL << HSEM_C1IER_ISE22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1IER_ISE22         HSEM_C1IER_ISE22_Msk                          /*!<semaphore 22 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE23_Pos     (23U)
+#define HSEM_C1IER_ISE23_Msk     (0x1UL << HSEM_C1IER_ISE23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1IER_ISE23         HSEM_C1IER_ISE23_Msk                          /*!<semaphore 23 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE24_Pos     (24U)
+#define HSEM_C1IER_ISE24_Msk     (0x1UL << HSEM_C1IER_ISE24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1IER_ISE24         HSEM_C1IER_ISE24_Msk                          /*!<semaphore 24 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE25_Pos     (25U)
+#define HSEM_C1IER_ISE25_Msk     (0x1UL << HSEM_C1IER_ISE25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1IER_ISE25         HSEM_C1IER_ISE25_Msk                          /*!<semaphore 25 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE26_Pos     (26U)
+#define HSEM_C1IER_ISE26_Msk     (0x1UL << HSEM_C1IER_ISE26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1IER_ISE26         HSEM_C1IER_ISE26_Msk                          /*!<semaphore 26 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE27_Pos     (27U)
+#define HSEM_C1IER_ISE27_Msk     (0x1UL << HSEM_C1IER_ISE27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1IER_ISE27         HSEM_C1IER_ISE27_Msk                          /*!<semaphore 27 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE28_Pos     (28U)
+#define HSEM_C1IER_ISE28_Msk     (0x1UL << HSEM_C1IER_ISE28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1IER_ISE28         HSEM_C1IER_ISE28_Msk                          /*!<semaphore 28 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE29_Pos     (29U)
+#define HSEM_C1IER_ISE29_Msk     (0x1UL << HSEM_C1IER_ISE29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1IER_ISE29         HSEM_C1IER_ISE29_Msk                          /*!<semaphore 29 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE30_Pos     (30U)
+#define HSEM_C1IER_ISE30_Msk     (0x1UL << HSEM_C1IER_ISE30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1IER_ISE30         HSEM_C1IER_ISE30_Msk                          /*!<semaphore 30 CPU1 interrupt enable bit. */
+#define HSEM_C1IER_ISE31_Pos     (31U)
+#define HSEM_C1IER_ISE31_Msk     (0x1UL << HSEM_C1IER_ISE31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1IER_ISE31         HSEM_C1IER_ISE31_Msk                          /*!<semaphore 31 CPU1 interrupt enable bit. */
+
+/********************  Bit definition for HSEM_C1ICR register  *****************/
+#define HSEM_C1ICR_ISC0_Pos      (0U)
+#define HSEM_C1ICR_ISC0_Msk      (0x1UL << HSEM_C1ICR_ISC0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1ICR_ISC0          HSEM_C1ICR_ISC0_Msk                           /*!<semaphore 0 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC1_Pos      (1U)
+#define HSEM_C1ICR_ISC1_Msk      (0x1UL << HSEM_C1ICR_ISC1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1ICR_ISC1          HSEM_C1ICR_ISC1_Msk                           /*!<semaphore 1 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC2_Pos      (2U)
+#define HSEM_C1ICR_ISC2_Msk      (0x1UL << HSEM_C1ICR_ISC2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1ICR_ISC2          HSEM_C1ICR_ISC2_Msk                           /*!<semaphore 2 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC3_Pos      (3U)
+#define HSEM_C1ICR_ISC3_Msk      (0x1UL << HSEM_C1ICR_ISC3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1ICR_ISC3          HSEM_C1ICR_ISC3_Msk                           /*!<semaphore 3 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC4_Pos      (4U)
+#define HSEM_C1ICR_ISC4_Msk      (0x1UL << HSEM_C1ICR_ISC4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1ICR_ISC4          HSEM_C1ICR_ISC4_Msk                           /*!<semaphore 4 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC5_Pos      (5U)
+#define HSEM_C1ICR_ISC5_Msk      (0x1UL << HSEM_C1ICR_ISC5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1ICR_ISC5          HSEM_C1ICR_ISC5_Msk                           /*!<semaphore 5 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC6_Pos      (6U)
+#define HSEM_C1ICR_ISC6_Msk      (0x1UL << HSEM_C1ICR_ISC6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1ICR_ISC6          HSEM_C1ICR_ISC6_Msk                           /*!<semaphore 6 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC7_Pos      (7U)
+#define HSEM_C1ICR_ISC7_Msk      (0x1UL << HSEM_C1ICR_ISC7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1ICR_ISC7          HSEM_C1ICR_ISC7_Msk                           /*!<semaphore 7 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC8_Pos      (8U)
+#define HSEM_C1ICR_ISC8_Msk      (0x1UL << HSEM_C1ICR_ISC8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1ICR_ISC8          HSEM_C1ICR_ISC8_Msk                           /*!<semaphore 8 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC9_Pos      (9U)
+#define HSEM_C1ICR_ISC9_Msk      (0x1UL << HSEM_C1ICR_ISC9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1ICR_ISC9          HSEM_C1ICR_ISC9_Msk                           /*!<semaphore 9 CPU1 interrupt clear bit.  */
+#define HSEM_C1ICR_ISC10_Pos     (10U)
+#define HSEM_C1ICR_ISC10_Msk     (0x1UL << HSEM_C1ICR_ISC10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1ICR_ISC10         HSEM_C1ICR_ISC10_Msk                          /*!<semaphore 10 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC11_Pos     (11U)
+#define HSEM_C1ICR_ISC11_Msk     (0x1UL << HSEM_C1ICR_ISC11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1ICR_ISC11         HSEM_C1ICR_ISC11_Msk                          /*!<semaphore 11 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC12_Pos     (12U)
+#define HSEM_C1ICR_ISC12_Msk     (0x1UL << HSEM_C1ICR_ISC12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1ICR_ISC12         HSEM_C1ICR_ISC12_Msk                          /*!<semaphore 12 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC13_Pos     (13U)
+#define HSEM_C1ICR_ISC13_Msk     (0x1UL << HSEM_C1ICR_ISC13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1ICR_ISC13         HSEM_C1ICR_ISC13_Msk                          /*!<semaphore 13 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC14_Pos     (14U)
+#define HSEM_C1ICR_ISC14_Msk     (0x1UL << HSEM_C1ICR_ISC14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1ICR_ISC14         HSEM_C1ICR_ISC14_Msk                          /*!<semaphore 14 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC15_Pos     (15U)
+#define HSEM_C1ICR_ISC15_Msk     (0x1UL << HSEM_C1ICR_ISC15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1ICR_ISC15         HSEM_C1ICR_ISC15_Msk                          /*!<semaphore 15 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC16_Pos     (16U)
+#define HSEM_C1ICR_ISC16_Msk     (0x1UL << HSEM_C1ICR_ISC16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1ICR_ISC16         HSEM_C1ICR_ISC16_Msk                          /*!<semaphore 16 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC17_Pos     (17U)
+#define HSEM_C1ICR_ISC17_Msk     (0x1UL << HSEM_C1ICR_ISC17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1ICR_ISC17         HSEM_C1ICR_ISC17_Msk                          /*!<semaphore 17 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC18_Pos     (18U)
+#define HSEM_C1ICR_ISC18_Msk     (0x1UL << HSEM_C1ICR_ISC18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1ICR_ISC18         HSEM_C1ICR_ISC18_Msk                          /*!<semaphore 18 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC19_Pos     (19U)
+#define HSEM_C1ICR_ISC19_Msk     (0x1UL << HSEM_C1ICR_ISC19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1ICR_ISC19         HSEM_C1ICR_ISC19_Msk                          /*!<semaphore 19 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC20_Pos     (20U)
+#define HSEM_C1ICR_ISC20_Msk     (0x1UL << HSEM_C1ICR_ISC20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1ICR_ISC20         HSEM_C1ICR_ISC20_Msk                          /*!<semaphore 20 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC21_Pos     (21U)
+#define HSEM_C1ICR_ISC21_Msk     (0x1UL << HSEM_C1ICR_ISC21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1ICR_ISC21         HSEM_C1ICR_ISC21_Msk                          /*!<semaphore 21 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC22_Pos     (22U)
+#define HSEM_C1ICR_ISC22_Msk     (0x1UL << HSEM_C1ICR_ISC22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1ICR_ISC22         HSEM_C1ICR_ISC22_Msk                          /*!<semaphore 22 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC23_Pos     (23U)
+#define HSEM_C1ICR_ISC23_Msk     (0x1UL << HSEM_C1ICR_ISC23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1ICR_ISC23         HSEM_C1ICR_ISC23_Msk                          /*!<semaphore 23 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC24_Pos     (24U)
+#define HSEM_C1ICR_ISC24_Msk     (0x1UL << HSEM_C1ICR_ISC24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1ICR_ISC24         HSEM_C1ICR_ISC24_Msk                          /*!<semaphore 24 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC25_Pos     (25U)
+#define HSEM_C1ICR_ISC25_Msk     (0x1UL << HSEM_C1ICR_ISC25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1ICR_ISC25         HSEM_C1ICR_ISC25_Msk                          /*!<semaphore 25 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC26_Pos     (26U)
+#define HSEM_C1ICR_ISC26_Msk     (0x1UL << HSEM_C1ICR_ISC26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1ICR_ISC26         HSEM_C1ICR_ISC26_Msk                          /*!<semaphore 26 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC27_Pos     (27U)
+#define HSEM_C1ICR_ISC27_Msk     (0x1UL << HSEM_C1ICR_ISC27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1ICR_ISC27         HSEM_C1ICR_ISC27_Msk                          /*!<semaphore 27 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC28_Pos     (28U)
+#define HSEM_C1ICR_ISC28_Msk     (0x1UL << HSEM_C1ICR_ISC28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1ICR_ISC28         HSEM_C1ICR_ISC28_Msk                          /*!<semaphore 28 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC29_Pos     (29U)
+#define HSEM_C1ICR_ISC29_Msk     (0x1UL << HSEM_C1ICR_ISC29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1ICR_ISC29         HSEM_C1ICR_ISC29_Msk                          /*!<semaphore 29 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC30_Pos     (30U)
+#define HSEM_C1ICR_ISC30_Msk     (0x1UL << HSEM_C1ICR_ISC30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1ICR_ISC30         HSEM_C1ICR_ISC30_Msk                          /*!<semaphore 30 CPU1 interrupt clear bit. */
+#define HSEM_C1ICR_ISC31_Pos     (31U)
+#define HSEM_C1ICR_ISC31_Msk     (0x1UL << HSEM_C1ICR_ISC31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1ICR_ISC31         HSEM_C1ICR_ISC31_Msk                          /*!<semaphore 31 CPU1 interrupt clear bit. */
+
+/********************  Bit definition for HSEM_C1ISR register  *****************/
+#define HSEM_C1ISR_ISF0_Pos      (0U)
+#define HSEM_C1ISR_ISF0_Msk      (0x1UL << HSEM_C1ISR_ISF0_Pos)                /*!< 0x00000001 */
+#define HSEM_C1ISR_ISF0          HSEM_C1ISR_ISF0_Msk                           /*!<semaphore 0 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF1_Pos      (1U)
+#define HSEM_C1ISR_ISF1_Msk      (0x1UL << HSEM_C1ISR_ISF1_Pos)                /*!< 0x00000002 */
+#define HSEM_C1ISR_ISF1          HSEM_C1ISR_ISF1_Msk                           /*!<semaphore 1 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF2_Pos      (2U)
+#define HSEM_C1ISR_ISF2_Msk      (0x1UL << HSEM_C1ISR_ISF2_Pos)                /*!< 0x00000004 */
+#define HSEM_C1ISR_ISF2          HSEM_C1ISR_ISF2_Msk                           /*!<semaphore 2 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF3_Pos      (3U)
+#define HSEM_C1ISR_ISF3_Msk      (0x1UL << HSEM_C1ISR_ISF3_Pos)                /*!< 0x00000008 */
+#define HSEM_C1ISR_ISF3          HSEM_C1ISR_ISF3_Msk                           /*!<semaphore 3 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF4_Pos      (4U)
+#define HSEM_C1ISR_ISF4_Msk      (0x1UL << HSEM_C1ISR_ISF4_Pos)                /*!< 0x00000010 */
+#define HSEM_C1ISR_ISF4          HSEM_C1ISR_ISF4_Msk                           /*!<semaphore 4 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF5_Pos      (5U)
+#define HSEM_C1ISR_ISF5_Msk      (0x1UL << HSEM_C1ISR_ISF5_Pos)                /*!< 0x00000020 */
+#define HSEM_C1ISR_ISF5          HSEM_C1ISR_ISF5_Msk                           /*!<semaphore 5 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF6_Pos      (6U)
+#define HSEM_C1ISR_ISF6_Msk      (0x1UL << HSEM_C1ISR_ISF6_Pos)                /*!< 0x00000040 */
+#define HSEM_C1ISR_ISF6          HSEM_C1ISR_ISF6_Msk                           /*!<semaphore 6 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF7_Pos      (7U)
+#define HSEM_C1ISR_ISF7_Msk      (0x1UL << HSEM_C1ISR_ISF7_Pos)                /*!< 0x00000080 */
+#define HSEM_C1ISR_ISF7          HSEM_C1ISR_ISF7_Msk                           /*!<semaphore 7 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF8_Pos      (8U)
+#define HSEM_C1ISR_ISF8_Msk      (0x1UL << HSEM_C1ISR_ISF8_Pos)                /*!< 0x00000100 */
+#define HSEM_C1ISR_ISF8          HSEM_C1ISR_ISF8_Msk                           /*!<semaphore 8 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF9_Pos      (9U)
+#define HSEM_C1ISR_ISF9_Msk      (0x1UL << HSEM_C1ISR_ISF9_Pos)                /*!< 0x00000200 */
+#define HSEM_C1ISR_ISF9          HSEM_C1ISR_ISF9_Msk                           /*!<semaphore 9 CPU1 interrupt status bit.  */
+#define HSEM_C1ISR_ISF10_Pos     (10U)
+#define HSEM_C1ISR_ISF10_Msk     (0x1UL << HSEM_C1ISR_ISF10_Pos)               /*!< 0x00000400 */
+#define HSEM_C1ISR_ISF10         HSEM_C1ISR_ISF10_Msk                          /*!<semaphore 10 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF11_Pos     (11U)
+#define HSEM_C1ISR_ISF11_Msk     (0x1UL << HSEM_C1ISR_ISF11_Pos)               /*!< 0x00000800 */
+#define HSEM_C1ISR_ISF11         HSEM_C1ISR_ISF11_Msk                          /*!<semaphore 11 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF12_Pos     (12U)
+#define HSEM_C1ISR_ISF12_Msk     (0x1UL << HSEM_C1ISR_ISF12_Pos)               /*!< 0x00001000 */
+#define HSEM_C1ISR_ISF12         HSEM_C1ISR_ISF12_Msk                          /*!<semaphore 12 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF13_Pos     (13U)
+#define HSEM_C1ISR_ISF13_Msk     (0x1UL << HSEM_C1ISR_ISF13_Pos)               /*!< 0x00002000 */
+#define HSEM_C1ISR_ISF13         HSEM_C1ISR_ISF13_Msk                          /*!<semaphore 13 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF14_Pos     (14U)
+#define HSEM_C1ISR_ISF14_Msk     (0x1UL << HSEM_C1ISR_ISF14_Pos)               /*!< 0x00004000 */
+#define HSEM_C1ISR_ISF14         HSEM_C1ISR_ISF14_Msk                          /*!<semaphore 14 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF15_Pos     (15U)
+#define HSEM_C1ISR_ISF15_Msk     (0x1UL << HSEM_C1ISR_ISF15_Pos)               /*!< 0x00008000 */
+#define HSEM_C1ISR_ISF15         HSEM_C1ISR_ISF15_Msk                          /*!<semaphore 15 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF16_Pos     (16U)
+#define HSEM_C1ISR_ISF16_Msk     (0x1UL << HSEM_C1ISR_ISF16_Pos)               /*!< 0x00010000 */
+#define HSEM_C1ISR_ISF16         HSEM_C1ISR_ISF16_Msk                          /*!<semaphore 16 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF17_Pos     (17U)
+#define HSEM_C1ISR_ISF17_Msk     (0x1UL << HSEM_C1ISR_ISF17_Pos)               /*!< 0x00020000 */
+#define HSEM_C1ISR_ISF17         HSEM_C1ISR_ISF17_Msk                          /*!<semaphore 17 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF18_Pos     (18U)
+#define HSEM_C1ISR_ISF18_Msk     (0x1UL << HSEM_C1ISR_ISF18_Pos)               /*!< 0x00040000 */
+#define HSEM_C1ISR_ISF18         HSEM_C1ISR_ISF18_Msk                          /*!<semaphore 18 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF19_Pos     (19U)
+#define HSEM_C1ISR_ISF19_Msk     (0x1UL << HSEM_C1ISR_ISF19_Pos)               /*!< 0x00080000 */
+#define HSEM_C1ISR_ISF19         HSEM_C1ISR_ISF19_Msk                          /*!<semaphore 19 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF20_Pos     (20U)
+#define HSEM_C1ISR_ISF20_Msk     (0x1UL << HSEM_C1ISR_ISF20_Pos)               /*!< 0x00100000 */
+#define HSEM_C1ISR_ISF20         HSEM_C1ISR_ISF20_Msk                          /*!<semaphore 20 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF21_Pos     (21U)
+#define HSEM_C1ISR_ISF21_Msk     (0x1UL << HSEM_C1ISR_ISF21_Pos)               /*!< 0x00200000 */
+#define HSEM_C1ISR_ISF21         HSEM_C1ISR_ISF21_Msk                          /*!<semaphore 21 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF22_Pos     (22U)
+#define HSEM_C1ISR_ISF22_Msk     (0x1UL << HSEM_C1ISR_ISF22_Pos)               /*!< 0x00400000 */
+#define HSEM_C1ISR_ISF22         HSEM_C1ISR_ISF22_Msk                          /*!<semaphore 22 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF23_Pos     (23U)
+#define HSEM_C1ISR_ISF23_Msk     (0x1UL << HSEM_C1ISR_ISF23_Pos)               /*!< 0x00800000 */
+#define HSEM_C1ISR_ISF23         HSEM_C1ISR_ISF23_Msk                          /*!<semaphore 23 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF24_Pos     (24U)
+#define HSEM_C1ISR_ISF24_Msk     (0x1UL << HSEM_C1ISR_ISF24_Pos)               /*!< 0x01000000 */
+#define HSEM_C1ISR_ISF24         HSEM_C1ISR_ISF24_Msk                          /*!<semaphore 24 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF25_Pos     (25U)
+#define HSEM_C1ISR_ISF25_Msk     (0x1UL << HSEM_C1ISR_ISF25_Pos)               /*!< 0x02000000 */
+#define HSEM_C1ISR_ISF25         HSEM_C1ISR_ISF25_Msk                          /*!<semaphore 25 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF26_Pos     (26U)
+#define HSEM_C1ISR_ISF26_Msk     (0x1UL << HSEM_C1ISR_ISF26_Pos)               /*!< 0x04000000 */
+#define HSEM_C1ISR_ISF26         HSEM_C1ISR_ISF26_Msk                          /*!<semaphore 26 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF27_Pos     (27U)
+#define HSEM_C1ISR_ISF27_Msk     (0x1UL << HSEM_C1ISR_ISF27_Pos)               /*!< 0x08000000 */
+#define HSEM_C1ISR_ISF27         HSEM_C1ISR_ISF27_Msk                          /*!<semaphore 27 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF28_Pos     (28U)
+#define HSEM_C1ISR_ISF28_Msk     (0x1UL << HSEM_C1ISR_ISF28_Pos)               /*!< 0x10000000 */
+#define HSEM_C1ISR_ISF28         HSEM_C1ISR_ISF28_Msk                          /*!<semaphore 28 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF29_Pos     (29U)
+#define HSEM_C1ISR_ISF29_Msk     (0x1UL << HSEM_C1ISR_ISF29_Pos)               /*!< 0x20000000 */
+#define HSEM_C1ISR_ISF29         HSEM_C1ISR_ISF29_Msk                          /*!<semaphore 29 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF30_Pos     (30U)
+#define HSEM_C1ISR_ISF30_Msk     (0x1UL << HSEM_C1ISR_ISF30_Pos)               /*!< 0x40000000 */
+#define HSEM_C1ISR_ISF30         HSEM_C1ISR_ISF30_Msk                          /*!<semaphore 30 CPU1 interrupt status bit. */
+#define HSEM_C1ISR_ISF31_Pos     (31U)
+#define HSEM_C1ISR_ISF31_Msk     (0x1UL << HSEM_C1ISR_ISF31_Pos)               /*!< 0x80000000 */
+#define HSEM_C1ISR_ISF31         HSEM_C1ISR_ISF31_Msk                          /*!<semaphore 31 CPU1 interrupt status bit. */
+
+/********************  Bit definition for HSEM_C1MISR register  *****************/
+#define HSEM_C1MISR_MISF0_Pos     (0U)
+#define HSEM_C1MISR_MISF0_Msk     (0x1UL << HSEM_C1MISR_MISF0_Pos)               /*!< 0x00000001 */
+#define HSEM_C1MISR_MISF0         HSEM_C1MISR_MISF0_Msk                          /*!<semaphore 0 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF1_Pos     (1U)
+#define HSEM_C1MISR_MISF1_Msk     (0x1UL << HSEM_C1MISR_MISF1_Pos)               /*!< 0x00000002 */
+#define HSEM_C1MISR_MISF1         HSEM_C1MISR_MISF1_Msk                          /*!<semaphore 1 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF2_Pos     (2U)
+#define HSEM_C1MISR_MISF2_Msk     (0x1UL << HSEM_C1MISR_MISF2_Pos)               /*!< 0x00000004 */
+#define HSEM_C1MISR_MISF2         HSEM_C1MISR_MISF2_Msk                          /*!<semaphore 2 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF3_Pos     (3U)
+#define HSEM_C1MISR_MISF3_Msk     (0x1UL << HSEM_C1MISR_MISF3_Pos)               /*!< 0x00000008 */
+#define HSEM_C1MISR_MISF3         HSEM_C1MISR_MISF3_Msk                          /*!<semaphore 3 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF4_Pos     (4U)
+#define HSEM_C1MISR_MISF4_Msk     (0x1UL << HSEM_C1MISR_MISF4_Pos)               /*!< 0x00000010 */
+#define HSEM_C1MISR_MISF4         HSEM_C1MISR_MISF4_Msk                          /*!<semaphore 4 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF5_Pos     (5U)
+#define HSEM_C1MISR_MISF5_Msk     (0x1UL << HSEM_C1MISR_MISF5_Pos)               /*!< 0x00000020 */
+#define HSEM_C1MISR_MISF5         HSEM_C1MISR_MISF5_Msk                          /*!<semaphore 5 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF6_Pos     (6U)
+#define HSEM_C1MISR_MISF6_Msk     (0x1UL << HSEM_C1MISR_MISF6_Pos)               /*!< 0x00000040 */
+#define HSEM_C1MISR_MISF6         HSEM_C1MISR_MISF6_Msk                          /*!<semaphore 6 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF7_Pos     (7U)
+#define HSEM_C1MISR_MISF7_Msk     (0x1UL << HSEM_C1MISR_MISF7_Pos)               /*!< 0x00000080 */
+#define HSEM_C1MISR_MISF7         HSEM_C1MISR_MISF7_Msk                          /*!<semaphore 7 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF8_Pos     (8U)
+#define HSEM_C1MISR_MISF8_Msk     (0x1UL << HSEM_C1MISR_MISF8_Pos)               /*!< 0x00000100 */
+#define HSEM_C1MISR_MISF8         HSEM_C1MISR_MISF8_Msk                          /*!<semaphore 8 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF9_Pos     (9U)
+#define HSEM_C1MISR_MISF9_Msk     (0x1UL << HSEM_C1MISR_MISF9_Pos)               /*!< 0x00000200 */
+#define HSEM_C1MISR_MISF9         HSEM_C1MISR_MISF9_Msk                          /*!<semaphore 9 CPU1 interrupt masked status bit.  */
+#define HSEM_C1MISR_MISF10_Pos    (10U)
+#define HSEM_C1MISR_MISF10_Msk    (0x1UL << HSEM_C1MISR_MISF10_Pos)              /*!< 0x00000400 */
+#define HSEM_C1MISR_MISF10        HSEM_C1MISR_MISF10_Msk                         /*!<semaphore 10 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF11_Pos    (11U)
+#define HSEM_C1MISR_MISF11_Msk    (0x1UL << HSEM_C1MISR_MISF11_Pos)              /*!< 0x00000800 */
+#define HSEM_C1MISR_MISF11        HSEM_C1MISR_MISF11_Msk                         /*!<semaphore 11 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF12_Pos    (12U)
+#define HSEM_C1MISR_MISF12_Msk    (0x1UL << HSEM_C1MISR_MISF12_Pos)              /*!< 0x00001000 */
+#define HSEM_C1MISR_MISF12        HSEM_C1MISR_MISF12_Msk                         /*!<semaphore 12 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF13_Pos    (13U)
+#define HSEM_C1MISR_MISF13_Msk    (0x1UL << HSEM_C1MISR_MISF13_Pos)              /*!< 0x00002000 */
+#define HSEM_C1MISR_MISF13        HSEM_C1MISR_MISF13_Msk                         /*!<semaphore 13 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF14_Pos    (14U)
+#define HSEM_C1MISR_MISF14_Msk    (0x1UL << HSEM_C1MISR_MISF14_Pos)              /*!< 0x00004000 */
+#define HSEM_C1MISR_MISF14        HSEM_C1MISR_MISF14_Msk                         /*!<semaphore 14 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF15_Pos    (15U)
+#define HSEM_C1MISR_MISF15_Msk    (0x1UL << HSEM_C1MISR_MISF15_Pos)              /*!< 0x00008000 */
+#define HSEM_C1MISR_MISF15        HSEM_C1MISR_MISF15_Msk                         /*!<semaphore 15 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF16_Pos    (16U)
+#define HSEM_C1MISR_MISF16_Msk    (0x1UL << HSEM_C1MISR_MISF16_Pos)              /*!< 0x00010000 */
+#define HSEM_C1MISR_MISF16        HSEM_C1MISR_MISF16_Msk                         /*!<semaphore 16 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF17_Pos    (17U)
+#define HSEM_C1MISR_MISF17_Msk    (0x1UL << HSEM_C1MISR_MISF17_Pos)              /*!< 0x00020000 */
+#define HSEM_C1MISR_MISF17        HSEM_C1MISR_MISF17_Msk                         /*!<semaphore 17 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF18_Pos    (18U)
+#define HSEM_C1MISR_MISF18_Msk    (0x1UL << HSEM_C1MISR_MISF18_Pos)              /*!< 0x00040000 */
+#define HSEM_C1MISR_MISF18        HSEM_C1MISR_MISF18_Msk                         /*!<semaphore 18 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF19_Pos    (19U)
+#define HSEM_C1MISR_MISF19_Msk    (0x1UL << HSEM_C1MISR_MISF19_Pos)              /*!< 0x00080000 */
+#define HSEM_C1MISR_MISF19        HSEM_C1MISR_MISF19_Msk                         /*!<semaphore 19 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF20_Pos    (20U)
+#define HSEM_C1MISR_MISF20_Msk    (0x1UL << HSEM_C1MISR_MISF20_Pos)              /*!< 0x00100000 */
+#define HSEM_C1MISR_MISF20        HSEM_C1MISR_MISF20_Msk                         /*!<semaphore 20 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF21_Pos    (21U)
+#define HSEM_C1MISR_MISF21_Msk    (0x1UL << HSEM_C1MISR_MISF21_Pos)              /*!< 0x00200000 */
+#define HSEM_C1MISR_MISF21        HSEM_C1MISR_MISF21_Msk                         /*!<semaphore 21 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF22_Pos    (22U)
+#define HSEM_C1MISR_MISF22_Msk    (0x1UL << HSEM_C1MISR_MISF22_Pos)              /*!< 0x00400000 */
+#define HSEM_C1MISR_MISF22        HSEM_C1MISR_MISF22_Msk                         /*!<semaphore 22 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF23_Pos    (23U)
+#define HSEM_C1MISR_MISF23_Msk    (0x1UL << HSEM_C1MISR_MISF23_Pos)              /*!< 0x00800000 */
+#define HSEM_C1MISR_MISF23        HSEM_C1MISR_MISF23_Msk                         /*!<semaphore 23 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF24_Pos    (24U)
+#define HSEM_C1MISR_MISF24_Msk    (0x1UL << HSEM_C1MISR_MISF24_Pos)              /*!< 0x01000000 */
+#define HSEM_C1MISR_MISF24        HSEM_C1MISR_MISF24_Msk                         /*!<semaphore 24 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF25_Pos    (25U)
+#define HSEM_C1MISR_MISF25_Msk    (0x1UL << HSEM_C1MISR_MISF25_Pos)              /*!< 0x02000000 */
+#define HSEM_C1MISR_MISF25        HSEM_C1MISR_MISF25_Msk                         /*!<semaphore 25 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF26_Pos    (26U)
+#define HSEM_C1MISR_MISF26_Msk    (0x1UL << HSEM_C1MISR_MISF26_Pos)              /*!< 0x04000000 */
+#define HSEM_C1MISR_MISF26        HSEM_C1MISR_MISF26_Msk                         /*!<semaphore 26 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF27_Pos    (27U)
+#define HSEM_C1MISR_MISF27_Msk    (0x1UL << HSEM_C1MISR_MISF27_Pos)              /*!< 0x08000000 */
+#define HSEM_C1MISR_MISF27        HSEM_C1MISR_MISF27_Msk                         /*!<semaphore 27 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF28_Pos    (28U)
+#define HSEM_C1MISR_MISF28_Msk    (0x1UL << HSEM_C1MISR_MISF28_Pos)              /*!< 0x10000000 */
+#define HSEM_C1MISR_MISF28        HSEM_C1MISR_MISF28_Msk                         /*!<semaphore 28 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF29_Pos    (29U)
+#define HSEM_C1MISR_MISF29_Msk    (0x1UL << HSEM_C1MISR_MISF29_Pos)              /*!< 0x20000000 */
+#define HSEM_C1MISR_MISF29        HSEM_C1MISR_MISF29_Msk                         /*!<semaphore 29 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF30_Pos    (30U)
+#define HSEM_C1MISR_MISF30_Msk    (0x1UL << HSEM_C1MISR_MISF30_Pos)              /*!< 0x40000000 */
+#define HSEM_C1MISR_MISF30        HSEM_C1MISR_MISF30_Msk                         /*!<semaphore 30 CPU1 interrupt masked status bit. */
+#define HSEM_C1MISR_MISF31_Pos    (31U)
+#define HSEM_C1MISR_MISF31_Msk    (0x1UL << HSEM_C1MISR_MISF31_Pos)              /*!< 0x80000000 */
+#define HSEM_C1MISR_MISF31        HSEM_C1MISR_MISF31_Msk                         /*!<semaphore 31 CPU1 interrupt masked status bit. */
+
+/********************  Bit definition for HSEM_C2IER register  *****************/
+#define HSEM_C2IER_ISE0_Pos      (0U)
+#define HSEM_C2IER_ISE0_Msk      (0x1UL << HSEM_C2IER_ISE0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2IER_ISE0          HSEM_C2IER_ISE0_Msk                           /*!<semaphore 0 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE1_Pos      (1U)
+#define HSEM_C2IER_ISE1_Msk      (0x1UL << HSEM_C2IER_ISE1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2IER_ISE1          HSEM_C2IER_ISE1_Msk                           /*!<semaphore 1 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE2_Pos      (2U)
+#define HSEM_C2IER_ISE2_Msk      (0x1UL << HSEM_C2IER_ISE2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2IER_ISE2          HSEM_C2IER_ISE2_Msk                           /*!<semaphore 2 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE3_Pos      (3U)
+#define HSEM_C2IER_ISE3_Msk      (0x1UL << HSEM_C2IER_ISE3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2IER_ISE3          HSEM_C2IER_ISE3_Msk                           /*!<semaphore 3 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE4_Pos      (4U)
+#define HSEM_C2IER_ISE4_Msk      (0x1UL << HSEM_C2IER_ISE4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2IER_ISE4          HSEM_C2IER_ISE4_Msk                           /*!<semaphore 4 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE5_Pos      (5U)
+#define HSEM_C2IER_ISE5_Msk      (0x1UL << HSEM_C2IER_ISE5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2IER_ISE5          HSEM_C2IER_ISE5_Msk                           /*!<semaphore 5 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE6_Pos      (6U)
+#define HSEM_C2IER_ISE6_Msk      (0x1UL << HSEM_C2IER_ISE6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2IER_ISE6          HSEM_C2IER_ISE6_Msk                           /*!<semaphore 6 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE7_Pos      (7U)
+#define HSEM_C2IER_ISE7_Msk      (0x1UL << HSEM_C2IER_ISE7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2IER_ISE7          HSEM_C2IER_ISE7_Msk                           /*!<semaphore 7 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE8_Pos      (8U)
+#define HSEM_C2IER_ISE8_Msk      (0x1UL << HSEM_C2IER_ISE8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2IER_ISE8          HSEM_C2IER_ISE8_Msk                           /*!<semaphore 8 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE9_Pos      (9U)
+#define HSEM_C2IER_ISE9_Msk      (0x1UL << HSEM_C2IER_ISE9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2IER_ISE9          HSEM_C2IER_ISE9_Msk                           /*!<semaphore 9 CPU2 interrupt enable bit.  */
+#define HSEM_C2IER_ISE10_Pos     (10U)
+#define HSEM_C2IER_ISE10_Msk     (0x1UL << HSEM_C2IER_ISE10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2IER_ISE10         HSEM_C2IER_ISE10_Msk                          /*!<semaphore 10 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE11_Pos     (11U)
+#define HSEM_C2IER_ISE11_Msk     (0x1UL << HSEM_C2IER_ISE11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2IER_ISE11         HSEM_C2IER_ISE11_Msk                          /*!<semaphore 11 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE12_Pos     (12U)
+#define HSEM_C2IER_ISE12_Msk     (0x1UL << HSEM_C2IER_ISE12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2IER_ISE12         HSEM_C2IER_ISE12_Msk                          /*!<semaphore 12 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE13_Pos     (13U)
+#define HSEM_C2IER_ISE13_Msk     (0x1UL << HSEM_C2IER_ISE13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2IER_ISE13         HSEM_C2IER_ISE13_Msk                          /*!<semaphore 13 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE14_Pos     (14U)
+#define HSEM_C2IER_ISE14_Msk     (0x1UL << HSEM_C2IER_ISE14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2IER_ISE14         HSEM_C2IER_ISE14_Msk                          /*!<semaphore 14 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE15_Pos     (15U)
+#define HSEM_C2IER_ISE15_Msk     (0x1UL << HSEM_C2IER_ISE15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2IER_ISE15         HSEM_C2IER_ISE15_Msk                          /*!<semaphore 15 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE16_Pos     (16U)
+#define HSEM_C2IER_ISE16_Msk     (0x1UL << HSEM_C2IER_ISE16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2IER_ISE16         HSEM_C2IER_ISE16_Msk                          /*!<semaphore 16 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE17_Pos     (17U)
+#define HSEM_C2IER_ISE17_Msk     (0x1UL << HSEM_C2IER_ISE17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2IER_ISE17         HSEM_C2IER_ISE17_Msk                          /*!<semaphore 17 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE18_Pos     (18U)
+#define HSEM_C2IER_ISE18_Msk     (0x1UL << HSEM_C2IER_ISE18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2IER_ISE18         HSEM_C2IER_ISE18_Msk                          /*!<semaphore 18 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE19_Pos     (19U)
+#define HSEM_C2IER_ISE19_Msk     (0x1UL << HSEM_C2IER_ISE19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2IER_ISE19         HSEM_C2IER_ISE19_Msk                          /*!<semaphore 19 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE20_Pos     (20U)
+#define HSEM_C2IER_ISE20_Msk     (0x1UL << HSEM_C2IER_ISE20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2IER_ISE20         HSEM_C2IER_ISE20_Msk                          /*!<semaphore 20 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE21_Pos     (21U)
+#define HSEM_C2IER_ISE21_Msk     (0x1UL << HSEM_C2IER_ISE21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2IER_ISE21         HSEM_C2IER_ISE21_Msk                          /*!<semaphore 21 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE22_Pos     (22U)
+#define HSEM_C2IER_ISE22_Msk     (0x1UL << HSEM_C2IER_ISE22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2IER_ISE22         HSEM_C2IER_ISE22_Msk                          /*!<semaphore 22 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE23_Pos     (23U)
+#define HSEM_C2IER_ISE23_Msk     (0x1UL << HSEM_C2IER_ISE23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2IER_ISE23         HSEM_C2IER_ISE23_Msk                          /*!<semaphore 23 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE24_Pos     (24U)
+#define HSEM_C2IER_ISE24_Msk     (0x1UL << HSEM_C2IER_ISE24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2IER_ISE24         HSEM_C2IER_ISE24_Msk                          /*!<semaphore 24 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE25_Pos     (25U)
+#define HSEM_C2IER_ISE25_Msk     (0x1UL << HSEM_C2IER_ISE25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2IER_ISE25         HSEM_C2IER_ISE25_Msk                          /*!<semaphore 25 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE26_Pos     (26U)
+#define HSEM_C2IER_ISE26_Msk     (0x1UL << HSEM_C2IER_ISE26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2IER_ISE26         HSEM_C2IER_ISE26_Msk                          /*!<semaphore 26 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE27_Pos     (27U)
+#define HSEM_C2IER_ISE27_Msk     (0x1UL << HSEM_C2IER_ISE27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2IER_ISE27         HSEM_C2IER_ISE27_Msk                          /*!<semaphore 27 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE28_Pos     (28U)
+#define HSEM_C2IER_ISE28_Msk     (0x1UL << HSEM_C2IER_ISE28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2IER_ISE28         HSEM_C2IER_ISE28_Msk                          /*!<semaphore 28 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE29_Pos     (29U)
+#define HSEM_C2IER_ISE29_Msk     (0x1UL << HSEM_C2IER_ISE29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2IER_ISE29         HSEM_C2IER_ISE29_Msk                          /*!<semaphore 29 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE30_Pos     (30U)
+#define HSEM_C2IER_ISE30_Msk     (0x1UL << HSEM_C2IER_ISE30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2IER_ISE30         HSEM_C2IER_ISE30_Msk                          /*!<semaphore 30 CPU2 interrupt enable bit. */
+#define HSEM_C2IER_ISE31_Pos     (31U)
+#define HSEM_C2IER_ISE31_Msk     (0x1UL << HSEM_C2IER_ISE31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2IER_ISE31         HSEM_C2IER_ISE31_Msk                          /*!<semaphore 31 CPU2 interrupt enable bit. */
+
+/********************  Bit definition for HSEM_C2ICR register  *****************/
+#define HSEM_C2ICR_ISC0_Pos      (0U)
+#define HSEM_C2ICR_ISC0_Msk      (0x1UL << HSEM_C2ICR_ISC0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2ICR_ISC0          HSEM_C2ICR_ISC0_Msk                           /*!<semaphore 0 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC1_Pos      (1U)
+#define HSEM_C2ICR_ISC1_Msk      (0x1UL << HSEM_C2ICR_ISC1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2ICR_ISC1          HSEM_C2ICR_ISC1_Msk                           /*!<semaphore 1 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC2_Pos      (2U)
+#define HSEM_C2ICR_ISC2_Msk      (0x1UL << HSEM_C2ICR_ISC2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2ICR_ISC2          HSEM_C2ICR_ISC2_Msk                           /*!<semaphore 2 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC3_Pos      (3U)
+#define HSEM_C2ICR_ISC3_Msk      (0x1UL << HSEM_C2ICR_ISC3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2ICR_ISC3          HSEM_C2ICR_ISC3_Msk                           /*!<semaphore 3 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC4_Pos      (4U)
+#define HSEM_C2ICR_ISC4_Msk      (0x1UL << HSEM_C2ICR_ISC4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2ICR_ISC4          HSEM_C2ICR_ISC4_Msk                           /*!<semaphore 4 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC5_Pos      (5U)
+#define HSEM_C2ICR_ISC5_Msk      (0x1UL << HSEM_C2ICR_ISC5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2ICR_ISC5          HSEM_C2ICR_ISC5_Msk                           /*!<semaphore 5 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC6_Pos      (6U)
+#define HSEM_C2ICR_ISC6_Msk      (0x1UL << HSEM_C2ICR_ISC6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2ICR_ISC6          HSEM_C2ICR_ISC6_Msk                           /*!<semaphore 6 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC7_Pos      (7U)
+#define HSEM_C2ICR_ISC7_Msk      (0x1UL << HSEM_C2ICR_ISC7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2ICR_ISC7          HSEM_C2ICR_ISC7_Msk                           /*!<semaphore 7 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC8_Pos      (8U)
+#define HSEM_C2ICR_ISC8_Msk      (0x1UL << HSEM_C2ICR_ISC8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2ICR_ISC8          HSEM_C2ICR_ISC8_Msk                           /*!<semaphore 8 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC9_Pos      (9U)
+#define HSEM_C2ICR_ISC9_Msk      (0x1UL << HSEM_C2ICR_ISC9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2ICR_ISC9          HSEM_C2ICR_ISC9_Msk                           /*!<semaphore 9 CPU2 interrupt clear bit.  */
+#define HSEM_C2ICR_ISC10_Pos     (10U)
+#define HSEM_C2ICR_ISC10_Msk     (0x1UL << HSEM_C2ICR_ISC10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2ICR_ISC10         HSEM_C2ICR_ISC10_Msk                          /*!<semaphore 10 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC11_Pos     (11U)
+#define HSEM_C2ICR_ISC11_Msk     (0x1UL << HSEM_C2ICR_ISC11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2ICR_ISC11         HSEM_C2ICR_ISC11_Msk                          /*!<semaphore 11 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC12_Pos     (12U)
+#define HSEM_C2ICR_ISC12_Msk     (0x1UL << HSEM_C2ICR_ISC12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2ICR_ISC12         HSEM_C2ICR_ISC12_Msk                          /*!<semaphore 12 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC13_Pos     (13U)
+#define HSEM_C2ICR_ISC13_Msk     (0x1UL << HSEM_C2ICR_ISC13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2ICR_ISC13         HSEM_C2ICR_ISC13_Msk                          /*!<semaphore 13 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC14_Pos     (14U)
+#define HSEM_C2ICR_ISC14_Msk     (0x1UL << HSEM_C2ICR_ISC14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2ICR_ISC14         HSEM_C2ICR_ISC14_Msk                          /*!<semaphore 14 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC15_Pos     (15U)
+#define HSEM_C2ICR_ISC15_Msk     (0x1UL << HSEM_C2ICR_ISC15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2ICR_ISC15         HSEM_C2ICR_ISC15_Msk                          /*!<semaphore 15 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC16_Pos     (16U)
+#define HSEM_C2ICR_ISC16_Msk     (0x1UL << HSEM_C2ICR_ISC16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2ICR_ISC16         HSEM_C2ICR_ISC16_Msk                          /*!<semaphore 16 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC17_Pos     (17U)
+#define HSEM_C2ICR_ISC17_Msk     (0x1UL << HSEM_C2ICR_ISC17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2ICR_ISC17         HSEM_C2ICR_ISC17_Msk                          /*!<semaphore 17 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC18_Pos     (18U)
+#define HSEM_C2ICR_ISC18_Msk     (0x1UL << HSEM_C2ICR_ISC18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2ICR_ISC18         HSEM_C2ICR_ISC18_Msk                          /*!<semaphore 18 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC19_Pos     (19U)
+#define HSEM_C2ICR_ISC19_Msk     (0x1UL << HSEM_C2ICR_ISC19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2ICR_ISC19         HSEM_C2ICR_ISC19_Msk                          /*!<semaphore 19 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC20_Pos     (20U)
+#define HSEM_C2ICR_ISC20_Msk     (0x1UL << HSEM_C2ICR_ISC20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2ICR_ISC20         HSEM_C2ICR_ISC20_Msk                          /*!<semaphore 20 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC21_Pos     (21U)
+#define HSEM_C2ICR_ISC21_Msk     (0x1UL << HSEM_C2ICR_ISC21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2ICR_ISC21         HSEM_C2ICR_ISC21_Msk                          /*!<semaphore 21 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC22_Pos     (22U)
+#define HSEM_C2ICR_ISC22_Msk     (0x1UL << HSEM_C2ICR_ISC22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2ICR_ISC22         HSEM_C2ICR_ISC22_Msk                          /*!<semaphore 22 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC23_Pos     (23U)
+#define HSEM_C2ICR_ISC23_Msk     (0x1UL << HSEM_C2ICR_ISC23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2ICR_ISC23         HSEM_C2ICR_ISC23_Msk                          /*!<semaphore 23 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC24_Pos     (24U)
+#define HSEM_C2ICR_ISC24_Msk     (0x1UL << HSEM_C2ICR_ISC24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2ICR_ISC24         HSEM_C2ICR_ISC24_Msk                          /*!<semaphore 24 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC25_Pos     (25U)
+#define HSEM_C2ICR_ISC25_Msk     (0x1UL << HSEM_C2ICR_ISC25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2ICR_ISC25         HSEM_C2ICR_ISC25_Msk                          /*!<semaphore 25 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC26_Pos     (26U)
+#define HSEM_C2ICR_ISC26_Msk     (0x1UL << HSEM_C2ICR_ISC26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2ICR_ISC26         HSEM_C2ICR_ISC26_Msk                          /*!<semaphore 26 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC27_Pos     (27U)
+#define HSEM_C2ICR_ISC27_Msk     (0x1UL << HSEM_C2ICR_ISC27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2ICR_ISC27         HSEM_C2ICR_ISC27_Msk                          /*!<semaphore 27 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC28_Pos     (28U)
+#define HSEM_C2ICR_ISC28_Msk     (0x1UL << HSEM_C2ICR_ISC28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2ICR_ISC28         HSEM_C2ICR_ISC28_Msk                          /*!<semaphore 28 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC29_Pos     (29U)
+#define HSEM_C2ICR_ISC29_Msk     (0x1UL << HSEM_C2ICR_ISC29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2ICR_ISC29         HSEM_C2ICR_ISC29_Msk                          /*!<semaphore 29 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC30_Pos     (30U)
+#define HSEM_C2ICR_ISC30_Msk     (0x1UL << HSEM_C2ICR_ISC30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2ICR_ISC30         HSEM_C2ICR_ISC30_Msk                          /*!<semaphore 30 CPU2 interrupt clear bit. */
+#define HSEM_C2ICR_ISC31_Pos     (31U)
+#define HSEM_C2ICR_ISC31_Msk     (0x1UL << HSEM_C2ICR_ISC31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2ICR_ISC31         HSEM_C2ICR_ISC31_Msk                          /*!<semaphore 31 CPU2 interrupt clear bit. */
+
+/********************  Bit definition for HSEM_C2ISR register  *****************/
+#define HSEM_C2ISR_ISF0_Pos      (0U)
+#define HSEM_C2ISR_ISF0_Msk      (0x1UL << HSEM_C2ISR_ISF0_Pos)                /*!< 0x00000001 */
+#define HSEM_C2ISR_ISF0          HSEM_C2ISR_ISF0_Msk                           /*!<semaphore 0 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF1_Pos      (1U)
+#define HSEM_C2ISR_ISF1_Msk      (0x1UL << HSEM_C2ISR_ISF1_Pos)                /*!< 0x00000002 */
+#define HSEM_C2ISR_ISF1          HSEM_C2ISR_ISF1_Msk                           /*!<semaphore 1 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF2_Pos      (2U)
+#define HSEM_C2ISR_ISF2_Msk      (0x1UL << HSEM_C2ISR_ISF2_Pos)                /*!< 0x00000004 */
+#define HSEM_C2ISR_ISF2          HSEM_C2ISR_ISF2_Msk                           /*!<semaphore 2 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF3_Pos      (3U)
+#define HSEM_C2ISR_ISF3_Msk      (0x1UL << HSEM_C2ISR_ISF3_Pos)                /*!< 0x00000008 */
+#define HSEM_C2ISR_ISF3          HSEM_C2ISR_ISF3_Msk                           /*!<semaphore 3 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF4_Pos      (4U)
+#define HSEM_C2ISR_ISF4_Msk      (0x1UL << HSEM_C2ISR_ISF4_Pos)                /*!< 0x00000010 */
+#define HSEM_C2ISR_ISF4          HSEM_C2ISR_ISF4_Msk                           /*!<semaphore 4 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF5_Pos      (5U)
+#define HSEM_C2ISR_ISF5_Msk      (0x1UL << HSEM_C2ISR_ISF5_Pos)                /*!< 0x00000020 */
+#define HSEM_C2ISR_ISF5          HSEM_C2ISR_ISF5_Msk                           /*!<semaphore 5 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF6_Pos      (6U)
+#define HSEM_C2ISR_ISF6_Msk      (0x1UL << HSEM_C2ISR_ISF6_Pos)                /*!< 0x00000040 */
+#define HSEM_C2ISR_ISF6          HSEM_C2ISR_ISF6_Msk                           /*!<semaphore 6 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF7_Pos      (7U)
+#define HSEM_C2ISR_ISF7_Msk      (0x1UL << HSEM_C2ISR_ISF7_Pos)                /*!< 0x00000080 */
+#define HSEM_C2ISR_ISF7          HSEM_C2ISR_ISF7_Msk                           /*!<semaphore 7 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF8_Pos      (8U)
+#define HSEM_C2ISR_ISF8_Msk      (0x1UL << HSEM_C2ISR_ISF8_Pos)                /*!< 0x00000100 */
+#define HSEM_C2ISR_ISF8          HSEM_C2ISR_ISF8_Msk                           /*!<semaphore 8 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF9_Pos      (9U)
+#define HSEM_C2ISR_ISF9_Msk      (0x1UL << HSEM_C2ISR_ISF9_Pos)                /*!< 0x00000200 */
+#define HSEM_C2ISR_ISF9          HSEM_C2ISR_ISF9_Msk                           /*!<semaphore 9 CPU2 interrupt status bit.  */
+#define HSEM_C2ISR_ISF10_Pos     (10U)
+#define HSEM_C2ISR_ISF10_Msk     (0x1UL << HSEM_C2ISR_ISF10_Pos)               /*!< 0x00000400 */
+#define HSEM_C2ISR_ISF10         HSEM_C2ISR_ISF10_Msk                          /*!<semaphore 10 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF11_Pos     (11U)
+#define HSEM_C2ISR_ISF11_Msk     (0x1UL << HSEM_C2ISR_ISF11_Pos)               /*!< 0x00000800 */
+#define HSEM_C2ISR_ISF11         HSEM_C2ISR_ISF11_Msk                          /*!<semaphore 11 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF12_Pos     (12U)
+#define HSEM_C2ISR_ISF12_Msk     (0x1UL << HSEM_C2ISR_ISF12_Pos)               /*!< 0x00001000 */
+#define HSEM_C2ISR_ISF12         HSEM_C2ISR_ISF12_Msk                          /*!<semaphore 12 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF13_Pos     (13U)
+#define HSEM_C2ISR_ISF13_Msk     (0x1UL << HSEM_C2ISR_ISF13_Pos)               /*!< 0x00002000 */
+#define HSEM_C2ISR_ISF13         HSEM_C2ISR_ISF13_Msk                          /*!<semaphore 13 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF14_Pos     (14U)
+#define HSEM_C2ISR_ISF14_Msk     (0x1UL << HSEM_C2ISR_ISF14_Pos)               /*!< 0x00004000 */
+#define HSEM_C2ISR_ISF14         HSEM_C2ISR_ISF14_Msk                          /*!<semaphore 14 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF15_Pos     (15U)
+#define HSEM_C2ISR_ISF15_Msk     (0x1UL << HSEM_C2ISR_ISF15_Pos)               /*!< 0x00008000 */
+#define HSEM_C2ISR_ISF15         HSEM_C2ISR_ISF15_Msk                          /*!<semaphore 15 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF16_Pos     (16U)
+#define HSEM_C2ISR_ISF16_Msk     (0x1UL << HSEM_C2ISR_ISF16_Pos)               /*!< 0x00010000 */
+#define HSEM_C2ISR_ISF16         HSEM_C2ISR_ISF16_Msk                          /*!<semaphore 16 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF17_Pos     (17U)
+#define HSEM_C2ISR_ISF17_Msk     (0x1UL << HSEM_C2ISR_ISF17_Pos)               /*!< 0x00020000 */
+#define HSEM_C2ISR_ISF17         HSEM_C2ISR_ISF17_Msk                          /*!<semaphore 17 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF18_Pos     (18U)
+#define HSEM_C2ISR_ISF18_Msk     (0x1UL << HSEM_C2ISR_ISF18_Pos)               /*!< 0x00040000 */
+#define HSEM_C2ISR_ISF18         HSEM_C2ISR_ISF18_Msk                          /*!<semaphore 18 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF19_Pos     (19U)
+#define HSEM_C2ISR_ISF19_Msk     (0x1UL << HSEM_C2ISR_ISF19_Pos)               /*!< 0x00080000 */
+#define HSEM_C2ISR_ISF19         HSEM_C2ISR_ISF19_Msk                          /*!<semaphore 19 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF20_Pos     (20U)
+#define HSEM_C2ISR_ISF20_Msk     (0x1UL << HSEM_C2ISR_ISF20_Pos)               /*!< 0x00100000 */
+#define HSEM_C2ISR_ISF20         HSEM_C2ISR_ISF20_Msk                          /*!<semaphore 20 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF21_Pos     (21U)
+#define HSEM_C2ISR_ISF21_Msk     (0x1UL << HSEM_C2ISR_ISF21_Pos)               /*!< 0x00200000 */
+#define HSEM_C2ISR_ISF21         HSEM_C2ISR_ISF21_Msk                          /*!<semaphore 21 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF22_Pos     (22U)
+#define HSEM_C2ISR_ISF22_Msk     (0x1UL << HSEM_C2ISR_ISF22_Pos)               /*!< 0x00400000 */
+#define HSEM_C2ISR_ISF22         HSEM_C2ISR_ISF22_Msk                          /*!<semaphore 22 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF23_Pos     (23U)
+#define HSEM_C2ISR_ISF23_Msk     (0x1UL << HSEM_C2ISR_ISF23_Pos)               /*!< 0x00800000 */
+#define HSEM_C2ISR_ISF23         HSEM_C2ISR_ISF23_Msk                          /*!<semaphore 23 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF24_Pos     (24U)
+#define HSEM_C2ISR_ISF24_Msk     (0x1UL << HSEM_C2ISR_ISF24_Pos)               /*!< 0x01000000 */
+#define HSEM_C2ISR_ISF24         HSEM_C2ISR_ISF24_Msk                          /*!<semaphore 24 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF25_Pos     (25U)
+#define HSEM_C2ISR_ISF25_Msk     (0x1UL << HSEM_C2ISR_ISF25_Pos)               /*!< 0x02000000 */
+#define HSEM_C2ISR_ISF25         HSEM_C2ISR_ISF25_Msk                          /*!<semaphore 25 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF26_Pos     (26U)
+#define HSEM_C2ISR_ISF26_Msk     (0x1UL << HSEM_C2ISR_ISF26_Pos)               /*!< 0x04000000 */
+#define HSEM_C2ISR_ISF26         HSEM_C2ISR_ISF26_Msk                          /*!<semaphore 26 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF27_Pos     (27U)
+#define HSEM_C2ISR_ISF27_Msk     (0x1UL << HSEM_C2ISR_ISF27_Pos)               /*!< 0x08000000 */
+#define HSEM_C2ISR_ISF27         HSEM_C2ISR_ISF27_Msk                          /*!<semaphore 27 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF28_Pos     (28U)
+#define HSEM_C2ISR_ISF28_Msk     (0x1UL << HSEM_C2ISR_ISF28_Pos)               /*!< 0x10000000 */
+#define HSEM_C2ISR_ISF28         HSEM_C2ISR_ISF28_Msk                          /*!<semaphore 28 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF29_Pos     (29U)
+#define HSEM_C2ISR_ISF29_Msk     (0x1UL << HSEM_C2ISR_ISF29_Pos)               /*!< 0x20000000 */
+#define HSEM_C2ISR_ISF29         HSEM_C2ISR_ISF29_Msk                          /*!<semaphore 29 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF30_Pos     (30U)
+#define HSEM_C2ISR_ISF30_Msk     (0x1UL << HSEM_C2ISR_ISF30_Pos)               /*!< 0x40000000 */
+#define HSEM_C2ISR_ISF30         HSEM_C2ISR_ISF30_Msk                          /*!<semaphore 30 CPU2 interrupt status bit. */
+#define HSEM_C2ISR_ISF31_Pos     (31U)
+#define HSEM_C2ISR_ISF31_Msk     (0x1UL << HSEM_C2ISR_ISF31_Pos)               /*!< 0x80000000 */
+#define HSEM_C2ISR_ISF31         HSEM_C2ISR_ISF31_Msk                          /*!<semaphore 31 CPU2 interrupt status bit. */
+
+/********************  Bit definition for HSEM_C2MISR register  *****************/
+#define HSEM_C2MISR_MISF0_Pos     (0U)
+#define HSEM_C2MISR_MISF0_Msk     (0x1UL << HSEM_C2MISR_MISF0_Pos)               /*!< 0x00000001 */
+#define HSEM_C2MISR_MISF0         HSEM_C2MISR_MISF0_Msk                          /*!<semaphore 0 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF1_Pos     (1U)
+#define HSEM_C2MISR_MISF1_Msk     (0x1UL << HSEM_C2MISR_MISF1_Pos)               /*!< 0x00000002 */
+#define HSEM_C2MISR_MISF1         HSEM_C2MISR_MISF1_Msk                          /*!<semaphore 1 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF2_Pos     (2U)
+#define HSEM_C2MISR_MISF2_Msk     (0x1UL << HSEM_C2MISR_MISF2_Pos)               /*!< 0x00000004 */
+#define HSEM_C2MISR_MISF2         HSEM_C2MISR_MISF2_Msk                          /*!<semaphore 2 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF3_Pos     (3U)
+#define HSEM_C2MISR_MISF3_Msk     (0x1UL << HSEM_C2MISR_MISF3_Pos)               /*!< 0x00000008 */
+#define HSEM_C2MISR_MISF3         HSEM_C2MISR_MISF3_Msk                          /*!<semaphore 3 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF4_Pos     (4U)
+#define HSEM_C2MISR_MISF4_Msk     (0x1UL << HSEM_C2MISR_MISF4_Pos)               /*!< 0x00000010 */
+#define HSEM_C2MISR_MISF4         HSEM_C2MISR_MISF4_Msk                          /*!<semaphore 4 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF5_Pos     (5U)
+#define HSEM_C2MISR_MISF5_Msk     (0x1UL << HSEM_C2MISR_MISF5_Pos)               /*!< 0x00000020 */
+#define HSEM_C2MISR_MISF5         HSEM_C2MISR_MISF5_Msk                          /*!<semaphore 5 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF6_Pos     (6U)
+#define HSEM_C2MISR_MISF6_Msk     (0x1UL << HSEM_C2MISR_MISF6_Pos)               /*!< 0x00000040 */
+#define HSEM_C2MISR_MISF6         HSEM_C2MISR_MISF6_Msk                          /*!<semaphore 6 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF7_Pos     (7U)
+#define HSEM_C2MISR_MISF7_Msk     (0x1UL << HSEM_C2MISR_MISF7_Pos)               /*!< 0x00000080 */
+#define HSEM_C2MISR_MISF7         HSEM_C2MISR_MISF7_Msk                          /*!<semaphore 7 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF8_Pos     (8U)
+#define HSEM_C2MISR_MISF8_Msk     (0x1UL << HSEM_C2MISR_MISF8_Pos)               /*!< 0x00000100 */
+#define HSEM_C2MISR_MISF8         HSEM_C2MISR_MISF8_Msk                          /*!<semaphore 8 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF9_Pos     (9U)
+#define HSEM_C2MISR_MISF9_Msk     (0x1UL << HSEM_C2MISR_MISF9_Pos)               /*!< 0x00000200 */
+#define HSEM_C2MISR_MISF9         HSEM_C2MISR_MISF9_Msk                          /*!<semaphore 9 CPU2 interrupt masked status bit.  */
+#define HSEM_C2MISR_MISF10_Pos    (10U)
+#define HSEM_C2MISR_MISF10_Msk    (0x1UL << HSEM_C2MISR_MISF10_Pos)              /*!< 0x00000400 */
+#define HSEM_C2MISR_MISF10        HSEM_C2MISR_MISF10_Msk                         /*!<semaphore 10 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF11_Pos    (11U)
+#define HSEM_C2MISR_MISF11_Msk    (0x1UL << HSEM_C2MISR_MISF11_Pos)              /*!< 0x00000800 */
+#define HSEM_C2MISR_MISF11        HSEM_C2MISR_MISF11_Msk                         /*!<semaphore 11 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF12_Pos    (12U)
+#define HSEM_C2MISR_MISF12_Msk    (0x1UL << HSEM_C2MISR_MISF12_Pos)              /*!< 0x00001000 */
+#define HSEM_C2MISR_MISF12        HSEM_C2MISR_MISF12_Msk                         /*!<semaphore 12 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF13_Pos    (13U)
+#define HSEM_C2MISR_MISF13_Msk    (0x1UL << HSEM_C2MISR_MISF13_Pos)              /*!< 0x00002000 */
+#define HSEM_C2MISR_MISF13        HSEM_C2MISR_MISF13_Msk                         /*!<semaphore 13 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF14_Pos    (14U)
+#define HSEM_C2MISR_MISF14_Msk    (0x1UL << HSEM_C2MISR_MISF14_Pos)              /*!< 0x00004000 */
+#define HSEM_C2MISR_MISF14        HSEM_C2MISR_MISF14_Msk                         /*!<semaphore 14 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF15_Pos    (15U)
+#define HSEM_C2MISR_MISF15_Msk    (0x1UL << HSEM_C2MISR_MISF15_Pos)              /*!< 0x00008000 */
+#define HSEM_C2MISR_MISF15        HSEM_C2MISR_MISF15_Msk                         /*!<semaphore 15 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF16_Pos    (16U)
+#define HSEM_C2MISR_MISF16_Msk    (0x1UL << HSEM_C2MISR_MISF16_Pos)              /*!< 0x00010000 */
+#define HSEM_C2MISR_MISF16        HSEM_C2MISR_MISF16_Msk                         /*!<semaphore 16 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF17_Pos    (17U)
+#define HSEM_C2MISR_MISF17_Msk    (0x1UL << HSEM_C2MISR_MISF17_Pos)              /*!< 0x00020000 */
+#define HSEM_C2MISR_MISF17        HSEM_C2MISR_MISF17_Msk                         /*!<semaphore 17 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF18_Pos    (18U)
+#define HSEM_C2MISR_MISF18_Msk    (0x1UL << HSEM_C2MISR_MISF18_Pos)              /*!< 0x00040000 */
+#define HSEM_C2MISR_MISF18        HSEM_C2MISR_MISF18_Msk                         /*!<semaphore 18 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF19_Pos    (19U)
+#define HSEM_C2MISR_MISF19_Msk    (0x1UL << HSEM_C2MISR_MISF19_Pos)              /*!< 0x00080000 */
+#define HSEM_C2MISR_MISF19        HSEM_C2MISR_MISF19_Msk                         /*!<semaphore 19 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF20_Pos    (20U)
+#define HSEM_C2MISR_MISF20_Msk    (0x1UL << HSEM_C2MISR_MISF20_Pos)              /*!< 0x00100000 */
+#define HSEM_C2MISR_MISF20        HSEM_C2MISR_MISF20_Msk                         /*!<semaphore 20 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF21_Pos    (21U)
+#define HSEM_C2MISR_MISF21_Msk    (0x1UL << HSEM_C2MISR_MISF21_Pos)              /*!< 0x00200000 */
+#define HSEM_C2MISR_MISF21        HSEM_C2MISR_MISF21_Msk                         /*!<semaphore 21 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF22_Pos    (22U)
+#define HSEM_C2MISR_MISF22_Msk    (0x1UL << HSEM_C2MISR_MISF22_Pos)              /*!< 0x00400000 */
+#define HSEM_C2MISR_MISF22        HSEM_C2MISR_MISF22_Msk                         /*!<semaphore 22 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF23_Pos    (23U)
+#define HSEM_C2MISR_MISF23_Msk    (0x1UL << HSEM_C2MISR_MISF23_Pos)              /*!< 0x00800000 */
+#define HSEM_C2MISR_MISF23        HSEM_C2MISR_MISF23_Msk                         /*!<semaphore 23 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF24_Pos    (24U)
+#define HSEM_C2MISR_MISF24_Msk    (0x1UL << HSEM_C2MISR_MISF24_Pos)              /*!< 0x01000000 */
+#define HSEM_C2MISR_MISF24        HSEM_C2MISR_MISF24_Msk                         /*!<semaphore 24 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF25_Pos    (25U)
+#define HSEM_C2MISR_MISF25_Msk    (0x1UL << HSEM_C2MISR_MISF25_Pos)              /*!< 0x02000000 */
+#define HSEM_C2MISR_MISF25        HSEM_C2MISR_MISF25_Msk                         /*!<semaphore 25 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF26_Pos    (26U)
+#define HSEM_C2MISR_MISF26_Msk    (0x1UL << HSEM_C2MISR_MISF26_Pos)              /*!< 0x04000000 */
+#define HSEM_C2MISR_MISF26        HSEM_C2MISR_MISF26_Msk                         /*!<semaphore 26 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF27_Pos    (27U)
+#define HSEM_C2MISR_MISF27_Msk    (0x1UL << HSEM_C2MISR_MISF27_Pos)              /*!< 0x08000000 */
+#define HSEM_C2MISR_MISF27        HSEM_C2MISR_MISF27_Msk                         /*!<semaphore 27 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF28_Pos    (28U)
+#define HSEM_C2MISR_MISF28_Msk    (0x1UL << HSEM_C2MISR_MISF28_Pos)              /*!< 0x10000000 */
+#define HSEM_C2MISR_MISF28        HSEM_C2MISR_MISF28_Msk                         /*!<semaphore 28 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF29_Pos    (29U)
+#define HSEM_C2MISR_MISF29_Msk    (0x1UL << HSEM_C2MISR_MISF29_Pos)              /*!< 0x20000000 */
+#define HSEM_C2MISR_MISF29        HSEM_C2MISR_MISF29_Msk                         /*!<semaphore 29 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF30_Pos    (30U)
+#define HSEM_C2MISR_MISF30_Msk    (0x1UL << HSEM_C2MISR_MISF30_Pos)              /*!< 0x40000000 */
+#define HSEM_C2MISR_MISF30        HSEM_C2MISR_MISF30_Msk                         /*!<semaphore 30 CPU2 interrupt masked status bit. */
+#define HSEM_C2MISR_MISF31_Pos    (31U)
+#define HSEM_C2MISR_MISF31_Msk    (0x1UL << HSEM_C2MISR_MISF31_Pos)              /*!< 0x80000000 */
+#define HSEM_C2MISR_MISF31        HSEM_C2MISR_MISF31_Msk                         /*!<semaphore 31 CPU2 interrupt masked status bit. */
+
+/********************  Bit definition for HSEM_CR register  *****************/
+#define HSEM_CR_COREID_Pos       (8U)
+#define HSEM_CR_COREID_Msk       (0xFUL << HSEM_CR_COREID_Pos)                 /*!< 0x00000F00 */
+#define HSEM_CR_COREID           HSEM_CR_COREID_Msk                            /*!<CoreID of semaphores to be cleared. */
+#define HSEM_CR_COREID_CPU1      (0x4U << HSEM_CR_COREID_Pos)
+#define HSEM_CR_COREID_CPU2      (0x8U << HSEM_CR_COREID_Pos)
+#define HSEM_CR_COREID_CURRENT   HSEM_CR_COREID_CPU1
+#define HSEM_CR_KEY_Pos          (16U)
+#define HSEM_CR_KEY_Msk          (0xFFFFUL << HSEM_CR_KEY_Pos)                 /*!< 0xFFFF0000 */
+#define HSEM_CR_KEY              HSEM_CR_KEY_Msk                               /*!<semaphores clear key. */
+
+/********************  Bit definition for HSEM_KEYR register  *****************/
+#define HSEM_KEYR_KEY_Pos        (16U)
+#define HSEM_KEYR_KEY_Msk        (0xFFFFUL << HSEM_KEYR_KEY_Pos)               /*!< 0xFFFF0000 */
+#define HSEM_KEYR_KEY            HSEM_KEYR_KEY_Msk                             /*!<semaphores clear key. */
+
+/******************************************************************************/
+/*                                                                            */
+/*                      Inter-integrated Circuit Interface (I2C)              */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for I2C_CR1 register  *******************/
+#define I2C_CR1_PE_Pos               (0U)
+#define I2C_CR1_PE_Msk               (0x1UL << I2C_CR1_PE_Pos)                 /*!< 0x00000001 */
+#define I2C_CR1_PE                   I2C_CR1_PE_Msk                            /*!< Peripheral enable */
+#define I2C_CR1_TXIE_Pos             (1U)
+#define I2C_CR1_TXIE_Msk             (0x1UL << I2C_CR1_TXIE_Pos)               /*!< 0x00000002 */
+#define I2C_CR1_TXIE                 I2C_CR1_TXIE_Msk                          /*!< TX interrupt enable */
+#define I2C_CR1_RXIE_Pos             (2U)
+#define I2C_CR1_RXIE_Msk             (0x1UL << I2C_CR1_RXIE_Pos)               /*!< 0x00000004 */
+#define I2C_CR1_RXIE                 I2C_CR1_RXIE_Msk                          /*!< RX interrupt enable */
+#define I2C_CR1_ADDRIE_Pos           (3U)
+#define I2C_CR1_ADDRIE_Msk           (0x1UL << I2C_CR1_ADDRIE_Pos)             /*!< 0x00000008 */
+#define I2C_CR1_ADDRIE               I2C_CR1_ADDRIE_Msk                        /*!< Address match interrupt enable */
+#define I2C_CR1_NACKIE_Pos           (4U)
+#define I2C_CR1_NACKIE_Msk           (0x1UL << I2C_CR1_NACKIE_Pos)             /*!< 0x00000010 */
+#define I2C_CR1_NACKIE               I2C_CR1_NACKIE_Msk                        /*!< NACK received interrupt enable */
+#define I2C_CR1_STOPIE_Pos           (5U)
+#define I2C_CR1_STOPIE_Msk           (0x1UL << I2C_CR1_STOPIE_Pos)             /*!< 0x00000020 */
+#define I2C_CR1_STOPIE               I2C_CR1_STOPIE_Msk                        /*!< STOP detection interrupt enable */
+#define I2C_CR1_TCIE_Pos             (6U)
+#define I2C_CR1_TCIE_Msk             (0x1UL << I2C_CR1_TCIE_Pos)               /*!< 0x00000040 */
+#define I2C_CR1_TCIE                 I2C_CR1_TCIE_Msk                          /*!< Transfer complete interrupt enable */
+#define I2C_CR1_ERRIE_Pos            (7U)
+#define I2C_CR1_ERRIE_Msk            (0x1UL << I2C_CR1_ERRIE_Pos)              /*!< 0x00000080 */
+#define I2C_CR1_ERRIE                I2C_CR1_ERRIE_Msk                         /*!< Errors interrupt enable */
+#define I2C_CR1_DNF_Pos              (8U)
+#define I2C_CR1_DNF_Msk              (0xFUL << I2C_CR1_DNF_Pos)                /*!< 0x00000F00 */
+#define I2C_CR1_DNF                  I2C_CR1_DNF_Msk                           /*!< Digital noise filter */
+#define I2C_CR1_ANFOFF_Pos           (12U)
+#define I2C_CR1_ANFOFF_Msk           (0x1UL << I2C_CR1_ANFOFF_Pos)             /*!< 0x00001000 */
+#define I2C_CR1_ANFOFF               I2C_CR1_ANFOFF_Msk                        /*!< Analog noise filter OFF */
+#define I2C_CR1_SWRST_Pos            (13U)
+#define I2C_CR1_SWRST_Msk            (0x1UL << I2C_CR1_SWRST_Pos)              /*!< 0x00002000 */
+#define I2C_CR1_SWRST                I2C_CR1_SWRST_Msk                         /*!< Software reset */
+#define I2C_CR1_TXDMAEN_Pos          (14U)
+#define I2C_CR1_TXDMAEN_Msk          (0x1UL << I2C_CR1_TXDMAEN_Pos)            /*!< 0x00004000 */
+#define I2C_CR1_TXDMAEN              I2C_CR1_TXDMAEN_Msk                       /*!< DMA transmission requests enable */
+#define I2C_CR1_RXDMAEN_Pos          (15U)
+#define I2C_CR1_RXDMAEN_Msk          (0x1UL << I2C_CR1_RXDMAEN_Pos)            /*!< 0x00008000 */
+#define I2C_CR1_RXDMAEN              I2C_CR1_RXDMAEN_Msk                       /*!< DMA reception requests enable */
+#define I2C_CR1_SBC_Pos              (16U)
+#define I2C_CR1_SBC_Msk              (0x1UL << I2C_CR1_SBC_Pos)                /*!< 0x00010000 */
+#define I2C_CR1_SBC                  I2C_CR1_SBC_Msk                           /*!< Slave byte control */
+#define I2C_CR1_NOSTRETCH_Pos        (17U)
+#define I2C_CR1_NOSTRETCH_Msk        (0x1UL << I2C_CR1_NOSTRETCH_Pos)          /*!< 0x00020000 */
+#define I2C_CR1_NOSTRETCH            I2C_CR1_NOSTRETCH_Msk                     /*!< Clock stretching disable */
+#define I2C_CR1_WUPEN_Pos            (18U)
+#define I2C_CR1_WUPEN_Msk            (0x1UL << I2C_CR1_WUPEN_Pos)              /*!< 0x00040000 */
+#define I2C_CR1_WUPEN                I2C_CR1_WUPEN_Msk                         /*!< Wakeup from STOP enable */
+#define I2C_CR1_GCEN_Pos             (19U)
+#define I2C_CR1_GCEN_Msk             (0x1UL << I2C_CR1_GCEN_Pos)               /*!< 0x00080000 */
+#define I2C_CR1_GCEN                 I2C_CR1_GCEN_Msk                          /*!< General call enable */
+#define I2C_CR1_SMBHEN_Pos           (20U)
+#define I2C_CR1_SMBHEN_Msk           (0x1UL << I2C_CR1_SMBHEN_Pos)             /*!< 0x00100000 */
+#define I2C_CR1_SMBHEN               I2C_CR1_SMBHEN_Msk                        /*!< SMBus host address enable */
+#define I2C_CR1_SMBDEN_Pos           (21U)
+#define I2C_CR1_SMBDEN_Msk           (0x1UL << I2C_CR1_SMBDEN_Pos)             /*!< 0x00200000 */
+#define I2C_CR1_SMBDEN               I2C_CR1_SMBDEN_Msk                        /*!< SMBus device default address enable */
+#define I2C_CR1_ALERTEN_Pos          (22U)
+#define I2C_CR1_ALERTEN_Msk          (0x1UL << I2C_CR1_ALERTEN_Pos)            /*!< 0x00400000 */
+#define I2C_CR1_ALERTEN              I2C_CR1_ALERTEN_Msk                       /*!< SMBus alert enable */
+#define I2C_CR1_PECEN_Pos            (23U)
+#define I2C_CR1_PECEN_Msk            (0x1UL << I2C_CR1_PECEN_Pos)              /*!< 0x00800000 */
+#define I2C_CR1_PECEN                I2C_CR1_PECEN_Msk                         /*!< PEC enable */
+
+/******************  Bit definition for I2C_CR2 register  ********************/
+#define I2C_CR2_SADD_Pos             (0U)
+#define I2C_CR2_SADD_Msk             (0x3FFUL << I2C_CR2_SADD_Pos)             /*!< 0x000003FF */
+#define I2C_CR2_SADD                 I2C_CR2_SADD_Msk                          /*!< Slave address (master mode) */
+#define I2C_CR2_RD_WRN_Pos           (10U)
+#define I2C_CR2_RD_WRN_Msk           (0x1UL << I2C_CR2_RD_WRN_Pos)             /*!< 0x00000400 */
+#define I2C_CR2_RD_WRN               I2C_CR2_RD_WRN_Msk                        /*!< Transfer direction (master mode) */
+#define I2C_CR2_ADD10_Pos            (11U)
+#define I2C_CR2_ADD10_Msk            (0x1UL << I2C_CR2_ADD10_Pos)              /*!< 0x00000800 */
+#define I2C_CR2_ADD10                I2C_CR2_ADD10_Msk                         /*!< 10-bit addressing mode (master mode) */
+#define I2C_CR2_HEAD10R_Pos          (12U)
+#define I2C_CR2_HEAD10R_Msk          (0x1UL << I2C_CR2_HEAD10R_Pos)            /*!< 0x00001000 */
+#define I2C_CR2_HEAD10R              I2C_CR2_HEAD10R_Msk                       /*!< 10-bit address header only read direction (master mode) */
+#define I2C_CR2_START_Pos            (13U)
+#define I2C_CR2_START_Msk            (0x1UL << I2C_CR2_START_Pos)              /*!< 0x00002000 */
+#define I2C_CR2_START                I2C_CR2_START_Msk                         /*!< START generation */
+#define I2C_CR2_STOP_Pos             (14U)
+#define I2C_CR2_STOP_Msk             (0x1UL << I2C_CR2_STOP_Pos)               /*!< 0x00004000 */
+#define I2C_CR2_STOP                 I2C_CR2_STOP_Msk                          /*!< STOP generation (master mode) */
+#define I2C_CR2_NACK_Pos             (15U)
+#define I2C_CR2_NACK_Msk             (0x1UL << I2C_CR2_NACK_Pos)               /*!< 0x00008000 */
+#define I2C_CR2_NACK                 I2C_CR2_NACK_Msk                          /*!< NACK generation (slave mode) */
+#define I2C_CR2_NBYTES_Pos           (16U)
+#define I2C_CR2_NBYTES_Msk           (0xFFUL << I2C_CR2_NBYTES_Pos)            /*!< 0x00FF0000 */
+#define I2C_CR2_NBYTES               I2C_CR2_NBYTES_Msk                        /*!< Number of bytes */
+#define I2C_CR2_RELOAD_Pos           (24U)
+#define I2C_CR2_RELOAD_Msk           (0x1UL << I2C_CR2_RELOAD_Pos)             /*!< 0x01000000 */
+#define I2C_CR2_RELOAD               I2C_CR2_RELOAD_Msk                        /*!< NBYTES reload mode */
+#define I2C_CR2_AUTOEND_Pos          (25U)
+#define I2C_CR2_AUTOEND_Msk          (0x1UL << I2C_CR2_AUTOEND_Pos)            /*!< 0x02000000 */
+#define I2C_CR2_AUTOEND              I2C_CR2_AUTOEND_Msk                       /*!< Automatic end mode (master mode) */
+#define I2C_CR2_PECBYTE_Pos          (26U)
+#define I2C_CR2_PECBYTE_Msk          (0x1UL << I2C_CR2_PECBYTE_Pos)            /*!< 0x04000000 */
+#define I2C_CR2_PECBYTE              I2C_CR2_PECBYTE_Msk                       /*!< Packet error checking byte */
+
+/*******************  Bit definition for I2C_OAR1 register  ******************/
+#define I2C_OAR1_OA1_Pos             (0U)
+#define I2C_OAR1_OA1_Msk             (0x3FFUL << I2C_OAR1_OA1_Pos)             /*!< 0x000003FF */
+#define I2C_OAR1_OA1                 I2C_OAR1_OA1_Msk                          /*!< Interface own address 1 */
+#define I2C_OAR1_OA1MODE_Pos         (10U)
+#define I2C_OAR1_OA1MODE_Msk         (0x1UL << I2C_OAR1_OA1MODE_Pos)           /*!< 0x00000400 */
+#define I2C_OAR1_OA1MODE             I2C_OAR1_OA1MODE_Msk                      /*!< Own address 1 10-bit mode */
+#define I2C_OAR1_OA1EN_Pos           (15U)
+#define I2C_OAR1_OA1EN_Msk           (0x1UL << I2C_OAR1_OA1EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR1_OA1EN               I2C_OAR1_OA1EN_Msk                        /*!< Own address 1 enable */
+
+/*******************  Bit definition for I2C_OAR2 register  ******************/
+#define I2C_OAR2_OA2_Pos             (1U)
+#define I2C_OAR2_OA2_Msk             (0x7FUL << I2C_OAR2_OA2_Pos)              /*!< 0x000000FE */
+#define I2C_OAR2_OA2                 I2C_OAR2_OA2_Msk                          /*!< Interface own address 2 */
+#define I2C_OAR2_OA2MSK_Pos          (8U)
+#define I2C_OAR2_OA2MSK_Msk          (0x7UL << I2C_OAR2_OA2MSK_Pos)            /*!< 0x00000700 */
+#define I2C_OAR2_OA2MSK              I2C_OAR2_OA2MSK_Msk                       /*!< Own address 2 masks */
+#define I2C_OAR2_OA2NOMASK           (0x00000000UL)                            /*!< No mask                                        */
+#define I2C_OAR2_OA2MASK01_Pos       (8U)
+#define I2C_OAR2_OA2MASK01_Msk       (0x1UL << I2C_OAR2_OA2MASK01_Pos)         /*!< 0x00000100 */
+#define I2C_OAR2_OA2MASK01           I2C_OAR2_OA2MASK01_Msk                    /*!< OA2[1] is masked, Only OA2[7:2] are compared   */
+#define I2C_OAR2_OA2MASK02_Pos       (9U)
+#define I2C_OAR2_OA2MASK02_Msk       (0x1UL << I2C_OAR2_OA2MASK02_Pos)         /*!< 0x00000200 */
+#define I2C_OAR2_OA2MASK02           I2C_OAR2_OA2MASK02_Msk                    /*!< OA2[2:1] is masked, Only OA2[7:3] are compared */
+#define I2C_OAR2_OA2MASK03_Pos       (8U)
+#define I2C_OAR2_OA2MASK03_Msk       (0x3UL << I2C_OAR2_OA2MASK03_Pos)         /*!< 0x00000300 */
+#define I2C_OAR2_OA2MASK03           I2C_OAR2_OA2MASK03_Msk                    /*!< OA2[3:1] is masked, Only OA2[7:4] are compared */
+#define I2C_OAR2_OA2MASK04_Pos       (10U)
+#define I2C_OAR2_OA2MASK04_Msk       (0x1UL << I2C_OAR2_OA2MASK04_Pos)         /*!< 0x00000400 */
+#define I2C_OAR2_OA2MASK04           I2C_OAR2_OA2MASK04_Msk                    /*!< OA2[4:1] is masked, Only OA2[7:5] are compared */
+#define I2C_OAR2_OA2MASK05_Pos       (8U)
+#define I2C_OAR2_OA2MASK05_Msk       (0x5UL << I2C_OAR2_OA2MASK05_Pos)         /*!< 0x00000500 */
+#define I2C_OAR2_OA2MASK05           I2C_OAR2_OA2MASK05_Msk                    /*!< OA2[5:1] is masked, Only OA2[7:6] are compared */
+#define I2C_OAR2_OA2MASK06_Pos       (9U)
+#define I2C_OAR2_OA2MASK06_Msk       (0x3UL << I2C_OAR2_OA2MASK06_Pos)         /*!< 0x00000600 */
+#define I2C_OAR2_OA2MASK06           I2C_OAR2_OA2MASK06_Msk                    /*!< OA2[6:1] is masked, Only OA2[7] are compared   */
+#define I2C_OAR2_OA2MASK07_Pos       (8U)
+#define I2C_OAR2_OA2MASK07_Msk       (0x7UL << I2C_OAR2_OA2MASK07_Pos)         /*!< 0x00000700 */
+#define I2C_OAR2_OA2MASK07           I2C_OAR2_OA2MASK07_Msk                    /*!< OA2[7:1] is masked, No comparison is done      */
+#define I2C_OAR2_OA2EN_Pos           (15U)
+#define I2C_OAR2_OA2EN_Msk           (0x1UL << I2C_OAR2_OA2EN_Pos)             /*!< 0x00008000 */
+#define I2C_OAR2_OA2EN               I2C_OAR2_OA2EN_Msk                        /*!< Own address 2 enable */
+
+/*******************  Bit definition for I2C_TIMINGR register *******************/
+#define I2C_TIMINGR_SCLL_Pos         (0U)
+#define I2C_TIMINGR_SCLL_Msk         (0xFFUL << I2C_TIMINGR_SCLL_Pos)          /*!< 0x000000FF */
+#define I2C_TIMINGR_SCLL             I2C_TIMINGR_SCLL_Msk                      /*!< SCL low period (master mode) */
+#define I2C_TIMINGR_SCLH_Pos         (8U)
+#define I2C_TIMINGR_SCLH_Msk         (0xFFUL << I2C_TIMINGR_SCLH_Pos)          /*!< 0x0000FF00 */
+#define I2C_TIMINGR_SCLH             I2C_TIMINGR_SCLH_Msk                      /*!< SCL high period (master mode) */
+#define I2C_TIMINGR_SDADEL_Pos       (16U)
+#define I2C_TIMINGR_SDADEL_Msk       (0xFUL << I2C_TIMINGR_SDADEL_Pos)         /*!< 0x000F0000 */
+#define I2C_TIMINGR_SDADEL           I2C_TIMINGR_SDADEL_Msk                    /*!< Data hold time */
+#define I2C_TIMINGR_SCLDEL_Pos       (20U)
+#define I2C_TIMINGR_SCLDEL_Msk       (0xFUL << I2C_TIMINGR_SCLDEL_Pos)         /*!< 0x00F00000 */
+#define I2C_TIMINGR_SCLDEL           I2C_TIMINGR_SCLDEL_Msk                    /*!< Data setup time */
+#define I2C_TIMINGR_PRESC_Pos        (28U)
+#define I2C_TIMINGR_PRESC_Msk        (0xFUL << I2C_TIMINGR_PRESC_Pos)          /*!< 0xF0000000 */
+#define I2C_TIMINGR_PRESC            I2C_TIMINGR_PRESC_Msk                     /*!< Timings prescaler */
+
+/******************* Bit definition for I2C_TIMEOUTR register *******************/
+#define I2C_TIMEOUTR_TIMEOUTA_Pos    (0U)
+#define I2C_TIMEOUTR_TIMEOUTA_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTA_Pos)    /*!< 0x00000FFF */
+#define I2C_TIMEOUTR_TIMEOUTA        I2C_TIMEOUTR_TIMEOUTA_Msk                 /*!< Bus timeout A */
+#define I2C_TIMEOUTR_TIDLE_Pos       (12U)
+#define I2C_TIMEOUTR_TIDLE_Msk       (0x1UL << I2C_TIMEOUTR_TIDLE_Pos)         /*!< 0x00001000 */
+#define I2C_TIMEOUTR_TIDLE           I2C_TIMEOUTR_TIDLE_Msk                    /*!< Idle clock timeout detection */
+#define I2C_TIMEOUTR_TIMOUTEN_Pos    (15U)
+#define I2C_TIMEOUTR_TIMOUTEN_Msk    (0x1UL << I2C_TIMEOUTR_TIMOUTEN_Pos)      /*!< 0x00008000 */
+#define I2C_TIMEOUTR_TIMOUTEN        I2C_TIMEOUTR_TIMOUTEN_Msk                 /*!< Clock timeout enable */
+#define I2C_TIMEOUTR_TIMEOUTB_Pos    (16U)
+#define I2C_TIMEOUTR_TIMEOUTB_Msk    (0xFFFUL << I2C_TIMEOUTR_TIMEOUTB_Pos)    /*!< 0x0FFF0000 */
+#define I2C_TIMEOUTR_TIMEOUTB        I2C_TIMEOUTR_TIMEOUTB_Msk                 /*!< Bus timeout B*/
+#define I2C_TIMEOUTR_TEXTEN_Pos      (31U)
+#define I2C_TIMEOUTR_TEXTEN_Msk      (0x1UL << I2C_TIMEOUTR_TEXTEN_Pos)        /*!< 0x80000000 */
+#define I2C_TIMEOUTR_TEXTEN          I2C_TIMEOUTR_TEXTEN_Msk                   /*!< Extended clock timeout enable */
+
+/******************  Bit definition for I2C_ISR register  *********************/
+#define I2C_ISR_TXE_Pos              (0U)
+#define I2C_ISR_TXE_Msk              (0x1UL << I2C_ISR_TXE_Pos)                /*!< 0x00000001 */
+#define I2C_ISR_TXE                  I2C_ISR_TXE_Msk                           /*!< Transmit data register empty */
+#define I2C_ISR_TXIS_Pos             (1U)
+#define I2C_ISR_TXIS_Msk             (0x1UL << I2C_ISR_TXIS_Pos)               /*!< 0x00000002 */
+#define I2C_ISR_TXIS                 I2C_ISR_TXIS_Msk                          /*!< Transmit interrupt status */
+#define I2C_ISR_RXNE_Pos             (2U)
+#define I2C_ISR_RXNE_Msk             (0x1UL << I2C_ISR_RXNE_Pos)               /*!< 0x00000004 */
+#define I2C_ISR_RXNE                 I2C_ISR_RXNE_Msk                          /*!< Receive data register not empty */
+#define I2C_ISR_ADDR_Pos             (3U)
+#define I2C_ISR_ADDR_Msk             (0x1UL << I2C_ISR_ADDR_Pos)               /*!< 0x00000008 */
+#define I2C_ISR_ADDR                 I2C_ISR_ADDR_Msk                          /*!< Address matched (slave mode)*/
+#define I2C_ISR_NACKF_Pos            (4U)
+#define I2C_ISR_NACKF_Msk            (0x1UL << I2C_ISR_NACKF_Pos)              /*!< 0x00000010 */
+#define I2C_ISR_NACKF                I2C_ISR_NACKF_Msk                         /*!< NACK received flag */
+#define I2C_ISR_STOPF_Pos            (5U)
+#define I2C_ISR_STOPF_Msk            (0x1UL << I2C_ISR_STOPF_Pos)              /*!< 0x00000020 */
+#define I2C_ISR_STOPF                I2C_ISR_STOPF_Msk                         /*!< STOP detection flag */
+#define I2C_ISR_TC_Pos               (6U)
+#define I2C_ISR_TC_Msk               (0x1UL << I2C_ISR_TC_Pos)                 /*!< 0x00000040 */
+#define I2C_ISR_TC                   I2C_ISR_TC_Msk                            /*!< Transfer complete (master mode) */
+#define I2C_ISR_TCR_Pos              (7U)
+#define I2C_ISR_TCR_Msk              (0x1UL << I2C_ISR_TCR_Pos)                /*!< 0x00000080 */
+#define I2C_ISR_TCR                  I2C_ISR_TCR_Msk                           /*!< Transfer complete reload */
+#define I2C_ISR_BERR_Pos             (8U)
+#define I2C_ISR_BERR_Msk             (0x1UL << I2C_ISR_BERR_Pos)               /*!< 0x00000100 */
+#define I2C_ISR_BERR                 I2C_ISR_BERR_Msk                          /*!< Bus error */
+#define I2C_ISR_ARLO_Pos             (9U)
+#define I2C_ISR_ARLO_Msk             (0x1UL << I2C_ISR_ARLO_Pos)               /*!< 0x00000200 */
+#define I2C_ISR_ARLO                 I2C_ISR_ARLO_Msk                          /*!< Arbitration lost */
+#define I2C_ISR_OVR_Pos              (10U)
+#define I2C_ISR_OVR_Msk              (0x1UL << I2C_ISR_OVR_Pos)                /*!< 0x00000400 */
+#define I2C_ISR_OVR                  I2C_ISR_OVR_Msk                           /*!< Overrun/Underrun */
+#define I2C_ISR_PECERR_Pos           (11U)
+#define I2C_ISR_PECERR_Msk           (0x1UL << I2C_ISR_PECERR_Pos)             /*!< 0x00000800 */
+#define I2C_ISR_PECERR               I2C_ISR_PECERR_Msk                        /*!< PEC error in reception */
+#define I2C_ISR_TIMEOUT_Pos          (12U)
+#define I2C_ISR_TIMEOUT_Msk          (0x1UL << I2C_ISR_TIMEOUT_Pos)            /*!< 0x00001000 */
+#define I2C_ISR_TIMEOUT              I2C_ISR_TIMEOUT_Msk                       /*!< Timeout or Tlow detection flag */
+#define I2C_ISR_ALERT_Pos            (13U)
+#define I2C_ISR_ALERT_Msk            (0x1UL << I2C_ISR_ALERT_Pos)              /*!< 0x00002000 */
+#define I2C_ISR_ALERT                I2C_ISR_ALERT_Msk                         /*!< SMBus alert */
+#define I2C_ISR_BUSY_Pos             (15U)
+#define I2C_ISR_BUSY_Msk             (0x1UL << I2C_ISR_BUSY_Pos)               /*!< 0x00008000 */
+#define I2C_ISR_BUSY                 I2C_ISR_BUSY_Msk                          /*!< Bus busy */
+#define I2C_ISR_DIR_Pos              (16U)
+#define I2C_ISR_DIR_Msk              (0x1UL << I2C_ISR_DIR_Pos)                /*!< 0x00010000 */
+#define I2C_ISR_DIR                  I2C_ISR_DIR_Msk                           /*!< Transfer direction (slave mode) */
+#define I2C_ISR_ADDCODE_Pos          (17U)
+#define I2C_ISR_ADDCODE_Msk          (0x7FUL << I2C_ISR_ADDCODE_Pos)           /*!< 0x00FE0000 */
+#define I2C_ISR_ADDCODE              I2C_ISR_ADDCODE_Msk                       /*!< Address match code (slave mode) */
+
+/******************  Bit definition for I2C_ICR register  *********************/
+#define I2C_ICR_ADDRCF_Pos           (3U)
+#define I2C_ICR_ADDRCF_Msk           (0x1UL << I2C_ICR_ADDRCF_Pos)             /*!< 0x00000008 */
+#define I2C_ICR_ADDRCF               I2C_ICR_ADDRCF_Msk                        /*!< Address matched clear flag */
+#define I2C_ICR_NACKCF_Pos           (4U)
+#define I2C_ICR_NACKCF_Msk           (0x1UL << I2C_ICR_NACKCF_Pos)             /*!< 0x00000010 */
+#define I2C_ICR_NACKCF               I2C_ICR_NACKCF_Msk                        /*!< NACK clear flag */
+#define I2C_ICR_STOPCF_Pos           (5U)
+#define I2C_ICR_STOPCF_Msk           (0x1UL << I2C_ICR_STOPCF_Pos)             /*!< 0x00000020 */
+#define I2C_ICR_STOPCF               I2C_ICR_STOPCF_Msk                        /*!< STOP detection clear flag */
+#define I2C_ICR_BERRCF_Pos           (8U)
+#define I2C_ICR_BERRCF_Msk           (0x1UL << I2C_ICR_BERRCF_Pos)             /*!< 0x00000100 */
+#define I2C_ICR_BERRCF               I2C_ICR_BERRCF_Msk                        /*!< Bus error clear flag */
+#define I2C_ICR_ARLOCF_Pos           (9U)
+#define I2C_ICR_ARLOCF_Msk           (0x1UL << I2C_ICR_ARLOCF_Pos)             /*!< 0x00000200 */
+#define I2C_ICR_ARLOCF               I2C_ICR_ARLOCF_Msk                        /*!< Arbitration lost clear flag */
+#define I2C_ICR_OVRCF_Pos            (10U)
+#define I2C_ICR_OVRCF_Msk            (0x1UL << I2C_ICR_OVRCF_Pos)              /*!< 0x00000400 */
+#define I2C_ICR_OVRCF                I2C_ICR_OVRCF_Msk                         /*!< Overrun/Underrun clear flag */
+#define I2C_ICR_PECCF_Pos            (11U)
+#define I2C_ICR_PECCF_Msk            (0x1UL << I2C_ICR_PECCF_Pos)              /*!< 0x00000800 */
+#define I2C_ICR_PECCF                I2C_ICR_PECCF_Msk                         /*!< PAC error clear flag */
+#define I2C_ICR_TIMOUTCF_Pos         (12U)
+#define I2C_ICR_TIMOUTCF_Msk         (0x1UL << I2C_ICR_TIMOUTCF_Pos)           /*!< 0x00001000 */
+#define I2C_ICR_TIMOUTCF             I2C_ICR_TIMOUTCF_Msk                      /*!< Timeout clear flag */
+#define I2C_ICR_ALERTCF_Pos          (13U)
+#define I2C_ICR_ALERTCF_Msk          (0x1UL << I2C_ICR_ALERTCF_Pos)            /*!< 0x00002000 */
+#define I2C_ICR_ALERTCF              I2C_ICR_ALERTCF_Msk                       /*!< Alert clear flag */
+
+/******************  Bit definition for I2C_PECR register  *********************/
+#define I2C_PECR_PEC_Pos             (0U)
+#define I2C_PECR_PEC_Msk             (0xFFUL << I2C_PECR_PEC_Pos)              /*!< 0x000000FF */
+#define I2C_PECR_PEC                 I2C_PECR_PEC_Msk                          /*!< PEC register */
+
+/******************  Bit definition for I2C_RXDR register  *********************/
+#define I2C_RXDR_RXDATA_Pos          (0U)
+#define I2C_RXDR_RXDATA_Msk          (0xFFUL << I2C_RXDR_RXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_RXDR_RXDATA              I2C_RXDR_RXDATA_Msk                       /*!< 8-bit receive data */
+
+/******************  Bit definition for I2C_TXDR register  *********************/
+#define I2C_TXDR_TXDATA_Pos          (0U)
+#define I2C_TXDR_TXDATA_Msk          (0xFFUL << I2C_TXDR_TXDATA_Pos)           /*!< 0x000000FF */
+#define I2C_TXDR_TXDATA              I2C_TXDR_TXDATA_Msk                       /*!< 8-bit transmit data */
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Independent WATCHDOG (IWDG)                         */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_KR_KEY_Pos      (0U)
+#define IWDG_KR_KEY_Msk      (0xFFFFUL << IWDG_KR_KEY_Pos)                     /*!< 0x0000FFFF */
+#define IWDG_KR_KEY          IWDG_KR_KEY_Msk                                   /*!<Key value (write only, read 0000h)  */
+
+/*******************  Bit definition for IWDG_PR register  ********************/
+#define IWDG_PR_PR_Pos       (0U)
+#define IWDG_PR_PR_Msk       (0x7UL << IWDG_PR_PR_Pos)                         /*!< 0x00000007 */
+#define IWDG_PR_PR           IWDG_PR_PR_Msk                                    /*!<PR[2:0] (Prescaler divider)         */
+#define IWDG_PR_PR_0         (0x1U << IWDG_PR_PR_Pos)                          /*!< 0x00000001 */
+#define IWDG_PR_PR_1         (0x2U << IWDG_PR_PR_Pos)                          /*!< 0x00000002 */
+#define IWDG_PR_PR_2         (0x4U << IWDG_PR_PR_Pos)                          /*!< 0x00000004 */
+
+/*******************  Bit definition for IWDG_RLR register  *******************/
+#define IWDG_RLR_RL_Pos      (0U)
+#define IWDG_RLR_RL_Msk      (0xFFFUL << IWDG_RLR_RL_Pos)                      /*!< 0x00000FFF */
+#define IWDG_RLR_RL          IWDG_RLR_RL_Msk                                   /*!<Watchdog counter reload value        */
+
+/*******************  Bit definition for IWDG_SR register  ********************/
+#define IWDG_SR_PVU_Pos      (0U)
+#define IWDG_SR_PVU_Msk      (0x1UL << IWDG_SR_PVU_Pos)                        /*!< 0x00000001 */
+#define IWDG_SR_PVU          IWDG_SR_PVU_Msk                                   /*!< Watchdog prescaler value update */
+#define IWDG_SR_RVU_Pos      (1U)
+#define IWDG_SR_RVU_Msk      (0x1UL << IWDG_SR_RVU_Pos)                        /*!< 0x00000002 */
+#define IWDG_SR_RVU          IWDG_SR_RVU_Msk                                   /*!< Watchdog counter reload value update */
+#define IWDG_SR_WVU_Pos      (2U)
+#define IWDG_SR_WVU_Msk      (0x1UL << IWDG_SR_WVU_Pos)                        /*!< 0x00000004 */
+#define IWDG_SR_WVU          IWDG_SR_WVU_Msk                                   /*!< Watchdog counter window value update */
+
+/*******************  Bit definition for IWDG_KR register  ********************/
+#define IWDG_WINR_WIN_Pos    (0U)
+#define IWDG_WINR_WIN_Msk    (0xFFFUL << IWDG_WINR_WIN_Pos)                    /*!< 0x00000FFF */
+#define IWDG_WINR_WIN        IWDG_WINR_WIN_Msk                                 /*!< Watchdog counter window value */
+
+/******************************************************************************/
+/*                                                                            */
+/*                               Power Control                                */
+/*                                                                            */
+/******************************************************************************/
+
+/********************  Bit definition for PWR_CR1 register  ********************/
+#define PWR_CR1_LPMS_Pos               (0U)
+#define PWR_CR1_LPMS_Msk               (0x7UL << PWR_CR1_LPMS_Pos)             /*!< 0x00000007 */
+#define PWR_CR1_LPMS                   PWR_CR1_LPMS_Msk                        /*!< Low Power Mode Selection for CPU1 */
+#define PWR_CR1_LPMS_0                 (0x1U << PWR_CR1_LPMS_Pos)              /*!< 0x00000001 */
+#define PWR_CR1_LPMS_1                 (0x2U << PWR_CR1_LPMS_Pos)              /*!< 0x00000002 */
+#define PWR_CR1_LPMS_2                 (0x4U << PWR_CR1_LPMS_Pos)              /*!< 0x00000004 */
+
+#define PWR_CR1_FPDR_Pos               (4U)
+#define PWR_CR1_FPDR_Msk               (0x1UL << PWR_CR1_FPDR_Pos)             /*!< 0x00000010 */
+#define PWR_CR1_FPDR                   PWR_CR1_FPDR_Msk                        /*!< Flash power down mode during LPrun for CPU1 */
+
+#define PWR_CR1_FPDS_Pos               (5U)
+#define PWR_CR1_FPDS_Msk               (0x1UL << PWR_CR1_FPDS_Pos)             /*!< 0x00000020 */
+#define PWR_CR1_FPDS                   PWR_CR1_FPDS_Msk                        /*!< Flash power down mode during LPsleep for CPU1 */
+
+#define PWR_CR1_DBP_Pos                (8U)
+#define PWR_CR1_DBP_Msk                (0x1UL << PWR_CR1_DBP_Pos)              /*!< 0x00000100 */
+#define PWR_CR1_DBP                    PWR_CR1_DBP_Msk                         /*!< Disable Backup Domain write protection */
+
+#define PWR_CR1_LPR_Pos                (14U)
+#define PWR_CR1_LPR_Msk                (0x1UL << PWR_CR1_LPR_Pos)              /*!< 0x00004000 */
+#define PWR_CR1_LPR                    PWR_CR1_LPR_Msk                         /*!< Regulator Low-Power Run mode */
+
+/********************  Bit definition for PWR_CR2 register  ********************/
+#define PWR_CR2_PVDE_Pos               (0U)
+#define PWR_CR2_PVDE_Msk               (0x1UL << PWR_CR2_PVDE_Pos)             /*!< 0x00000001 */
+#define PWR_CR2_PVDE                   PWR_CR2_PVDE_Msk                        /*!< Power voltage detector enable */
+
+#define PWR_CR2_PLS_Pos                (1U)
+#define PWR_CR2_PLS_Msk                (0x7UL << PWR_CR2_PLS_Pos)              /*!< 0x0000000E */
+#define PWR_CR2_PLS                    PWR_CR2_PLS_Msk                         /*!< Power voltage detector level selection */
+#define PWR_CR2_PLS_0                  (0x1U << PWR_CR2_PLS_Pos)               /*!< 0x00000002 */
+#define PWR_CR2_PLS_1                  (0x2U << PWR_CR2_PLS_Pos)               /*!< 0x00000004 */
+#define PWR_CR2_PLS_2                  (0x4U << PWR_CR2_PLS_Pos)               /*!< 0x00000008 */
+
+#define PWR_CR2_PVME_Pos               (4U)
+#define PWR_CR2_PVME_Msk               (0x4UL << PWR_CR2_PVME_Pos)             /*!< 0x00000040 */
+#define PWR_CR2_PVME                   PWR_CR2_PVME_Msk                        /*!< Peripherical Voltage Monitor Enable for all power domains */
+#define PWR_CR2_PVME3_Pos              (6U)
+#define PWR_CR2_PVME3_Msk              (0x1UL << PWR_CR2_PVME3_Pos)            /*!< 0x00000040 */
+#define PWR_CR2_PVME3                  PWR_CR2_PVME3_Msk                       /*!< Peripherical Voltage Monitor Vdda Enable */
+
+/********************  Bit definition for PWR_CR3 register  ********************/
+#define PWR_CR3_EWUP_Pos               (0U)
+#define PWR_CR3_EWUP_Msk               (0x09UL << PWR_CR3_EWUP_Pos)            /*!< 0x00000009 */
+#define PWR_CR3_EWUP                   PWR_CR3_EWUP_Msk                        /*!< Enable all external Wake-Up lines  */
+#define PWR_CR3_EWUP1_Pos              (0U)
+#define PWR_CR3_EWUP1_Msk              (0x1UL << PWR_CR3_EWUP1_Pos)            /*!< 0x00000001 */
+#define PWR_CR3_EWUP1                  PWR_CR3_EWUP1_Msk                       /*!< Enable external WKUP Pin 1 [line 0] */
+#define PWR_CR3_EWUP4_Pos              (3U)
+#define PWR_CR3_EWUP4_Msk              (0x1UL << PWR_CR3_EWUP4_Pos)            /*!< 0x00000008 */
+#define PWR_CR3_EWUP4                  PWR_CR3_EWUP4_Msk                       /*!< Enable external WKUP Pin 4 [line 3] */
+
+#define PWR_CR3_EBORHSMPSFB_Pos        (8U)
+#define PWR_CR3_EBORHSMPSFB_Msk        (0x1UL << PWR_CR3_EBORHSMPSFB_Pos)      /*!< 0x00000100 */
+#define PWR_CR3_EBORHSMPSFB            PWR_CR3_EBORHSMPSFB_Msk                 /*!< BORH and SMPS Step Down converter forced in Bypass interrupts for CPU1 */
+
+#define PWR_CR3_RRS_Pos                (9U)
+#define PWR_CR3_RRS_Msk                (0x1UL << PWR_CR3_RRS_Pos)              /*!< 0x00000200 */
+#define PWR_CR3_RRS                    PWR_CR3_RRS_Msk                         /*!< SRAM2 retention in STANDBY mode */
+
+#define PWR_CR3_APC_Pos                (10U)
+#define PWR_CR3_APC_Msk                (0x1UL << PWR_CR3_APC_Pos)              /*!< 0x00000400 */
+#define PWR_CR3_APC                    PWR_CR3_APC_Msk                         /*!< Apply pull-up and pull-down configuration for CPU1 */
+
+#define PWR_CR3_ECRPE_Pos              (11U)
+#define PWR_CR3_ECRPE_Msk              (0x1UL << PWR_CR3_ECRPE_Pos)            /*!< 0x00000800 */
+#define PWR_CR3_ECRPE                  PWR_CR3_ECRPE_Msk                       /*!< Critical radio phase end of activity interrupt for CPU1 */
+#define PWR_CR3_EBLEA_Pos              (12U)
+#define PWR_CR3_EBLEA_Msk              (0x1UL << PWR_CR3_EBLEA_Pos)            /*!< 0x00010000 */
+#define PWR_CR3_EBLEA                  PWR_CR3_EBLEA_Msk                       /*!< BLE end of activity interrupt for CPU1 */
+#define PWR_CR3_EC2H_Pos               (14U)
+#define PWR_CR3_EC2H_Msk               (0x1UL << PWR_CR3_EC2H_Pos)             /*!< 0x00040000 */
+#define PWR_CR3_EC2H                    PWR_CR3_EC2H_Msk                       /*!< CPU2 Hold interrupt for CPU1 */
+
+#define PWR_CR3_EIWUL_Pos              (15U)
+#define PWR_CR3_EIWUL_Msk              (0x1UL << PWR_CR3_EIWUL_Pos)            /*!< 0x00080000 */
+#define PWR_CR3_EIWUL                  PWR_CR3_EIWUL_Msk                       /*!< Internal Wake-Up line interrupt for CPU1 */
+
+/********************  Bit definition for PWR_CR4 register  ********************/
+#define PWR_CR4_WP_Pos                 (0U)
+#define PWR_CR4_WP_Msk                 (0x09UL << PWR_CR4_WP_Pos)              /*!< 0x00000009 */
+#define PWR_CR4_WP                     PWR_CR4_WP_Msk                          /*!< Wake-Up polarity for all pins */
+#define PWR_CR4_WP1_Pos                (0U)
+#define PWR_CR4_WP1_Msk                (0x1UL << PWR_CR4_WP1_Pos)              /*!< 0x00000001 */
+#define PWR_CR4_WP1                    PWR_CR4_WP1_Msk                         /*!< Wake-Up Pin 1 [line 0] polarity */
+#define PWR_CR4_WP4_Pos                (3U)
+#define PWR_CR4_WP4_Msk                (0x1UL << PWR_CR4_WP4_Pos)              /*!< 0x00000008 */
+#define PWR_CR4_WP4                    PWR_CR4_WP4_Msk                         /*!< Wake-Up Pin 4 [line 3] polarity */
+
+#define PWR_CR4_VBE_Pos                (8U)
+#define PWR_CR4_VBE_Msk                (0x1UL << PWR_CR4_VBE_Pos)              /*!< 0x00000100 */
+#define PWR_CR4_VBE                    PWR_CR4_VBE_Msk                         /*!< VBAT battery charging enable  */
+#define PWR_CR4_VBRS_Pos               (9U)
+#define PWR_CR4_VBRS_Msk               (0x1UL << PWR_CR4_VBRS_Pos)             /*!< 0x00000200 */
+#define PWR_CR4_VBRS                   PWR_CR4_VBRS_Msk                        /*!< VBAT battery charging resistor selection */
+
+#define PWR_CR4_C2BOOT_Pos             (15U)
+#define PWR_CR4_C2BOOT_Msk             (0x1UL << PWR_CR4_C2BOOT_Pos)           /*!< 0x00008000 */
+#define PWR_CR4_C2BOOT                 PWR_CR4_C2BOOT_Msk                      /*!< Boot CPU2 after reset or wakeup from Stop or Standby modes */
+
+/********************  Bit definition for PWR_SR1 register  ********************/
+#define PWR_SR1_WUF_Pos                (0U)
+#define PWR_SR1_WUF_Msk                (0x09UL << PWR_SR1_WUF_Pos)             /*!< 0x00000009 */
+#define PWR_SR1_WUF                    PWR_SR1_WUF_Msk                         /*!< Wakeup Flags of all pins */
+#define PWR_SR1_WUF1_Pos               (0U)
+#define PWR_SR1_WUF1_Msk               (0x1UL << PWR_SR1_WUF1_Pos)             /*!< 0x00000001 */
+#define PWR_SR1_WUF1                   PWR_SR1_WUF1_Msk                        /*!< Wakeup Pin 1 [Flag 0] */
+#define PWR_SR1_WUF4_Pos               (3U)
+#define PWR_SR1_WUF4_Msk               (0x1UL << PWR_SR1_WUF4_Pos)             /*!< 0x00000008 */
+#define PWR_SR1_WUF4                   PWR_SR1_WUF4_Msk                        /*!< Wakeup Pin 4 [Flag 3] */
+
+#define PWR_SR1_SMPSFBF_Pos            (7U)
+#define PWR_SR1_SMPSFBF_Msk            (0x1UL << PWR_SR1_SMPSFBF_Pos)          /*!< 0x00000100 */
+#define PWR_SR1_SMPSFBF                PWR_SR1_SMPSFBF_Msk                     /*!< SMPS Step Down converter forced in bypass mode interrupt flag */
+
+#define PWR_SR1_BORHF_Pos              (8U)
+#define PWR_SR1_BORHF_Msk              (0x1UL << PWR_SR1_BORHF_Pos)            /*!< 0x00000100 */
+#define PWR_SR1_BORHF                  PWR_SR1_BORHF_Msk                       /*!< BORH interrupt flag */
+
+#define PWR_SR1_BLEWUF_Pos             (9U)
+#define PWR_SR1_BLEWUF_Msk             (0x1UL << PWR_SR1_BLEWUF_Pos)           /*!< 0x00000200 */
+#define PWR_SR1_BLEWUF                 PWR_SR1_BLEWUF_Msk                      /*!< BLE wakeup interrupt flag */
+
+#define PWR_SR1_CRPEF_Pos              (11U)
+#define PWR_SR1_CRPEF_Msk              (0x1UL << PWR_SR1_CRPEF_Pos)            /*!< 0x00000800 */
+#define PWR_SR1_CRPEF                  PWR_SR1_CRPEF_Msk                       /*!< Critical radio phase end of activity interrupt flag */
+#define PWR_SR1_BLEAF_Pos              (12U)
+#define PWR_SR1_BLEAF_Msk              (0x1UL << PWR_SR1_BLEAF_Pos)            /*!< 0x00001000 */
+#define PWR_SR1_BLEAF                  PWR_SR1_BLEAF_Msk                       /*!< BLE end of activity interrupt flag */
+
+#define PWR_SR1_C2HF_Pos               (14U)
+#define PWR_SR1_C2HF_Msk               (0x1UL << PWR_SR1_C2HF_Pos)             /*!< 0x00004000 */
+#define PWR_SR1_C2HF                   PWR_SR1_C2HF_Msk                        /*!< CPU2 Hold interrupt flag */
+
+#define PWR_SR1_WUFI_Pos               (15U)
+#define PWR_SR1_WUFI_Msk               (0x1UL << PWR_SR1_WUFI_Pos)             /*!< 0x00008000 */
+#define PWR_SR1_WUFI                   PWR_SR1_WUFI_Msk                        /*!< Internal wakeup interrupt flag */
+
+/********************  Bit definition for PWR_SR2 register  ********************/
+#define PWR_SR2_SMPSBF_Pos             (0U)
+#define PWR_SR2_SMPSBF_Msk             (0x1UL << PWR_SR2_SMPSBF_Pos)           /*!< 0x00000001 */
+#define PWR_SR2_SMPSBF                 PWR_SR2_SMPSBF_Msk                      /*!< SMPS step down converter in operating mode bypass flag */
+#define PWR_SR2_SMPSF_Pos              (1U)
+#define PWR_SR2_SMPSF_Msk              (0x1UL << PWR_SR2_SMPSF_Pos)            /*!< 0x00000002 */
+#define PWR_SR2_SMPSF                  PWR_SR2_SMPSF_Msk                       /*!< SMPS step down converter in operating mode step down flag */
+
+#define PWR_SR2_REGLPS_Pos             (8U)
+#define PWR_SR2_REGLPS_Msk             (0x1UL << PWR_SR2_REGLPS_Pos)           /*!< 0x00000100 */
+#define PWR_SR2_REGLPS                 PWR_SR2_REGLPS_Msk                      /*!< Low-power regulator started */
+#define PWR_SR2_REGLPF_Pos             (9U)
+#define PWR_SR2_REGLPF_Msk             (0x1UL << PWR_SR2_REGLPF_Pos)           /*!< 0x00000200 */
+#define PWR_SR2_REGLPF                 PWR_SR2_REGLPF_Msk                      /*!< Low-power regulator flag */
+
+#define PWR_SR2_PVDO_Pos               (11U)
+#define PWR_SR2_PVDO_Msk               (0x1UL << PWR_SR2_PVDO_Pos)             /*!< 0x00000800 */
+#define PWR_SR2_PVDO                   PWR_SR2_PVDO_Msk                        /*!< Power voltage detector output */
+
+#define PWR_SR2_PVMO3_Pos              (14U)
+#define PWR_SR2_PVMO3_Msk              (0x1UL << PWR_SR2_PVMO3_Pos)            /*!< 0x00004000 */
+#define PWR_SR2_PVMO3                  PWR_SR2_PVMO3_Msk                       /*!< Peripheral voltage monitor output 3: VDDA vs. 1.62V */
+
+/********************  Bit definition for PWR_SCR register  ********************/
+#define PWR_SCR_CWUF_Pos               (0U)
+#define PWR_SCR_CWUF_Msk               (0x09UL << PWR_SCR_CWUF_Pos)            /*!< 0x00000009 */
+#define PWR_SCR_CWUF                   PWR_SCR_CWUF_Msk                        /*!< Clear Wake-up Flags for all pins */
+#define PWR_SCR_CWUF1_Pos              (0U)
+#define PWR_SCR_CWUF1_Msk              (0x1UL << PWR_SCR_CWUF1_Pos)            /*!< 0x00000001 */
+#define PWR_SCR_CWUF1                  PWR_SCR_CWUF1_Msk                       /*!< Clear Wake-up Pin 1 [Flag 0] */
+#define PWR_SCR_CWUF4_Pos              (3U)
+#define PWR_SCR_CWUF4_Msk              (0x1UL << PWR_SCR_CWUF4_Pos)            /*!< 0x00000008 */
+#define PWR_SCR_CWUF4                  PWR_SCR_CWUF4_Msk                       /*!< Clear Wake-up Pin 4 [Flag 3] */
+
+#define PWR_SCR_CSMPSFBF_Pos           (7U)
+#define PWR_SCR_CSMPSFBF_Msk           (0x1UL << PWR_SCR_CSMPSFBF_Pos)         /*!< 0x00000080 */
+#define PWR_SCR_CSMPSFBF               PWR_SCR_CSMPSFBF_Msk                    /*!< Clear SMPS Step Down converter forced in bypass mode interrupt flag  */
+
+#define PWR_SCR_CBORHF_Pos             (8U)
+#define PWR_SCR_CBORHF_Msk             (0x1UL << PWR_SCR_CBORHF_Pos)           /*!< 0x00000100 */
+#define PWR_SCR_CBORHF                 PWR_SCR_CBORHF_Msk                      /*!< Clear BORH interrupt flag  */
+
+#define PWR_SCR_CBLEWUF_Pos            (9U)
+#define PWR_SCR_CBLEWUF_Msk            (0x1UL << PWR_SCR_CBLEWUF_Pos)          /*!< 0x00000200 */
+#define PWR_SCR_CBLEWUF                PWR_SCR_CBLEWUF_Msk                     /*!< Clear BLE wakeup interrupt flag */
+
+#define PWR_SCR_CCRPEF_Pos             (11U)
+#define PWR_SCR_CCRPEF_Msk             (0x1UL << PWR_SCR_CCRPEF_Pos)           /*!< 0x00000800 */
+#define PWR_SCR_CCRPEF                 PWR_SCR_CCRPEF_Msk                      /*!< Clear Critical radio phase end of activity interrupt flag */
+#define PWR_SCR_CBLEAF_Pos             (12U)
+#define PWR_SCR_CBLEAF_Msk             (0x1UL << PWR_SCR_CBLEAF_Pos)           /*!< 0x00001000 */
+#define PWR_SCR_CBLEAF                 PWR_SCR_CBLEAF_Msk                      /*!< Clear BLE end of activity interrupt flag */
+
+#define PWR_SCR_CC2HF_Pos              (14U)
+#define PWR_SCR_CC2HF_Msk              (0x1UL << PWR_SCR_CC2HF_Pos)            /*!< 0x00004000 */
+#define PWR_SCR_CC2HF                  PWR_SCR_CC2HF_Msk                       /*!< Clear CPU2 Hold interrupt flag */
+
+/********************  Bit definition for PWR_CR5 register  ********************/
+#define PWR_CR5_SMPSVOS_Pos            (0U)
+#define PWR_CR5_SMPSVOS_Msk            (0xFUL << PWR_CR5_SMPSVOS_Pos)          /*!< 0x0000000F */
+#define PWR_CR5_SMPSVOS                PWR_CR5_SMPSVOS_Msk                     /*!< SMPS step down converter voltage output scaling voltage level */
+#define PWR_CR5_SMPSVOS_0              (0x01U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000001 */
+#define PWR_CR5_SMPSVOS_1              (0x02U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000002 */
+#define PWR_CR5_SMPSVOS_2              (0x04U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000004 */
+#define PWR_CR5_SMPSVOS_3              (0x08U << PWR_CR5_SMPSVOS_Pos)          /*!< 0x00000008 */
+
+#define PWR_CR5_SMPSSC_Pos             (4U)
+#define PWR_CR5_SMPSSC_Msk             (0x7UL << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000070 */
+#define PWR_CR5_SMPSSC                 PWR_CR5_SMPSSC_Msk                      /*!< SMPS step down converter supply startup current selection */
+#define PWR_CR5_SMPSSC_0               (0x01U << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000010 */
+#define PWR_CR5_SMPSSC_1               (0x02U << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000020 */
+#define PWR_CR5_SMPSSC_2               (0x04U << PWR_CR5_SMPSSC_Pos)           /*!< 0x00000040 */
+
+#define PWR_CR5_BORHC_Pos              (8U)
+#define PWR_CR5_BORHC_Msk              (0x1UL << PWR_CR5_BORHC_Pos)            /*!< 0x00000100 */
+#define PWR_CR5_BORHC                  PWR_CR5_BORHC_Msk                       /*!< BORH configuration selection */
+
+#define PWR_CR5_SMPSEN_Pos             (15U)
+#define PWR_CR5_SMPSEN_Msk             (0x1UL << PWR_CR5_SMPSEN_Pos)           /*!< 0x00008000 */
+#define PWR_CR5_SMPSEN                 PWR_CR5_SMPSEN_Msk                      /*!< Enable SMPS Step Down converter SMPS mode enable */
+
+/********************  Bit definition for PWR_PUCRA register  *****************/
+#define PWR_PUCRA_PA0_Pos              (0U)
+#define PWR_PUCRA_PA0_Msk              (0x1UL << PWR_PUCRA_PA0_Pos)            /*!< 0x00000001 */
+#define PWR_PUCRA_PA0                  PWR_PUCRA_PA0_Msk                       /*!< Pin PA0 Pull-Up set */
+#define PWR_PUCRA_PA1_Pos              (1U)
+#define PWR_PUCRA_PA1_Msk              (0x1UL << PWR_PUCRA_PA1_Pos)            /*!< 0x00000002 */
+#define PWR_PUCRA_PA1                  PWR_PUCRA_PA1_Msk                       /*!< Pin PA1 Pull-Up set */
+#define PWR_PUCRA_PA2_Pos              (2U)
+#define PWR_PUCRA_PA2_Msk              (0x1UL << PWR_PUCRA_PA2_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRA_PA2                  PWR_PUCRA_PA2_Msk                       /*!< Pin PA2 Pull-Up set */
+#define PWR_PUCRA_PA3_Pos              (3U)
+#define PWR_PUCRA_PA3_Msk              (0x1UL << PWR_PUCRA_PA3_Pos)            /*!< 0x00000008 */
+#define PWR_PUCRA_PA3                  PWR_PUCRA_PA3_Msk                       /*!< Pin PA3 Pull-Up set */
+#define PWR_PUCRA_PA4_Pos              (4U)
+#define PWR_PUCRA_PA4_Msk              (0x1UL << PWR_PUCRA_PA4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRA_PA4                  PWR_PUCRA_PA4_Msk                       /*!< Pin PA4 Pull-Up set */
+#define PWR_PUCRA_PA5_Pos              (5U)
+#define PWR_PUCRA_PA5_Msk              (0x1UL << PWR_PUCRA_PA5_Pos)            /*!< 0x00000020 */
+#define PWR_PUCRA_PA5                  PWR_PUCRA_PA5_Msk                       /*!< Pin PA5 Pull-Up set */
+#define PWR_PUCRA_PA6_Pos              (6U)
+#define PWR_PUCRA_PA6_Msk              (0x1UL << PWR_PUCRA_PA6_Pos)            /*!< 0x00000040 */
+#define PWR_PUCRA_PA6                  PWR_PUCRA_PA6_Msk                       /*!< Pin PA6 Pull-Up set */
+#define PWR_PUCRA_PA7_Pos              (7U)
+#define PWR_PUCRA_PA7_Msk              (0x1UL << PWR_PUCRA_PA7_Pos)            /*!< 0x00000080 */
+#define PWR_PUCRA_PA7                  PWR_PUCRA_PA7_Msk                       /*!< Pin PA7 Pull-Up set */
+#define PWR_PUCRA_PA8_Pos              (8U)
+#define PWR_PUCRA_PA8_Msk              (0x1UL << PWR_PUCRA_PA8_Pos)            /*!< 0x00000100 */
+#define PWR_PUCRA_PA8                  PWR_PUCRA_PA8_Msk                       /*!< Pin PA8 Pull-Up set */
+#define PWR_PUCRA_PA9_Pos              (9U)
+#define PWR_PUCRA_PA9_Msk              (0x1UL << PWR_PUCRA_PA9_Pos)            /*!< 0x00000200 */
+#define PWR_PUCRA_PA9                  PWR_PUCRA_PA9_Msk                       /*!< Pin PA9 Pull-Up set */
+#define PWR_PUCRA_PA10_Pos             (10U)
+#define PWR_PUCRA_PA10_Msk             (0x1UL << PWR_PUCRA_PA10_Pos)           /*!< 0x00000400 */
+#define PWR_PUCRA_PA10                 PWR_PUCRA_PA10_Msk                      /*!< Pin PA10 Pull-Up set */
+#define PWR_PUCRA_PA11_Pos             (11U)
+#define PWR_PUCRA_PA11_Msk             (0x1UL << PWR_PUCRA_PA11_Pos)           /*!< 0x00000800 */
+#define PWR_PUCRA_PA11                 PWR_PUCRA_PA11_Msk                      /*!< Pin PA11 Pull-Up set */
+#define PWR_PUCRA_PA12_Pos             (12U)
+#define PWR_PUCRA_PA12_Msk             (0x1UL << PWR_PUCRA_PA12_Pos)           /*!< 0x00001000 */
+#define PWR_PUCRA_PA12                 PWR_PUCRA_PA12_Msk                      /*!< Pin PA12 Pull-Up set */
+#define PWR_PUCRA_PA13_Pos             (13U)
+#define PWR_PUCRA_PA13_Msk             (0x1UL << PWR_PUCRA_PA13_Pos)           /*!< 0x00002000 */
+#define PWR_PUCRA_PA13                 PWR_PUCRA_PA13_Msk                      /*!< Pin PA13 Pull-Up set */
+#define PWR_PUCRA_PA15_Pos             (15U)
+#define PWR_PUCRA_PA15_Msk             (0x1UL << PWR_PUCRA_PA15_Pos)           /*!< 0x00008000 */
+#define PWR_PUCRA_PA15                 PWR_PUCRA_PA15_Msk                      /*!< Pin PA15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRA register  *****************/
+#define PWR_PDCRA_PA0_Pos              (0U)
+#define PWR_PDCRA_PA0_Msk              (0x1UL << PWR_PDCRA_PA0_Pos)            /*!< 0x00000001 */
+#define PWR_PDCRA_PA0                  PWR_PDCRA_PA0_Msk                       /*!< Pin PA0 Pull-Down set */
+#define PWR_PDCRA_PA1_Pos              (1U)
+#define PWR_PDCRA_PA1_Msk              (0x1UL << PWR_PDCRA_PA1_Pos)            /*!< 0x00000002 */
+#define PWR_PDCRA_PA1                  PWR_PDCRA_PA1_Msk                       /*!< Pin PA1 Pull-Down set */
+#define PWR_PDCRA_PA2_Pos              (2U)
+#define PWR_PDCRA_PA2_Msk              (0x1UL << PWR_PDCRA_PA2_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRA_PA2                  PWR_PDCRA_PA2_Msk                       /*!< Pin PA2 Pull-Down set */
+#define PWR_PDCRA_PA3_Pos              (3U)
+#define PWR_PDCRA_PA3_Msk              (0x1UL << PWR_PDCRA_PA3_Pos)            /*!< 0x00000008 */
+#define PWR_PDCRA_PA3                  PWR_PDCRA_PA3_Msk                       /*!< Pin PA3 Pull-Down set */
+#define PWR_PDCRA_PA4_Pos              (4U)
+#define PWR_PDCRA_PA4_Msk              (0x1UL << PWR_PDCRA_PA4_Pos)            /*!< 0x00000010 */
+#define PWR_PDCRA_PA4                  PWR_PDCRA_PA4_Msk                       /*!< Pin PA4 Pull-Down set */
+#define PWR_PDCRA_PA5_Pos              (5U)
+#define PWR_PDCRA_PA5_Msk              (0x1UL << PWR_PDCRA_PA5_Pos)            /*!< 0x00000020 */
+#define PWR_PDCRA_PA5                  PWR_PDCRA_PA5_Msk                       /*!< Pin PA5 Pull-Down set */
+#define PWR_PDCRA_PA6_Pos              (6U)
+#define PWR_PDCRA_PA6_Msk              (0x1UL << PWR_PDCRA_PA6_Pos)            /*!< 0x00000040 */
+#define PWR_PDCRA_PA6                  PWR_PDCRA_PA6_Msk                       /*!< Pin PA6 Pull-Down set */
+#define PWR_PDCRA_PA7_Pos              (7U)
+#define PWR_PDCRA_PA7_Msk              (0x1UL << PWR_PDCRA_PA7_Pos)            /*!< 0x00000080 */
+#define PWR_PDCRA_PA7                  PWR_PDCRA_PA7_Msk                       /*!< Pin PA7 Pull-Down set */
+#define PWR_PDCRA_PA8_Pos              (8U)
+#define PWR_PDCRA_PA8_Msk              (0x1UL << PWR_PDCRA_PA8_Pos)            /*!< 0x00000100 */
+#define PWR_PDCRA_PA8                  PWR_PDCRA_PA8_Msk                       /*!< Pin PA8 Pull-Down set */
+#define PWR_PDCRA_PA9_Pos              (9U)
+#define PWR_PDCRA_PA9_Msk              (0x1UL << PWR_PDCRA_PA9_Pos)            /*!< 0x00000200 */
+#define PWR_PDCRA_PA9                  PWR_PDCRA_PA9_Msk                       /*!< Pin PA9 Pull-Down set */
+#define PWR_PDCRA_PA10_Pos             (10U)
+#define PWR_PDCRA_PA10_Msk             (0x1UL << PWR_PDCRA_PA10_Pos)           /*!< 0x00000400 */
+#define PWR_PDCRA_PA10                 PWR_PDCRA_PA10_Msk                      /*!< Pin PA10 Pull-Down set */
+#define PWR_PDCRA_PA11_Pos             (11U)
+#define PWR_PDCRA_PA11_Msk             (0x1UL << PWR_PDCRA_PA11_Pos)           /*!< 0x00000800 */
+#define PWR_PDCRA_PA11                 PWR_PDCRA_PA11_Msk                      /*!< Pin PA11 Pull-Down set */
+#define PWR_PDCRA_PA12_Pos             (12U)
+#define PWR_PDCRA_PA12_Msk             (0x1UL << PWR_PDCRA_PA12_Pos)           /*!< 0x00001000 */
+#define PWR_PDCRA_PA12                 PWR_PDCRA_PA12_Msk                      /*!< Pin PA12 Pull-Down set */
+#define PWR_PDCRA_PA14_Pos             (14U)
+#define PWR_PDCRA_PA14_Msk             (0x1UL << PWR_PDCRA_PA14_Pos)           /*!< 0x00004000 */
+#define PWR_PDCRA_PA14                 PWR_PDCRA_PA14_Msk                      /*!< Pin PA14 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRB register  *****************/
+#define PWR_PUCRB_PB0_Pos              (0U)
+#define PWR_PUCRB_PB0_Msk              (0x1UL << PWR_PUCRB_PB0_Pos)            /*!< 0x00000001 */
+#define PWR_PUCRB_PB0                  PWR_PUCRB_PB0_Msk                       /*!< Pin PB0 Pull-Up set */
+#define PWR_PUCRB_PB1_Pos              (1U)
+#define PWR_PUCRB_PB1_Msk              (0x1UL << PWR_PUCRB_PB1_Pos)            /*!< 0x00000002 */
+#define PWR_PUCRB_PB1                  PWR_PUCRB_PB1_Msk                       /*!< Pin PB1 Pull-Up set */
+#define PWR_PUCRB_PB2_Pos              (2U)
+#define PWR_PUCRB_PB2_Msk              (0x1UL << PWR_PUCRB_PB2_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRB_PB2                  PWR_PUCRB_PB2_Msk                       /*!< Pin PB2 Pull-Up set */
+#define PWR_PUCRB_PB3_Pos              (3U)
+#define PWR_PUCRB_PB3_Msk              (0x1UL << PWR_PUCRB_PB3_Pos)            /*!< 0x00000008 */
+#define PWR_PUCRB_PB3                  PWR_PUCRB_PB3_Msk                       /*!< Pin PB3 Pull-Up set */
+#define PWR_PUCRB_PB4_Pos              (4U)
+#define PWR_PUCRB_PB4_Msk              (0x1UL << PWR_PUCRB_PB4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRB_PB4                  PWR_PUCRB_PB4_Msk                       /*!< Pin PB4 Pull-Up set */
+#define PWR_PUCRB_PB5_Pos              (5U)
+#define PWR_PUCRB_PB5_Msk              (0x1UL << PWR_PUCRB_PB5_Pos)            /*!< 0x00000020 */
+#define PWR_PUCRB_PB5                  PWR_PUCRB_PB5_Msk                       /*!< Pin PB5 Pull-Up set */
+#define PWR_PUCRB_PB6_Pos              (6U)
+#define PWR_PUCRB_PB6_Msk              (0x1UL << PWR_PUCRB_PB6_Pos)            /*!< 0x00000040 */
+#define PWR_PUCRB_PB6                  PWR_PUCRB_PB6_Msk                       /*!< Pin PB6 Pull-Up set */
+#define PWR_PUCRB_PB7_Pos              (7U)
+#define PWR_PUCRB_PB7_Msk              (0x1UL << PWR_PUCRB_PB7_Pos)            /*!< 0x00000080 */
+#define PWR_PUCRB_PB7                  PWR_PUCRB_PB7_Msk                       /*!< Pin PB7 Pull-Up set */
+#define PWR_PUCRB_PB8_Pos              (8U)
+#define PWR_PUCRB_PB8_Msk              (0x1UL << PWR_PUCRB_PB8_Pos)            /*!< 0x00000100 */
+#define PWR_PUCRB_PB8                  PWR_PUCRB_PB8_Msk                       /*!< Pin PB8 Pull-Up set */
+#define PWR_PUCRB_PB9_Pos              (9U)
+#define PWR_PUCRB_PB9_Msk              (0x1UL << PWR_PUCRB_PB9_Pos)            /*!< 0x00000200 */
+#define PWR_PUCRB_PB9                  PWR_PUCRB_PB9_Msk                       /*!< Pin PB9 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRB register  *****************/
+#define PWR_PDCRB_PB0_Pos              (0U)
+#define PWR_PDCRB_PB0_Msk              (0x1UL << PWR_PDCRB_PB0_Pos)            /*!< 0x00000001 */
+#define PWR_PDCRB_PB0                  PWR_PDCRB_PB0_Msk                       /*!< Pin PB0 Pull-Down set */
+#define PWR_PDCRB_PB1_Pos              (1U)
+#define PWR_PDCRB_PB1_Msk              (0x1UL << PWR_PDCRB_PB1_Pos)            /*!< 0x00000002 */
+#define PWR_PDCRB_PB1                  PWR_PDCRB_PB1_Msk                       /*!< Pin PB1 Pull-Down set */
+#define PWR_PDCRB_PB2_Pos              (2U)
+#define PWR_PDCRB_PB2_Msk              (0x1UL << PWR_PDCRB_PB2_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRB_PB2                  PWR_PDCRB_PB2_Msk                       /*!< Pin PB2 Pull-Down set */
+#define PWR_PDCRB_PB3_Pos              (3U)
+#define PWR_PDCRB_PB3_Msk              (0x1UL << PWR_PDCRB_PB3_Pos)            /*!< 0x00000008 */
+#define PWR_PDCRB_PB3                  PWR_PDCRB_PB3_Msk                       /*!< Pin PB3 Pull-Down set */
+#define PWR_PDCRB_PB5_Pos              (5U)
+#define PWR_PDCRB_PB5_Msk              (0x1UL << PWR_PDCRB_PB5_Pos)            /*!< 0x00000020 */
+#define PWR_PDCRB_PB5                  PWR_PDCRB_PB5_Msk                       /*!< Pin PB5 Pull-Down set */
+#define PWR_PDCRB_PB6_Pos              (6U)
+#define PWR_PDCRB_PB6_Msk              (0x1UL << PWR_PDCRB_PB6_Pos)            /*!< 0x00000040 */
+#define PWR_PDCRB_PB6                  PWR_PDCRB_PB6_Msk                       /*!< Pin PB6 Pull-Down set */
+#define PWR_PDCRB_PB7_Pos              (7U)
+#define PWR_PDCRB_PB7_Msk              (0x1UL << PWR_PDCRB_PB7_Pos)            /*!< 0x00000080 */
+#define PWR_PDCRB_PB7                  PWR_PDCRB_PB7_Msk                       /*!< Pin PB7 Pull-Down set */
+#define PWR_PDCRB_PB8_Pos              (8U)
+#define PWR_PDCRB_PB8_Msk              (0x1UL << PWR_PDCRB_PB8_Pos)            /*!< 0x00000100 */
+#define PWR_PDCRB_PB8                  PWR_PDCRB_PB8_Msk                       /*!< Pin PB8 Pull-Down set */
+#define PWR_PDCRB_PB9_Pos              (9U)
+#define PWR_PDCRB_PB9_Msk              (0x1UL << PWR_PDCRB_PB9_Pos)            /*!< 0x00000200 */
+#define PWR_PDCRB_PB9                  PWR_PDCRB_PB9_Msk                       /*!< Pin PB9 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRC register  *****************/
+#define PWR_PUCRC_PC14_Pos             (14U)
+#define PWR_PUCRC_PC14_Msk             (0x1UL << PWR_PUCRC_PC14_Pos)           /*!< 0x00004000 */
+#define PWR_PUCRC_PC14                 PWR_PUCRC_PC14_Msk                      /*!< Pin PC14 Pull-Up set */
+#define PWR_PUCRC_PC15_Pos             (15U)
+#define PWR_PUCRC_PC15_Msk             (0x1UL << PWR_PUCRC_PC15_Pos)           /*!< 0x00008000 */
+#define PWR_PUCRC_PC15                 PWR_PUCRC_PC15_Msk                      /*!< Pin PC15 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRC register  *****************/
+#define PWR_PDCRC_PC14_Pos             (14U)
+#define PWR_PDCRC_PC14_Msk             (0x1UL << PWR_PDCRC_PC14_Pos)           /*!< 0x00004000 */
+#define PWR_PDCRC_PC14                 PWR_PDCRC_PC14_Msk                      /*!< Pin PC14 Pull-Down set */
+#define PWR_PDCRC_PC15_Pos             (15U)
+#define PWR_PDCRC_PC15_Msk             (0x1UL << PWR_PDCRC_PC15_Pos)           /*!< 0x00008000 */
+#define PWR_PDCRC_PC15                 PWR_PDCRC_PC15_Msk                      /*!< Pin PC15 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRE register  *****************/
+#define PWR_PUCRE_PE4_Pos              (4U)
+#define PWR_PUCRE_PE4_Msk              (0x1UL << PWR_PUCRE_PE4_Pos)            /*!< 0x00000010 */
+#define PWR_PUCRE_PE4                  PWR_PUCRE_PE4_Msk                       /*!< Pin PE4 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRE register  *****************/
+#define PWR_PDCRE_PE4_Pos              (4U)
+#define PWR_PDCRE_PE4_Msk              (0x1UL << PWR_PDCRE_PE4_Pos)            /*!< 0x00000010 */
+#define PWR_PDCRE_PE4                  PWR_PDCRE_PE4_Msk                       /*!< Pin PE4 Pull-Down set */
+
+/********************  Bit definition for PWR_PUCRH register  *****************/
+#define PWR_PUCRH_PH3_Pos              (3U)
+#define PWR_PUCRH_PH3_Msk              (0x1UL << PWR_PUCRH_PH3_Pos)            /*!< 0x00000004 */
+#define PWR_PUCRH_PH3                  PWR_PUCRH_PH3_Msk                       /*!< Pin PH3 Pull-Up set */
+
+/********************  Bit definition for PWR_PDCRH register  *****************/
+#define PWR_PDCRH_PH3_Pos              (3U)
+#define PWR_PDCRH_PH3_Msk              (0x1UL << PWR_PDCRH_PH3_Pos)            /*!< 0x00000004 */
+#define PWR_PDCRH_PH3                  PWR_PDCRH_PH3_Msk                       /*!< Pin PH3 Pull-Down set */
+
+/********************  Bit definition for PWR_C2CR1 register  ********************/
+#define PWR_C2CR1_LPMS_Pos             (0U)
+#define PWR_C2CR1_LPMS_Msk             (0x7UL << PWR_C2CR1_LPMS_Pos)           /*!< 0x00000007 */
+#define PWR_C2CR1_LPMS                 PWR_C2CR1_LPMS_Msk                      /*!< Low Power Mode Selection for CPU2 */
+#define PWR_C2CR1_LPMS_0               (0x1U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000001 */
+#define PWR_C2CR1_LPMS_1               (0x2U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000002 */
+#define PWR_C2CR1_LPMS_2               (0x4U << PWR_C2CR1_LPMS_Pos)            /*!< 0x00000004 */
+
+#define PWR_C2CR1_FPDR_Pos             (4U)
+#define PWR_C2CR1_FPDR_Msk             (0x1UL << PWR_C2CR1_FPDR_Pos)           /*!< 0x00000010 */
+#define PWR_C2CR1_FPDR                 PWR_C2CR1_FPDR_Msk                      /*!< Flash power down mode during LPrun for CPU2 */
+
+#define PWR_C2CR1_FPDS_Pos             (5U)
+#define PWR_C2CR1_FPDS_Msk             (0x1UL << PWR_C2CR1_FPDS_Pos)           /*!< 0x00000020 */
+#define PWR_C2CR1_FPDS                 PWR_C2CR1_FPDS_Msk                      /*!< Flash power down mode during LPsleep for CPU2 */
+
+#define PWR_C2CR1_BLEEWKUP_Pos         (14U)
+#define PWR_C2CR1_BLEEWKUP_Msk         (0x1UL << PWR_C2CR1_BLEEWKUP_Pos)       /*!< 0x00008000 */
+#define PWR_C2CR1_BLEEWKUP             PWR_C2CR1_BLEEWKUP_Msk                  /*!< Radio BLE external wakeup signal */
+
+/********************  Bit definition for PWR_C2CR3 register  ********************/
+#define PWR_C2CR3_EWUP_Pos             (0U)
+#define PWR_C2CR3_EWUP_Msk             (0x09UL << PWR_C2CR3_EWUP_Pos)           /*!< 0x00000009 */
+#define PWR_C2CR3_EWUP                 PWR_C2CR3_EWUP_Msk                       /*!< Enable all external Wake-Up lines for CPU2 */
+#define PWR_C2CR3_EWUP1_Pos            (0U)
+#define PWR_C2CR3_EWUP1_Msk            (0x1UL << PWR_C2CR3_EWUP1_Pos)           /*!< 0x00000001 */
+#define PWR_C2CR3_EWUP1                PWR_C2CR3_EWUP1_Msk                      /*!< Enable external WKUP Pin 1 [line 0] for CPU2 */
+#define PWR_C2CR3_EWUP4_Pos            (3U)
+#define PWR_C2CR3_EWUP4_Msk            (0x1UL << PWR_C2CR3_EWUP4_Pos)           /*!< 0x00000008 */
+#define PWR_C2CR3_EWUP4                PWR_C2CR3_EWUP4_Msk                      /*!< Enable external WKUP Pin 4 [line 3] for CPU2 */
+
+#define PWR_C2CR3_EBLEWUP_Pos          (9U)
+#define PWR_C2CR3_EBLEWUP_Msk          (0x1UL << PWR_C2CR3_EBLEWUP_Pos)       /*!< 0x00000200 */
+#define PWR_C2CR3_EBLEWUP              PWR_C2CR3_EBLEWUP_Msk                 /*!< Enable BLE host wakeup interrupt for CPU2 */
+
+#define PWR_C2CR3_APC_Pos              (12U)
+#define PWR_C2CR3_APC_Msk              (0x1UL << PWR_C2CR3_APC_Pos)            /*!< 0x00001000 */
+#define PWR_C2CR3_APC                  PWR_C2CR3_APC_Msk                       /*!< Apply pull-up and pull-down configuration for CPU2 */
+
+#define PWR_C2CR3_EIWUL_Pos            (15U)
+#define PWR_C2CR3_EIWUL_Msk            (0x1UL << PWR_C2CR3_EIWUL_Pos)          /*!< 0x00008000 */
+#define PWR_C2CR3_EIWUL                PWR_C2CR3_EIWUL_Msk                     /*!< Internal Wake-Up line interrupt for CPU2 */
+
+/********************  Bit definition for PWR_EXTSCR register  ********************/
+#define PWR_EXTSCR_C1CSSF_Pos          (0U)
+#define PWR_EXTSCR_C1CSSF_Msk          (0x1UL << PWR_EXTSCR_C1CSSF_Pos)        /*!< 0x00000001 */
+#define PWR_EXTSCR_C1CSSF              PWR_EXTSCR_C1CSSF_Msk                   /*!< Clear standby and stop flags for CPU1 */
+#define PWR_EXTSCR_C2CSSF_Pos          (1U)
+#define PWR_EXTSCR_C2CSSF_Msk          (0x1UL << PWR_EXTSCR_C2CSSF_Pos)        /*!< 0x00000002 */
+#define PWR_EXTSCR_C2CSSF              PWR_EXTSCR_C2CSSF_Msk                   /*!< Clear standby and stop flags for CPU2 */
+#define PWR_EXTSCR_CCRPF_Pos           (2U)
+#define PWR_EXTSCR_CCRPF_Msk           (0x1UL << PWR_EXTSCR_CCRPF_Pos)         /*!< 0x00000004 */
+#define PWR_EXTSCR_CCRPF               PWR_EXTSCR_CCRPF_Msk                    /*!< Clear critical radio system phase flag */
+
+#define PWR_EXTSCR_C1SBF_Pos           (8U)
+#define PWR_EXTSCR_C1SBF_Msk           (0x1UL << PWR_EXTSCR_C1SBF_Pos)         /*!< 0x00000100 */
+#define PWR_EXTSCR_C1SBF               PWR_EXTSCR_C1SBF_Msk                    /*!< System standby flag for CPU1 */
+#define PWR_EXTSCR_C1STOPF_Pos         (9U)
+#define PWR_EXTSCR_C1STOPF_Msk         (0x1UL << PWR_EXTSCR_C1STOPF_Pos)       /*!< 0x00000200 */
+#define PWR_EXTSCR_C1STOPF             PWR_EXTSCR_C1STOPF_Msk                  /*!< System stop flag for CPU1 */
+#define PWR_EXTSCR_C2SBF_Pos           (10U)
+#define PWR_EXTSCR_C2SBF_Msk           (0x1UL << PWR_EXTSCR_C2SBF_Pos)         /*!< 0x00000400 */
+#define PWR_EXTSCR_C2SBF               PWR_EXTSCR_C2SBF_Msk                    /*!< System standby flag for CPU2 */
+#define PWR_EXTSCR_C2STOPF_Pos         (11U)
+#define PWR_EXTSCR_C2STOPF_Msk         (0x1UL << PWR_EXTSCR_C2STOPF_Pos)       /*!< 0x00000800 */
+#define PWR_EXTSCR_C2STOPF             PWR_EXTSCR_C2STOPF_Msk                  /*!< System stop flag for CPU2 */
+
+#define PWR_EXTSCR_CRPF_Pos            (13U)
+#define PWR_EXTSCR_CRPF_Msk            (0x1UL << PWR_EXTSCR_CRPF_Pos)          /*!< 0x00002000 */
+#define PWR_EXTSCR_CRPF                PWR_EXTSCR_CRPF_Msk                     /*!< Critical radio system phase flag */
+
+#define PWR_EXTSCR_C1DS_Pos            (14U)
+#define PWR_EXTSCR_C1DS_Msk            (0x1UL << PWR_EXTSCR_C1DS_Pos)          /*!< 0x00004000 */
+#define PWR_EXTSCR_C1DS                PWR_EXTSCR_C1DS_Msk                     /*!< CPU1 deepsleep mode flag */
+#define PWR_EXTSCR_C2DS_Pos            (15U)
+#define PWR_EXTSCR_C2DS_Msk            (0x1UL << PWR_EXTSCR_C2DS_Pos)          /*!< 0x00008000 */
+#define PWR_EXTSCR_C2DS                PWR_EXTSCR_C2DS_Msk                     /*!< CPU2 deepsleep mode flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Reset and Clock Control                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+  * @brief Specific device feature definitions
+  */
+#define RCC_SMPS_SUPPORT
+
+/********************  Bit definition for RCC_CR register  *****************/
+#define RCC_CR_MSION_Pos                     (0U)
+#define RCC_CR_MSION_Msk                     (0x1UL << RCC_CR_MSION_Pos)       /*!< 0x00000001 */
+#define RCC_CR_MSION                         RCC_CR_MSION_Msk                  /*!< Internal Multi Speed oscillator (MSI) clock enable */
+#define RCC_CR_MSIRDY_Pos                    (1U)
+#define RCC_CR_MSIRDY_Msk                    (0x1UL << RCC_CR_MSIRDY_Pos)      /*!< 0x00000002 */
+#define RCC_CR_MSIRDY                        RCC_CR_MSIRDY_Msk                 /*!< Internal Multi Speed oscillator (MSI) clock ready flag */
+#define RCC_CR_MSIPLLEN_Pos                  (2U)
+#define RCC_CR_MSIPLLEN_Msk                  (0x1UL << RCC_CR_MSIPLLEN_Pos)    /*!< 0x00000004 */
+#define RCC_CR_MSIPLLEN                      RCC_CR_MSIPLLEN_Msk               /*!< Internal Multi Speed oscillator (MSI) PLL enable */
+
+/*!< MSIRANGE configuration : 12 frequency ranges available */
+#define RCC_CR_MSIRANGE_Pos                  (4U)
+#define RCC_CR_MSIRANGE_Msk                  (0xFUL << RCC_CR_MSIRANGE_Pos)    /*!< 0x000000F0 */
+#define RCC_CR_MSIRANGE                      RCC_CR_MSIRANGE_Msk               /*!< Internal Multi Speed oscillator (MSI) clock Range */
+#define RCC_CR_MSIRANGE_0                    (0x0U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000000 */
+#define RCC_CR_MSIRANGE_1                    (0x1U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000010 */
+#define RCC_CR_MSIRANGE_2                    (0x2U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000020 */
+#define RCC_CR_MSIRANGE_3                    (0x3U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000030 */
+#define RCC_CR_MSIRANGE_4                    (0x4U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000040 */
+#define RCC_CR_MSIRANGE_5                    (0x5U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000050 */
+#define RCC_CR_MSIRANGE_6                    (0x6U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000060 */
+#define RCC_CR_MSIRANGE_7                    (0x7U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000070 */
+#define RCC_CR_MSIRANGE_8                    (0x8U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000080 */
+#define RCC_CR_MSIRANGE_9                    (0x9U << RCC_CR_MSIRANGE_Pos)     /*!< 0x00000090 */
+#define RCC_CR_MSIRANGE_10                   (0xAU << RCC_CR_MSIRANGE_Pos)     /*!< 0x000000A0 */
+#define RCC_CR_MSIRANGE_11                   (0xBU << RCC_CR_MSIRANGE_Pos)     /*!< 0x000000B0 */
+
+#define RCC_CR_HSION_Pos                     (8U)
+#define RCC_CR_HSION_Msk                     (0x1UL << RCC_CR_HSION_Pos)       /*!< 0x00000100 */
+#define RCC_CR_HSION                         RCC_CR_HSION_Msk                  /*!< Internal High Speed oscillator (HSI16) clock enable */
+#define RCC_CR_HSIKERON_Pos                  (9U)
+#define RCC_CR_HSIKERON_Msk                  (0x1UL << RCC_CR_HSIKERON_Pos)    /*!< 0x00000200 */
+#define RCC_CR_HSIKERON                      RCC_CR_HSIKERON_Msk               /*!< Internal High Speed oscillator (HSI16) clock enable for some IPs Kernel */
+#define RCC_CR_HSIRDY_Pos                    (10U)
+#define RCC_CR_HSIRDY_Msk                    (0x1UL << RCC_CR_HSIRDY_Pos)      /*!< 0x00000400 */
+#define RCC_CR_HSIRDY                        RCC_CR_HSIRDY_Msk                 /*!< Internal High Speed oscillator (HSI16) clock ready flag */
+#define RCC_CR_HSIASFS_Pos                   (11U)
+#define RCC_CR_HSIASFS_Msk                   (0x1UL << RCC_CR_HSIASFS_Pos)     /*!< 0x00000800 */
+#define RCC_CR_HSIASFS                       RCC_CR_HSIASFS_Msk                /*!< HSI16 Automatic Start from Stop */
+#define RCC_CR_HSIKERDY_Pos                  (12U)
+#define RCC_CR_HSIKERDY_Msk                  (0x1UL << RCC_CR_HSIKERDY_Pos)     /*!< 0x00001000 */
+#define RCC_CR_HSIKERDY                       RCC_CR_HSIKERDY_Msk               /*!< Internal High Speed oscillator (HSI16) clock enable for some IPs Kernel ready flag*/
+
+#define RCC_CR_HSEON_Pos                     (16U)
+#define RCC_CR_HSEON_Msk                     (0x1UL << RCC_CR_HSEON_Pos)       /*!< 0x00010000 */
+#define RCC_CR_HSEON                         RCC_CR_HSEON_Msk                  /*!< External High Speed oscillator (HSE) clock enable */
+#define RCC_CR_HSERDY_Pos                    (17U)
+#define RCC_CR_HSERDY_Msk                    (0x1UL << RCC_CR_HSERDY_Pos)      /*!< 0x00020000 */
+#define RCC_CR_HSERDY                        RCC_CR_HSERDY_Msk                 /*!< External High Speed oscillator (HSE) clock ready */
+#define RCC_CR_CSSON_Pos                     (19U)
+#define RCC_CR_CSSON_Msk                     (0x1UL << RCC_CR_CSSON_Pos)       /*!< 0x00080000 */
+#define RCC_CR_CSSON                         RCC_CR_CSSON_Msk                  /*!< HSE Clock Security System enable */
+#define RCC_CR_HSEPRE_Pos                    (20U)
+#define RCC_CR_HSEPRE_Msk                    (0x1UL << RCC_CR_HSEPRE_Pos)       /*!< 0x00100000 */
+#define RCC_CR_HSEPRE                        RCC_CR_HSEPRE_Msk                  /*!< HSE sysclk prescaler */
+
+#define RCC_CR_PLLON_Pos                     (24U)
+#define RCC_CR_PLLON_Msk                     (0x1UL << RCC_CR_PLLON_Pos)       /*!< 0x01000000 */
+#define RCC_CR_PLLON                         RCC_CR_PLLON_Msk                  /*!< System PLL clock enable */
+#define RCC_CR_PLLRDY_Pos                    (25U)
+#define RCC_CR_PLLRDY_Msk                    (0x1UL << RCC_CR_PLLRDY_Pos)      /*!< 0x02000000 */
+#define RCC_CR_PLLRDY                        RCC_CR_PLLRDY_Msk                 /*!< System PLL clock ready */
+
+/********************  Bit definition for RCC_ICSCR register  ***************/
+/*!< MSICAL configuration */
+#define RCC_ICSCR_MSICAL_Pos                 (0U)
+#define RCC_ICSCR_MSICAL_Msk                 (0xFFUL << RCC_ICSCR_MSICAL_Pos)  /*!< 0x000000FF */
+#define RCC_ICSCR_MSICAL                     RCC_ICSCR_MSICAL_Msk              /*!< MSICAL[7:0] bits */
+#define RCC_ICSCR_MSICAL_0                   (0x01U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000001 */
+#define RCC_ICSCR_MSICAL_1                   (0x02U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000002 */
+#define RCC_ICSCR_MSICAL_2                   (0x04U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000004 */
+#define RCC_ICSCR_MSICAL_3                   (0x08U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000008 */
+#define RCC_ICSCR_MSICAL_4                   (0x10U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000010 */
+#define RCC_ICSCR_MSICAL_5                   (0x20U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000020 */
+#define RCC_ICSCR_MSICAL_6                   (0x40U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000040 */
+#define RCC_ICSCR_MSICAL_7                   (0x80U << RCC_ICSCR_MSICAL_Pos)   /*!< 0x00000080 */
+
+/*!< MSITRIM configuration */
+#define RCC_ICSCR_MSITRIM_Pos                (8U)
+#define RCC_ICSCR_MSITRIM_Msk                (0xFFUL << RCC_ICSCR_MSITRIM_Pos) /*!< 0x0000FF00 */
+#define RCC_ICSCR_MSITRIM                    RCC_ICSCR_MSITRIM_Msk             /*!< MSITRIM[7:0] bits */
+#define RCC_ICSCR_MSITRIM_0                  (0x01U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000100 */
+#define RCC_ICSCR_MSITRIM_1                  (0x02U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000200 */
+#define RCC_ICSCR_MSITRIM_2                  (0x04U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000400 */
+#define RCC_ICSCR_MSITRIM_3                  (0x08U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00000800 */
+#define RCC_ICSCR_MSITRIM_4                  (0x10U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00001000 */
+#define RCC_ICSCR_MSITRIM_5                  (0x20U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00002000 */
+#define RCC_ICSCR_MSITRIM_6                  (0x40U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00004000 */
+#define RCC_ICSCR_MSITRIM_7                  (0x80U << RCC_ICSCR_MSITRIM_Pos)  /*!< 0x00008000 */
+
+/*!< HSICAL configuration */
+#define RCC_ICSCR_HSICAL_Pos                 (16U)
+#define RCC_ICSCR_HSICAL_Msk                 (0xFFUL << RCC_ICSCR_HSICAL_Pos)  /*!< 0x00FF0000 */
+#define RCC_ICSCR_HSICAL                     RCC_ICSCR_HSICAL_Msk              /*!< HSICAL[7:0] bits */
+#define RCC_ICSCR_HSICAL_0                   (0x01U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00010000 */
+#define RCC_ICSCR_HSICAL_1                   (0x02U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00020000 */
+#define RCC_ICSCR_HSICAL_2                   (0x04U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00040000 */
+#define RCC_ICSCR_HSICAL_3                   (0x08U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00080000 */
+#define RCC_ICSCR_HSICAL_4                   (0x10U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00100000 */
+#define RCC_ICSCR_HSICAL_5                   (0x20U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00200000 */
+#define RCC_ICSCR_HSICAL_6                   (0x40U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00400000 */
+#define RCC_ICSCR_HSICAL_7                   (0x80U << RCC_ICSCR_HSICAL_Pos)   /*!< 0x00800000 */
+
+/*!< HSITRIM configuration */
+#define RCC_ICSCR_HSITRIM_Pos                (24U)
+#define RCC_ICSCR_HSITRIM_Msk                (0x7FUL << RCC_ICSCR_HSITRIM_Pos) /*!< 0x7F000000 */
+#define RCC_ICSCR_HSITRIM                    RCC_ICSCR_HSITRIM_Msk             /*!< HSITRIM[6:0] bits */
+#define RCC_ICSCR_HSITRIM_0                  (0x01U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x01000000 */
+#define RCC_ICSCR_HSITRIM_1                  (0x02U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x02000000 */
+#define RCC_ICSCR_HSITRIM_2                  (0x04U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x04000000 */
+#define RCC_ICSCR_HSITRIM_3                  (0x08U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x08000000 */
+#define RCC_ICSCR_HSITRIM_4                  (0x10U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x10000000 */
+#define RCC_ICSCR_HSITRIM_5                  (0x20U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x20000000 */
+#define RCC_ICSCR_HSITRIM_6                  (0x40U << RCC_ICSCR_HSITRIM_Pos)  /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_CFGR register  ******************/
+/*!< SW configuration */
+#define RCC_CFGR_SW_Pos                      (0U)
+#define RCC_CFGR_SW_Msk                      (0x3UL << RCC_CFGR_SW_Pos)        /*!< 0x00000003 */
+#define RCC_CFGR_SW                          RCC_CFGR_SW_Msk                   /*!< SW[1:0] bits (System clock Switch) */
+#define RCC_CFGR_SW_0                        (0x1U << RCC_CFGR_SW_Pos)         /*!< 0x00000001 */
+#define RCC_CFGR_SW_1                        (0x2U << RCC_CFGR_SW_Pos)         /*!< 0x00000002 */
+
+/*!< SWS configuration */
+#define RCC_CFGR_SWS_Pos                     (2U)
+#define RCC_CFGR_SWS_Msk                     (0x3UL << RCC_CFGR_SWS_Pos)       /*!< 0x0000000C */
+#define RCC_CFGR_SWS                         RCC_CFGR_SWS_Msk                  /*!< SWS[1:0] bits (System Clock Switch Status) */
+#define RCC_CFGR_SWS_0                       (0x1U << RCC_CFGR_SWS_Pos)        /*!< 0x00000004 */
+#define RCC_CFGR_SWS_1                       (0x2U << RCC_CFGR_SWS_Pos)        /*!< 0x00000008 */
+
+/*!< HPRE configuration */
+#define RCC_CFGR_HPRE_Pos                    (4U)
+#define RCC_CFGR_HPRE_Msk                    (0xFUL << RCC_CFGR_HPRE_Pos)      /*!< 0x000000F0 */
+#define RCC_CFGR_HPRE                        RCC_CFGR_HPRE_Msk                 /*!< HPRE[3:0] bits (AHB prescaler) */
+#define RCC_CFGR_HPRE_0                      (0x1U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000010 */
+#define RCC_CFGR_HPRE_1                      (0x2U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000020 */
+#define RCC_CFGR_HPRE_2                      (0x4U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000040 */
+#define RCC_CFGR_HPRE_3                      (0x8U << RCC_CFGR_HPRE_Pos)       /*!< 0x00000080 */
+
+/*!< PPRE1 configuration */
+#define RCC_CFGR_PPRE1_Pos                   (8U)
+#define RCC_CFGR_PPRE1_Msk                   (0x7UL << RCC_CFGR_PPRE1_Pos)     /*!< 0x00000700 */
+#define RCC_CFGR_PPRE1                       RCC_CFGR_PPRE1_Msk                /*!< PRE1[2:0] bits (APB1 prescaler) */
+#define RCC_CFGR_PPRE1_0                     (0x1U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000100 */
+#define RCC_CFGR_PPRE1_1                     (0x2U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000200 */
+#define RCC_CFGR_PPRE1_2                     (0x4U << RCC_CFGR_PPRE1_Pos)      /*!< 0x00000400 */
+
+/*!< PPRE2 configuration */
+#define RCC_CFGR_PPRE2_Pos                   (11U)
+#define RCC_CFGR_PPRE2_Msk                   (0x7UL << RCC_CFGR_PPRE2_Pos)     /*!< 0x00003800 */
+#define RCC_CFGR_PPRE2                       RCC_CFGR_PPRE2_Msk                /*!< PRE2[2:0] bits (APB2 prescaler) */
+#define RCC_CFGR_PPRE2_0                     (0x1U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00000800 */
+#define RCC_CFGR_PPRE2_1                     (0x2U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00001000 */
+#define RCC_CFGR_PPRE2_2                     (0x4U << RCC_CFGR_PPRE2_Pos)      /*!< 0x00002000 */
+
+/*!< STOPWUCK configuration */
+#define RCC_CFGR_STOPWUCK_Pos                (15U)
+#define RCC_CFGR_STOPWUCK_Msk                (0x1UL << RCC_CFGR_STOPWUCK_Pos)  /*!< 0x00008000 */
+#define RCC_CFGR_STOPWUCK                    RCC_CFGR_STOPWUCK_Msk             /*!< Wake Up from stop and CSS backup clock selection */
+
+/*!< HPREF configuration */
+#define RCC_CFGR_HPREF_Pos                   (16U)
+#define RCC_CFGR_HPREF_Msk                   (0x1UL << RCC_CFGR_HPREF_Pos)     /*!< 0x00010000 */
+#define RCC_CFGR_HPREF                       RCC_CFGR_HPREF_Msk                /*!< AHB prescaler flag */
+
+/*!< PPRE1F configuration */
+#define RCC_CFGR_PPRE1F_Pos                  (17U)
+#define RCC_CFGR_PPRE1F_Msk                  (0x1UL << RCC_CFGR_PPRE1F_Pos)    /*!< 0x00020000 */
+#define RCC_CFGR_PPRE1F                      RCC_CFGR_PPRE1F_Msk               /*!< CPU1 APB1 prescaler flag */
+
+/*!< PPRE2F configuration */
+#define RCC_CFGR_PPRE2F_Pos                  (18U)
+#define RCC_CFGR_PPRE2F_Msk                  (0x1UL << RCC_CFGR_PPRE2F_Pos)    /*!< 0x00040000 */
+#define RCC_CFGR_PPRE2F                      RCC_CFGR_PPRE2F_Msk               /*!< APB2 prescaler flag */
+
+/*!< MCOSEL configuration */
+#define RCC_CFGR_MCOSEL_Pos                  (24U)
+#define RCC_CFGR_MCOSEL_Msk                  (0xFUL << RCC_CFGR_MCOSEL_Pos)    /*!< 0x0F000000 */
+#define RCC_CFGR_MCOSEL                      RCC_CFGR_MCOSEL_Msk               /*!< MCOSEL [3:0] bits (Clock output selection) */
+#define RCC_CFGR_MCOSEL_0                    (0x1U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x01000000 */
+#define RCC_CFGR_MCOSEL_1                    (0x2U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x02000000 */
+#define RCC_CFGR_MCOSEL_2                    (0x4U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x04000000 */
+#define RCC_CFGR_MCOSEL_3                    (0x8U << RCC_CFGR_MCOSEL_Pos)     /*!< 0x08000000 */
+
+/*!< MCOPRE configuration */
+#define RCC_CFGR_MCOPRE_Pos                  (28U)
+#define RCC_CFGR_MCOPRE_Msk                  (0x7UL << RCC_CFGR_MCOPRE_Pos)    /*!< 0x70000000 */
+#define RCC_CFGR_MCOPRE                      RCC_CFGR_MCOPRE_Msk               /*!< MCO prescaler */
+#define RCC_CFGR_MCOPRE_0                    (0x1U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x10000000 */
+#define RCC_CFGR_MCOPRE_1                    (0x2U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x20000000 */
+#define RCC_CFGR_MCOPRE_2                    (0x4U << RCC_CFGR_MCOPRE_Pos)     /*!< 0x40000000 */
+
+/********************  Bit definition for RCC_PLLCFGR register  ***************/
+#define RCC_PLLCFGR_PLLSRC_Pos               (0U)
+#define RCC_PLLCFGR_PLLSRC_Msk               (0x3UL << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000003 */
+#define RCC_PLLCFGR_PLLSRC                   RCC_PLLCFGR_PLLSRC_Msk
+#define RCC_PLLCFGR_PLLSRC_0                 (0x1U << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000001 */
+#define RCC_PLLCFGR_PLLSRC_1                 (0x2U << RCC_PLLCFGR_PLLSRC_Pos) /*!< 0x00000002 */
+
+#define RCC_PLLCFGR_PLLM_Pos                 (4U)
+#define RCC_PLLCFGR_PLLM_Msk                 (0x7UL << RCC_PLLCFGR_PLLM_Pos) /*!< 0x00000070 */
+#define RCC_PLLCFGR_PLLM                     RCC_PLLCFGR_PLLM_Msk
+#define RCC_PLLCFGR_PLLM_0                   (0x1U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000010 */
+#define RCC_PLLCFGR_PLLM_1                   (0x2U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000020 */
+#define RCC_PLLCFGR_PLLM_2                   (0x4U << RCC_PLLCFGR_PLLM_Pos)  /*!< 0x00000040 */
+
+#define RCC_PLLCFGR_PLLN_Pos                 (8U)
+#define RCC_PLLCFGR_PLLN_Msk                 (0x7FUL << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00007F00 */
+#define RCC_PLLCFGR_PLLN                     RCC_PLLCFGR_PLLN_Msk
+#define RCC_PLLCFGR_PLLN_0                   (0x01U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000100 */
+#define RCC_PLLCFGR_PLLN_1                   (0x02U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000200 */
+#define RCC_PLLCFGR_PLLN_2                   (0x04U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000400 */
+#define RCC_PLLCFGR_PLLN_3                   (0x08U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00000800 */
+#define RCC_PLLCFGR_PLLN_4                   (0x10U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00001000 */
+#define RCC_PLLCFGR_PLLN_5                   (0x20U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00002000 */
+#define RCC_PLLCFGR_PLLN_6                   (0x40U << RCC_PLLCFGR_PLLN_Pos) /*!< 0x00004000 */
+
+#define RCC_PLLCFGR_PLLPEN_Pos               (16U)
+#define RCC_PLLCFGR_PLLPEN_Msk               (0x1UL << RCC_PLLCFGR_PLLPEN_Pos) /*!< 0x00010000 */
+#define RCC_PLLCFGR_PLLPEN                   RCC_PLLCFGR_PLLPEN_Msk
+#define RCC_PLLCFGR_PLLP_Pos                 (17U)
+#define RCC_PLLCFGR_PLLP_Msk                 (0x1FUL << RCC_PLLCFGR_PLLP_Pos) /*!< 0x003E0000 */
+#define RCC_PLLCFGR_PLLP                     RCC_PLLCFGR_PLLP_Msk
+#define RCC_PLLCFGR_PLLP_0                   (0x01U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00020000 */
+#define RCC_PLLCFGR_PLLP_1                   (0x02U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00040000 */
+#define RCC_PLLCFGR_PLLP_2                   (0x04U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00080000 */
+#define RCC_PLLCFGR_PLLP_3                   (0x08U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00100000 */
+#define RCC_PLLCFGR_PLLP_4                   (0x10U << RCC_PLLCFGR_PLLP_Pos) /*!< 0x00200000 */
+
+#define RCC_PLLCFGR_PLLQEN_Pos               (24U)
+#define RCC_PLLCFGR_PLLQEN_Msk               (0x1UL << RCC_PLLCFGR_PLLQEN_Pos) /*!< 0x01000000 */
+#define RCC_PLLCFGR_PLLQEN                   RCC_PLLCFGR_PLLQEN_Msk
+#define RCC_PLLCFGR_PLLQ_Pos                 (25U)
+#define RCC_PLLCFGR_PLLQ_Msk                 (0x7UL << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x0E000000 */
+#define RCC_PLLCFGR_PLLQ                     RCC_PLLCFGR_PLLQ_Msk
+#define RCC_PLLCFGR_PLLQ_0                   (0x1U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x02000000 */
+#define RCC_PLLCFGR_PLLQ_1                   (0x2U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x04000000 */
+#define RCC_PLLCFGR_PLLQ_2                   (0x4U << RCC_PLLCFGR_PLLQ_Pos) /*!< 0x08000000 */
+
+#define RCC_PLLCFGR_PLLREN_Pos               (28U)
+#define RCC_PLLCFGR_PLLREN_Msk               (0x1UL << RCC_PLLCFGR_PLLREN_Pos) /*!< 0x10000000 */
+#define RCC_PLLCFGR_PLLREN                   RCC_PLLCFGR_PLLREN_Msk
+#define RCC_PLLCFGR_PLLR_Pos                 (29U)
+#define RCC_PLLCFGR_PLLR_Msk                 (0x7UL << RCC_PLLCFGR_PLLR_Pos) /*!< 0xE0000000 */
+#define RCC_PLLCFGR_PLLR                     RCC_PLLCFGR_PLLR_Msk
+#define RCC_PLLCFGR_PLLR_0                   (0x1U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x20000000 */
+#define RCC_PLLCFGR_PLLR_1                   (0x2U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x40000000 */
+#define RCC_PLLCFGR_PLLR_2                   (0x4U << RCC_PLLCFGR_PLLR_Pos) /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_CIER register  ******************/
+#define RCC_CIER_LSI1RDYIE_Pos               (0U)
+#define RCC_CIER_LSI1RDYIE_Msk               (0x1UL << RCC_CIER_LSI1RDYIE_Pos)  /*!< 0x00000001 */
+#define RCC_CIER_LSI1RDYIE                   RCC_CIER_LSI1RDYIE_Msk
+#define RCC_CIER_LSERDYIE_Pos                (1U)
+#define RCC_CIER_LSERDYIE_Msk                (0x1UL << RCC_CIER_LSERDYIE_Pos)   /*!< 0x00000002 */
+#define RCC_CIER_LSERDYIE                    RCC_CIER_LSERDYIE_Msk
+#define RCC_CIER_MSIRDYIE_Pos                (2U)
+#define RCC_CIER_MSIRDYIE_Msk                (0x1UL << RCC_CIER_MSIRDYIE_Pos)   /*!< 0x00000004 */
+#define RCC_CIER_MSIRDYIE                    RCC_CIER_MSIRDYIE_Msk
+#define RCC_CIER_HSIRDYIE_Pos                (3U)
+#define RCC_CIER_HSIRDYIE_Msk                (0x1UL << RCC_CIER_HSIRDYIE_Pos)   /*!< 0x00000008 */
+#define RCC_CIER_HSIRDYIE                    RCC_CIER_HSIRDYIE_Msk
+#define RCC_CIER_HSERDYIE_Pos                (4U)
+#define RCC_CIER_HSERDYIE_Msk                (0x1UL << RCC_CIER_HSERDYIE_Pos)   /*!< 0x00000010 */
+#define RCC_CIER_HSERDYIE                    RCC_CIER_HSERDYIE_Msk
+#define RCC_CIER_PLLRDYIE_Pos                (5U)
+#define RCC_CIER_PLLRDYIE_Msk                (0x1UL << RCC_CIER_PLLRDYIE_Pos) /*!< 0x00000020 */
+#define RCC_CIER_PLLRDYIE                    RCC_CIER_PLLRDYIE_Msk
+#define RCC_CIER_LSECSSIE_Pos                (9U)
+#define RCC_CIER_LSECSSIE_Msk                (0x1UL << RCC_CIER_LSECSSIE_Pos)   /*!< 0x00000200 */
+#define RCC_CIER_LSECSSIE                    RCC_CIER_LSECSSIE_Msk
+#define RCC_CIER_LSI2RDYIE_Pos               (11U)
+#define RCC_CIER_LSI2RDYIE_Msk               (0x1UL << RCC_CIER_LSI2RDYIE_Pos)  /*!< 0x00000800 */
+#define RCC_CIER_LSI2RDYIE                   RCC_CIER_LSI2RDYIE_Msk
+
+
+/********************  Bit definition for RCC_CIFR register  ******************/
+#define RCC_CIFR_LSI1RDYF_Pos                (0U)
+#define RCC_CIFR_LSI1RDYF_Msk                (0x1UL << RCC_CIFR_LSI1RDYF_Pos)  /*!< 0x00000001 */
+#define RCC_CIFR_LSI1RDYF                    RCC_CIFR_LSI1RDYF_Msk
+#define RCC_CIFR_LSERDYF_Pos                 (1U)
+#define RCC_CIFR_LSERDYF_Msk                 (0x1UL << RCC_CIFR_LSERDYF_Pos)   /*!< 0x00000002 */
+#define RCC_CIFR_LSERDYF                     RCC_CIFR_LSERDYF_Msk
+#define RCC_CIFR_MSIRDYF_Pos                 (2U)
+#define RCC_CIFR_MSIRDYF_Msk                 (0x1UL << RCC_CIFR_MSIRDYF_Pos)   /*!< 0x00000004 */
+#define RCC_CIFR_MSIRDYF                     RCC_CIFR_MSIRDYF_Msk
+#define RCC_CIFR_HSIRDYF_Pos                 (3U)
+#define RCC_CIFR_HSIRDYF_Msk                 (0x1UL << RCC_CIFR_HSIRDYF_Pos)   /*!< 0x00000008 */
+#define RCC_CIFR_HSIRDYF                     RCC_CIFR_HSIRDYF_Msk
+#define RCC_CIFR_HSERDYF_Pos                 (4U)
+#define RCC_CIFR_HSERDYF_Msk                 (0x1UL << RCC_CIFR_HSERDYF_Pos)   /*!< 0x00000010 */
+#define RCC_CIFR_HSERDYF                     RCC_CIFR_HSERDYF_Msk
+#define RCC_CIFR_PLLRDYF_Pos                 (5U)
+#define RCC_CIFR_PLLRDYF_Msk                 (0x1UL << RCC_CIFR_PLLRDYF_Pos) /*!< 0x00000020 */
+#define RCC_CIFR_PLLRDYF                     RCC_CIFR_PLLRDYF_Msk
+#define RCC_CIFR_CSSF_Pos                    (8U)
+#define RCC_CIFR_CSSF_Msk                    (0x1UL << RCC_CIFR_CSSF_Pos)   /*!< 0x00000100 */
+#define RCC_CIFR_CSSF                        RCC_CIFR_CSSF_Msk
+#define RCC_CIFR_LSECSSF_Pos                 (9U)
+#define RCC_CIFR_LSECSSF_Msk                 (0x1UL << RCC_CIFR_LSECSSF_Pos)   /*!< 0x00000200 */
+#define RCC_CIFR_LSECSSF                     RCC_CIFR_LSECSSF_Msk
+#define RCC_CIFR_LSI2RDYF_Pos                (11U)
+#define RCC_CIFR_LSI2RDYF_Msk                (0x1UL << RCC_CIFR_LSI2RDYF_Pos)  /*!< 0x00000800 */
+#define RCC_CIFR_LSI2RDYF                    RCC_CIFR_LSI2RDYF_Msk
+
+/********************  Bit definition for RCC_CICR register  ******************/
+#define RCC_CICR_LSI1RDYC_Pos               (0U)
+#define RCC_CICR_LSI1RDYC_Msk               (0x1UL << RCC_CICR_LSI1RDYC_Pos)  /*!< 0x00000001 */
+#define RCC_CICR_LSI1RDYC                   RCC_CICR_LSI1RDYC_Msk
+#define RCC_CICR_LSERDYC_Pos                (1U)
+#define RCC_CICR_LSERDYC_Msk                (0x1UL << RCC_CICR_LSERDYC_Pos)   /*!< 0x00000002 */
+#define RCC_CICR_LSERDYC                    RCC_CICR_LSERDYC_Msk
+#define RCC_CICR_MSIRDYC_Pos                (2U)
+#define RCC_CICR_MSIRDYC_Msk                (0x1UL << RCC_CICR_MSIRDYC_Pos)   /*!< 0x00000004 */
+#define RCC_CICR_MSIRDYC                    RCC_CICR_MSIRDYC_Msk
+#define RCC_CICR_HSIRDYC_Pos                (3U)
+#define RCC_CICR_HSIRDYC_Msk                (0x1UL << RCC_CICR_HSIRDYC_Pos)   /*!< 0x00000008 */
+#define RCC_CICR_HSIRDYC                    RCC_CICR_HSIRDYC_Msk
+#define RCC_CICR_HSERDYC_Pos                (4U)
+#define RCC_CICR_HSERDYC_Msk                (0x1UL << RCC_CICR_HSERDYC_Pos)   /*!< 0x00000010 */
+#define RCC_CICR_HSERDYC                    RCC_CICR_HSERDYC_Msk
+#define RCC_CICR_PLLRDYC_Pos                (5U)
+#define RCC_CICR_PLLRDYC_Msk                (0x1UL << RCC_CICR_PLLRDYC_Pos) /*!< 0x00000020 */
+#define RCC_CICR_PLLRDYC                    RCC_CICR_PLLRDYC_Msk
+#define RCC_CICR_CSSC_Pos                   (8U)
+#define RCC_CICR_CSSC_Msk                   (0x1UL << RCC_CICR_CSSC_Pos)   /*!< 0x00000100 */
+#define RCC_CICR_CSSC                       RCC_CICR_CSSC_Msk
+#define RCC_CICR_LSECSSC_Pos                (9U)
+#define RCC_CICR_LSECSSC_Msk                (0x1UL << RCC_CICR_LSECSSC_Pos)   /*!< 0x00000200 */
+#define RCC_CICR_LSECSSC                    RCC_CICR_LSECSSC_Msk
+#define RCC_CICR_LSI2RDYC_Pos               (11U)
+#define RCC_CICR_LSI2RDYC_Msk               (0x1UL << RCC_CICR_LSI2RDYC_Pos)  /*!< 0x00000800 */
+#define RCC_CICR_LSI2RDYC                   RCC_CICR_LSI2RDYC_Msk
+
+/********************  Bit definition for RCC_SMPSCR register  ******************/
+#define RCC_SMPSCR_SMPSSEL_Pos               (0U)
+#define RCC_SMPSCR_SMPSSEL_Msk               (0x3UL << RCC_SMPSCR_SMPSSEL_Pos)  /*!< 0x00000003 */
+#define RCC_SMPSCR_SMPSSEL                   RCC_SMPSCR_SMPSSEL_Msk
+#define RCC_SMPSCR_SMPSSEL_0                 (0x1U << RCC_SMPSCR_SMPSSEL_Pos)   /*!< 0x00000001 */
+#define RCC_SMPSCR_SMPSSEL_1                 (0x2U << RCC_SMPSCR_SMPSSEL_Pos)   /*!< 0x00000002 */
+
+#define RCC_SMPSCR_SMPSDIV_Pos               (4U)
+#define RCC_SMPSCR_SMPSDIV_Msk               (0x3UL << RCC_SMPSCR_SMPSDIV_Pos)  /*!< 0x00000030 */
+#define RCC_SMPSCR_SMPSDIV                   RCC_SMPSCR_SMPSDIV_Msk
+#define RCC_SMPSCR_SMPSDIV_0                 (0x1U << RCC_SMPSCR_SMPSDIV_Pos)   /*!< 0x00000010 */
+#define RCC_SMPSCR_SMPSDIV_1                 (0x2U << RCC_SMPSCR_SMPSDIV_Pos)   /*!< 0x00000020 */
+
+#define RCC_SMPSCR_SMPSSWS_Pos               (8U)
+#define RCC_SMPSCR_SMPSSWS_Msk               (0x3UL << RCC_SMPSCR_SMPSSWS_Pos)  /*!< 0x00000300 */
+#define RCC_SMPSCR_SMPSSWS                   RCC_SMPSCR_SMPSSWS_Msk
+#define RCC_SMPSCR_SMPSSWS_0                 (0x1U << RCC_SMPSCR_SMPSSWS_Pos)   /*!< 0x00000100 */
+#define RCC_SMPSCR_SMPSSWS_1                 (0x2U << RCC_SMPSCR_SMPSSWS_Pos)   /*!< 0x00000200 */
+
+/********************  Bit definition for RCC_AHB1RSTR register  **************/
+#define RCC_AHB1RSTR_DMA1RST_Pos             (0U)
+#define RCC_AHB1RSTR_DMA1RST_Msk             (0x1UL << RCC_AHB1RSTR_DMA1RST_Pos) /*!< 0x00000001 */
+#define RCC_AHB1RSTR_DMA1RST                 RCC_AHB1RSTR_DMA1RST_Msk
+#define RCC_AHB1RSTR_DMAMUX1RST_Pos          (2U)
+#define RCC_AHB1RSTR_DMAMUX1RST_Msk          (0x1UL << RCC_AHB1RSTR_DMAMUX1RST_Pos) /*!< 0x00000004 */
+#define RCC_AHB1RSTR_DMAMUX1RST              RCC_AHB1RSTR_DMAMUX1RST_Msk
+#define RCC_AHB1RSTR_CRCRST_Pos              (12U)
+#define RCC_AHB1RSTR_CRCRST_Msk              (0x1UL << RCC_AHB1RSTR_CRCRST_Pos) /*!< 0x00001000 */
+#define RCC_AHB1RSTR_CRCRST                  RCC_AHB1RSTR_CRCRST_Msk
+#define RCC_AHB1RSTR_TSCRST_Pos              (16U)
+#define RCC_AHB1RSTR_TSCRST_Msk              (0x1UL << RCC_AHB1RSTR_TSCRST_Pos) /*!< 0x00010000 */
+#define RCC_AHB1RSTR_TSCRST                  RCC_AHB1RSTR_TSCRST_Msk
+
+/********************  Bit definition for RCC_AHB2RSTR register  ***************/
+#define RCC_AHB2RSTR_GPIOARST_Pos           (0U)
+#define RCC_AHB2RSTR_GPIOARST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOARST_Pos) /*!< 0x00000001 */
+#define RCC_AHB2RSTR_GPIOARST               RCC_AHB2RSTR_GPIOARST_Msk
+#define RCC_AHB2RSTR_GPIOBRST_Pos           (1U)
+#define RCC_AHB2RSTR_GPIOBRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOBRST_Pos) /*!< 0x00000002 */
+#define RCC_AHB2RSTR_GPIOBRST               RCC_AHB2RSTR_GPIOBRST_Msk
+#define RCC_AHB2RSTR_GPIOCRST_Pos           (2U)
+#define RCC_AHB2RSTR_GPIOCRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOCRST_Pos) /*!< 0x00000004 */
+#define RCC_AHB2RSTR_GPIOCRST               RCC_AHB2RSTR_GPIOCRST_Msk
+#define RCC_AHB2RSTR_GPIOERST_Pos           (4U)
+#define RCC_AHB2RSTR_GPIOERST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOERST_Pos) /*!< 0x00000010 */
+#define RCC_AHB2RSTR_GPIOERST               RCC_AHB2RSTR_GPIOERST_Msk
+#define RCC_AHB2RSTR_GPIOHRST_Pos           (7U)
+#define RCC_AHB2RSTR_GPIOHRST_Msk           (0x1UL << RCC_AHB2RSTR_GPIOHRST_Pos) /*!< 0x00000080 */
+#define RCC_AHB2RSTR_GPIOHRST               RCC_AHB2RSTR_GPIOHRST_Msk
+
+/********************  Bit definition for RCC_AHB3RSTR register  ***************/
+#define RCC_AHB3RSTR_PKARST_Pos             (16U)
+#define RCC_AHB3RSTR_PKARST_Msk             (0x1UL << RCC_AHB3RSTR_PKARST_Pos) /*!< 0x00010000 */
+#define RCC_AHB3RSTR_PKARST                 RCC_AHB3RSTR_PKARST_Msk
+#define RCC_AHB3RSTR_AES2RST_Pos            (17U)
+#define RCC_AHB3RSTR_AES2RST_Msk            (0x1UL << RCC_AHB3RSTR_AES2RST_Pos) /*!< 0x00020000 */
+#define RCC_AHB3RSTR_AES2RST                RCC_AHB3RSTR_AES2RST_Msk
+#define RCC_AHB3RSTR_RNGRST_Pos             (18U)
+#define RCC_AHB3RSTR_RNGRST_Msk             (0x1UL << RCC_AHB3RSTR_RNGRST_Pos) /*!< 0x00040000 */
+#define RCC_AHB3RSTR_RNGRST                 RCC_AHB3RSTR_RNGRST_Msk
+#define RCC_AHB3RSTR_HSEMRST_Pos            (19U)
+#define RCC_AHB3RSTR_HSEMRST_Msk            (0x1UL << RCC_AHB3RSTR_HSEMRST_Pos) /*!< 0x00080000 */
+#define RCC_AHB3RSTR_HSEMRST                RCC_AHB3RSTR_HSEMRST_Msk
+#define RCC_AHB3RSTR_IPCCRST_Pos            (20U)
+#define RCC_AHB3RSTR_IPCCRST_Msk            (0x1UL << RCC_AHB3RSTR_IPCCRST_Pos) /*!< 0x00100000 */
+#define RCC_AHB3RSTR_IPCCRST                RCC_AHB3RSTR_IPCCRST_Msk
+#define RCC_AHB3RSTR_FLASHRST_Pos           (25U)
+#define RCC_AHB3RSTR_FLASHRST_Msk           (0x1UL << RCC_AHB3RSTR_FLASHRST_Pos) /*!< 0x02000000 */
+#define RCC_AHB3RSTR_FLASHRST               RCC_AHB3RSTR_FLASHRST_Msk
+
+/********************  Bit definition for RCC_APB1RSTR1 register  **************/
+#define RCC_APB1RSTR1_TIM2RST_Pos           (0U)
+#define RCC_APB1RSTR1_TIM2RST_Msk           (0x1UL << RCC_APB1RSTR1_TIM2RST_Pos) /*!< 0x00000001 */
+#define RCC_APB1RSTR1_TIM2RST               RCC_APB1RSTR1_TIM2RST_Msk
+#define RCC_APB1RSTR1_I2C1RST_Pos           (21U)
+#define RCC_APB1RSTR1_I2C1RST_Msk           (0x1UL << RCC_APB1RSTR1_I2C1RST_Pos) /*!< 0x00200000 */
+#define RCC_APB1RSTR1_I2C1RST               RCC_APB1RSTR1_I2C1RST_Msk
+#define RCC_APB1RSTR1_LPTIM1RST_Pos         (31U)
+#define RCC_APB1RSTR1_LPTIM1RST_Msk         (0x1UL << RCC_APB1RSTR1_LPTIM1RST_Pos) /*!< 0x80000000 */
+#define RCC_APB1RSTR1_LPTIM1RST             RCC_APB1RSTR1_LPTIM1RST_Msk
+
+/********************  Bit definition for RCC_APB1RSTR2 register  **************/
+#define RCC_APB1RSTR2_LPUART1RST_Pos        (0U)
+#define RCC_APB1RSTR2_LPUART1RST_Msk        (0x1UL << RCC_APB1RSTR2_LPUART1RST_Pos) /*!< 0x00000001 */
+#define RCC_APB1RSTR2_LPUART1RST            RCC_APB1RSTR2_LPUART1RST_Msk
+#define RCC_APB1RSTR2_LPTIM2RST_Pos         (5U)
+#define RCC_APB1RSTR2_LPTIM2RST_Msk         (0x1UL << RCC_APB1RSTR2_LPTIM2RST_Pos) /*!< 0x00000020 */
+#define RCC_APB1RSTR2_LPTIM2RST             RCC_APB1RSTR2_LPTIM2RST_Msk
+
+/********************  Bit definition for RCC_APB2RSTR register  **************/
+#define RCC_APB2RSTR_ADCRST_Pos             (9U)
+#define RCC_APB2RSTR_ADCRST_Msk             (0x1UL << RCC_APB2RSTR_ADCRST_Pos)    /*!< 0x00000200 */
+#define RCC_APB2RSTR_ADCRST                 RCC_APB2RSTR_ADCRST_Msk
+#define RCC_APB2RSTR_TIM1RST_Pos            (11U)
+#define RCC_APB2RSTR_TIM1RST_Msk            (0x1UL << RCC_APB2RSTR_TIM1RST_Pos)   /*!< 0x00000800 */
+#define RCC_APB2RSTR_TIM1RST                RCC_APB2RSTR_TIM1RST_Msk
+#define RCC_APB2RSTR_SPI1RST_Pos            (12U)
+#define RCC_APB2RSTR_SPI1RST_Msk            (0x1UL << RCC_APB2RSTR_SPI1RST_Pos)   /*!< 0x00001000 */
+#define RCC_APB2RSTR_SPI1RST                RCC_APB2RSTR_SPI1RST_Msk
+#define RCC_APB2RSTR_USART1RST_Pos          (14U)
+#define RCC_APB2RSTR_USART1RST_Msk          (0x1UL << RCC_APB2RSTR_USART1RST_Pos) /*!< 0x00004000 */
+#define RCC_APB2RSTR_USART1RST              RCC_APB2RSTR_USART1RST_Msk
+
+/********************  Bit definition for RCC_APB3RSTR register  **************/
+#define RCC_APB3RSTR_RFRST_Pos             (0U)
+#define RCC_APB3RSTR_RFRST_Msk             (0x1UL << RCC_APB3RSTR_RFRST_Pos) /*!< 0x00000001 */
+#define RCC_APB3RSTR_RFRST                 RCC_APB3RSTR_RFRST_Msk
+
+/********************  Bit definition for RCC_AHB1ENR register  ****************/
+#define RCC_AHB1ENR_DMA1EN_Pos              (0U)
+#define RCC_AHB1ENR_DMA1EN_Msk              (0x1UL << RCC_AHB1ENR_DMA1EN_Pos)  /*!< 0x00000001 */
+#define RCC_AHB1ENR_DMA1EN                  RCC_AHB1ENR_DMA1EN_Msk
+#define RCC_AHB1ENR_DMAMUX1EN_Pos           (2U)
+#define RCC_AHB1ENR_DMAMUX1EN_Msk           (0x1UL << RCC_AHB1ENR_DMAMUX1EN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1ENR_DMAMUX1EN               RCC_AHB1ENR_DMAMUX1EN_Msk
+#define RCC_AHB1ENR_CRCEN_Pos               (12U)
+#define RCC_AHB1ENR_CRCEN_Msk               (0x1UL << RCC_AHB1ENR_CRCEN_Pos)   /*!< 0x00001000 */
+#define RCC_AHB1ENR_CRCEN                   RCC_AHB1ENR_CRCEN_Msk
+#define RCC_AHB1ENR_TSCEN_Pos               (16U)
+#define RCC_AHB1ENR_TSCEN_Msk               (0x1UL << RCC_AHB1ENR_TSCEN_Pos)   /*!< 0x00010000 */
+#define RCC_AHB1ENR_TSCEN                   RCC_AHB1ENR_TSCEN_Msk
+
+/********************  Bit definition for RCC_AHB2ENR register  ***************/
+#define RCC_AHB2ENR_GPIOAEN_Pos             (0U)
+#define RCC_AHB2ENR_GPIOAEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOAEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB2ENR_GPIOAEN                 RCC_AHB2ENR_GPIOAEN_Msk
+#define RCC_AHB2ENR_GPIOBEN_Pos             (1U)
+#define RCC_AHB2ENR_GPIOBEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOBEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB2ENR_GPIOBEN                 RCC_AHB2ENR_GPIOBEN_Msk
+#define RCC_AHB2ENR_GPIOCEN_Pos             (2U)
+#define RCC_AHB2ENR_GPIOCEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOCEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB2ENR_GPIOCEN                 RCC_AHB2ENR_GPIOCEN_Msk
+#define RCC_AHB2ENR_GPIOEEN_Pos             (4U)
+#define RCC_AHB2ENR_GPIOEEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOEEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB2ENR_GPIOEEN                 RCC_AHB2ENR_GPIOEEN_Msk
+#define RCC_AHB2ENR_GPIOHEN_Pos             (7U)
+#define RCC_AHB2ENR_GPIOHEN_Msk             (0x1UL << RCC_AHB2ENR_GPIOHEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2ENR_GPIOHEN                 RCC_AHB2ENR_GPIOHEN_Msk
+
+/********************  Bit definition for RCC_AHB3ENR register  ***************/
+#define RCC_AHB3ENR_PKAEN_Pos               (16U)
+#define RCC_AHB3ENR_PKAEN_Msk               (0x1UL << RCC_AHB3ENR_PKAEN_Pos)   /*!< 0x00010000 */
+#define RCC_AHB3ENR_PKAEN                   RCC_AHB3ENR_PKAEN_Msk
+#define RCC_AHB3ENR_AES2EN_Pos              (17U)
+#define RCC_AHB3ENR_AES2EN_Msk              (0x1UL << RCC_AHB3ENR_AES2EN_Pos) /*!< 0x00020000 */
+#define RCC_AHB3ENR_AES2EN                  RCC_AHB3ENR_AES2EN_Msk
+#define RCC_AHB3ENR_RNGEN_Pos               (18U)
+#define RCC_AHB3ENR_RNGEN_Msk               (0x1UL << RCC_AHB3ENR_RNGEN_Pos)  /*!< 0x00040000 */
+#define RCC_AHB3ENR_RNGEN                   RCC_AHB3ENR_RNGEN_Msk
+#define RCC_AHB3ENR_HSEMEN_Pos              (19U)
+#define RCC_AHB3ENR_HSEMEN_Msk              (0x1UL << RCC_AHB3ENR_HSEMEN_Pos)  /*!< 0x00080000 */
+#define RCC_AHB3ENR_HSEMEN                  RCC_AHB3ENR_HSEMEN_Msk
+#define RCC_AHB3ENR_IPCCEN_Pos              (20U)
+#define RCC_AHB3ENR_IPCCEN_Msk              (0x1UL << RCC_AHB3ENR_IPCCEN_Pos)  /*!< 0x00100000 */
+#define RCC_AHB3ENR_IPCCEN                  RCC_AHB3ENR_IPCCEN_Msk
+#define RCC_AHB3ENR_FLASHEN_Pos             (25U)
+#define RCC_AHB3ENR_FLASHEN_Msk             (0x1UL << RCC_AHB3ENR_FLASHEN_Pos)   /*!< 0x02000000 */
+#define RCC_AHB3ENR_FLASHEN                 RCC_AHB3ENR_FLASHEN_Msk
+
+/********************  Bit definition for RCC_APB1ENR1 register  **************/
+#define RCC_APB1ENR1_TIM2EN_Pos             (0U)
+#define RCC_APB1ENR1_TIM2EN_Msk             (0x1UL << RCC_APB1ENR1_TIM2EN_Pos) /*!< 0x00000001 */
+#define RCC_APB1ENR1_TIM2EN                 RCC_APB1ENR1_TIM2EN_Msk
+#define RCC_APB1ENR1_RTCAPBEN_Pos           (10U)
+#define RCC_APB1ENR1_RTCAPBEN_Msk           (0x1UL << RCC_APB1ENR1_RTCAPBEN_Pos) /*!< 0x00000400 */
+#define RCC_APB1ENR1_RTCAPBEN               RCC_APB1ENR1_RTCAPBEN_Msk
+#define RCC_APB1ENR1_WWDGEN_Pos             (11U)
+#define RCC_APB1ENR1_WWDGEN_Msk             (0x1UL << RCC_APB1ENR1_WWDGEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1ENR1_WWDGEN                 RCC_APB1ENR1_WWDGEN_Msk
+#define RCC_APB1ENR1_I2C1EN_Pos             (21U)
+#define RCC_APB1ENR1_I2C1EN_Msk             (0x1UL << RCC_APB1ENR1_I2C1EN_Pos) /*!< 0x00200000 */
+#define RCC_APB1ENR1_I2C1EN                 RCC_APB1ENR1_I2C1EN_Msk
+#define RCC_APB1ENR1_LPTIM1EN_Pos           (31U)
+#define RCC_APB1ENR1_LPTIM1EN_Msk           (0x1UL << RCC_APB1ENR1_LPTIM1EN_Pos) /*!< 0x80000000 */
+#define RCC_APB1ENR1_LPTIM1EN               RCC_APB1ENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_APB1ENR2 register  **************/
+#define RCC_APB1ENR2_LPUART1EN_Pos          (0U)
+#define RCC_APB1ENR2_LPUART1EN_Msk         (0x1UL << RCC_APB1ENR2_LPUART1EN_Pos) /*!< 0x00000001 */
+#define RCC_APB1ENR2_LPUART1EN              RCC_APB1ENR2_LPUART1EN_Msk
+#define RCC_APB1ENR2_LPTIM2EN_Pos           (5U)
+#define RCC_APB1ENR2_LPTIM2EN_Msk           (0x1UL << RCC_APB1ENR2_LPTIM2EN_Pos) /*!< 0x00000020 */
+#define RCC_APB1ENR2_LPTIM2EN               RCC_APB1ENR2_LPTIM2EN_Msk
+
+/********************  Bit definition for RCC_APB2ENR register  **************/
+#define RCC_APB2ENR_ADCEN_Pos               (9U)
+#define RCC_APB2ENR_ADCEN_Msk               (0x1UL << RCC_APB2ENR_ADCEN_Pos)    /*!< 0x00000200 */
+#define RCC_APB2ENR_ADCEN                   RCC_APB2ENR_ADCEN_Msk
+#define RCC_APB2ENR_TIM1EN_Pos              (11U)
+#define RCC_APB2ENR_TIM1EN_Msk              (0x1UL << RCC_APB2ENR_TIM1EN_Pos)   /*!< 0x00000800 */
+#define RCC_APB2ENR_TIM1EN                  RCC_APB2ENR_TIM1EN_Msk
+#define RCC_APB2ENR_SPI1EN_Pos              (12U)
+#define RCC_APB2ENR_SPI1EN_Msk              (0x1UL << RCC_APB2ENR_SPI1EN_Pos)   /*!< 0x00001000 */
+#define RCC_APB2ENR_SPI1EN                  RCC_APB2ENR_SPI1EN_Msk
+#define RCC_APB2ENR_USART1EN_Pos            (14U)
+#define RCC_APB2ENR_USART1EN_Msk            (0x1UL << RCC_APB2ENR_USART1EN_Pos) /*!< 0x00004000 */
+#define RCC_APB2ENR_USART1EN                RCC_APB2ENR_USART1EN_Msk
+
+/********************  Bit definition for RCC_AHB1SMENR register  ****************/
+#define RCC_AHB1SMENR_DMA1SMEN_Pos          (0U)
+#define RCC_AHB1SMENR_DMA1SMEN_Msk          (0x1UL << RCC_AHB1SMENR_DMA1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB1SMENR_DMA1SMEN              RCC_AHB1SMENR_DMA1SMEN_Msk
+#define RCC_AHB1SMENR_DMAMUX1SMEN_Pos       (2U)
+#define RCC_AHB1SMENR_DMAMUX1SMEN_Msk       (0x1UL << RCC_AHB1SMENR_DMAMUX1SMEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB1SMENR_DMAMUX1SMEN           RCC_AHB1SMENR_DMAMUX1SMEN_Msk
+#define RCC_AHB1SMENR_SRAM1SMEN_Pos         (9U)
+#define RCC_AHB1SMENR_SRAM1SMEN_Msk         (0x1UL << RCC_AHB1SMENR_SRAM1SMEN_Pos) /*!< 0x00000200 */
+#define RCC_AHB1SMENR_SRAM1SMEN             RCC_AHB1SMENR_SRAM1SMEN_Msk
+#define RCC_AHB1SMENR_CRCSMEN_Pos           (12U)
+#define RCC_AHB1SMENR_CRCSMEN_Msk           (0x1UL << RCC_AHB1SMENR_CRCSMEN_Pos) /*!< 0x00001000 */
+#define RCC_AHB1SMENR_CRCSMEN               RCC_AHB1SMENR_CRCSMEN_Msk
+#define RCC_AHB1SMENR_TSCSMEN_Pos           (16U)
+#define RCC_AHB1SMENR_TSCSMEN_Msk           (0x1UL << RCC_AHB1SMENR_TSCSMEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB1SMENR_TSCSMEN               RCC_AHB1SMENR_TSCSMEN_Msk
+
+/********************  Bit definition for RCC_AHB2SMENR register  ***************/
+#define RCC_AHB2SMENR_GPIOASMEN_Pos         (0U)
+#define RCC_AHB2SMENR_GPIOASMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOASMEN_Pos) /*!< 0x00000001 */
+#define RCC_AHB2SMENR_GPIOASMEN             RCC_AHB2SMENR_GPIOASMEN_Msk
+#define RCC_AHB2SMENR_GPIOBSMEN_Pos         (1U)
+#define RCC_AHB2SMENR_GPIOBSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOBSMEN_Pos) /*!< 0x00000002 */
+#define RCC_AHB2SMENR_GPIOBSMEN             RCC_AHB2SMENR_GPIOBSMEN_Msk
+#define RCC_AHB2SMENR_GPIOCSMEN_Pos         (2U)
+#define RCC_AHB2SMENR_GPIOCSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOCSMEN_Pos) /*!< 0x00000004 */
+#define RCC_AHB2SMENR_GPIOCSMEN             RCC_AHB2SMENR_GPIOCSMEN_Msk
+#define RCC_AHB2SMENR_GPIOESMEN_Pos         (4U)
+#define RCC_AHB2SMENR_GPIOESMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOESMEN_Pos) /*!< 0x00000010 */
+#define RCC_AHB2SMENR_GPIOESMEN             RCC_AHB2SMENR_GPIOESMEN_Msk
+#define RCC_AHB2SMENR_GPIOHSMEN_Pos         (7U)
+#define RCC_AHB2SMENR_GPIOHSMEN_Msk         (0x1UL << RCC_AHB2SMENR_GPIOHSMEN_Pos) /*!< 0x00000080 */
+#define RCC_AHB2SMENR_GPIOHSMEN             RCC_AHB2SMENR_GPIOHSMEN_Msk
+
+/********************  Bit definition for RCC_AHB3SMENR register  ***************/
+#define RCC_AHB3SMENR_PKASMEN_Pos           (16U)
+#define RCC_AHB3SMENR_PKASMEN_Msk           (0x1UL << RCC_AHB3SMENR_PKASMEN_Pos) /*!< 0x00010000 */
+#define RCC_AHB3SMENR_PKASMEN               RCC_AHB3SMENR_PKASMEN_Msk
+#define RCC_AHB3SMENR_AES2SMEN_Pos          (17U)
+#define RCC_AHB3SMENR_AES2SMEN_Msk          (0x1UL << RCC_AHB3SMENR_AES2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_AHB3SMENR_AES2SMEN              RCC_AHB3SMENR_AES2SMEN_Msk
+#define RCC_AHB3SMENR_RNGSMEN_Pos           (18U)
+#define RCC_AHB3SMENR_RNGSMEN_Msk           (0x1UL << RCC_AHB3SMENR_RNGSMEN_Pos) /*!< 0x00040000 */
+#define RCC_AHB3SMENR_RNGSMEN                RCC_AHB3SMENR_RNGSMEN_Msk
+#define RCC_AHB3SMENR_SRAM2SMEN_Pos         (24U)
+#define RCC_AHB3SMENR_SRAM2SMEN_Msk         (0x1UL << RCC_AHB3SMENR_SRAM2SMEN_Pos) /*!< 0x01000000 */
+#define RCC_AHB3SMENR_SRAM2SMEN             RCC_AHB3SMENR_SRAM2SMEN_Msk
+#define RCC_AHB3SMENR_FLASHSMEN_Pos         (25U)
+#define RCC_AHB3SMENR_FLASHSMEN_Msk         (0x1UL << RCC_AHB3SMENR_FLASHSMEN_Pos) /*!< 0x02000000 */
+#define RCC_AHB3SMENR_FLASHSMEN             RCC_AHB3SMENR_FLASHSMEN_Msk
+
+/********************  Bit definition for RCC_APB1SMENR1 register  **************/
+#define RCC_APB1SMENR1_TIM2SMEN_Pos         (0U)
+#define RCC_APB1SMENR1_TIM2SMEN_Msk         (0x1UL << RCC_APB1SMENR1_TIM2SMEN_Pos) /*!< 0x00000001 */
+#define RCC_APB1SMENR1_TIM2SMEN             RCC_APB1SMENR1_TIM2SMEN_Msk
+#define RCC_APB1SMENR1_RTCAPBSMEN_Pos       (10U)
+#define RCC_APB1SMENR1_RTCAPBSMEN_Msk       (0x1UL << RCC_APB1SMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_APB1SMENR1_RTCAPBSMEN           RCC_APB1SMENR1_RTCAPBSMEN_Msk
+#define RCC_APB1SMENR1_WWDGSMEN_Pos         (11U)
+#define RCC_APB1SMENR1_WWDGSMEN_Msk         (0x1UL << RCC_APB1SMENR1_WWDGSMEN_Pos) /*!< 0x00000800 */
+#define RCC_APB1SMENR1_WWDGSMEN             RCC_APB1SMENR1_WWDGSMEN_Msk
+#define RCC_APB1SMENR1_I2C1SMEN_Pos         (21U)
+#define RCC_APB1SMENR1_I2C1SMEN_Msk         (0x1UL << RCC_APB1SMENR1_I2C1SMEN_Pos) /*!< 0x00200000 */
+#define RCC_APB1SMENR1_I2C1SMEN             RCC_APB1SMENR1_I2C1SMEN_Msk
+#define RCC_APB1SMENR1_LPTIM1SMEN_Pos       (31U)
+#define RCC_APB1SMENR1_LPTIM1SMEN_Msk       (0x1UL << RCC_APB1SMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_APB1SMENR1_LPTIM1SMEN           RCC_APB1SMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_APB1SMENR2 register  **************/
+#define RCC_APB1SMENR2_LPUART1SMEN_Pos      (0U)
+#define RCC_APB1SMENR2_LPUART1SMEN_Msk      (0x1UL << RCC_APB1SMENR2_LPUART1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_APB1SMENR2_LPUART1SMEN          RCC_APB1SMENR2_LPUART1SMEN_Msk
+#define RCC_APB1SMENR2_LPTIM2SMEN_Pos       (5U)
+#define RCC_APB1SMENR2_LPTIM2SMEN_Msk       (0x1UL << RCC_APB1SMENR2_LPTIM2SMEN_Pos) /*!< 0x00000020 */
+#define RCC_APB1SMENR2_LPTIM2SMEN           RCC_APB1SMENR2_LPTIM2SMEN_Msk
+
+/********************  Bit definition for RCC_APB2SMENR register  **************/
+#define RCC_APB2SMENR_ADCSMEN_Pos           (9U)
+#define RCC_APB2SMENR_ADCSMEN_Msk           (0x1UL << RCC_APB2SMENR_ADCSMEN_Pos)    /*!< 0x00000200 */
+#define RCC_APB2SMENR_ADCSMEN               RCC_APB2SMENR_ADCSMEN_Msk
+#define RCC_APB2SMENR_TIM1SMEN_Pos          (11U)
+#define RCC_APB2SMENR_TIM1SMEN_Msk          (0x1UL << RCC_APB2SMENR_TIM1SMEN_Pos)   /*!< 0x00000800 */
+#define RCC_APB2SMENR_TIM1SMEN              RCC_APB2SMENR_TIM1SMEN_Msk
+#define RCC_APB2SMENR_SPI1SMEN_Pos          (12U)
+#define RCC_APB2SMENR_SPI1SMEN_Msk          (0x1UL << RCC_APB2SMENR_SPI1SMEN_Pos)   /*!< 0x00001000 */
+#define RCC_APB2SMENR_SPI1SMEN              RCC_APB2SMENR_SPI1SMEN_Msk
+#define RCC_APB2SMENR_USART1SMEN_Pos        (14U)
+#define RCC_APB2SMENR_USART1SMEN_Msk        (0x1UL << RCC_APB2SMENR_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_APB2SMENR_USART1SMEN            RCC_APB2SMENR_USART1SMEN_Msk
+
+/********************  Bit definition for RCC_CCIPR register  ******************/
+#define RCC_CCIPR_USART1SEL_Pos             (0U)
+#define RCC_CCIPR_USART1SEL_Msk             (0x3UL << RCC_CCIPR_USART1SEL_Pos) /*!< 0x00000003 */
+#define RCC_CCIPR_USART1SEL                 RCC_CCIPR_USART1SEL_Msk
+#define RCC_CCIPR_USART1SEL_0               (0x1U << RCC_CCIPR_USART1SEL_Pos)  /*!< 0x00000001 */
+#define RCC_CCIPR_USART1SEL_1               (0x2U << RCC_CCIPR_USART1SEL_Pos)  /*!< 0x00000002 */
+
+#define RCC_CCIPR_LPUART1SEL_Pos            (10U)
+#define RCC_CCIPR_LPUART1SEL_Msk            (0x3UL << RCC_CCIPR_LPUART1SEL_Pos) /*!< 0x00000C00 */
+#define RCC_CCIPR_LPUART1SEL                RCC_CCIPR_LPUART1SEL_Msk
+#define RCC_CCIPR_LPUART1SEL_0              (0x1U << RCC_CCIPR_LPUART1SEL_Pos)  /*!< 0x00000400 */
+#define RCC_CCIPR_LPUART1SEL_1              (0x2U << RCC_CCIPR_LPUART1SEL_Pos)  /*!< 0x00000800 */
+
+#define RCC_CCIPR_I2C1SEL_Pos               (12U)
+#define RCC_CCIPR_I2C1SEL_Msk               (0x3UL << RCC_CCIPR_I2C1SEL_Pos)   /*!< 0x00003000 */
+#define RCC_CCIPR_I2C1SEL                   RCC_CCIPR_I2C1SEL_Msk
+#define RCC_CCIPR_I2C1SEL_0                 (0x1U << RCC_CCIPR_I2C1SEL_Pos)    /*!< 0x00001000 */
+#define RCC_CCIPR_I2C1SEL_1                 (0x2U << RCC_CCIPR_I2C1SEL_Pos)    /*!< 0x00002000 */
+
+#define RCC_CCIPR_LPTIM1SEL_Pos             (18U)
+#define RCC_CCIPR_LPTIM1SEL_Msk             (0x3UL << RCC_CCIPR_LPTIM1SEL_Pos) /*!< 0x000C0000 */
+#define RCC_CCIPR_LPTIM1SEL                 RCC_CCIPR_LPTIM1SEL_Msk
+#define RCC_CCIPR_LPTIM1SEL_0               (0x1U << RCC_CCIPR_LPTIM1SEL_Pos)  /*!< 0x00040000 */
+#define RCC_CCIPR_LPTIM1SEL_1               (0x2U << RCC_CCIPR_LPTIM1SEL_Pos)  /*!< 0x00080000 */
+
+#define RCC_CCIPR_LPTIM2SEL_Pos             (20U)
+#define RCC_CCIPR_LPTIM2SEL_Msk             (0x3UL << RCC_CCIPR_LPTIM2SEL_Pos) /*!< 0x00300000 */
+#define RCC_CCIPR_LPTIM2SEL                 RCC_CCIPR_LPTIM2SEL_Msk
+#define RCC_CCIPR_LPTIM2SEL_0               (0x1U << RCC_CCIPR_LPTIM2SEL_Pos)  /*!< 0x00100000 */
+#define RCC_CCIPR_LPTIM2SEL_1               (0x2U << RCC_CCIPR_LPTIM2SEL_Pos)  /*!< 0x00200000 */
+
+#define RCC_CCIPR_CLK48SEL_Pos              (26U)
+#define RCC_CCIPR_CLK48SEL_Msk              (0x3UL << RCC_CCIPR_CLK48SEL_Pos)  /*!< 0x0C000000 */
+#define RCC_CCIPR_CLK48SEL                  RCC_CCIPR_CLK48SEL_Msk
+#define RCC_CCIPR_CLK48SEL_0                (0x1U << RCC_CCIPR_CLK48SEL_Pos)   /*!< 0x04000000 */
+#define RCC_CCIPR_CLK48SEL_1                (0x2U << RCC_CCIPR_CLK48SEL_Pos)   /*!< 0x08000000 */
+
+#define RCC_CCIPR_ADCSEL_Pos                (28U)
+#define RCC_CCIPR_ADCSEL_Msk                (0x3UL << RCC_CCIPR_ADCSEL_Pos)    /*!< 0x30000000 */
+#define RCC_CCIPR_ADCSEL                    RCC_CCIPR_ADCSEL_Msk
+#define RCC_CCIPR_ADCSEL_0                  (0x1U << RCC_CCIPR_ADCSEL_Pos)     /*!< 0x10000000 */
+#define RCC_CCIPR_ADCSEL_1                  (0x2U << RCC_CCIPR_ADCSEL_Pos)     /*!< 0x20000000 */
+
+#define RCC_CCIPR_RNGSEL_Pos                (30U)
+#define RCC_CCIPR_RNGSEL_Msk                (0x3UL << RCC_CCIPR_RNGSEL_Pos)    /*!< 0xC0000000 */
+#define RCC_CCIPR_RNGSEL                    RCC_CCIPR_RNGSEL_Msk
+#define RCC_CCIPR_RNGSEL_0                  (0x1U << RCC_CCIPR_RNGSEL_Pos)     /*!< 0x40000000 */
+#define RCC_CCIPR_RNGSEL_1                  (0x2U << RCC_CCIPR_RNGSEL_Pos)     /*!< 0x80000000 */
+
+/********************  Bit definition for RCC_BDCR register  ******************/
+#define RCC_BDCR_LSEON_Pos                  (0U)
+#define RCC_BDCR_LSEON_Msk                  (0x1UL << RCC_BDCR_LSEON_Pos)      /*!< 0x00000001 */
+#define RCC_BDCR_LSEON                      RCC_BDCR_LSEON_Msk
+#define RCC_BDCR_LSERDY_Pos                 (1U)
+#define RCC_BDCR_LSERDY_Msk                 (0x1UL << RCC_BDCR_LSERDY_Pos)     /*!< 0x00000002 */
+#define RCC_BDCR_LSERDY                     RCC_BDCR_LSERDY_Msk
+#define RCC_BDCR_LSEBYP_Pos                 (2U)
+#define RCC_BDCR_LSEBYP_Msk                 (0x1UL << RCC_BDCR_LSEBYP_Pos)     /*!< 0x00000004 */
+#define RCC_BDCR_LSEBYP                     RCC_BDCR_LSEBYP_Msk
+
+#define RCC_BDCR_LSEDRV_Pos                 (3U)
+#define RCC_BDCR_LSEDRV_Msk                 (0x3UL << RCC_BDCR_LSEDRV_Pos)     /*!< 0x00000018 */
+#define RCC_BDCR_LSEDRV                     RCC_BDCR_LSEDRV_Msk
+#define RCC_BDCR_LSEDRV_0                   (0x1U << RCC_BDCR_LSEDRV_Pos)      /*!< 0x00000008 */
+#define RCC_BDCR_LSEDRV_1                   (0x2U << RCC_BDCR_LSEDRV_Pos)      /*!< 0x00000010 */
+
+#define RCC_BDCR_LSECSSON_Pos               (5U)
+#define RCC_BDCR_LSECSSON_Msk               (0x1UL << RCC_BDCR_LSECSSON_Pos)   /*!< 0x00000020 */
+#define RCC_BDCR_LSECSSON                   RCC_BDCR_LSECSSON_Msk
+#define RCC_BDCR_LSECSSD_Pos                (6U)
+#define RCC_BDCR_LSECSSD_Msk                (0x1UL << RCC_BDCR_LSECSSD_Pos)    /*!< 0x00000040 */
+#define RCC_BDCR_LSECSSD                    RCC_BDCR_LSECSSD_Msk
+
+#define RCC_BDCR_RTCSEL_Pos                 (8U)
+#define RCC_BDCR_RTCSEL_Msk                 (0x3UL << RCC_BDCR_RTCSEL_Pos)     /*!< 0x00000300 */
+#define RCC_BDCR_RTCSEL                     RCC_BDCR_RTCSEL_Msk
+#define RCC_BDCR_RTCSEL_0                   (0x1U << RCC_BDCR_RTCSEL_Pos)      /*!< 0x00000100 */
+#define RCC_BDCR_RTCSEL_1                   (0x2U << RCC_BDCR_RTCSEL_Pos)      /*!< 0x00000200 */
+
+#define RCC_BDCR_RTCEN_Pos                  (15U)
+#define RCC_BDCR_RTCEN_Msk                  (0x1UL << RCC_BDCR_RTCEN_Pos)      /*!< 0x00008000 */
+#define RCC_BDCR_RTCEN                      RCC_BDCR_RTCEN_Msk
+
+#define RCC_BDCR_BDRST_Pos                  (16U)
+#define RCC_BDCR_BDRST_Msk                  (0x1UL << RCC_BDCR_BDRST_Pos)      /*!< 0x00010000 */
+#define RCC_BDCR_BDRST                      RCC_BDCR_BDRST_Msk
+
+#define RCC_BDCR_LSCOEN_Pos                 (24U)
+#define RCC_BDCR_LSCOEN_Msk                 (0x1UL << RCC_BDCR_LSCOEN_Pos)     /*!< 0x01000000 */
+#define RCC_BDCR_LSCOEN                     RCC_BDCR_LSCOEN_Msk
+#define RCC_BDCR_LSCOSEL_Pos                (25U)
+#define RCC_BDCR_LSCOSEL_Msk                (0x1UL << RCC_BDCR_LSCOSEL_Pos)    /*!< 0x02000000 */
+#define RCC_BDCR_LSCOSEL                    RCC_BDCR_LSCOSEL_Msk
+
+/********************  Bit definition for RCC_CSR register  *******************/
+#define RCC_CSR_LSI1ON_Pos                  (0U)
+#define RCC_CSR_LSI1ON_Msk                  (0x1UL << RCC_CSR_LSI1ON_Pos)      /*!< 0x00000001 */
+#define RCC_CSR_LSI1ON                      RCC_CSR_LSI1ON_Msk
+#define RCC_CSR_LSI1RDY_Pos                 (1U)
+#define RCC_CSR_LSI1RDY_Msk                 (0x1UL << RCC_CSR_LSI1RDY_Pos)     /*!< 0x00000002 */
+#define RCC_CSR_LSI1RDY                     RCC_CSR_LSI1RDY_Msk
+#define RCC_CSR_LSI2ON_Pos                  (2U)
+#define RCC_CSR_LSI2ON_Msk                  (0x1UL << RCC_CSR_LSI2ON_Pos)      /*!< 0x00000004 */
+#define RCC_CSR_LSI2ON                      RCC_CSR_LSI2ON_Msk
+#define RCC_CSR_LSI2RDY_Pos                 (3U)
+#define RCC_CSR_LSI2RDY_Msk                 (0x1UL << RCC_CSR_LSI2RDY_Pos)     /*!< 0x00000008 */
+#define RCC_CSR_LSI2RDY                     RCC_CSR_LSI2RDY_Msk
+#define RCC_CSR_LSI2TRIM_Pos                (8U)
+#define RCC_CSR_LSI2TRIM_Msk                (0xFUL << RCC_CSR_LSI2TRIM_Pos)      /*!< 0x00000F00 */
+#define RCC_CSR_LSI2TRIM                    RCC_CSR_LSI2TRIM_Msk
+#define RCC_CSR_LSI2TRIM_0                  (0x1U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000100 */
+#define RCC_CSR_LSI2TRIM_1                  (0x2U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000200 */
+#define RCC_CSR_LSI2TRIM_2                  (0x4U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000400 */
+#define RCC_CSR_LSI2TRIM_3                  (0x8U << RCC_CSR_LSI2TRIM_Pos)       /*!< 0x00000800 */
+#define RCC_CSR_RFWKPSEL_Pos                (14U)
+#define RCC_CSR_RFWKPSEL_Msk                (0x3UL << RCC_CSR_RFWKPSEL_Pos)    /*!< 0x0000C000 */
+#define RCC_CSR_RFWKPSEL                    RCC_CSR_RFWKPSEL_Msk
+#define RCC_CSR_RFWKPSEL_0                  (0x1U << RCC_CSR_RFWKPSEL_Pos)     /*!< 0x00004000 */
+#define RCC_CSR_RFWKPSEL_1                  (0x2U << RCC_CSR_RFWKPSEL_Pos)     /*!< 0x00008000 */
+#define RCC_CSR_RFRSTS_Pos                  (16U)
+#define RCC_CSR_RFRSTS_Msk                  (0x1UL << RCC_CSR_RFRSTS_Pos)      /*!< 0x00010000 */
+#define RCC_CSR_RFRSTS                      RCC_CSR_RFRSTS_Msk
+#define RCC_CSR_RMVF_Pos                    (23U)
+#define RCC_CSR_RMVF_Msk                    (0x1UL << RCC_CSR_RMVF_Pos)        /*!< 0x00800000 */
+#define RCC_CSR_RMVF                        RCC_CSR_RMVF_Msk
+#define RCC_CSR_OBLRSTF_Pos                 (25U)
+#define RCC_CSR_OBLRSTF_Msk                 (0x1UL << RCC_CSR_OBLRSTF_Pos)     /*!< 0x02000000 */
+#define RCC_CSR_OBLRSTF                     RCC_CSR_OBLRSTF_Msk
+#define RCC_CSR_PINRSTF_Pos                 (26U)
+#define RCC_CSR_PINRSTF_Msk                 (0x1UL << RCC_CSR_PINRSTF_Pos)     /*!< 0x04000000 */
+#define RCC_CSR_PINRSTF                     RCC_CSR_PINRSTF_Msk
+#define RCC_CSR_BORRSTF_Pos                 (27U)
+#define RCC_CSR_BORRSTF_Msk                 (0x1UL << RCC_CSR_BORRSTF_Pos)     /*!< 0x08000000 */
+#define RCC_CSR_BORRSTF                     RCC_CSR_BORRSTF_Msk
+#define RCC_CSR_SFTRSTF_Pos                 (28U)
+#define RCC_CSR_SFTRSTF_Msk                 (0x1UL << RCC_CSR_SFTRSTF_Pos)     /*!< 0x10000000 */
+#define RCC_CSR_SFTRSTF                     RCC_CSR_SFTRSTF_Msk
+#define RCC_CSR_IWDGRSTF_Pos                (29U)
+#define RCC_CSR_IWDGRSTF_Msk                (0x1UL << RCC_CSR_IWDGRSTF_Pos)     /*!< 0x20000000 */
+#define RCC_CSR_IWDGRSTF                    RCC_CSR_IWDGRSTF_Msk
+#define RCC_CSR_WWDGRSTF_Pos                (30U)
+#define RCC_CSR_WWDGRSTF_Msk                (0x1UL << RCC_CSR_WWDGRSTF_Pos)    /*!< 0x40000000 */
+#define RCC_CSR_WWDGRSTF                    RCC_CSR_WWDGRSTF_Msk
+#define RCC_CSR_LPWRRSTF_Pos                (31U)
+#define RCC_CSR_LPWRRSTF_Msk                (0x1UL << RCC_CSR_LPWRRSTF_Pos)    /*!< 0x80000000 */
+#define RCC_CSR_LPWRRSTF                    RCC_CSR_LPWRRSTF_Msk
+
+/********************  Bit definition for RCC_HSECR register  *******************/
+#define RCC_HSECR_UNLOCKED_Pos              (0U)
+#define RCC_HSECR_UNLOCKED_Msk              (0x1UL << RCC_HSECR_UNLOCKED_Pos)  /*!< 0x00000001 */
+#define RCC_HSECR_UNLOCKED                  RCC_HSECR_UNLOCKED_Msk
+
+#define RCC_HSECR_HSES_Pos                  (3U)
+#define RCC_HSECR_HSES_Msk                  (0x1UL << RCC_HSECR_HSES_Pos)      /*!< 0x00000008 */
+#define RCC_HSECR_HSES                      RCC_HSECR_HSES_Msk
+
+#define RCC_HSECR_HSEGMC_Pos                (4U)
+#define RCC_HSECR_HSEGMC_Msk                (0x7UL << RCC_HSECR_HSEGMC_Pos)       /*!< 0x00000070 */
+#define RCC_HSECR_HSEGMC                    RCC_HSECR_HSEGMC_Msk
+#define RCC_HSECR_HSEGMC0_Pos               (4U)
+#define RCC_HSECR_HSEGMC0_Msk               (0x1UL << RCC_HSECR_HSEGMC0_Pos)      /*!< 0x00000010 */
+#define RCC_HSECR_HSEGMC0                   RCC_HSECR_HSEGMC0_Msk
+#define RCC_HSECR_HSEGMC1_Pos               (5U)
+#define RCC_HSECR_HSEGMC1_Msk               (0x1UL << RCC_HSECR_HSEGMC1_Pos)      /*!< 0x00000020 */
+#define RCC_HSECR_HSEGMC1                   RCC_HSECR_HSEGMC1_Msk
+#define RCC_HSECR_HSEGMC2_Pos               (6U)
+#define RCC_HSECR_HSEGMC2_Msk               (0x1UL << RCC_HSECR_HSEGMC2_Pos)      /*!< 0x00000040 */
+#define RCC_HSECR_HSEGMC2                   RCC_HSECR_HSEGMC2_Msk
+
+#define RCC_HSECR_HSETUNE_Pos              (8U)
+#define RCC_HSECR_HSETUNE_Msk              (0x3FUL << RCC_HSECR_HSETUNE_Pos)   /*!< 0x00003F00 */
+#define RCC_HSECR_HSETUNE                  RCC_HSECR_HSETUNE_Msk
+#define RCC_HSECR_HSETUNE0_Pos             (8U)
+#define RCC_HSECR_HSETUNE0_Msk             (0x1UL << RCC_HSECR_HSETUNE0_Pos)   /*!< 0x00000100 */
+#define RCC_HSECR_HSETUNE0                 RCC_HSECR_HSETUNE0_Msk
+#define RCC_HSECR_HSETUNE1_Pos             (9U)
+#define RCC_HSECR_HSETUNE1_Msk             (0x1UL << RCC_HSECR_HSETUNE1_Pos)   /*!< 0x00000200 */
+#define RCC_HSECR_HSETUNE1                 RCC_HSECR_HSETUNE1_Msk
+#define RCC_HSECR_HSETUNE2_Pos             (10U)
+#define RCC_HSECR_HSETUNE2_Msk             (0x1UL << RCC_HSECR_HSETUNE2_Pos)   /*!< 0x00000400 */
+#define RCC_HSECR_HSETUNE2                 RCC_HSECR_HSETUNE2_Msk
+#define RCC_HSECR_HSETUNE3_Pos             (11U)
+#define RCC_HSECR_HSETUNE3_Msk             (0x1UL << RCC_HSECR_HSETUNE3_Pos)   /*!< 0x00000800 */
+#define RCC_HSECR_HSETUNE3                 RCC_HSECR_HSETUNE3_Msk
+#define RCC_HSECR_HSETUNE4_Pos             (12U)
+#define RCC_HSECR_HSETUNE4_Msk             (0x1UL << RCC_HSECR_HSETUNE4_Pos)   /*!< 0x00001000 */
+#define RCC_HSECR_HSETUNE4                 RCC_HSECR_HSETUNE4_Msk
+#define RCC_HSECR_HSETUNE5_Pos             (13U)
+#define RCC_HSECR_HSETUNE5_Msk             (0x1UL << RCC_HSECR_HSETUNE5_Pos)   /*!< 0x00002000 */
+#define RCC_HSECR_HSETUNE5                 RCC_HSECR_HSETUNE5_Msk
+
+/********************  Bit definition for RCC_EXTCFGR register  *******************/
+#define RCC_EXTCFGR_SHDHPRE_Pos             (0U)
+#define RCC_EXTCFGR_SHDHPRE_Msk             (0xFUL << RCC_EXTCFGR_SHDHPRE_Pos) /*!< 0x0000000F */
+#define RCC_EXTCFGR_SHDHPRE                 RCC_EXTCFGR_SHDHPRE_Msk
+#define RCC_EXTCFGR_SHDHPRE_0               (0x1U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000001 */
+#define RCC_EXTCFGR_SHDHPRE_1               (0x2U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000002 */
+#define RCC_EXTCFGR_SHDHPRE_2               (0x4U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000004 */
+#define RCC_EXTCFGR_SHDHPRE_3               (0x8U << RCC_EXTCFGR_SHDHPRE_Pos)  /*!< 0x00000008 */
+
+#define RCC_EXTCFGR_C2HPRE_Pos              (4U)
+#define RCC_EXTCFGR_C2HPRE_Msk              (0xFUL << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x000000F0 */
+#define RCC_EXTCFGR_C2HPRE                  RCC_EXTCFGR_C2HPRE_Msk
+#define RCC_EXTCFGR_C2HPRE_0                (0x1U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000010 */
+#define RCC_EXTCFGR_C2HPRE_1                (0x2U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000020 */
+#define RCC_EXTCFGR_C2HPRE_2                (0x4U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000040 */
+#define RCC_EXTCFGR_C2HPRE_3                (0x8U << RCC_EXTCFGR_C2HPRE_Pos) /*!< 0x00000080 */
+
+#define RCC_EXTCFGR_SHDHPREF_Pos            (16U)
+#define RCC_EXTCFGR_SHDHPREF_Msk            (0x1UL << RCC_EXTCFGR_SHDHPREF_Pos) /*!< 0x00010000 */
+#define RCC_EXTCFGR_SHDHPREF                RCC_EXTCFGR_SHDHPREF_Msk
+#define RCC_EXTCFGR_C2HPREF_Pos             (17U)
+#define RCC_EXTCFGR_C2HPREF_Msk             (0x1UL << RCC_EXTCFGR_C2HPREF_Pos) /*!< 0x00020000 */
+#define RCC_EXTCFGR_C2HPREF                 RCC_EXTCFGR_C2HPREF_Msk
+#define RCC_EXTCFGR_RFCSS_Pos               (20U)
+#define RCC_EXTCFGR_RFCSS_Msk               (0x1UL << RCC_EXTCFGR_RFCSS_Pos)   /*!< 0x00100000 */
+#define RCC_EXTCFGR_RFCSS                   RCC_EXTCFGR_RFCSS_Msk
+
+/********************  Bit definition for RCC_C2AHB1ENR register  ****************/
+#define RCC_C2AHB1ENR_DMA1EN_Pos            (0U)
+#define RCC_C2AHB1ENR_DMA1EN_Msk            (0x1UL << RCC_C2AHB1ENR_DMA1EN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB1ENR_DMA1EN                RCC_C2AHB1ENR_DMA1EN_Msk
+#define RCC_C2AHB1ENR_DMAMUX1EN_Pos         (2U)
+#define RCC_C2AHB1ENR_DMAMUX1EN_Msk         (0x1UL << RCC_C2AHB1ENR_DMAMUX1EN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB1ENR_DMAMUX1EN             RCC_C2AHB1ENR_DMAMUX1EN_Msk
+#define RCC_C2AHB1ENR_SRAM1EN_Pos           (9U)
+#define RCC_C2AHB1ENR_SRAM1EN_Msk           (0x1UL << RCC_C2AHB1ENR_SRAM1EN_Pos) /*!< 0x00000200 */
+#define RCC_C2AHB1ENR_SRAM1EN                RCC_C2AHB1ENR_SRAM1EN_Msk
+#define RCC_C2AHB1ENR_CRCEN_Pos             (12U)
+#define RCC_C2AHB1ENR_CRCEN_Msk             (0x1UL << RCC_C2AHB1ENR_CRCEN_Pos) /*!< 0x00001000 */
+#define RCC_C2AHB1ENR_CRCEN                  RCC_C2AHB1ENR_CRCEN_Msk
+#define RCC_C2AHB1ENR_TSCEN_Pos             (16U)
+#define RCC_C2AHB1ENR_TSCEN_Msk             (0x1UL << RCC_C2AHB1ENR_TSCEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB1ENR_TSCEN                 RCC_C2AHB1ENR_TSCEN_Msk
+
+/********************  Bit definition for RCC_C2AHB2ENR register  ***************/
+#define RCC_C2AHB2ENR_GPIOAEN_Pos          (0U)
+#define RCC_C2AHB2ENR_GPIOAEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOAEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB2ENR_GPIOAEN              RCC_C2AHB2ENR_GPIOAEN_Msk
+#define RCC_C2AHB2ENR_GPIOBEN_Pos          (1U)
+#define RCC_C2AHB2ENR_GPIOBEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOBEN_Pos) /*!< 0x00000002 */
+#define RCC_C2AHB2ENR_GPIOBEN              RCC_C2AHB2ENR_GPIOBEN_Msk
+#define RCC_C2AHB2ENR_GPIOCEN_Pos          (2U)
+#define RCC_C2AHB2ENR_GPIOCEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOCEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB2ENR_GPIOCEN              RCC_C2AHB2ENR_GPIOCEN_Msk
+#define RCC_C2AHB2ENR_GPIOEEN_Pos          (4U)
+#define RCC_C2AHB2ENR_GPIOEEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOEEN_Pos) /*!< 0x00000010 */
+#define RCC_C2AHB2ENR_GPIOEEN              RCC_C2AHB2ENR_GPIOEEN_Msk
+#define RCC_C2AHB2ENR_GPIOHEN_Pos          (7U)
+#define RCC_C2AHB2ENR_GPIOHEN_Msk          (0x1UL << RCC_C2AHB2ENR_GPIOHEN_Pos) /*!< 0x00000080 */
+#define RCC_C2AHB2ENR_GPIOHEN              RCC_C2AHB2ENR_GPIOHEN_Msk
+
+/********************  Bit definition for RCC_C2AHB3ENR register  ***************/
+#define RCC_C2AHB3ENR_PKAEN_Pos            (16U)
+#define RCC_C2AHB3ENR_PKAEN_Msk            (0x1UL << RCC_C2AHB3ENR_PKAEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB3ENR_PKAEN                RCC_C2AHB3ENR_PKAEN_Msk
+#define RCC_C2AHB3ENR_AES2EN_Pos           (17U)
+#define RCC_C2AHB3ENR_AES2EN_Msk           (0x1UL << RCC_C2AHB3ENR_AES2EN_Pos) /*!< 0x00020000 */
+#define RCC_C2AHB3ENR_AES2EN               RCC_C2AHB3ENR_AES2EN_Msk
+#define RCC_C2AHB3ENR_RNGEN_Pos            (18U)
+#define RCC_C2AHB3ENR_RNGEN_Msk            (0x1UL << RCC_C2AHB3ENR_RNGEN_Pos) /*!< 0x00040000 */
+#define RCC_C2AHB3ENR_RNGEN                RCC_C2AHB3ENR_RNGEN_Msk
+#define RCC_C2AHB3ENR_HSEMEN_Pos           (19U)
+#define RCC_C2AHB3ENR_HSEMEN_Msk           (0x1UL << RCC_C2AHB3ENR_HSEMEN_Pos) /*!< 0x00080000 */
+#define RCC_C2AHB3ENR_HSEMEN               RCC_C2AHB3ENR_HSEMEN_Msk
+#define RCC_C2AHB3ENR_IPCCEN_Pos           (20U)
+#define RCC_C2AHB3ENR_IPCCEN_Msk           (0x1UL << RCC_C2AHB3ENR_IPCCEN_Pos) /*!< 0x00100000 */
+#define RCC_C2AHB3ENR_IPCCEN               RCC_C2AHB3ENR_IPCCEN_Msk
+#define RCC_C2AHB3ENR_FLASHEN_Pos          (25U)
+#define RCC_C2AHB3ENR_FLASHEN_Msk          (0x1UL << RCC_C2AHB3ENR_FLASHEN_Pos) /*!< 0x02000000 */
+#define RCC_C2AHB3ENR_FLASHEN              RCC_C2AHB3ENR_FLASHEN_Msk
+
+/********************  Bit definition for RCC_C2APB1ENR1 register  **************/
+#define RCC_C2APB1ENR1_TIM2EN_Pos          (0U)
+#define RCC_C2APB1ENR1_TIM2EN_Msk          (0x1UL << RCC_C2APB1ENR1_TIM2EN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1ENR1_TIM2EN              RCC_C2APB1ENR1_TIM2EN_Msk
+#define RCC_C2APB1ENR1_RTCAPBEN_Pos        (10U)
+#define RCC_C2APB1ENR1_RTCAPBEN_Msk        (0x1UL << RCC_C2APB1ENR1_RTCAPBEN_Pos) /*!< 0x00000400 */
+#define RCC_C2APB1ENR1_RTCAPBEN            RCC_C2APB1ENR1_RTCAPBEN_Msk
+#define RCC_C2APB1ENR1_I2C1EN_Pos          (21U)
+#define RCC_C2APB1ENR1_I2C1EN_Msk          (0x1UL << RCC_C2APB1ENR1_I2C1EN_Pos) /*!< 0x00200000 */
+#define RCC_C2APB1ENR1_I2C1EN              RCC_C2APB1ENR1_I2C1EN_Msk
+#define RCC_C2APB1ENR1_LPTIM1EN_Pos        (31U)
+#define RCC_C2APB1ENR1_LPTIM1EN_Msk        (0x1UL << RCC_C2APB1ENR1_LPTIM1EN_Pos) /*!< 0x80000000 */
+#define RCC_C2APB1ENR1_LPTIM1EN            RCC_C2APB1ENR1_LPTIM1EN_Msk
+
+/********************  Bit definition for RCC_C2APB1ENR2 register  **************/
+#define RCC_C2APB1ENR2_LPUART1EN_Pos       (0U)
+#define RCC_C2APB1ENR2_LPUART1EN_Msk       (0x1UL << RCC_C2APB1ENR2_LPUART1EN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1ENR2_LPUART1EN           RCC_C2APB1ENR2_LPUART1EN_Msk
+#define RCC_C2APB1ENR2_LPTIM2EN_Pos        (5U)
+#define RCC_C2APB1ENR2_LPTIM2EN_Msk        (0x1UL << RCC_C2APB1ENR2_LPTIM2EN_Pos) /*!< 0x00000020 */
+#define RCC_C2APB1ENR2_LPTIM2EN            RCC_C2APB1ENR2_LPTIM2EN_Msk
+
+/********************  Bit definition for RCC_C2APB2ENR register  **************/
+#define RCC_C2APB2ENR_ADCEN_Pos            (9U)
+#define RCC_C2APB2ENR_ADCEN_Msk            (0x1UL << RCC_C2APB2ENR_ADCEN_Pos)    /*!< 0x00000200 */
+#define RCC_C2APB2ENR_ADCEN                RCC_C2APB2ENR_ADCEN_Msk
+#define RCC_C2APB2ENR_TIM1EN_Pos           (11U)
+#define RCC_C2APB2ENR_TIM1EN_Msk           (0x1UL << RCC_C2APB2ENR_TIM1EN_Pos)   /*!< 0x00000800 */
+#define RCC_C2APB2ENR_TIM1EN               RCC_C2APB2ENR_TIM1EN_Msk
+#define RCC_C2APB2ENR_SPI1EN_Pos           (12U)
+#define RCC_C2APB2ENR_SPI1EN_Msk           (0x1UL << RCC_C2APB2ENR_SPI1EN_Pos)   /*!< 0x00001000 */
+#define RCC_C2APB2ENR_SPI1EN               RCC_C2APB2ENR_SPI1EN_Msk
+#define RCC_C2APB2ENR_USART1EN_Pos         (14U)
+#define RCC_C2APB2ENR_USART1EN_Msk         (0x1UL << RCC_C2APB2ENR_USART1EN_Pos) /*!< 0x00004000 */
+#define RCC_C2APB2ENR_USART1EN             RCC_C2APB2ENR_USART1EN_Msk
+
+/********************  Bit definition for RCC_C2APB3ENR register  **************/
+#define RCC_C2APB3ENR_BLEEN_Pos            (0U)
+#define RCC_C2APB3ENR_BLEEN_Msk            (0x1UL << RCC_C2APB3ENR_BLEEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB3ENR_BLEEN                RCC_C2APB3ENR_BLEEN_Msk
+
+/********************  Bit definition for RCC_C2AHB1SMENR register  ****************/
+#define RCC_C2AHB1SMENR_DMA1SMEN_Pos       (0U)
+#define RCC_C2AHB1SMENR_DMA1SMEN_Msk       (0x1UL << RCC_C2AHB1SMENR_DMA1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB1SMENR_DMA1SMEN           RCC_C2AHB1SMENR_DMA1SMEN_Msk
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN_Pos    (2U)
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN_Msk    (0x1UL << RCC_C2AHB1SMENR_DMAMUX1SMEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB1SMENR_DMAMUX1SMEN        RCC_C2AHB1SMENR_DMAMUX1SMEN_Msk
+#define RCC_C2AHB1SMENR_SRAM1SMEN_Pos      (9U)
+#define RCC_C2AHB1SMENR_SRAM1SMEN_Msk      (0x1UL << RCC_C2AHB1SMENR_SRAM1SMEN_Pos) /*!< 0x00000200 */
+#define RCC_C2AHB1SMENR_SRAM1SMEN          RCC_C2AHB1SMENR_SRAM1SMEN_Msk
+#define RCC_C2AHB1SMENR_CRCSMEN_Pos        (12U)
+#define RCC_C2AHB1SMENR_CRCSMEN_Msk        (0x1UL << RCC_C2AHB1SMENR_CRCSMEN_Pos) /*!< 0x00001000 */
+#define RCC_C2AHB1SMENR_CRCSMEN            RCC_C2AHB1SMENR_CRCSMEN_Msk
+#define RCC_C2AHB1SMENR_TSCSMEN_Pos        (16U)
+#define RCC_C2AHB1SMENR_TSCSMEN_Msk        (0x1UL << RCC_C2AHB1SMENR_TSCSMEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB1SMENR_TSCSMEN            RCC_C2AHB1SMENR_TSCSMEN_Msk
+
+/********************  Bit definition for RCC_C2AHB2SMENR register  ***************/
+#define RCC_C2AHB2SMENR_GPIOASMEN_Pos      (0U)
+#define RCC_C2AHB2SMENR_GPIOASMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOASMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2AHB2SMENR_GPIOASMEN          RCC_C2AHB2SMENR_GPIOASMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOBSMEN_Pos      (1U)
+#define RCC_C2AHB2SMENR_GPIOBSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOBSMEN_Pos) /*!< 0x00000002 */
+#define RCC_C2AHB2SMENR_GPIOBSMEN          RCC_C2AHB2SMENR_GPIOBSMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOCSMEN_Pos      (2U)
+#define RCC_C2AHB2SMENR_GPIOCSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOCSMEN_Pos) /*!< 0x00000004 */
+#define RCC_C2AHB2SMENR_GPIOCSMEN          RCC_C2AHB2SMENR_GPIOCSMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOESMEN_Pos      (4U)
+#define RCC_C2AHB2SMENR_GPIOESMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOESMEN_Pos) /*!< 0x00000010 */
+#define RCC_C2AHB2SMENR_GPIOESMEN          RCC_C2AHB2SMENR_GPIOESMEN_Msk
+#define RCC_C2AHB2SMENR_GPIOHSMEN_Pos      (7U)
+#define RCC_C2AHB2SMENR_GPIOHSMEN_Msk      (0x1UL << RCC_C2AHB2SMENR_GPIOHSMEN_Pos) /*!< 0x00000080 */
+#define RCC_C2AHB2SMENR_GPIOHSMEN          RCC_C2AHB2SMENR_GPIOHSMEN_Msk
+
+/********************  Bit definition for RCC_C2AHB3SMENR register  ***************/
+#define RCC_C2AHB3SMENR_PKASMEN_Pos        (16U)
+#define RCC_C2AHB3SMENR_PKASMEN_Msk        (0x1UL << RCC_C2AHB3SMENR_PKASMEN_Pos) /*!< 0x00010000 */
+#define RCC_C2AHB3SMENR_PKASMEN            RCC_C2AHB3SMENR_PKASMEN_Msk
+#define RCC_C2AHB3SMENR_AES2SMEN_Pos       (17U)
+#define RCC_C2AHB3SMENR_AES2SMEN_Msk       (0x1UL << RCC_C2AHB3SMENR_AES2SMEN_Pos) /*!< 0x00020000 */
+#define RCC_C2AHB3SMENR_AES2SMEN           RCC_C2AHB3SMENR_AES2SMEN_Msk
+#define RCC_C2AHB3SMENR_RNGSMEN_Pos        (18U)
+#define RCC_C2AHB3SMENR_RNGSMEN_Msk        (0x1UL << RCC_C2AHB3SMENR_RNGSMEN_Pos) /*!< 0x00040000 */
+#define RCC_C2AHB3SMENR_RNGSMEN            RCC_C2AHB3SMENR_RNGSMEN_Msk
+#define RCC_C2AHB3SMENR_SRAM2SMEN_Pos      (24U)
+#define RCC_C2AHB3SMENR_SRAM2SMEN_Msk      (0x1UL << RCC_C2AHB3SMENR_SRAM2SMEN_Pos) /*!< 0x01000000 */
+#define RCC_C2AHB3SMENR_SRAM2SMEN           RCC_C2AHB3SMENR_SRAM2SMEN_Msk
+#define RCC_C2AHB3SMENR_FLASHSMEN_Pos      (25U)
+#define RCC_C2AHB3SMENR_FLASHSMEN_Msk      (0x1UL << RCC_C2AHB3SMENR_FLASHSMEN_Pos) /*!< 0x02000000 */
+#define RCC_C2AHB3SMENR_FLASHSMEN          RCC_C2AHB3SMENR_FLASHSMEN_Msk
+
+/********************  Bit definition for RCC_C2APB1SMENR1 register  **************/
+#define RCC_C2APB1SMENR1_TIM2SMEN_Pos      (0U)
+#define RCC_C2APB1SMENR1_TIM2SMEN_Msk      (0x1UL << RCC_C2APB1SMENR1_TIM2SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1SMENR1_TIM2SMEN          RCC_C2APB1SMENR1_TIM2SMEN_Msk
+#define RCC_C2APB1SMENR1_RTCAPBSMEN_Pos    (10U)
+#define RCC_C2APB1SMENR1_RTCAPBSMEN_Msk    (0x1UL << RCC_C2APB1SMENR1_RTCAPBSMEN_Pos) /*!< 0x00000400 */
+#define RCC_C2APB1SMENR1_RTCAPBSMEN        RCC_C2APB1SMENR1_RTCAPBSMEN_Msk
+#define RCC_C2APB1SMENR1_I2C1SMEN_Pos      (21U)
+#define RCC_C2APB1SMENR1_I2C1SMEN_Msk      (0x1UL << RCC_C2APB1SMENR1_I2C1SMEN_Pos) /*!< 0x00200000 */
+#define RCC_C2APB1SMENR1_I2C1SMEN          RCC_C2APB1SMENR1_I2C1SMEN_Msk
+#define RCC_C2APB1SMENR1_LPTIM1SMEN_Pos    (31U)
+#define RCC_C2APB1SMENR1_LPTIM1SMEN_Msk    (0x1UL << RCC_C2APB1SMENR1_LPTIM1SMEN_Pos) /*!< 0x80000000 */
+#define RCC_C2APB1SMENR1_LPTIM1SMEN        RCC_C2APB1SMENR1_LPTIM1SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB1SMENR2 register  **************/
+#define RCC_C2APB1SMENR2_LPUART1SMEN_Pos    (0U)
+#define RCC_C2APB1SMENR2_LPUART1SMEN_Msk    (0x1UL << RCC_C2APB1SMENR2_LPUART1SMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB1SMENR2_LPUART1SMEN        RCC_C2APB1SMENR2_LPUART1SMEN_Msk
+#define RCC_C2APB1SMENR2_LPTIM2SMEN_Pos     (5U)
+#define RCC_C2APB1SMENR2_LPTIM2SMEN_Msk     (0x1UL << RCC_C2APB1SMENR2_LPTIM2SMEN_Pos) /*!< 0x00000020 */
+#define RCC_C2APB1SMENR2_LPTIM2SMEN         RCC_C2APB1SMENR2_LPTIM2SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB2SMENR register  **************/
+#define RCC_C2APB2SMENR_ADCSMEN_Pos        (9U)
+#define RCC_C2APB2SMENR_ADCSMEN_Msk        (0x1UL << RCC_C2APB2SMENR_ADCSMEN_Pos)    /*!< 0x00000200 */
+#define RCC_C2APB2SMENR_ADCSMEN            RCC_C2APB2SMENR_ADCSMEN_Msk
+#define RCC_C2APB2SMENR_TIM1SMEN_Pos       (11U)
+#define RCC_C2APB2SMENR_TIM1SMEN_Msk       (0x1UL << RCC_C2APB2SMENR_TIM1SMEN_Pos)   /*!< 0x00000800 */
+#define RCC_C2APB2SMENR_TIM1SMEN           RCC_C2APB2SMENR_TIM1SMEN_Msk
+#define RCC_C2APB2SMENR_SPI1SMEN_Pos       (12U)
+#define RCC_C2APB2SMENR_SPI1SMEN_Msk       (0x1UL << RCC_C2APB2SMENR_SPI1SMEN_Pos)   /*!< 0x00001000 */
+#define RCC_C2APB2SMENR_SPI1SMEN           RCC_C2APB2SMENR_SPI1SMEN_Msk
+#define RCC_C2APB2SMENR_USART1SMEN_Pos     (14U)
+#define RCC_C2APB2SMENR_USART1SMEN_Msk     (0x1UL << RCC_C2APB2SMENR_USART1SMEN_Pos) /*!< 0x00004000 */
+#define RCC_C2APB2SMENR_USART1SMEN         RCC_C2APB2SMENR_USART1SMEN_Msk
+
+/********************  Bit definition for RCC_C2APB3SMENR register  **************/
+#define RCC_C2APB3SMENR_BLESMEN_Pos        (0U)
+#define RCC_C2APB3SMENR_BLESMEN_Msk        (0x1UL << RCC_C2APB3SMENR_BLESMEN_Pos) /*!< 0x00000001 */
+#define RCC_C2APB3SMENR_BLESMEN            RCC_C2APB3SMENR_BLESMEN_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    RNG                                     */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bits definition for  register  *******************/
+#define RNG_CR_RNGEN_Pos    (2U)
+#define RNG_CR_RNGEN_Msk    (0x1UL << RNG_CR_RNGEN_Pos)                        /*!< 0x00000004 */
+#define RNG_CR_RNGEN        RNG_CR_RNGEN_Msk
+#define RNG_CR_IE_Pos       (3U)
+#define RNG_CR_IE_Msk       (0x1UL << RNG_CR_IE_Pos)                           /*!< 0x00000008 */
+#define RNG_CR_IE           RNG_CR_IE_Msk
+#define RNG_CR_CED_Pos      (5U)
+#define RNG_CR_CED_Msk      (0x1UL << RNG_CR_CED_Pos)                          /*!< 0x00000020 */
+#define RNG_CR_CED          RNG_CR_CED_Msk
+
+/********************  Bits definition for RNG_SR register  *******************/
+#define RNG_SR_DRDY_Pos     (0U)
+#define RNG_SR_DRDY_Msk     (0x1UL << RNG_SR_DRDY_Pos)                         /*!< 0x00000001 */
+#define RNG_SR_DRDY         RNG_SR_DRDY_Msk
+#define RNG_SR_CECS_Pos     (1U)
+#define RNG_SR_CECS_Msk     (0x1UL << RNG_SR_CECS_Pos)                         /*!< 0x00000002 */
+#define RNG_SR_CECS         RNG_SR_CECS_Msk
+#define RNG_SR_SECS_Pos     (2U)
+#define RNG_SR_SECS_Msk     (0x1UL << RNG_SR_SECS_Pos)                         /*!< 0x00000004 */
+#define RNG_SR_SECS         RNG_SR_SECS_Msk
+#define RNG_SR_CEIS_Pos     (5U)
+#define RNG_SR_CEIS_Msk     (0x1UL << RNG_SR_CEIS_Pos)                         /*!< 0x00000020 */
+#define RNG_SR_CEIS         RNG_SR_CEIS_Msk
+#define RNG_SR_SEIS_Pos     (6U)
+#define RNG_SR_SEIS_Msk     (0x1UL << RNG_SR_SEIS_Pos)                         /*!< 0x00000040 */
+#define RNG_SR_SEIS         RNG_SR_SEIS_Msk
+
+/******************************************************************************/
+/*                                                                            */
+/*                           Real-Time Clock (RTC)                            */
+/*                                                                            */
+/******************************************************************************/
+/*
+  * @brief Specific device feature definitions
+  */
+#define RTC_TAMPER2_SUPPORT
+#define RTC_WAKEUP_SUPPORT
+#define RTC_BACKUP_SUPPORT
+#define RTC_CPU2_SUPPORT_D
+#define RTC_INTERNALTS_SUPPORT
+
+/********************  Bits definition for RTC_TR register  *******************/
+#define RTC_TR_PM_Pos                  (22U)
+#define RTC_TR_PM_Msk                  (0x1UL << RTC_TR_PM_Pos)                /*!< 0x00400000 */
+#define RTC_TR_PM                      RTC_TR_PM_Msk                           /*!< AM/PM notation */
+#define RTC_TR_HT_Pos                  (20U)
+#define RTC_TR_HT_Msk                  (0x3UL << RTC_TR_HT_Pos)                /*!< 0x00300000 */
+#define RTC_TR_HT                      RTC_TR_HT_Msk                           /*!< Hour tens in BCD format */
+#define RTC_TR_HT_0                    (0x1U << RTC_TR_HT_Pos)                 /*!< 0x00100000 */
+#define RTC_TR_HT_1                    (0x2U << RTC_TR_HT_Pos)                 /*!< 0x00200000 */
+#define RTC_TR_HU_Pos                  (16U)
+#define RTC_TR_HU_Msk                  (0xFUL << RTC_TR_HU_Pos)                /*!< 0x000F0000 */
+#define RTC_TR_HU                      RTC_TR_HU_Msk                           /*!< Hour units in BCD format */
+#define RTC_TR_HU_0                    (0x1U << RTC_TR_HU_Pos)                 /*!< 0x00010000 */
+#define RTC_TR_HU_1                    (0x2U << RTC_TR_HU_Pos)                 /*!< 0x00020000 */
+#define RTC_TR_HU_2                    (0x4U << RTC_TR_HU_Pos)                 /*!< 0x00040000 */
+#define RTC_TR_HU_3                    (0x8U << RTC_TR_HU_Pos)                 /*!< 0x00080000 */
+#define RTC_TR_MNT_Pos                 (12U)
+#define RTC_TR_MNT_Msk                 (0x7UL << RTC_TR_MNT_Pos)               /*!< 0x00007000 */
+#define RTC_TR_MNT                     RTC_TR_MNT_Msk                          /*!< Minute tens in BCD format */
+#define RTC_TR_MNT_0                   (0x1U << RTC_TR_MNT_Pos)                /*!< 0x00001000 */
+#define RTC_TR_MNT_1                   (0x2U << RTC_TR_MNT_Pos)                /*!< 0x00002000 */
+#define RTC_TR_MNT_2                   (0x4U << RTC_TR_MNT_Pos)                /*!< 0x00004000 */
+#define RTC_TR_MNU_Pos                 (8U)
+#define RTC_TR_MNU_Msk                 (0xFUL << RTC_TR_MNU_Pos)               /*!< 0x00000F00 */
+#define RTC_TR_MNU                     RTC_TR_MNU_Msk                          /*!< Minute unit in BCD format */
+#define RTC_TR_MNU_0                   (0x1U << RTC_TR_MNU_Pos)                /*!< 0x00000100 */
+#define RTC_TR_MNU_1                   (0x2U << RTC_TR_MNU_Pos)                /*!< 0x00000200 */
+#define RTC_TR_MNU_2                   (0x4U << RTC_TR_MNU_Pos)                /*!< 0x00000400 */
+#define RTC_TR_MNU_3                   (0x8U << RTC_TR_MNU_Pos)                /*!< 0x00000800 */
+#define RTC_TR_ST_Pos                  (4U)
+#define RTC_TR_ST_Msk                  (0x7UL << RTC_TR_ST_Pos)                /*!< 0x00000070 */
+#define RTC_TR_ST                      RTC_TR_ST_Msk                           /*!< Second tens in BCD format */
+#define RTC_TR_ST_0                    (0x1U << RTC_TR_ST_Pos)                 /*!< 0x00000010 */
+#define RTC_TR_ST_1                    (0x2U << RTC_TR_ST_Pos)                 /*!< 0x00000020 */
+#define RTC_TR_ST_2                    (0x4U << RTC_TR_ST_Pos)                 /*!< 0x00000040 */
+#define RTC_TR_SU_Pos                  (0U)
+#define RTC_TR_SU_Msk                  (0xFUL << RTC_TR_SU_Pos)                /*!< 0x0000000F */
+#define RTC_TR_SU                      RTC_TR_SU_Msk                           /*!< Second units in BCD format */
+#define RTC_TR_SU_0                    (0x1U << RTC_TR_SU_Pos)                 /*!< 0x00000001 */
+#define RTC_TR_SU_1                    (0x2U << RTC_TR_SU_Pos)                 /*!< 0x00000002 */
+#define RTC_TR_SU_2                    (0x4U << RTC_TR_SU_Pos)                 /*!< 0x00000004 */
+#define RTC_TR_SU_3                    (0x8U << RTC_TR_SU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_DR register  *******************/
+#define RTC_DR_YT_Pos                  (20U)
+#define RTC_DR_YT_Msk                  (0xFUL << RTC_DR_YT_Pos)                /*!< 0x00F00000 */
+#define RTC_DR_YT                      RTC_DR_YT_Msk                           /*!< Year tens in BCD format */
+#define RTC_DR_YT_0                    (0x1U << RTC_DR_YT_Pos)                 /*!< 0x00100000 */
+#define RTC_DR_YT_1                    (0x2U << RTC_DR_YT_Pos)                 /*!< 0x00200000 */
+#define RTC_DR_YT_2                    (0x4U << RTC_DR_YT_Pos)                 /*!< 0x00400000 */
+#define RTC_DR_YT_3                    (0x8U << RTC_DR_YT_Pos)                 /*!< 0x00800000 */
+#define RTC_DR_YU_Pos                  (16U)
+#define RTC_DR_YU_Msk                  (0xFUL << RTC_DR_YU_Pos)                /*!< 0x000F0000 */
+#define RTC_DR_YU                      RTC_DR_YU_Msk                           /*!< Years units in BCD format */
+#define RTC_DR_YU_0                    (0x1U << RTC_DR_YU_Pos)                 /*!< 0x00010000 */
+#define RTC_DR_YU_1                    (0x2U << RTC_DR_YU_Pos)                 /*!< 0x00020000 */
+#define RTC_DR_YU_2                    (0x4U << RTC_DR_YU_Pos)                 /*!< 0x00040000 */
+#define RTC_DR_YU_3                    (0x8U << RTC_DR_YU_Pos)                 /*!< 0x00080000 */
+#define RTC_DR_WDU_Pos                 (13U)
+#define RTC_DR_WDU_Msk                 (0x7UL << RTC_DR_WDU_Pos)               /*!< 0x0000E000 */
+#define RTC_DR_WDU                     RTC_DR_WDU_Msk                          /*!< Week day units */
+#define RTC_DR_WDU_0                   (0x1U << RTC_DR_WDU_Pos)                /*!< 0x00002000 */
+#define RTC_DR_WDU_1                   (0x2U << RTC_DR_WDU_Pos)                /*!< 0x00004000 */
+#define RTC_DR_WDU_2                   (0x4U << RTC_DR_WDU_Pos)                /*!< 0x00008000 */
+#define RTC_DR_MT_Pos                  (12U)
+#define RTC_DR_MT_Msk                  (0x1UL << RTC_DR_MT_Pos)                /*!< 0x00001000 */
+#define RTC_DR_MT                      RTC_DR_MT_Msk                           /*!< Month tens in BCD format */
+#define RTC_DR_MU_Pos                  (8U)
+#define RTC_DR_MU_Msk                  (0xFUL << RTC_DR_MU_Pos)                /*!< 0x00000F00 */
+#define RTC_DR_MU                      RTC_DR_MU_Msk                           /*!< Month units in BCD format */
+#define RTC_DR_MU_0                    (0x1U << RTC_DR_MU_Pos)                 /*!< 0x00000100 */
+#define RTC_DR_MU_1                    (0x2U << RTC_DR_MU_Pos)                 /*!< 0x00000200 */
+#define RTC_DR_MU_2                    (0x4U << RTC_DR_MU_Pos)                 /*!< 0x00000400 */
+#define RTC_DR_MU_3                    (0x8U << RTC_DR_MU_Pos)                 /*!< 0x00000800 */
+#define RTC_DR_DT_Pos                  (4U)
+#define RTC_DR_DT_Msk                  (0x3UL << RTC_DR_DT_Pos)                /*!< 0x00000030 */
+#define RTC_DR_DT                      RTC_DR_DT_Msk                           /*!< Date tens in BCD format */
+#define RTC_DR_DT_0                    (0x1U << RTC_DR_DT_Pos)                 /*!< 0x00000010 */
+#define RTC_DR_DT_1                    (0x2U << RTC_DR_DT_Pos)                 /*!< 0x00000020 */
+#define RTC_DR_DU_Pos                  (0U)
+#define RTC_DR_DU_Msk                  (0xFUL << RTC_DR_DU_Pos)                /*!< 0x0000000F */
+#define RTC_DR_DU                      RTC_DR_DU_Msk                           /*!< Date units in BCD format */
+#define RTC_DR_DU_0                    (0x1U << RTC_DR_DU_Pos)                 /*!< 0x00000001 */
+#define RTC_DR_DU_1                    (0x2U << RTC_DR_DU_Pos)                 /*!< 0x00000002 */
+#define RTC_DR_DU_2                    (0x4U << RTC_DR_DU_Pos)                 /*!< 0x00000004 */
+#define RTC_DR_DU_3                    (0x8U << RTC_DR_DU_Pos)                 /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_CR register  *******************/
+#define RTC_CR_ITSE_Pos                (24U)
+#define RTC_CR_ITSE_Msk                (0x1UL << RTC_CR_ITSE_Pos)              /*!< 0x01000000 */
+#define RTC_CR_ITSE                    RTC_CR_ITSE_Msk                         /*!< Timestamp on internal event enable */
+#define RTC_CR_COE_Pos                 (23U)
+#define RTC_CR_COE_Msk                 (0x1UL << RTC_CR_COE_Pos)               /*!< 0x00800000 */
+#define RTC_CR_COE                     RTC_CR_COE_Msk                          /*!< Calibration output enable */
+#define RTC_CR_OSEL_Pos                (21U)
+#define RTC_CR_OSEL_Msk                (0x3UL << RTC_CR_OSEL_Pos)              /*!< 0x00600000 */
+#define RTC_CR_OSEL                    RTC_CR_OSEL_Msk                         /*!< Output selection */
+#define RTC_CR_OSEL_0                  (0x1U << RTC_CR_OSEL_Pos)               /*!< 0x00200000 */
+#define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
+#define RTC_CR_POL_Pos                 (20U)
+#define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
+#define RTC_CR_COSEL_Pos               (19U)
+#define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
+#define RTC_CR_BKP_Pos                 (18U)
+#define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
+#define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
+#define RTC_CR_SUB1H_Pos               (17U)
+#define RTC_CR_SUB1H_Msk               (0x1UL << RTC_CR_SUB1H_Pos)             /*!< 0x00020000 */
+#define RTC_CR_SUB1H                   RTC_CR_SUB1H_Msk                        /*!< Subtract 1 hour (winter time change) */
+#define RTC_CR_ADD1H_Pos               (16U)
+#define RTC_CR_ADD1H_Msk               (0x1UL << RTC_CR_ADD1H_Pos)             /*!< 0x00010000 */
+#define RTC_CR_ADD1H                   RTC_CR_ADD1H_Msk                        /*!< Add 1 hour (summer time change) */
+#define RTC_CR_TSIE_Pos                (15U)
+#define RTC_CR_TSIE_Msk                (0x1UL << RTC_CR_TSIE_Pos)              /*!< 0x00008000 */
+#define RTC_CR_TSIE                    RTC_CR_TSIE_Msk                         /*!< Time-stamp interrupt enable */
+#define RTC_CR_WUTIE_Pos               (14U)
+#define RTC_CR_WUTIE_Msk               (0x1UL << RTC_CR_WUTIE_Pos)             /*!< 0x00004000 */
+#define RTC_CR_WUTIE                   RTC_CR_WUTIE_Msk                        /*!< Wakeup timer interrupt enable */
+#define RTC_CR_ALRBIE_Pos              (13U)
+#define RTC_CR_ALRBIE_Msk              (0x1UL << RTC_CR_ALRBIE_Pos)            /*!< 0x00002000 */
+#define RTC_CR_ALRBIE                  RTC_CR_ALRBIE_Msk                       /*!< Alarm B interrupt enable */
+#define RTC_CR_ALRAIE_Pos              (12U)
+#define RTC_CR_ALRAIE_Msk              (0x1UL << RTC_CR_ALRAIE_Pos)            /*!< 0x00001000 */
+#define RTC_CR_ALRAIE                  RTC_CR_ALRAIE_Msk                       /*!< Alarm A interrupt enable */
+#define RTC_CR_TSE_Pos                 (11U)
+#define RTC_CR_TSE_Msk                 (0x1UL << RTC_CR_TSE_Pos)               /*!< 0x00000800 */
+#define RTC_CR_TSE                     RTC_CR_TSE_Msk                          /*!< Timestamp on RTC TS input edge enable */
+#define RTC_CR_WUTE_Pos                (10U)
+#define RTC_CR_WUTE_Msk                (0x1UL << RTC_CR_WUTE_Pos)              /*!< 0x00000400 */
+#define RTC_CR_WUTE                    RTC_CR_WUTE_Msk                         /*!< Wakeup timer enable */
+#define RTC_CR_ALRBE_Pos               (9U)
+#define RTC_CR_ALRBE_Msk               (0x1UL << RTC_CR_ALRBE_Pos)             /*!< 0x00000200 */
+#define RTC_CR_ALRBE                   RTC_CR_ALRBE_Msk                        /*!< Alarm B enable */
+#define RTC_CR_ALRAE_Pos               (8U)
+#define RTC_CR_ALRAE_Msk               (0x1UL << RTC_CR_ALRAE_Pos)             /*!< 0x00000100 */
+#define RTC_CR_ALRAE                   RTC_CR_ALRAE_Msk                        /*!< Alarm A enable */
+#define RTC_CR_FMT_Pos                 (6U)
+#define RTC_CR_FMT_Msk                 (0x1UL << RTC_CR_FMT_Pos)               /*!< 0x00000040 */
+#define RTC_CR_FMT                     RTC_CR_FMT_Msk                          /*!< Hour AM/PM or 24H format */
+#define RTC_CR_BYPSHAD_Pos             (5U)
+#define RTC_CR_BYPSHAD_Msk             (0x1UL << RTC_CR_BYPSHAD_Pos)           /*!< 0x00000020 */
+#define RTC_CR_BYPSHAD                 RTC_CR_BYPSHAD_Msk                      /*!< Bypass the shadow registers */
+#define RTC_CR_REFCKON_Pos             (4U)
+#define RTC_CR_REFCKON_Msk             (0x1UL << RTC_CR_REFCKON_Pos)           /*!< 0x00000010 */
+#define RTC_CR_REFCKON                 RTC_CR_REFCKON_Msk                      /*!< RTC_REFIN reference clock detection enable (50 or 60 Hz) */
+#define RTC_CR_TSEDGE_Pos              (3U)
+#define RTC_CR_TSEDGE_Msk              (0x1UL << RTC_CR_TSEDGE_Pos)            /*!< 0x00000008 */
+#define RTC_CR_TSEDGE                  RTC_CR_TSEDGE_Msk                       /*!< Timestamp event active edge */
+#define RTC_CR_WUCKSEL_Pos             (0U)
+#define RTC_CR_WUCKSEL_Msk             (0x7UL << RTC_CR_WUCKSEL_Pos)           /*!< 0x00000007 */
+#define RTC_CR_WUCKSEL                 RTC_CR_WUCKSEL_Msk                      /*!< Wakekup clock selection */
+#define RTC_CR_WUCKSEL_0               (0x1U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000001 */
+#define RTC_CR_WUCKSEL_1               (0x2U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000002 */
+#define RTC_CR_WUCKSEL_2               (0x4U << RTC_CR_WUCKSEL_Pos)            /*!< 0x00000004 */
+
+/********************  Bits definition for RTC_ISR register  ******************/
+#define RTC_ISR_ITSF_Pos               (17U)
+#define RTC_ISR_ITSF_Msk               (0x1UL << RTC_ISR_ITSF_Pos)             /*!< 0x00020000 */
+#define RTC_ISR_ITSF                   RTC_ISR_ITSF_Msk                        /*!< Internal timestamp flag */
+#define RTC_ISR_RECALPF_Pos            (16U)
+#define RTC_ISR_RECALPF_Msk            (0x1UL << RTC_ISR_RECALPF_Pos)          /*!< 0x00010000 */
+#define RTC_ISR_RECALPF                RTC_ISR_RECALPF_Msk                     /*!< Recalibration pending flag */
+#define RTC_ISR_TAMP2F_Pos             (14U)
+#define RTC_ISR_TAMP2F_Msk             (0x1UL << RTC_ISR_TAMP2F_Pos)           /*!< 0x00004000 */
+#define RTC_ISR_TAMP2F                 RTC_ISR_TAMP2F_Msk                      /*!< RTC_TAMP2 detection flag */
+#define RTC_ISR_TSOVF_Pos              (12U)
+#define RTC_ISR_TSOVF_Msk              (0x1UL << RTC_ISR_TSOVF_Pos)            /*!< 0x00001000 */
+#define RTC_ISR_TSOVF                  RTC_ISR_TSOVF_Msk                       /*!< Timestamp overflow flag */
+#define RTC_ISR_TSF_Pos                (11U)
+#define RTC_ISR_TSF_Msk                (0x1UL << RTC_ISR_TSF_Pos)              /*!< 0x00000800 */
+#define RTC_ISR_TSF                    RTC_ISR_TSF_Msk                         /*!< Timestamp flag */
+#define RTC_ISR_WUTF_Pos               (10U)
+#define RTC_ISR_WUTF_Msk               (0x1UL << RTC_ISR_WUTF_Pos)             /*!< 0x00000400 */
+#define RTC_ISR_WUTF                   RTC_ISR_WUTF_Msk                        /*!< Wakeup timer flag */
+#define RTC_ISR_ALRBF_Pos              (9U)
+#define RTC_ISR_ALRBF_Msk              (0x1UL << RTC_ISR_ALRBF_Pos)            /*!< 0x00000200 */
+#define RTC_ISR_ALRBF                  RTC_ISR_ALRBF_Msk                       /*!< Alarm B flag */
+#define RTC_ISR_ALRAF_Pos              (8U)
+#define RTC_ISR_ALRAF_Msk              (0x1UL << RTC_ISR_ALRAF_Pos)            /*!< 0x00000100 */
+#define RTC_ISR_ALRAF                  RTC_ISR_ALRAF_Msk                       /*!< Alarm A flag */
+#define RTC_ISR_INIT_Pos               (7U)
+#define RTC_ISR_INIT_Msk               (0x1UL << RTC_ISR_INIT_Pos)             /*!< 0x00000080 */
+#define RTC_ISR_INIT                   RTC_ISR_INIT_Msk                        /*!< Initialization mode */
+#define RTC_ISR_INITF_Pos              (6U)
+#define RTC_ISR_INITF_Msk              (0x1UL << RTC_ISR_INITF_Pos)            /*!< 0x00000040 */
+#define RTC_ISR_INITF                  RTC_ISR_INITF_Msk                       /*!< Initialization flag */
+#define RTC_ISR_RSF_Pos                (5U)
+#define RTC_ISR_RSF_Msk                (0x1UL << RTC_ISR_RSF_Pos)              /*!< 0x00000020 */
+#define RTC_ISR_RSF                    RTC_ISR_RSF_Msk                         /*!< Registers synchronization flag */
+#define RTC_ISR_INITS_Pos              (4U)
+#define RTC_ISR_INITS_Msk              (0x1UL << RTC_ISR_INITS_Pos)            /*!< 0x00000010 */
+#define RTC_ISR_INITS                  RTC_ISR_INITS_Msk                       /*!< Initialization status flag */
+#define RTC_ISR_SHPF_Pos               (3U)
+#define RTC_ISR_SHPF_Msk               (0x1UL << RTC_ISR_SHPF_Pos)             /*!< 0x00000008 */
+#define RTC_ISR_SHPF                   RTC_ISR_SHPF_Msk                        /*!< Shift operation pending */
+#define RTC_ISR_WUTWF_Pos              (2U)
+#define RTC_ISR_WUTWF_Msk              (0x1UL << RTC_ISR_WUTWF_Pos)            /*!< 0x00000004 */
+#define RTC_ISR_WUTWF                  RTC_ISR_WUTWF_Msk                       /*!< Wakeup timer write flag */
+#define RTC_ISR_ALRBWF_Pos             (1U)
+#define RTC_ISR_ALRBWF_Msk             (0x1UL << RTC_ISR_ALRBWF_Pos)           /*!< 0x00000002 */
+#define RTC_ISR_ALRBWF                 RTC_ISR_ALRBWF_Msk                      /*!< Alarm B write flag */
+#define RTC_ISR_ALRAWF_Pos             (0U)
+#define RTC_ISR_ALRAWF_Msk             (0x1UL << RTC_ISR_ALRAWF_Pos)           /*!< 0x00000001 */
+#define RTC_ISR_ALRAWF                 RTC_ISR_ALRAWF_Msk                      /*!< Alarm A write flag */
+
+/********************  Bits definition for RTC_PRER register  *****************/
+#define RTC_PRER_PREDIV_A_Pos          (16U)
+#define RTC_PRER_PREDIV_A_Msk          (0x7FUL << RTC_PRER_PREDIV_A_Pos)       /*!< 0x007F0000 */
+#define RTC_PRER_PREDIV_A              RTC_PRER_PREDIV_A_Msk                   /*!< Asynchronous prescaler factor */
+#define RTC_PRER_PREDIV_S_Pos          (0U)
+#define RTC_PRER_PREDIV_S_Msk          (0x7FFFUL << RTC_PRER_PREDIV_S_Pos)     /*!< 0x00007FFF */
+#define RTC_PRER_PREDIV_S              RTC_PRER_PREDIV_S_Msk                   /*!< Synchronous prescaler factor */
+
+/********************  Bits definition for RTC_WUTR register  *****************/
+#define RTC_WUTR_WUT_Pos               (0U)
+#define RTC_WUTR_WUT_Msk               (0xFFFFUL << RTC_WUTR_WUT_Pos)          /*!< 0x0000FFFF */
+#define RTC_WUTR_WUT                   RTC_WUTR_WUT_Msk                        /*!< Wakeup auto-reload value bits */
+
+/********************  Bits definition for RTC_ALRMAR register  ***************/
+#define RTC_ALRMAR_MSK4_Pos            (31U)
+#define RTC_ALRMAR_MSK4_Msk            (0x1UL << RTC_ALRMAR_MSK4_Pos)          /*!< 0x80000000 */
+#define RTC_ALRMAR_MSK4                RTC_ALRMAR_MSK4_Msk                     /*!< Alarm A date mask */
+#define RTC_ALRMAR_WDSEL_Pos           (30U)
+#define RTC_ALRMAR_WDSEL_Msk           (0x1UL << RTC_ALRMAR_WDSEL_Pos)         /*!< 0x40000000 */
+#define RTC_ALRMAR_WDSEL               RTC_ALRMAR_WDSEL_Msk                    /*!< Alarm A week day selection */
+#define RTC_ALRMAR_DT_Pos              (28U)
+#define RTC_ALRMAR_DT_Msk              (0x3UL << RTC_ALRMAR_DT_Pos)            /*!< 0x30000000 */
+#define RTC_ALRMAR_DT                  RTC_ALRMAR_DT_Msk                       /*!< Alarm A date tens in BCD format */
+#define RTC_ALRMAR_DT_0                (0x1U << RTC_ALRMAR_DT_Pos)             /*!< 0x10000000 */
+#define RTC_ALRMAR_DT_1                (0x2U << RTC_ALRMAR_DT_Pos)             /*!< 0x20000000 */
+#define RTC_ALRMAR_DU_Pos              (24U)
+#define RTC_ALRMAR_DU_Msk              (0xFUL << RTC_ALRMAR_DU_Pos)            /*!< 0x0F000000 */
+#define RTC_ALRMAR_DU                  RTC_ALRMAR_DU_Msk                       /*!< Alarm A date units in BCD format */
+#define RTC_ALRMAR_DU_0                (0x1U << RTC_ALRMAR_DU_Pos)             /*!< 0x01000000 */
+#define RTC_ALRMAR_DU_1                (0x2U << RTC_ALRMAR_DU_Pos)             /*!< 0x02000000 */
+#define RTC_ALRMAR_DU_2                (0x4U << RTC_ALRMAR_DU_Pos)             /*!< 0x04000000 */
+#define RTC_ALRMAR_DU_3                (0x8U << RTC_ALRMAR_DU_Pos)             /*!< 0x08000000 */
+#define RTC_ALRMAR_MSK3_Pos            (23U)
+#define RTC_ALRMAR_MSK3_Msk            (0x1UL << RTC_ALRMAR_MSK3_Pos)          /*!< 0x00800000 */
+#define RTC_ALRMAR_MSK3                RTC_ALRMAR_MSK3_Msk                     /*!< Alarm A hours mask */
+#define RTC_ALRMAR_PM_Pos              (22U)
+#define RTC_ALRMAR_PM_Msk              (0x1UL << RTC_ALRMAR_PM_Pos)            /*!< 0x00400000 */
+#define RTC_ALRMAR_PM                  RTC_ALRMAR_PM_Msk                       /*!< Alarm A AM/PM or 24H format */
+#define RTC_ALRMAR_HT_Pos              (20U)
+#define RTC_ALRMAR_HT_Msk              (0x3UL << RTC_ALRMAR_HT_Pos)            /*!< 0x00300000 */
+#define RTC_ALRMAR_HT                  RTC_ALRMAR_HT_Msk                       /*!< Alarm A hour tens in BCD format */
+#define RTC_ALRMAR_HT_0                (0x1U << RTC_ALRMAR_HT_Pos)             /*!< 0x00100000 */
+#define RTC_ALRMAR_HT_1                (0x2U << RTC_ALRMAR_HT_Pos)             /*!< 0x00200000 */
+#define RTC_ALRMAR_HU_Pos              (16U)
+#define RTC_ALRMAR_HU_Msk              (0xFUL << RTC_ALRMAR_HU_Pos)            /*!< 0x000F0000 */
+#define RTC_ALRMAR_HU                  RTC_ALRMAR_HU_Msk                       /*!< Alarm A hour units in BCD format */
+#define RTC_ALRMAR_HU_0                (0x1U << RTC_ALRMAR_HU_Pos)             /*!< 0x00010000 */
+#define RTC_ALRMAR_HU_1                (0x2U << RTC_ALRMAR_HU_Pos)             /*!< 0x00020000 */
+#define RTC_ALRMAR_HU_2                (0x4U << RTC_ALRMAR_HU_Pos)             /*!< 0x00040000 */
+#define RTC_ALRMAR_HU_3                (0x8U << RTC_ALRMAR_HU_Pos)             /*!< 0x00080000 */
+#define RTC_ALRMAR_MSK2_Pos            (15U)
+#define RTC_ALRMAR_MSK2_Msk            (0x1UL << RTC_ALRMAR_MSK2_Pos)          /*!< 0x00008000 */
+#define RTC_ALRMAR_MSK2                RTC_ALRMAR_MSK2_Msk                     /*!< Alarm A minutes mask */
+#define RTC_ALRMAR_MNT_Pos             (12U)
+#define RTC_ALRMAR_MNT_Msk             (0x7UL << RTC_ALRMAR_MNT_Pos)           /*!< 0x00007000 */
+#define RTC_ALRMAR_MNT                 RTC_ALRMAR_MNT_Msk                      /*!< Alarm A minute tens in BCD format */
+#define RTC_ALRMAR_MNT_0               (0x1U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00001000 */
+#define RTC_ALRMAR_MNT_1               (0x2U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00002000 */
+#define RTC_ALRMAR_MNT_2               (0x4U << RTC_ALRMAR_MNT_Pos)            /*!< 0x00004000 */
+#define RTC_ALRMAR_MNU_Pos             (8U)
+#define RTC_ALRMAR_MNU_Msk             (0xFUL << RTC_ALRMAR_MNU_Pos)           /*!< 0x00000F00 */
+#define RTC_ALRMAR_MNU                 RTC_ALRMAR_MNU_Msk                      /*!< Alarm A minute units in BCD format */
+#define RTC_ALRMAR_MNU_0               (0x1U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000100 */
+#define RTC_ALRMAR_MNU_1               (0x2U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000200 */
+#define RTC_ALRMAR_MNU_2               (0x4U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000400 */
+#define RTC_ALRMAR_MNU_3               (0x8U << RTC_ALRMAR_MNU_Pos)            /*!< 0x00000800 */
+#define RTC_ALRMAR_MSK1_Pos            (7U)
+#define RTC_ALRMAR_MSK1_Msk            (0x1UL << RTC_ALRMAR_MSK1_Pos)          /*!< 0x00000080 */
+#define RTC_ALRMAR_MSK1                RTC_ALRMAR_MSK1_Msk                     /*!< Alarm A seconds mask */
+#define RTC_ALRMAR_ST_Pos              (4U)
+#define RTC_ALRMAR_ST_Msk              (0x7UL << RTC_ALRMAR_ST_Pos)            /*!< 0x00000070 */
+#define RTC_ALRMAR_ST                  RTC_ALRMAR_ST_Msk                       /*!< Alarm A second tens in BCD format */
+#define RTC_ALRMAR_ST_0                (0x1U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000010 */
+#define RTC_ALRMAR_ST_1                (0x2U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000020 */
+#define RTC_ALRMAR_ST_2                (0x4U << RTC_ALRMAR_ST_Pos)             /*!< 0x00000040 */
+#define RTC_ALRMAR_SU_Pos              (0U)
+#define RTC_ALRMAR_SU_Msk              (0xFUL << RTC_ALRMAR_SU_Pos)            /*!< 0x0000000F */
+#define RTC_ALRMAR_SU                  RTC_ALRMAR_SU_Msk                       /*!< Alarm A second units in BCD format */
+#define RTC_ALRMAR_SU_0                (0x1U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000001 */
+#define RTC_ALRMAR_SU_1                (0x2U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000002 */
+#define RTC_ALRMAR_SU_2                (0x4U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000004 */
+#define RTC_ALRMAR_SU_3                (0x8U << RTC_ALRMAR_SU_Pos)             /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_ALRMBR register  ***************/
+#define RTC_ALRMBR_MSK4_Pos            (31U)
+#define RTC_ALRMBR_MSK4_Msk            (0x1UL << RTC_ALRMBR_MSK4_Pos)          /*!< 0x80000000 */
+#define RTC_ALRMBR_MSK4                RTC_ALRMBR_MSK4_Msk                     /*!< Alarm B date mask */
+#define RTC_ALRMBR_WDSEL_Pos           (30U)
+#define RTC_ALRMBR_WDSEL_Msk           (0x1UL << RTC_ALRMBR_WDSEL_Pos)         /*!< 0x40000000 */
+#define RTC_ALRMBR_WDSEL               RTC_ALRMBR_WDSEL_Msk                    /*!< Alarm B week day selection */
+#define RTC_ALRMBR_DT_Pos              (28U)
+#define RTC_ALRMBR_DT_Msk              (0x3UL << RTC_ALRMBR_DT_Pos)            /*!< 0x30000000 */
+#define RTC_ALRMBR_DT                  RTC_ALRMBR_DT_Msk                       /*!< Alarm B data tens in BCD format */
+#define RTC_ALRMBR_DT_0                (0x1U << RTC_ALRMBR_DT_Pos)             /*!< 0x10000000 */
+#define RTC_ALRMBR_DT_1                (0x2U << RTC_ALRMBR_DT_Pos)             /*!< 0x20000000 */
+#define RTC_ALRMBR_DU_Pos              (24U)
+#define RTC_ALRMBR_DU_Msk              (0xFUL << RTC_ALRMBR_DU_Pos)            /*!< 0x0F000000 */
+#define RTC_ALRMBR_DU                  RTC_ALRMBR_DU_Msk                       /*!< Alarm B data units or day in BCD format */
+#define RTC_ALRMBR_DU_0                (0x1U << RTC_ALRMBR_DU_Pos)             /*!< 0x01000000 */
+#define RTC_ALRMBR_DU_1                (0x2U << RTC_ALRMBR_DU_Pos)             /*!< 0x02000000 */
+#define RTC_ALRMBR_DU_2                (0x4U << RTC_ALRMBR_DU_Pos)             /*!< 0x04000000 */
+#define RTC_ALRMBR_DU_3                (0x8U << RTC_ALRMBR_DU_Pos)             /*!< 0x08000000 */
+#define RTC_ALRMBR_MSK3_Pos            (23U)
+#define RTC_ALRMBR_MSK3_Msk            (0x1UL << RTC_ALRMBR_MSK3_Pos)          /*!< 0x00800000 */
+#define RTC_ALRMBR_MSK3                RTC_ALRMBR_MSK3_Msk                     /*!< Alarm B hour mask */
+#define RTC_ALRMBR_PM_Pos              (22U)
+#define RTC_ALRMBR_PM_Msk              (0x1UL << RTC_ALRMBR_PM_Pos)            /*!< 0x00400000 */
+#define RTC_ALRMBR_PM                  RTC_ALRMBR_PM_Msk                       /*!< Alarm B AM/PM or 24H format */
+#define RTC_ALRMBR_HT_Pos              (20U)
+#define RTC_ALRMBR_HT_Msk              (0x3UL << RTC_ALRMBR_HT_Pos)            /*!< 0x00300000 */
+#define RTC_ALRMBR_HT                  RTC_ALRMBR_HT_Msk                       /*!< Alarm B hour tens in BCD format */
+#define RTC_ALRMBR_HT_0                (0x1U << RTC_ALRMBR_HT_Pos)             /*!< 0x00100000 */
+#define RTC_ALRMBR_HT_1                (0x2U << RTC_ALRMBR_HT_Pos)             /*!< 0x00200000 */
+#define RTC_ALRMBR_HU_Pos              (16U)
+#define RTC_ALRMBR_HU_Msk              (0xFUL << RTC_ALRMBR_HU_Pos)            /*!< 0x000F0000 */
+#define RTC_ALRMBR_HU                  RTC_ALRMBR_HU_Msk                       /*!< Alarm B hour units in BCD format */
+#define RTC_ALRMBR_HU_0                (0x1U << RTC_ALRMBR_HU_Pos)             /*!< 0x00010000 */
+#define RTC_ALRMBR_HU_1                (0x2U << RTC_ALRMBR_HU_Pos)             /*!< 0x00020000 */
+#define RTC_ALRMBR_HU_2                (0x4U << RTC_ALRMBR_HU_Pos)             /*!< 0x00040000 */
+#define RTC_ALRMBR_HU_3                (0x8U << RTC_ALRMBR_HU_Pos)             /*!< 0x00080000 */
+#define RTC_ALRMBR_MSK2_Pos            (15U)
+#define RTC_ALRMBR_MSK2_Msk            (0x1UL << RTC_ALRMBR_MSK2_Pos)          /*!< 0x00008000 */
+#define RTC_ALRMBR_MSK2                RTC_ALRMBR_MSK2_Msk                     /*!< Alarm B minutes mask */
+#define RTC_ALRMBR_MNT_Pos             (12U)
+#define RTC_ALRMBR_MNT_Msk             (0x7UL << RTC_ALRMBR_MNT_Pos)           /*!< 0x00007000 */
+#define RTC_ALRMBR_MNT                 RTC_ALRMBR_MNT_Msk                      /*!< Alarm B minute tens in BCD format */
+#define RTC_ALRMBR_MNT_0               (0x1U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00001000 */
+#define RTC_ALRMBR_MNT_1               (0x2U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00002000 */
+#define RTC_ALRMBR_MNT_2               (0x4U << RTC_ALRMBR_MNT_Pos)            /*!< 0x00004000 */
+#define RTC_ALRMBR_MNU_Pos             (8U)
+#define RTC_ALRMBR_MNU_Msk             (0xFUL << RTC_ALRMBR_MNU_Pos)           /*!< 0x00000F00 */
+#define RTC_ALRMBR_MNU                 RTC_ALRMBR_MNU_Msk                      /*!< Alarm B minute units in BCD format */
+#define RTC_ALRMBR_MNU_0               (0x1U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000100 */
+#define RTC_ALRMBR_MNU_1               (0x2U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000200 */
+#define RTC_ALRMBR_MNU_2               (0x4U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000400 */
+#define RTC_ALRMBR_MNU_3               (0x8U << RTC_ALRMBR_MNU_Pos)            /*!< 0x00000800 */
+#define RTC_ALRMBR_MSK1_Pos            (7U)
+#define RTC_ALRMBR_MSK1_Msk            (0x1UL << RTC_ALRMBR_MSK1_Pos)          /*!< 0x00000080 */
+#define RTC_ALRMBR_MSK1                RTC_ALRMBR_MSK1_Msk                     /*!< Alarm B seconds mask */
+#define RTC_ALRMBR_ST_Pos              (4U)
+#define RTC_ALRMBR_ST_Msk              (0x7UL << RTC_ALRMBR_ST_Pos)            /*!< 0x00000070 */
+#define RTC_ALRMBR_ST                  RTC_ALRMBR_ST_Msk                       /*!< Alarm B second tens in BCD format */
+#define RTC_ALRMBR_ST_0                (0x1U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000010 */
+#define RTC_ALRMBR_ST_1                (0x2U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000020 */
+#define RTC_ALRMBR_ST_2                (0x4U << RTC_ALRMBR_ST_Pos)             /*!< 0x00000040 */
+#define RTC_ALRMBR_SU_Pos              (0U)
+#define RTC_ALRMBR_SU_Msk              (0xFUL << RTC_ALRMBR_SU_Pos)            /*!< 0x0000000F */
+#define RTC_ALRMBR_SU                  RTC_ALRMBR_SU_Msk                       /*!< Alarm B second units in BCD format */
+#define RTC_ALRMBR_SU_0                (0x1U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000001 */
+#define RTC_ALRMBR_SU_1                (0x2U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000002 */
+#define RTC_ALRMBR_SU_2                (0x4U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000004 */
+#define RTC_ALRMBR_SU_3                (0x8U << RTC_ALRMBR_SU_Pos)             /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_WPR register  ******************/
+#define RTC_WPR_KEY_Pos                (0U)
+#define RTC_WPR_KEY_Msk                (0xFFUL << RTC_WPR_KEY_Pos)             /*!< 0x000000FF */
+#define RTC_WPR_KEY                    RTC_WPR_KEY_Msk                         /*!< Write protection key */
+
+/********************  Bits definition for RTC_SSR register  ******************/
+#define RTC_SSR_SS_Pos                 (0U)
+#define RTC_SSR_SS_Msk                 (0xFFFFUL << RTC_SSR_SS_Pos)            /*!< 0x0000FFFF */
+#define RTC_SSR_SS                     RTC_SSR_SS_Msk                          /*!< Sub second value */
+
+/********************  Bits definition for RTC_SHIFTR register  ***************/
+#define RTC_SHIFTR_SUBFS_Pos           (0U)
+#define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
+#define RTC_SHIFTR_ADD1S_Pos           (31U)
+#define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
+#define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
+
+/********************  Bits definition for RTC_TSTR register  *****************/
+#define RTC_TSTR_PM_Pos                (22U)
+#define RTC_TSTR_PM_Msk                (0x1UL << RTC_TSTR_PM_Pos)              /*!< 0x00400000 */
+#define RTC_TSTR_PM                    RTC_TSTR_PM_Msk                         /*!< Timestamp AM/PM or 24H format */
+#define RTC_TSTR_HT_Pos                (20U)
+#define RTC_TSTR_HT_Msk                (0x3UL << RTC_TSTR_HT_Pos)              /*!< 0x00300000 */
+#define RTC_TSTR_HT                    RTC_TSTR_HT_Msk                         /*!< Timestamp hour tens in BCD format */
+#define RTC_TSTR_HT_0                  (0x1U << RTC_TSTR_HT_Pos)               /*!< 0x00100000 */
+#define RTC_TSTR_HT_1                  (0x2U << RTC_TSTR_HT_Pos)               /*!< 0x00200000 */
+#define RTC_TSTR_HU_Pos                (16U)
+#define RTC_TSTR_HU_Msk                (0xFUL << RTC_TSTR_HU_Pos)              /*!< 0x000F0000 */
+#define RTC_TSTR_HU                    RTC_TSTR_HU_Msk                         /*!< Timestamp hour units in BCD format */
+#define RTC_TSTR_HU_0                  (0x1U << RTC_TSTR_HU_Pos)               /*!< 0x00010000 */
+#define RTC_TSTR_HU_1                  (0x2U << RTC_TSTR_HU_Pos)               /*!< 0x00020000 */
+#define RTC_TSTR_HU_2                  (0x4U << RTC_TSTR_HU_Pos)               /*!< 0x00040000 */
+#define RTC_TSTR_HU_3                  (0x8U << RTC_TSTR_HU_Pos)               /*!< 0x00080000 */
+#define RTC_TSTR_MNT_Pos               (12U)
+#define RTC_TSTR_MNT_Msk               (0x7UL << RTC_TSTR_MNT_Pos)             /*!< 0x00007000 */
+#define RTC_TSTR_MNT                   RTC_TSTR_MNT_Msk                        /*!< Timestamp minute tens in BCD format */
+#define RTC_TSTR_MNT_0                 (0x1U << RTC_TSTR_MNT_Pos)              /*!< 0x00001000 */
+#define RTC_TSTR_MNT_1                 (0x2U << RTC_TSTR_MNT_Pos)              /*!< 0x00002000 */
+#define RTC_TSTR_MNT_2                 (0x4U << RTC_TSTR_MNT_Pos)              /*!< 0x00004000 */
+#define RTC_TSTR_MNU_Pos               (8U)
+#define RTC_TSTR_MNU_Msk               (0xFUL << RTC_TSTR_MNU_Pos)             /*!< 0x00000F00 */
+#define RTC_TSTR_MNU                   RTC_TSTR_MNU_Msk                        /*!< Timestamp minute units in BCD format */
+#define RTC_TSTR_MNU_0                 (0x1U << RTC_TSTR_MNU_Pos)              /*!< 0x00000100 */
+#define RTC_TSTR_MNU_1                 (0x2U << RTC_TSTR_MNU_Pos)              /*!< 0x00000200 */
+#define RTC_TSTR_MNU_2                 (0x4U << RTC_TSTR_MNU_Pos)              /*!< 0x00000400 */
+#define RTC_TSTR_MNU_3                 (0x8U << RTC_TSTR_MNU_Pos)              /*!< 0x00000800 */
+#define RTC_TSTR_ST_Pos                (4U)
+#define RTC_TSTR_ST_Msk                (0x7UL << RTC_TSTR_ST_Pos)              /*!< 0x00000070 */
+#define RTC_TSTR_ST                    RTC_TSTR_ST_Msk                         /*!< Timestamp second tens in BCD format */
+#define RTC_TSTR_ST_0                  (0x1U << RTC_TSTR_ST_Pos)               /*!< 0x00000010 */
+#define RTC_TSTR_ST_1                  (0x2U << RTC_TSTR_ST_Pos)               /*!< 0x00000020 */
+#define RTC_TSTR_ST_2                  (0x4U << RTC_TSTR_ST_Pos)               /*!< 0x00000040 */
+#define RTC_TSTR_SU_Pos                (0U)
+#define RTC_TSTR_SU_Msk                (0xFUL << RTC_TSTR_SU_Pos)              /*!< 0x0000000F */
+#define RTC_TSTR_SU                    RTC_TSTR_SU_Msk                         /*!< Timestamp second units in BCD format */
+#define RTC_TSTR_SU_0                  (0x1U << RTC_TSTR_SU_Pos)               /*!< 0x00000001 */
+#define RTC_TSTR_SU_1                  (0x2U << RTC_TSTR_SU_Pos)               /*!< 0x00000002 */
+#define RTC_TSTR_SU_2                  (0x4U << RTC_TSTR_SU_Pos)               /*!< 0x00000004 */
+#define RTC_TSTR_SU_3                  (0x8U << RTC_TSTR_SU_Pos)               /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSDR register  *****************/
+#define RTC_TSDR_WDU_Pos               (13U)
+#define RTC_TSDR_WDU_Msk               (0x7UL << RTC_TSDR_WDU_Pos)             /*!< 0x0000E000 */
+#define RTC_TSDR_WDU                   RTC_TSDR_WDU_Msk                        /*!< Timestamp week day units */
+#define RTC_TSDR_WDU_0                 (0x1U << RTC_TSDR_WDU_Pos)              /*!< 0x00002000 */
+#define RTC_TSDR_WDU_1                 (0x2U << RTC_TSDR_WDU_Pos)              /*!< 0x00004000 */
+#define RTC_TSDR_WDU_2                 (0x4U << RTC_TSDR_WDU_Pos)              /*!< 0x00008000 */
+#define RTC_TSDR_MT_Pos                (12U)
+#define RTC_TSDR_MT_Msk                (0x1UL << RTC_TSDR_MT_Pos)              /*!< 0x00001000 */
+#define RTC_TSDR_MT                    RTC_TSDR_MT_Msk                         /*!< Timestamp month tens in BCD format */
+#define RTC_TSDR_MU_Pos                (8U)
+#define RTC_TSDR_MU_Msk                (0xFUL << RTC_TSDR_MU_Pos)              /*!< 0x00000F00 */
+#define RTC_TSDR_MU                    RTC_TSDR_MU_Msk                         /*!< Timestamp month units in BCD format */
+#define RTC_TSDR_MU_0                  (0x1U << RTC_TSDR_MU_Pos)               /*!< 0x00000100 */
+#define RTC_TSDR_MU_1                  (0x2U << RTC_TSDR_MU_Pos)               /*!< 0x00000200 */
+#define RTC_TSDR_MU_2                  (0x4U << RTC_TSDR_MU_Pos)               /*!< 0x00000400 */
+#define RTC_TSDR_MU_3                  (0x8U << RTC_TSDR_MU_Pos)               /*!< 0x00000800 */
+#define RTC_TSDR_DT_Pos                (4U)
+#define RTC_TSDR_DT_Msk                (0x3UL << RTC_TSDR_DT_Pos)              /*!< 0x00000030 */
+#define RTC_TSDR_DT                    RTC_TSDR_DT_Msk                         /*!< Timestamp date tens in BCD format */
+#define RTC_TSDR_DT_0                  (0x1U << RTC_TSDR_DT_Pos)               /*!< 0x00000010 */
+#define RTC_TSDR_DT_1                  (0x2U << RTC_TSDR_DT_Pos)               /*!< 0x00000020 */
+#define RTC_TSDR_DU_Pos                (0U)
+#define RTC_TSDR_DU_Msk                (0xFUL << RTC_TSDR_DU_Pos)              /*!< 0x0000000F */
+#define RTC_TSDR_DU                    RTC_TSDR_DU_Msk                         /*!< Timestamp date units in BCD format */
+#define RTC_TSDR_DU_0                  (0x1U << RTC_TSDR_DU_Pos)               /*!< 0x00000001 */
+#define RTC_TSDR_DU_1                  (0x2U << RTC_TSDR_DU_Pos)               /*!< 0x00000002 */
+#define RTC_TSDR_DU_2                  (0x4U << RTC_TSDR_DU_Pos)               /*!< 0x00000004 */
+#define RTC_TSDR_DU_3                  (0x8U << RTC_TSDR_DU_Pos)               /*!< 0x00000008 */
+
+/********************  Bits definition for RTC_TSSSR register  ****************/
+#define RTC_TSSSR_SS_Pos               (0U)
+#define RTC_TSSSR_SS_Msk               (0xFFFFUL << RTC_TSSSR_SS_Pos)          /*!< 0x0000FFFF */
+#define RTC_TSSSR_SS                   RTC_TSSSR_SS_Msk                        /*!< Timestamp sub second value */
+
+/********************  Bits definition for RTC_CALR register  *****************/
+#define RTC_CALR_CALP_Pos              (15U)
+#define RTC_CALR_CALP_Msk              (0x1UL << RTC_CALR_CALP_Pos)            /*!< 0x00008000 */
+#define RTC_CALR_CALP                  RTC_CALR_CALP_Msk                       /*!< Increase frequency of RTC 488.5 ppm */
+#define RTC_CALR_CALW8_Pos             (14U)
+#define RTC_CALR_CALW8_Msk             (0x1UL << RTC_CALR_CALW8_Pos)           /*!< 0x00004000 */
+#define RTC_CALR_CALW8                 RTC_CALR_CALW8_Msk                      /*!< Use a 8-second calibration cycle period */
+#define RTC_CALR_CALW16_Pos            (13U)
+#define RTC_CALR_CALW16_Msk            (0x1UL << RTC_CALR_CALW16_Pos)          /*!< 0x00002000 */
+#define RTC_CALR_CALW16                RTC_CALR_CALW16_Msk                     /*!< Use a 16-second calibration cycle period */
+#define RTC_CALR_CALM_Pos              (0U)
+#define RTC_CALR_CALM_Msk              (0x1FFUL << RTC_CALR_CALM_Pos)          /*!< 0x000001FF */
+#define RTC_CALR_CALM                  RTC_CALR_CALM_Msk                       /*!< Calibration minus */
+#define RTC_CALR_CALM_0                (0x001U << RTC_CALR_CALM_Pos)           /*!< 0x00000001 */
+#define RTC_CALR_CALM_1                (0x002U << RTC_CALR_CALM_Pos)           /*!< 0x00000002 */
+#define RTC_CALR_CALM_2                (0x004U << RTC_CALR_CALM_Pos)           /*!< 0x00000004 */
+#define RTC_CALR_CALM_3                (0x008U << RTC_CALR_CALM_Pos)           /*!< 0x00000008 */
+#define RTC_CALR_CALM_4                (0x010U << RTC_CALR_CALM_Pos)           /*!< 0x00000010 */
+#define RTC_CALR_CALM_5                (0x020U << RTC_CALR_CALM_Pos)           /*!< 0x00000020 */
+#define RTC_CALR_CALM_6                (0x040U << RTC_CALR_CALM_Pos)           /*!< 0x00000040 */
+#define RTC_CALR_CALM_7                (0x080U << RTC_CALR_CALM_Pos)           /*!< 0x00000080 */
+#define RTC_CALR_CALM_8                (0x100U << RTC_CALR_CALM_Pos)           /*!< 0x00000100 */
+
+/********************  Bits definition for RTC_TAMPCR register  ****************/
+#define RTC_TAMPCR_TAMP2MF_Pos         (21U)
+#define RTC_TAMPCR_TAMP2MF_Msk         (0x1UL << RTC_TAMPCR_TAMP2MF_Pos)       /*!< 0x00200000 */
+#define RTC_TAMPCR_TAMP2MF             RTC_TAMPCR_TAMP2MF_Msk                  /*!< Tamper 2 generates a trigger event */
+#define RTC_TAMPCR_TAMP2NOERASE_Pos    (20U)
+#define RTC_TAMPCR_TAMP2NOERASE_Msk    (0x1UL << RTC_TAMPCR_TAMP2NOERASE_Pos)  /*!< 0x00100000 */
+#define RTC_TAMPCR_TAMP2NOERASE        RTC_TAMPCR_TAMP2NOERASE_Msk             /*!< Tamper 2 no erase backup registers */
+#define RTC_TAMPCR_TAMP2IE_Pos         (19U)
+#define RTC_TAMPCR_TAMP2IE_Msk         (0x1UL << RTC_TAMPCR_TAMP2IE_Pos)       /*!< 0x00080000 */
+#define RTC_TAMPCR_TAMP2IE             RTC_TAMPCR_TAMP2IE_Msk                  /*!< Tamper 2 interrupt enable */
+#define RTC_TAMPCR_TAMPPUDIS_Pos       (15U)
+#define RTC_TAMPCR_TAMPPUDIS_Msk       (0x1UL << RTC_TAMPCR_TAMPPUDIS_Pos)     /*!< 0x00008000 */
+#define RTC_TAMPCR_TAMPPUDIS           RTC_TAMPCR_TAMPPUDIS_Msk                /*!< RTC_TAMPx pull-up disable */
+#define RTC_TAMPCR_TAMPPRCH_Pos        (13U)
+#define RTC_TAMPCR_TAMPPRCH_Msk        (0x3UL << RTC_TAMPCR_TAMPPRCH_Pos)      /*!< 0x00006000 */
+#define RTC_TAMPCR_TAMPPRCH            RTC_TAMPCR_TAMPPRCH_Msk                 /*!< RTC_TAMPx precharge duration */
+#define RTC_TAMPCR_TAMPPRCH_0          (0x1U << RTC_TAMPCR_TAMPPRCH_Pos)       /*!< 0x00002000 */
+#define RTC_TAMPCR_TAMPPRCH_1          (0x2U << RTC_TAMPCR_TAMPPRCH_Pos)       /*!< 0x00004000 */
+#define RTC_TAMPCR_TAMPFLT_Pos         (11U)
+#define RTC_TAMPCR_TAMPFLT_Msk         (0x3UL << RTC_TAMPCR_TAMPFLT_Pos)       /*!< 0x00001800 */
+#define RTC_TAMPCR_TAMPFLT             RTC_TAMPCR_TAMPFLT_Msk                  /*!< RTC_TAMPx filter count */
+#define RTC_TAMPCR_TAMPFLT_0           (0x1U << RTC_TAMPCR_TAMPFLT_Pos)        /*!< 0x00000800 */
+#define RTC_TAMPCR_TAMPFLT_1           (0x2U << RTC_TAMPCR_TAMPFLT_Pos)        /*!< 0x00001000 */
+#define RTC_TAMPCR_TAMPFREQ_Pos        (8U)
+#define RTC_TAMPCR_TAMPFREQ_Msk        (0x7UL << RTC_TAMPCR_TAMPFREQ_Pos)      /*!< 0x00000700 */
+#define RTC_TAMPCR_TAMPFREQ            RTC_TAMPCR_TAMPFREQ_Msk                 /*!< Tamper sampling frequency */
+#define RTC_TAMPCR_TAMPFREQ_0          (0x1U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000100 */
+#define RTC_TAMPCR_TAMPFREQ_1          (0x2U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000200 */
+#define RTC_TAMPCR_TAMPFREQ_2          (0x4U << RTC_TAMPCR_TAMPFREQ_Pos)       /*!< 0x00000400 */
+#define RTC_TAMPCR_TAMPTS_Pos          (7U)
+#define RTC_TAMPCR_TAMPTS_Msk          (0x1UL << RTC_TAMPCR_TAMPTS_Pos)        /*!< 0x00000080 */
+#define RTC_TAMPCR_TAMPTS              RTC_TAMPCR_TAMPTS_Msk                   /*!< Activate timestamp on tamper detection event */
+#define RTC_TAMPCR_TAMP2TRG_Pos        (4U)
+#define RTC_TAMPCR_TAMP2TRG_Msk        (0x1UL << RTC_TAMPCR_TAMP2TRG_Pos)      /*!< 0x00000010 */
+#define RTC_TAMPCR_TAMP2TRG            RTC_TAMPCR_TAMP2TRG_Msk                 /*!< Active level for RTC_TAMP2 input */
+#define RTC_TAMPCR_TAMP2E_Pos          (3U)
+#define RTC_TAMPCR_TAMP2E_Msk          (0x1UL << RTC_TAMPCR_TAMP2E_Pos)        /*!< 0x00000008 */
+#define RTC_TAMPCR_TAMP2E              RTC_TAMPCR_TAMP2E_Msk                   /*!< RTC_TAMP2 detection enable */
+#define RTC_TAMPCR_TAMPIE_Pos          (2U)
+#define RTC_TAMPCR_TAMPIE_Msk          (0x1UL << RTC_TAMPCR_TAMPIE_Pos)        /*!< 0x00000004 */
+#define RTC_TAMPCR_TAMPIE              RTC_TAMPCR_TAMPIE_Msk                   /*!< Tampers interrupt enable */
+
+/********************  Bits definition for RTC_ALRMASSR register  *************/
+#define RTC_ALRMASSR_MASKSS_Pos        (24U)
+#define RTC_ALRMASSR_MASKSS_Msk        (0xFUL << RTC_ALRMASSR_MASKSS_Pos)      /*!< 0x0F000000 */
+#define RTC_ALRMASSR_MASKSS            RTC_ALRMASSR_MASKSS_Msk                 /*!< Alarm A mask the most-significant bits starting at this bit */
+#define RTC_ALRMASSR_MASKSS_0          (0x1U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x01000000 */
+#define RTC_ALRMASSR_MASKSS_1          (0x2U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x02000000 */
+#define RTC_ALRMASSR_MASKSS_2          (0x4U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x04000000 */
+#define RTC_ALRMASSR_MASKSS_3          (0x8U << RTC_ALRMASSR_MASKSS_Pos)       /*!< 0x08000000 */
+#define RTC_ALRMASSR_SS_Pos            (0U)                                    /*!< Alarm A sub seconds value*/
+#define RTC_ALRMASSR_SS_Msk            (0x7FFFUL << RTC_ALRMASSR_SS_Pos)       /*!< 0x00007FFF */
+#define RTC_ALRMASSR_SS                RTC_ALRMASSR_SS_Msk
+
+/********************  Bits definition for RTC_ALRMBSSR register  *************/
+#define RTC_ALRMBSSR_MASKSS_Pos        (24U)
+#define RTC_ALRMBSSR_MASKSS_Msk        (0xFUL << RTC_ALRMBSSR_MASKSS_Pos)      /*!< 0x0F000000 */
+#define RTC_ALRMBSSR_MASKSS            RTC_ALRMBSSR_MASKSS_Msk                 /*!< Alarm B mask the most-significant bits starting at this bit */
+#define RTC_ALRMBSSR_MASKSS_0          (0x1U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x01000000 */
+#define RTC_ALRMBSSR_MASKSS_1          (0x2U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x02000000 */
+#define RTC_ALRMBSSR_MASKSS_2          (0x4U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x04000000 */
+#define RTC_ALRMBSSR_MASKSS_3          (0x8U << RTC_ALRMBSSR_MASKSS_Pos)       /*!< 0x08000000 */
+#define RTC_ALRMBSSR_SS_Pos            (0U)                                    /*!< Alarm B sub seconds value*/
+#define RTC_ALRMBSSR_SS_Msk            (0x7FFFUL << RTC_ALRMBSSR_SS_Pos)       /*!< 0x00007FFF */
+#define RTC_ALRMBSSR_SS                RTC_ALRMBSSR_SS_Msk
+
+/********************  Bits definition for RTC_OR register  ****************/
+#define RTC_OR_OUT_RMP_Pos             (1U)
+#define RTC_OR_OUT_RMP_Msk             (0x1UL << RTC_OR_OUT_RMP_Pos)       /*!< 0x00000002 */
+#define RTC_OR_OUT_RMP                 RTC_OR_OUT_RMP_Msk                  /*!< RTC_OUT remap */
+
+/********************  Bits definition for RTC_BKP0R register  ****************/
+#define RTC_BKP0R_Pos                  (0U)
+#define RTC_BKP0R_Msk                  (0xFFFFFFFFUL << RTC_BKP0R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP0R                      RTC_BKP0R_Msk                           /*!< RTC backup register 0 */
+
+/********************  Bits definition for RTC_BKP1R register  ****************/
+#define RTC_BKP1R_Pos                  (0U)
+#define RTC_BKP1R_Msk                  (0xFFFFFFFFUL << RTC_BKP1R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP1R                      RTC_BKP1R_Msk                           /*!< RTC backup register 1 */
+
+/********************  Bits definition for RTC_BKP2R register  ****************/
+#define RTC_BKP2R_Pos                  (0U)
+#define RTC_BKP2R_Msk                  (0xFFFFFFFFUL << RTC_BKP2R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP2R                      RTC_BKP2R_Msk                           /*!< RTC backup register 2 */
+
+/********************  Bits definition for RTC_BKP3R register  ****************/
+#define RTC_BKP3R_Pos                  (0U)
+#define RTC_BKP3R_Msk                  (0xFFFFFFFFUL << RTC_BKP3R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP3R                      RTC_BKP3R_Msk                           /*!< RTC backup register 3 */
+
+/********************  Bits definition for RTC_BKP4R register  ****************/
+#define RTC_BKP4R_Pos                  (0U)
+#define RTC_BKP4R_Msk                  (0xFFFFFFFFUL << RTC_BKP4R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP4R                      RTC_BKP4R_Msk                           /*!< RTC backup register 4 */
+
+/********************  Bits definition for RTC_BKP5R register  ****************/
+#define RTC_BKP5R_Pos                  (0U)
+#define RTC_BKP5R_Msk                  (0xFFFFFFFFUL << RTC_BKP5R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP5R                      RTC_BKP5R_Msk                           /*!< RTC backup register 5 */
+
+/********************  Bits definition for RTC_BKP6R register  ****************/
+#define RTC_BKP6R_Pos                  (0U)
+#define RTC_BKP6R_Msk                  (0xFFFFFFFFUL << RTC_BKP6R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP6R                      RTC_BKP6R_Msk                           /*!< RTC backup register 6 */
+
+/********************  Bits definition for RTC_BKP7R register  ****************/
+#define RTC_BKP7R_Pos                  (0U)
+#define RTC_BKP7R_Msk                  (0xFFFFFFFFUL << RTC_BKP7R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP7R                      RTC_BKP7R_Msk                           /*!< RTC backup register 7 */
+
+/********************  Bits definition for RTC_BKP8R register  ****************/
+#define RTC_BKP8R_Pos                  (0U)
+#define RTC_BKP8R_Msk                  (0xFFFFFFFFUL << RTC_BKP8R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP8R                      RTC_BKP8R_Msk                           /*!< RTC backup register 8 */
+
+/********************  Bits definition for RTC_BKP9R register  ****************/
+#define RTC_BKP9R_Pos                  (0U)
+#define RTC_BKP9R_Msk                  (0xFFFFFFFFUL << RTC_BKP9R_Pos)         /*!< 0xFFFFFFFF */
+#define RTC_BKP9R                      RTC_BKP9R_Msk                           /*!< RTC backup register 9 */
+
+/********************  Bits definition for RTC_BKP10R register  ***************/
+#define RTC_BKP10R_Pos                 (0U)
+#define RTC_BKP10R_Msk                 (0xFFFFFFFFUL << RTC_BKP10R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP10R                     RTC_BKP10R_Msk                          /*!< RTC backup register 10 */
+
+/********************  Bits definition for RTC_BKP11R register  ***************/
+#define RTC_BKP11R_Pos                 (0U)
+#define RTC_BKP11R_Msk                 (0xFFFFFFFFUL << RTC_BKP11R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP11R                     RTC_BKP11R_Msk                          /*!< RTC backup register 11 */
+
+/********************  Bits definition for RTC_BKP12R register  ***************/
+#define RTC_BKP12R_Pos                 (0U)
+#define RTC_BKP12R_Msk                 (0xFFFFFFFFUL << RTC_BKP12R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP12R                     RTC_BKP12R_Msk                          /*!< RTC backup register 12 */
+
+/********************  Bits definition for RTC_BKP13R register  ***************/
+#define RTC_BKP13R_Pos                 (0U)
+#define RTC_BKP13R_Msk                 (0xFFFFFFFFUL << RTC_BKP13R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP13R                     RTC_BKP13R_Msk                          /*!< RTC backup register 13 */
+
+/********************  Bits definition for RTC_BKP14R register  ***************/
+#define RTC_BKP14R_Pos                 (0U)
+#define RTC_BKP14R_Msk                 (0xFFFFFFFFUL << RTC_BKP14R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP14R                     RTC_BKP14R_Msk                          /*!< RTC backup register 14 */
+
+/********************  Bits definition for RTC_BKP15R register  ***************/
+#define RTC_BKP15R_Pos                 (0U)
+#define RTC_BKP15R_Msk                 (0xFFFFFFFFUL << RTC_BKP15R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP15R                     RTC_BKP15R_Msk                          /*!< RTC backup register 15 */
+
+/********************  Bits definition for RTC_BKP16R register  ***************/
+#define RTC_BKP16R_Pos                 (0U)
+#define RTC_BKP16R_Msk                 (0xFFFFFFFFUL << RTC_BKP16R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP16R                     RTC_BKP16R_Msk                          /*!< RTC backup register 16 */
+
+/********************  Bits definition for RTC_BKP17R register  ***************/
+#define RTC_BKP17R_Pos                 (0U)
+#define RTC_BKP17R_Msk                 (0xFFFFFFFFUL << RTC_BKP17R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP17R                     RTC_BKP17R_Msk                          /*!< RTC backup register 17 */
+
+/********************  Bits definition for RTC_BKP18R register  ***************/
+#define RTC_BKP18R_Pos                 (0U)
+#define RTC_BKP18R_Msk                 (0xFFFFFFFFUL << RTC_BKP18R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP18R                     RTC_BKP18R_Msk                          /*!< RTC backup register 18 */
+
+/********************  Bits definition for RTC_BKP19R register  ***************/
+#define RTC_BKP19R_Pos                 (0U)
+#define RTC_BKP19R_Msk                 (0xFFFFFFFFUL << RTC_BKP19R_Pos)        /*!< 0xFFFFFFFF */
+#define RTC_BKP19R                     RTC_BKP19R_Msk                          /*!< RTC backup register 19 */
+
+/******************** Number of backup registers ******************************/
+#define RTC_BKP_NUMBER                 (20U)
+
+/******************************************************************************/
+/*                                                                            */
+/*                        Serial Peripheral Interface (SPI)                   */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for SPI_CR1 register  ********************/
+#define SPI_CR1_CPHA_Pos            (0U)
+#define SPI_CR1_CPHA_Msk            (0x1UL << SPI_CR1_CPHA_Pos)                /*!< 0x00000001 */
+#define SPI_CR1_CPHA                SPI_CR1_CPHA_Msk                           /*!<Clock Phase      */
+#define SPI_CR1_CPOL_Pos            (1U)
+#define SPI_CR1_CPOL_Msk            (0x1UL << SPI_CR1_CPOL_Pos)                /*!< 0x00000002 */
+#define SPI_CR1_CPOL                SPI_CR1_CPOL_Msk                           /*!<Clock Polarity   */
+#define SPI_CR1_MSTR_Pos            (2U)
+#define SPI_CR1_MSTR_Msk            (0x1UL << SPI_CR1_MSTR_Pos)                /*!< 0x00000004 */
+#define SPI_CR1_MSTR                SPI_CR1_MSTR_Msk                           /*!<Master Selection */
+
+#define SPI_CR1_BR_Pos              (3U)
+#define SPI_CR1_BR_Msk              (0x7UL << SPI_CR1_BR_Pos)                  /*!< 0x00000038 */
+#define SPI_CR1_BR                  SPI_CR1_BR_Msk                             /*!<BR[2:0] bits (Baud Rate Control) */
+#define SPI_CR1_BR_0                (0x1UL << SPI_CR1_BR_Pos)                  /*!< 0x00000008 */
+#define SPI_CR1_BR_1                (0x2UL << SPI_CR1_BR_Pos)                  /*!< 0x00000010 */
+#define SPI_CR1_BR_2                (0x4UL << SPI_CR1_BR_Pos)                  /*!< 0x00000020 */
+
+#define SPI_CR1_SPE_Pos             (6U)
+#define SPI_CR1_SPE_Msk             (0x1UL << SPI_CR1_SPE_Pos)                 /*!< 0x00000040 */
+#define SPI_CR1_SPE                 SPI_CR1_SPE_Msk                            /*!<SPI Enable                          */
+#define SPI_CR1_LSBFIRST_Pos        (7U)
+#define SPI_CR1_LSBFIRST_Msk        (0x1UL << SPI_CR1_LSBFIRST_Pos)            /*!< 0x00000080 */
+#define SPI_CR1_LSBFIRST            SPI_CR1_LSBFIRST_Msk                       /*!<Frame Format                        */
+#define SPI_CR1_SSI_Pos             (8U)
+#define SPI_CR1_SSI_Msk             (0x1UL << SPI_CR1_SSI_Pos)                 /*!< 0x00000100 */
+#define SPI_CR1_SSI                 SPI_CR1_SSI_Msk                            /*!<Internal slave select               */
+#define SPI_CR1_SSM_Pos             (9U)
+#define SPI_CR1_SSM_Msk             (0x1UL << SPI_CR1_SSM_Pos)                 /*!< 0x00000200 */
+#define SPI_CR1_SSM                 SPI_CR1_SSM_Msk                            /*!<Software slave management           */
+#define SPI_CR1_RXONLY_Pos          (10U)
+#define SPI_CR1_RXONLY_Msk          (0x1UL << SPI_CR1_RXONLY_Pos)              /*!< 0x00000400 */
+#define SPI_CR1_RXONLY              SPI_CR1_RXONLY_Msk                         /*!<Receive only                        */
+#define SPI_CR1_CRCL_Pos            (11U)
+#define SPI_CR1_CRCL_Msk            (0x1UL << SPI_CR1_CRCL_Pos)                /*!< 0x00000800 */
+#define SPI_CR1_CRCL                SPI_CR1_CRCL_Msk                           /*!< CRC Length */
+#define SPI_CR1_CRCNEXT_Pos         (12U)
+#define SPI_CR1_CRCNEXT_Msk         (0x1UL << SPI_CR1_CRCNEXT_Pos)             /*!< 0x00001000 */
+#define SPI_CR1_CRCNEXT             SPI_CR1_CRCNEXT_Msk                        /*!<Transmit CRC next                   */
+#define SPI_CR1_CRCEN_Pos           (13U)
+#define SPI_CR1_CRCEN_Msk           (0x1UL << SPI_CR1_CRCEN_Pos)               /*!< 0x00002000 */
+#define SPI_CR1_CRCEN               SPI_CR1_CRCEN_Msk                          /*!<Hardware CRC calculation enable     */
+#define SPI_CR1_BIDIOE_Pos          (14U)
+#define SPI_CR1_BIDIOE_Msk          (0x1UL << SPI_CR1_BIDIOE_Pos)              /*!< 0x00004000 */
+#define SPI_CR1_BIDIOE              SPI_CR1_BIDIOE_Msk                         /*!<Output enable in bidirectional mode */
+#define SPI_CR1_BIDIMODE_Pos        (15U)
+#define SPI_CR1_BIDIMODE_Msk        (0x1UL << SPI_CR1_BIDIMODE_Pos)            /*!< 0x00008000 */
+#define SPI_CR1_BIDIMODE            SPI_CR1_BIDIMODE_Msk                       /*!<Bidirectional data mode enable      */
+
+/*******************  Bit definition for SPI_CR2 register  ********************/
+#define SPI_CR2_RXDMAEN_Pos         (0U)
+#define SPI_CR2_RXDMAEN_Msk         (0x1UL << SPI_CR2_RXDMAEN_Pos)             /*!< 0x00000001 */
+#define SPI_CR2_RXDMAEN             SPI_CR2_RXDMAEN_Msk                        /*!< Rx Buffer DMA Enable */
+#define SPI_CR2_TXDMAEN_Pos         (1U)
+#define SPI_CR2_TXDMAEN_Msk         (0x1UL << SPI_CR2_TXDMAEN_Pos)             /*!< 0x00000002 */
+#define SPI_CR2_TXDMAEN             SPI_CR2_TXDMAEN_Msk                        /*!< Tx Buffer DMA Enable */
+#define SPI_CR2_SSOE_Pos            (2U)
+#define SPI_CR2_SSOE_Msk            (0x1UL << SPI_CR2_SSOE_Pos)                /*!< 0x00000004 */
+#define SPI_CR2_SSOE                SPI_CR2_SSOE_Msk                           /*!< SS Output Enable */
+#define SPI_CR2_NSSP_Pos            (3U)
+#define SPI_CR2_NSSP_Msk            (0x1UL << SPI_CR2_NSSP_Pos)                /*!< 0x00000008 */
+#define SPI_CR2_NSSP                SPI_CR2_NSSP_Msk                           /*!< NSS pulse management Enable */
+#define SPI_CR2_FRF_Pos             (4U)
+#define SPI_CR2_FRF_Msk             (0x1UL << SPI_CR2_FRF_Pos)                 /*!< 0x00000010 */
+#define SPI_CR2_FRF                 SPI_CR2_FRF_Msk                            /*!< Frame Format Enable */
+#define SPI_CR2_ERRIE_Pos           (5U)
+#define SPI_CR2_ERRIE_Msk           (0x1UL << SPI_CR2_ERRIE_Pos)               /*!< 0x00000020 */
+#define SPI_CR2_ERRIE               SPI_CR2_ERRIE_Msk                          /*!< Error Interrupt Enable */
+#define SPI_CR2_RXNEIE_Pos          (6U)
+#define SPI_CR2_RXNEIE_Msk          (0x1UL << SPI_CR2_RXNEIE_Pos)              /*!< 0x00000040 */
+#define SPI_CR2_RXNEIE              SPI_CR2_RXNEIE_Msk                         /*!< RX buffer Not Empty Interrupt Enable */
+#define SPI_CR2_TXEIE_Pos           (7U)
+#define SPI_CR2_TXEIE_Msk           (0x1UL << SPI_CR2_TXEIE_Pos)               /*!< 0x00000080 */
+#define SPI_CR2_TXEIE               SPI_CR2_TXEIE_Msk                          /*!< Tx buffer Empty Interrupt Enable */
+#define SPI_CR2_DS_Pos              (8U)
+#define SPI_CR2_DS_Msk              (0xFUL << SPI_CR2_DS_Pos)                  /*!< 0x00000F00 */
+#define SPI_CR2_DS                  SPI_CR2_DS_Msk                             /*!< DS[3:0] Data Size */
+#define SPI_CR2_DS_0                (0x1UL << SPI_CR2_DS_Pos)                  /*!< 0x00000100 */
+#define SPI_CR2_DS_1                (0x2UL << SPI_CR2_DS_Pos)                  /*!< 0x00000200 */
+#define SPI_CR2_DS_2                (0x4UL << SPI_CR2_DS_Pos)                  /*!< 0x00000400 */
+#define SPI_CR2_DS_3                (0x8UL << SPI_CR2_DS_Pos)                  /*!< 0x00000800 */
+#define SPI_CR2_FRXTH_Pos           (12U)
+#define SPI_CR2_FRXTH_Msk           (0x1UL << SPI_CR2_FRXTH_Pos)               /*!< 0x00001000 */
+#define SPI_CR2_FRXTH               SPI_CR2_FRXTH_Msk                          /*!< FIFO reception Threshold */
+#define SPI_CR2_LDMARX_Pos          (13U)
+#define SPI_CR2_LDMARX_Msk          (0x1UL << SPI_CR2_LDMARX_Pos)              /*!< 0x00002000 */
+#define SPI_CR2_LDMARX              SPI_CR2_LDMARX_Msk                         /*!< Last DMA transfer for reception */
+#define SPI_CR2_LDMATX_Pos          (14U)
+#define SPI_CR2_LDMATX_Msk          (0x1UL << SPI_CR2_LDMATX_Pos)              /*!< 0x00004000 */
+#define SPI_CR2_LDMATX              SPI_CR2_LDMATX_Msk                         /*!< Last DMA transfer for transmission */
+
+/********************  Bit definition for SPI_SR register  ********************/
+#define SPI_SR_RXNE_Pos             (0U)
+#define SPI_SR_RXNE_Msk             (0x1UL << SPI_SR_RXNE_Pos)                 /*!< 0x00000001 */
+#define SPI_SR_RXNE                 SPI_SR_RXNE_Msk                            /*!< Receive buffer Not Empty */
+#define SPI_SR_TXE_Pos              (1U)
+#define SPI_SR_TXE_Msk              (0x1UL << SPI_SR_TXE_Pos)                  /*!< 0x00000002 */
+#define SPI_SR_TXE                  SPI_SR_TXE_Msk                             /*!< Transmit buffer Empty */
+#define SPI_SR_CRCERR_Pos           (4U)
+#define SPI_SR_CRCERR_Msk           (0x1UL << SPI_SR_CRCERR_Pos)               /*!< 0x00000010 */
+#define SPI_SR_CRCERR               SPI_SR_CRCERR_Msk                          /*!< CRC Error flag */
+#define SPI_SR_MODF_Pos             (5U)
+#define SPI_SR_MODF_Msk             (0x1UL << SPI_SR_MODF_Pos)                 /*!< 0x00000020 */
+#define SPI_SR_MODF                 SPI_SR_MODF_Msk                            /*!< Mode fault */
+#define SPI_SR_OVR_Pos              (6U)
+#define SPI_SR_OVR_Msk              (0x1UL << SPI_SR_OVR_Pos)                  /*!< 0x00000040 */
+#define SPI_SR_OVR                  SPI_SR_OVR_Msk                             /*!< Overrun flag */
+#define SPI_SR_BSY_Pos              (7U)
+#define SPI_SR_BSY_Msk              (0x1UL << SPI_SR_BSY_Pos)                  /*!< 0x00000080 */
+#define SPI_SR_BSY                  SPI_SR_BSY_Msk                             /*!< Busy flag */
+#define SPI_SR_FRE_Pos              (8U)
+#define SPI_SR_FRE_Msk              (0x1UL << SPI_SR_FRE_Pos)                  /*!< 0x00000100 */
+#define SPI_SR_FRE                  SPI_SR_FRE_Msk                             /*!< TI frame format error */
+#define SPI_SR_FRLVL_Pos            (9U)
+#define SPI_SR_FRLVL_Msk            (0x3UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000600 */
+#define SPI_SR_FRLVL                SPI_SR_FRLVL_Msk                           /*!< FIFO Reception Level */
+#define SPI_SR_FRLVL_0              (0x1UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000200 */
+#define SPI_SR_FRLVL_1              (0x2UL << SPI_SR_FRLVL_Pos)                /*!< 0x00000400 */
+#define SPI_SR_FTLVL_Pos            (11U)
+#define SPI_SR_FTLVL_Msk            (0x3UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001800 */
+#define SPI_SR_FTLVL                SPI_SR_FTLVL_Msk                           /*!< FIFO Transmission Level */
+#define SPI_SR_FTLVL_0              (0x1UL << SPI_SR_FTLVL_Pos)                /*!< 0x00000800 */
+#define SPI_SR_FTLVL_1              (0x2UL << SPI_SR_FTLVL_Pos)                /*!< 0x00001000 */
+
+/********************  Bit definition for SPI_DR register  ********************/
+#define SPI_DR_DR_Pos               (0U)
+#define SPI_DR_DR_Msk               (0xFFFFUL << SPI_DR_DR_Pos)                /*!< 0x0000FFFF */
+#define SPI_DR_DR                   SPI_DR_DR_Msk                              /*!<Data Register           */
+
+/*******************  Bit definition for SPI_CRCPR register  ******************/
+#define SPI_CRCPR_CRCPOLY_Pos       (0U)
+#define SPI_CRCPR_CRCPOLY_Msk       (0xFFFFUL << SPI_CRCPR_CRCPOLY_Pos)        /*!< 0x0000FFFF */
+#define SPI_CRCPR_CRCPOLY           SPI_CRCPR_CRCPOLY_Msk                      /*!<CRC polynomial register */
+
+/******************  Bit definition for SPI_RXCRCR register  ******************/
+#define SPI_RXCRCR_RXCRC_Pos        (0U)
+#define SPI_RXCRCR_RXCRC_Msk        (0xFFFFUL << SPI_RXCRCR_RXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_RXCRCR_RXCRC            SPI_RXCRCR_RXCRC_Msk                       /*!<Rx CRC Register         */
+
+/******************  Bit definition for SPI_TXCRCR register  ******************/
+#define SPI_TXCRCR_TXCRC_Pos        (0U)
+#define SPI_TXCRCR_TXCRC_Msk        (0xFFFFUL << SPI_TXCRCR_TXCRC_Pos)         /*!< 0x0000FFFF */
+#define SPI_TXCRCR_TXCRC            SPI_TXCRCR_TXCRC_Msk                       /*!<Tx CRC Register         */
+
+/******************************************************************************/
+/*                                                                            */
+/*                          Touch Sensing Controller (TSC)                    */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TSC_CR register  *********************/
+#define TSC_CR_TSCE_Pos          (0U)
+#define TSC_CR_TSCE_Msk          (0x1UL << TSC_CR_TSCE_Pos)                    /*!< 0x00000001 */
+#define TSC_CR_TSCE              TSC_CR_TSCE_Msk                               /*!< Touch sensing controller enable */
+#define TSC_CR_START_Pos         (1U)
+#define TSC_CR_START_Msk         (0x1UL << TSC_CR_START_Pos)                   /*!< 0x00000002 */
+#define TSC_CR_START             TSC_CR_START_Msk                              /*!< Start a new acquisition */
+#define TSC_CR_AM_Pos            (2U)
+#define TSC_CR_AM_Msk            (0x1UL << TSC_CR_AM_Pos)                      /*!< 0x00000004 */
+#define TSC_CR_AM                TSC_CR_AM_Msk                                 /*!< Acquisition mode */
+#define TSC_CR_SYNCPOL_Pos       (3U)
+#define TSC_CR_SYNCPOL_Msk       (0x1UL << TSC_CR_SYNCPOL_Pos)                 /*!< 0x00000008 */
+#define TSC_CR_SYNCPOL           TSC_CR_SYNCPOL_Msk                            /*!< Synchronization pin polarity */
+#define TSC_CR_IODEF_Pos         (4U)
+#define TSC_CR_IODEF_Msk         (0x1UL << TSC_CR_IODEF_Pos)                   /*!< 0x00000010 */
+#define TSC_CR_IODEF             TSC_CR_IODEF_Msk                              /*!< IO default mode */
+
+#define TSC_CR_MCV_Pos           (5U)
+#define TSC_CR_MCV_Msk           (0x7UL << TSC_CR_MCV_Pos)                     /*!< 0x000000E0 */
+#define TSC_CR_MCV               TSC_CR_MCV_Msk                                /*!< MCV[2:0] bits (Max Count Value) */
+#define TSC_CR_MCV_0             (0x1U << TSC_CR_MCV_Pos)                      /*!< 0x00000020 */
+#define TSC_CR_MCV_1             (0x2U << TSC_CR_MCV_Pos)                      /*!< 0x00000040 */
+#define TSC_CR_MCV_2             (0x4U << TSC_CR_MCV_Pos)                      /*!< 0x00000080 */
+
+#define TSC_CR_PGPSC_Pos         (12U)
+#define TSC_CR_PGPSC_Msk         (0x7UL << TSC_CR_PGPSC_Pos)                   /*!< 0x00007000 */
+#define TSC_CR_PGPSC             TSC_CR_PGPSC_Msk                              /*!< PGPSC[2:0] bits (Pulse Generator Prescaler) */
+#define TSC_CR_PGPSC_0           (0x1U << TSC_CR_PGPSC_Pos)                    /*!< 0x00001000 */
+#define TSC_CR_PGPSC_1           (0x2U << TSC_CR_PGPSC_Pos)                    /*!< 0x00002000 */
+#define TSC_CR_PGPSC_2           (0x4U << TSC_CR_PGPSC_Pos)                    /*!< 0x00004000 */
+
+#define TSC_CR_SSPSC_Pos         (15U)
+#define TSC_CR_SSPSC_Msk         (0x1UL << TSC_CR_SSPSC_Pos)                   /*!< 0x00008000 */
+#define TSC_CR_SSPSC             TSC_CR_SSPSC_Msk                              /*!< Spread Spectrum Prescaler */
+#define TSC_CR_SSE_Pos           (16U)
+#define TSC_CR_SSE_Msk           (0x1UL << TSC_CR_SSE_Pos)                     /*!< 0x00010000 */
+#define TSC_CR_SSE               TSC_CR_SSE_Msk                                /*!< Spread Spectrum Enable */
+
+#define TSC_CR_SSD_Pos           (17U)
+#define TSC_CR_SSD_Msk           (0x7FUL << TSC_CR_SSD_Pos)                    /*!< 0x00FE0000 */
+#define TSC_CR_SSD               TSC_CR_SSD_Msk                                /*!< SSD[6:0] bits (Spread Spectrum Deviation) */
+#define TSC_CR_SSD_0             (0x01U << TSC_CR_SSD_Pos)                     /*!< 0x00020000 */
+#define TSC_CR_SSD_1             (0x02U << TSC_CR_SSD_Pos)                     /*!< 0x00040000 */
+#define TSC_CR_SSD_2             (0x04U << TSC_CR_SSD_Pos)                     /*!< 0x00080000 */
+#define TSC_CR_SSD_3             (0x08U << TSC_CR_SSD_Pos)                     /*!< 0x00100000 */
+#define TSC_CR_SSD_4             (0x10U << TSC_CR_SSD_Pos)                     /*!< 0x00200000 */
+#define TSC_CR_SSD_5             (0x20U << TSC_CR_SSD_Pos)                     /*!< 0x00400000 */
+#define TSC_CR_SSD_6             (0x40U << TSC_CR_SSD_Pos)                     /*!< 0x00800000 */
+
+#define TSC_CR_CTPL_Pos          (24U)
+#define TSC_CR_CTPL_Msk          (0xFUL << TSC_CR_CTPL_Pos)                    /*!< 0x0F000000 */
+#define TSC_CR_CTPL              TSC_CR_CTPL_Msk                               /*!< CTPL[3:0] bits (Charge Transfer pulse low) */
+#define TSC_CR_CTPL_0            (0x1U << TSC_CR_CTPL_Pos)                     /*!< 0x01000000 */
+#define TSC_CR_CTPL_1            (0x2U << TSC_CR_CTPL_Pos)                     /*!< 0x02000000 */
+#define TSC_CR_CTPL_2            (0x4U << TSC_CR_CTPL_Pos)                     /*!< 0x04000000 */
+#define TSC_CR_CTPL_3            (0x8U << TSC_CR_CTPL_Pos)                     /*!< 0x08000000 */
+
+#define TSC_CR_CTPH_Pos          (28U)
+#define TSC_CR_CTPH_Msk          (0xFUL << TSC_CR_CTPH_Pos)                    /*!< 0xF0000000 */
+#define TSC_CR_CTPH              TSC_CR_CTPH_Msk                               /*!< CTPH[3:0] bits (Charge Transfer pulse high) */
+#define TSC_CR_CTPH_0            (0x1U << TSC_CR_CTPH_Pos)                     /*!< 0x10000000 */
+#define TSC_CR_CTPH_1            (0x2U << TSC_CR_CTPH_Pos)                     /*!< 0x20000000 */
+#define TSC_CR_CTPH_2            (0x4U << TSC_CR_CTPH_Pos)                     /*!< 0x40000000 */
+#define TSC_CR_CTPH_3            (0x8U << TSC_CR_CTPH_Pos)                     /*!< 0x80000000 */
+
+/*******************  Bit definition for TSC_IER register  ********************/
+#define TSC_IER_EOAIE_Pos        (0U)
+#define TSC_IER_EOAIE_Msk        (0x1UL << TSC_IER_EOAIE_Pos)                  /*!< 0x00000001 */
+#define TSC_IER_EOAIE            TSC_IER_EOAIE_Msk                             /*!< End of acquisition interrupt enable */
+#define TSC_IER_MCEIE_Pos        (1U)
+#define TSC_IER_MCEIE_Msk        (0x1UL << TSC_IER_MCEIE_Pos)                  /*!< 0x00000002 */
+#define TSC_IER_MCEIE            TSC_IER_MCEIE_Msk                             /*!< Max count error interrupt enable */
+
+/*******************  Bit definition for TSC_ICR register  ********************/
+#define TSC_ICR_EOAIC_Pos        (0U)
+#define TSC_ICR_EOAIC_Msk        (0x1UL << TSC_ICR_EOAIC_Pos)                  /*!< 0x00000001 */
+#define TSC_ICR_EOAIC            TSC_ICR_EOAIC_Msk                             /*!< End of acquisition interrupt clear */
+#define TSC_ICR_MCEIC_Pos        (1U)
+#define TSC_ICR_MCEIC_Msk        (0x1UL << TSC_ICR_MCEIC_Pos)                  /*!< 0x00000002 */
+#define TSC_ICR_MCEIC            TSC_ICR_MCEIC_Msk                             /*!< Max count error interrupt clear */
+
+/*******************  Bit definition for TSC_ISR register  ********************/
+#define TSC_ISR_EOAF_Pos         (0U)
+#define TSC_ISR_EOAF_Msk         (0x1UL << TSC_ISR_EOAF_Pos)                   /*!< 0x00000001 */
+#define TSC_ISR_EOAF             TSC_ISR_EOAF_Msk                              /*!< End of acquisition flag */
+#define TSC_ISR_MCEF_Pos         (1U)
+#define TSC_ISR_MCEF_Msk         (0x1UL << TSC_ISR_MCEF_Pos)                   /*!< 0x00000002 */
+#define TSC_ISR_MCEF             TSC_ISR_MCEF_Msk                              /*!< Max count error flag */
+
+/*******************  Bit definition for TSC_IOHCR register  ******************/
+#define TSC_IOHCR_G1_IO1_Pos     (0U)
+#define TSC_IOHCR_G1_IO1_Msk     (0x1UL << TSC_IOHCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOHCR_G1_IO1         TSC_IOHCR_G1_IO1_Msk                          /*!< GROUP1_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO2_Pos     (1U)
+#define TSC_IOHCR_G1_IO2_Msk     (0x1UL << TSC_IOHCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOHCR_G1_IO2         TSC_IOHCR_G1_IO2_Msk                          /*!< GROUP1_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO3_Pos     (2U)
+#define TSC_IOHCR_G1_IO3_Msk     (0x1UL << TSC_IOHCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOHCR_G1_IO3         TSC_IOHCR_G1_IO3_Msk                          /*!< GROUP1_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G1_IO4_Pos     (3U)
+#define TSC_IOHCR_G1_IO4_Msk     (0x1UL << TSC_IOHCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOHCR_G1_IO4         TSC_IOHCR_G1_IO4_Msk                          /*!< GROUP1_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO1_Pos     (4U)
+#define TSC_IOHCR_G2_IO1_Msk     (0x1UL << TSC_IOHCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOHCR_G2_IO1         TSC_IOHCR_G2_IO1_Msk                          /*!< GROUP2_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO2_Pos     (5U)
+#define TSC_IOHCR_G2_IO2_Msk     (0x1UL << TSC_IOHCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOHCR_G2_IO2         TSC_IOHCR_G2_IO2_Msk                          /*!< GROUP2_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO3_Pos     (6U)
+#define TSC_IOHCR_G2_IO3_Msk     (0x1UL << TSC_IOHCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOHCR_G2_IO3         TSC_IOHCR_G2_IO3_Msk                          /*!< GROUP2_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G2_IO4_Pos     (7U)
+#define TSC_IOHCR_G2_IO4_Msk     (0x1UL << TSC_IOHCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOHCR_G2_IO4         TSC_IOHCR_G2_IO4_Msk                          /*!< GROUP2_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO1_Pos     (8U)
+#define TSC_IOHCR_G3_IO1_Msk     (0x1UL << TSC_IOHCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOHCR_G3_IO1         TSC_IOHCR_G3_IO1_Msk                          /*!< GROUP3_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO2_Pos     (9U)
+#define TSC_IOHCR_G3_IO2_Msk     (0x1UL << TSC_IOHCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOHCR_G3_IO2         TSC_IOHCR_G3_IO2_Msk                          /*!< GROUP3_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO3_Pos     (10U)
+#define TSC_IOHCR_G3_IO3_Msk     (0x1UL << TSC_IOHCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOHCR_G3_IO3         TSC_IOHCR_G3_IO3_Msk                          /*!< GROUP3_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G3_IO4_Pos     (11U)
+#define TSC_IOHCR_G3_IO4_Msk     (0x1UL << TSC_IOHCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOHCR_G3_IO4         TSC_IOHCR_G3_IO4_Msk                          /*!< GROUP3_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO1_Pos     (12U)
+#define TSC_IOHCR_G4_IO1_Msk     (0x1UL << TSC_IOHCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOHCR_G4_IO1         TSC_IOHCR_G4_IO1_Msk                          /*!< GROUP4_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO2_Pos     (13U)
+#define TSC_IOHCR_G4_IO2_Msk     (0x1UL << TSC_IOHCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOHCR_G4_IO2         TSC_IOHCR_G4_IO2_Msk                          /*!< GROUP4_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO3_Pos     (14U)
+#define TSC_IOHCR_G4_IO3_Msk     (0x1UL << TSC_IOHCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOHCR_G4_IO3         TSC_IOHCR_G4_IO3_Msk                          /*!< GROUP4_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G4_IO4_Pos     (15U)
+#define TSC_IOHCR_G4_IO4_Msk     (0x1UL << TSC_IOHCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOHCR_G4_IO4         TSC_IOHCR_G4_IO4_Msk                          /*!< GROUP4_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO1_Pos     (16U)
+#define TSC_IOHCR_G5_IO1_Msk     (0x1UL << TSC_IOHCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOHCR_G5_IO1         TSC_IOHCR_G5_IO1_Msk                          /*!< GROUP5_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO2_Pos     (17U)
+#define TSC_IOHCR_G5_IO2_Msk     (0x1UL << TSC_IOHCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOHCR_G5_IO2         TSC_IOHCR_G5_IO2_Msk                          /*!< GROUP5_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO3_Pos     (18U)
+#define TSC_IOHCR_G5_IO3_Msk     (0x1UL << TSC_IOHCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOHCR_G5_IO3         TSC_IOHCR_G5_IO3_Msk                          /*!< GROUP5_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G5_IO4_Pos     (19U)
+#define TSC_IOHCR_G5_IO4_Msk     (0x1UL << TSC_IOHCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOHCR_G5_IO4         TSC_IOHCR_G5_IO4_Msk                          /*!< GROUP5_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO1_Pos     (20U)
+#define TSC_IOHCR_G6_IO1_Msk     (0x1UL << TSC_IOHCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOHCR_G6_IO1         TSC_IOHCR_G6_IO1_Msk                          /*!< GROUP6_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO2_Pos     (21U)
+#define TSC_IOHCR_G6_IO2_Msk     (0x1UL << TSC_IOHCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOHCR_G6_IO2         TSC_IOHCR_G6_IO2_Msk                          /*!< GROUP6_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO3_Pos     (22U)
+#define TSC_IOHCR_G6_IO3_Msk     (0x1UL << TSC_IOHCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOHCR_G6_IO3         TSC_IOHCR_G6_IO3_Msk                          /*!< GROUP6_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G6_IO4_Pos     (23U)
+#define TSC_IOHCR_G6_IO4_Msk     (0x1UL << TSC_IOHCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOHCR_G6_IO4         TSC_IOHCR_G6_IO4_Msk                          /*!< GROUP6_IO4 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO1_Pos     (24U)
+#define TSC_IOHCR_G7_IO1_Msk     (0x1UL << TSC_IOHCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOHCR_G7_IO1         TSC_IOHCR_G7_IO1_Msk                          /*!< GROUP7_IO1 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO2_Pos     (25U)
+#define TSC_IOHCR_G7_IO2_Msk     (0x1UL << TSC_IOHCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOHCR_G7_IO2         TSC_IOHCR_G7_IO2_Msk                          /*!< GROUP7_IO2 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO3_Pos     (26U)
+#define TSC_IOHCR_G7_IO3_Msk     (0x1UL << TSC_IOHCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOHCR_G7_IO3         TSC_IOHCR_G7_IO3_Msk                          /*!< GROUP7_IO3 schmitt trigger hysteresis mode */
+#define TSC_IOHCR_G7_IO4_Pos     (27U)
+#define TSC_IOHCR_G7_IO4_Msk     (0x1UL << TSC_IOHCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOHCR_G7_IO4         TSC_IOHCR_G7_IO4_Msk                          /*!< GROUP7_IO4 schmitt trigger hysteresis mode */
+
+/*******************  Bit definition for TSC_IOASCR register  *****************/
+#define TSC_IOASCR_G1_IO1_Pos    (0U)
+#define TSC_IOASCR_G1_IO1_Msk    (0x1UL << TSC_IOASCR_G1_IO1_Pos)              /*!< 0x00000001 */
+#define TSC_IOASCR_G1_IO1        TSC_IOASCR_G1_IO1_Msk                         /*!< GROUP1_IO1 analog switch enable */
+#define TSC_IOASCR_G1_IO2_Pos    (1U)
+#define TSC_IOASCR_G1_IO2_Msk    (0x1UL << TSC_IOASCR_G1_IO2_Pos)              /*!< 0x00000002 */
+#define TSC_IOASCR_G1_IO2        TSC_IOASCR_G1_IO2_Msk                         /*!< GROUP1_IO2 analog switch enable */
+#define TSC_IOASCR_G1_IO3_Pos    (2U)
+#define TSC_IOASCR_G1_IO3_Msk    (0x1UL << TSC_IOASCR_G1_IO3_Pos)              /*!< 0x00000004 */
+#define TSC_IOASCR_G1_IO3        TSC_IOASCR_G1_IO3_Msk                         /*!< GROUP1_IO3 analog switch enable */
+#define TSC_IOASCR_G1_IO4_Pos    (3U)
+#define TSC_IOASCR_G1_IO4_Msk    (0x1UL << TSC_IOASCR_G1_IO4_Pos)              /*!< 0x00000008 */
+#define TSC_IOASCR_G1_IO4        TSC_IOASCR_G1_IO4_Msk                         /*!< GROUP1_IO4 analog switch enable */
+#define TSC_IOASCR_G2_IO1_Pos    (4U)
+#define TSC_IOASCR_G2_IO1_Msk    (0x1UL << TSC_IOASCR_G2_IO1_Pos)              /*!< 0x00000010 */
+#define TSC_IOASCR_G2_IO1        TSC_IOASCR_G2_IO1_Msk                         /*!< GROUP2_IO1 analog switch enable */
+#define TSC_IOASCR_G2_IO2_Pos    (5U)
+#define TSC_IOASCR_G2_IO2_Msk    (0x1UL << TSC_IOASCR_G2_IO2_Pos)              /*!< 0x00000020 */
+#define TSC_IOASCR_G2_IO2        TSC_IOASCR_G2_IO2_Msk                         /*!< GROUP2_IO2 analog switch enable */
+#define TSC_IOASCR_G2_IO3_Pos    (6U)
+#define TSC_IOASCR_G2_IO3_Msk    (0x1UL << TSC_IOASCR_G2_IO3_Pos)              /*!< 0x00000040 */
+#define TSC_IOASCR_G2_IO3        TSC_IOASCR_G2_IO3_Msk                         /*!< GROUP2_IO3 analog switch enable */
+#define TSC_IOASCR_G2_IO4_Pos    (7U)
+#define TSC_IOASCR_G2_IO4_Msk    (0x1UL << TSC_IOASCR_G2_IO4_Pos)              /*!< 0x00000080 */
+#define TSC_IOASCR_G2_IO4        TSC_IOASCR_G2_IO4_Msk                         /*!< GROUP2_IO4 analog switch enable */
+#define TSC_IOASCR_G3_IO1_Pos    (8U)
+#define TSC_IOASCR_G3_IO1_Msk    (0x1UL << TSC_IOASCR_G3_IO1_Pos)              /*!< 0x00000100 */
+#define TSC_IOASCR_G3_IO1        TSC_IOASCR_G3_IO1_Msk                         /*!< GROUP3_IO1 analog switch enable */
+#define TSC_IOASCR_G3_IO2_Pos    (9U)
+#define TSC_IOASCR_G3_IO2_Msk    (0x1UL << TSC_IOASCR_G3_IO2_Pos)              /*!< 0x00000200 */
+#define TSC_IOASCR_G3_IO2        TSC_IOASCR_G3_IO2_Msk                         /*!< GROUP3_IO2 analog switch enable */
+#define TSC_IOASCR_G3_IO3_Pos    (10U)
+#define TSC_IOASCR_G3_IO3_Msk    (0x1UL << TSC_IOASCR_G3_IO3_Pos)              /*!< 0x00000400 */
+#define TSC_IOASCR_G3_IO3        TSC_IOASCR_G3_IO3_Msk                         /*!< GROUP3_IO3 analog switch enable */
+#define TSC_IOASCR_G3_IO4_Pos    (11U)
+#define TSC_IOASCR_G3_IO4_Msk    (0x1UL << TSC_IOASCR_G3_IO4_Pos)              /*!< 0x00000800 */
+#define TSC_IOASCR_G3_IO4        TSC_IOASCR_G3_IO4_Msk                         /*!< GROUP3_IO4 analog switch enable */
+#define TSC_IOASCR_G4_IO1_Pos    (12U)
+#define TSC_IOASCR_G4_IO1_Msk    (0x1UL << TSC_IOASCR_G4_IO1_Pos)              /*!< 0x00001000 */
+#define TSC_IOASCR_G4_IO1        TSC_IOASCR_G4_IO1_Msk                         /*!< GROUP4_IO1 analog switch enable */
+#define TSC_IOASCR_G4_IO2_Pos    (13U)
+#define TSC_IOASCR_G4_IO2_Msk    (0x1UL << TSC_IOASCR_G4_IO2_Pos)              /*!< 0x00002000 */
+#define TSC_IOASCR_G4_IO2        TSC_IOASCR_G4_IO2_Msk                         /*!< GROUP4_IO2 analog switch enable */
+#define TSC_IOASCR_G4_IO3_Pos    (14U)
+#define TSC_IOASCR_G4_IO3_Msk    (0x1UL << TSC_IOASCR_G4_IO3_Pos)              /*!< 0x00004000 */
+#define TSC_IOASCR_G4_IO3        TSC_IOASCR_G4_IO3_Msk                         /*!< GROUP4_IO3 analog switch enable */
+#define TSC_IOASCR_G4_IO4_Pos    (15U)
+#define TSC_IOASCR_G4_IO4_Msk    (0x1UL << TSC_IOASCR_G4_IO4_Pos)              /*!< 0x00008000 */
+#define TSC_IOASCR_G4_IO4        TSC_IOASCR_G4_IO4_Msk                         /*!< GROUP4_IO4 analog switch enable */
+#define TSC_IOASCR_G5_IO1_Pos    (16U)
+#define TSC_IOASCR_G5_IO1_Msk    (0x1UL << TSC_IOASCR_G5_IO1_Pos)              /*!< 0x00010000 */
+#define TSC_IOASCR_G5_IO1        TSC_IOASCR_G5_IO1_Msk                         /*!< GROUP5_IO1 analog switch enable */
+#define TSC_IOASCR_G5_IO2_Pos    (17U)
+#define TSC_IOASCR_G5_IO2_Msk    (0x1UL << TSC_IOASCR_G5_IO2_Pos)              /*!< 0x00020000 */
+#define TSC_IOASCR_G5_IO2        TSC_IOASCR_G5_IO2_Msk                         /*!< GROUP5_IO2 analog switch enable */
+#define TSC_IOASCR_G5_IO3_Pos    (18U)
+#define TSC_IOASCR_G5_IO3_Msk    (0x1UL << TSC_IOASCR_G5_IO3_Pos)              /*!< 0x00040000 */
+#define TSC_IOASCR_G5_IO3        TSC_IOASCR_G5_IO3_Msk                         /*!< GROUP5_IO3 analog switch enable */
+#define TSC_IOASCR_G5_IO4_Pos    (19U)
+#define TSC_IOASCR_G5_IO4_Msk    (0x1UL << TSC_IOASCR_G5_IO4_Pos)              /*!< 0x00080000 */
+#define TSC_IOASCR_G5_IO4        TSC_IOASCR_G5_IO4_Msk                         /*!< GROUP5_IO4 analog switch enable */
+#define TSC_IOASCR_G6_IO1_Pos    (20U)
+#define TSC_IOASCR_G6_IO1_Msk    (0x1UL << TSC_IOASCR_G6_IO1_Pos)              /*!< 0x00100000 */
+#define TSC_IOASCR_G6_IO1        TSC_IOASCR_G6_IO1_Msk                         /*!< GROUP6_IO1 analog switch enable */
+#define TSC_IOASCR_G6_IO2_Pos    (21U)
+#define TSC_IOASCR_G6_IO2_Msk    (0x1UL << TSC_IOASCR_G6_IO2_Pos)              /*!< 0x00200000 */
+#define TSC_IOASCR_G6_IO2        TSC_IOASCR_G6_IO2_Msk                         /*!< GROUP6_IO2 analog switch enable */
+#define TSC_IOASCR_G6_IO3_Pos    (22U)
+#define TSC_IOASCR_G6_IO3_Msk    (0x1UL << TSC_IOASCR_G6_IO3_Pos)              /*!< 0x00400000 */
+#define TSC_IOASCR_G6_IO3        TSC_IOASCR_G6_IO3_Msk                         /*!< GROUP6_IO3 analog switch enable */
+#define TSC_IOASCR_G6_IO4_Pos    (23U)
+#define TSC_IOASCR_G6_IO4_Msk    (0x1UL << TSC_IOASCR_G6_IO4_Pos)              /*!< 0x00800000 */
+#define TSC_IOASCR_G6_IO4        TSC_IOASCR_G6_IO4_Msk                         /*!< GROUP6_IO4 analog switch enable */
+#define TSC_IOASCR_G7_IO1_Pos    (24U)
+#define TSC_IOASCR_G7_IO1_Msk    (0x1UL << TSC_IOASCR_G7_IO1_Pos)              /*!< 0x01000000 */
+#define TSC_IOASCR_G7_IO1        TSC_IOASCR_G7_IO1_Msk                         /*!< GROUP7_IO1 analog switch enable */
+#define TSC_IOASCR_G7_IO2_Pos    (25U)
+#define TSC_IOASCR_G7_IO2_Msk    (0x1UL << TSC_IOASCR_G7_IO2_Pos)              /*!< 0x02000000 */
+#define TSC_IOASCR_G7_IO2        TSC_IOASCR_G7_IO2_Msk                         /*!< GROUP7_IO2 analog switch enable */
+#define TSC_IOASCR_G7_IO3_Pos    (26U)
+#define TSC_IOASCR_G7_IO3_Msk    (0x1UL << TSC_IOASCR_G7_IO3_Pos)              /*!< 0x04000000 */
+#define TSC_IOASCR_G7_IO3        TSC_IOASCR_G7_IO3_Msk                         /*!< GROUP7_IO3 analog switch enable */
+#define TSC_IOASCR_G7_IO4_Pos    (27U)
+#define TSC_IOASCR_G7_IO4_Msk    (0x1UL << TSC_IOASCR_G7_IO4_Pos)              /*!< 0x08000000 */
+#define TSC_IOASCR_G7_IO4        TSC_IOASCR_G7_IO4_Msk                         /*!< GROUP7_IO4 analog switch enable */
+
+/*******************  Bit definition for TSC_IOSCR register  ******************/
+#define TSC_IOSCR_G1_IO1_Pos     (0U)
+#define TSC_IOSCR_G1_IO1_Msk     (0x1UL << TSC_IOSCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOSCR_G1_IO1         TSC_IOSCR_G1_IO1_Msk                          /*!< GROUP1_IO1 sampling mode */
+#define TSC_IOSCR_G1_IO2_Pos     (1U)
+#define TSC_IOSCR_G1_IO2_Msk     (0x1UL << TSC_IOSCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOSCR_G1_IO2         TSC_IOSCR_G1_IO2_Msk                          /*!< GROUP1_IO2 sampling mode */
+#define TSC_IOSCR_G1_IO3_Pos     (2U)
+#define TSC_IOSCR_G1_IO3_Msk     (0x1UL << TSC_IOSCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOSCR_G1_IO3         TSC_IOSCR_G1_IO3_Msk                          /*!< GROUP1_IO3 sampling mode */
+#define TSC_IOSCR_G1_IO4_Pos     (3U)
+#define TSC_IOSCR_G1_IO4_Msk     (0x1UL << TSC_IOSCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOSCR_G1_IO4         TSC_IOSCR_G1_IO4_Msk                          /*!< GROUP1_IO4 sampling mode */
+#define TSC_IOSCR_G2_IO1_Pos     (4U)
+#define TSC_IOSCR_G2_IO1_Msk     (0x1UL << TSC_IOSCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOSCR_G2_IO1         TSC_IOSCR_G2_IO1_Msk                          /*!< GROUP2_IO1 sampling mode */
+#define TSC_IOSCR_G2_IO2_Pos     (5U)
+#define TSC_IOSCR_G2_IO2_Msk     (0x1UL << TSC_IOSCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOSCR_G2_IO2         TSC_IOSCR_G2_IO2_Msk                          /*!< GROUP2_IO2 sampling mode */
+#define TSC_IOSCR_G2_IO3_Pos     (6U)
+#define TSC_IOSCR_G2_IO3_Msk     (0x1UL << TSC_IOSCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOSCR_G2_IO3         TSC_IOSCR_G2_IO3_Msk                          /*!< GROUP2_IO3 sampling mode */
+#define TSC_IOSCR_G2_IO4_Pos     (7U)
+#define TSC_IOSCR_G2_IO4_Msk     (0x1UL << TSC_IOSCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOSCR_G2_IO4         TSC_IOSCR_G2_IO4_Msk                          /*!< GROUP2_IO4 sampling mode */
+#define TSC_IOSCR_G3_IO1_Pos     (8U)
+#define TSC_IOSCR_G3_IO1_Msk     (0x1UL << TSC_IOSCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOSCR_G3_IO1         TSC_IOSCR_G3_IO1_Msk                          /*!< GROUP3_IO1 sampling mode */
+#define TSC_IOSCR_G3_IO2_Pos     (9U)
+#define TSC_IOSCR_G3_IO2_Msk     (0x1UL << TSC_IOSCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOSCR_G3_IO2         TSC_IOSCR_G3_IO2_Msk                          /*!< GROUP3_IO2 sampling mode */
+#define TSC_IOSCR_G3_IO3_Pos     (10U)
+#define TSC_IOSCR_G3_IO3_Msk     (0x1UL << TSC_IOSCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOSCR_G3_IO3         TSC_IOSCR_G3_IO3_Msk                          /*!< GROUP3_IO3 sampling mode */
+#define TSC_IOSCR_G3_IO4_Pos     (11U)
+#define TSC_IOSCR_G3_IO4_Msk     (0x1UL << TSC_IOSCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOSCR_G3_IO4         TSC_IOSCR_G3_IO4_Msk                          /*!< GROUP3_IO4 sampling mode */
+#define TSC_IOSCR_G4_IO1_Pos     (12U)
+#define TSC_IOSCR_G4_IO1_Msk     (0x1UL << TSC_IOSCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOSCR_G4_IO1         TSC_IOSCR_G4_IO1_Msk                          /*!< GROUP4_IO1 sampling mode */
+#define TSC_IOSCR_G4_IO2_Pos     (13U)
+#define TSC_IOSCR_G4_IO2_Msk     (0x1UL << TSC_IOSCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOSCR_G4_IO2         TSC_IOSCR_G4_IO2_Msk                          /*!< GROUP4_IO2 sampling mode */
+#define TSC_IOSCR_G4_IO3_Pos     (14U)
+#define TSC_IOSCR_G4_IO3_Msk     (0x1UL << TSC_IOSCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOSCR_G4_IO3         TSC_IOSCR_G4_IO3_Msk                          /*!< GROUP4_IO3 sampling mode */
+#define TSC_IOSCR_G4_IO4_Pos     (15U)
+#define TSC_IOSCR_G4_IO4_Msk     (0x1UL << TSC_IOSCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOSCR_G4_IO4         TSC_IOSCR_G4_IO4_Msk                          /*!< GROUP4_IO4 sampling mode */
+#define TSC_IOSCR_G5_IO1_Pos     (16U)
+#define TSC_IOSCR_G5_IO1_Msk     (0x1UL << TSC_IOSCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOSCR_G5_IO1         TSC_IOSCR_G5_IO1_Msk                          /*!< GROUP5_IO1 sampling mode */
+#define TSC_IOSCR_G5_IO2_Pos     (17U)
+#define TSC_IOSCR_G5_IO2_Msk     (0x1UL << TSC_IOSCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOSCR_G5_IO2         TSC_IOSCR_G5_IO2_Msk                          /*!< GROUP5_IO2 sampling mode */
+#define TSC_IOSCR_G5_IO3_Pos     (18U)
+#define TSC_IOSCR_G5_IO3_Msk     (0x1UL << TSC_IOSCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOSCR_G5_IO3         TSC_IOSCR_G5_IO3_Msk                          /*!< GROUP5_IO3 sampling mode */
+#define TSC_IOSCR_G5_IO4_Pos     (19U)
+#define TSC_IOSCR_G5_IO4_Msk     (0x1UL << TSC_IOSCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOSCR_G5_IO4         TSC_IOSCR_G5_IO4_Msk                          /*!< GROUP5_IO4 sampling mode */
+#define TSC_IOSCR_G6_IO1_Pos     (20U)
+#define TSC_IOSCR_G6_IO1_Msk     (0x1UL << TSC_IOSCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOSCR_G6_IO1         TSC_IOSCR_G6_IO1_Msk                          /*!< GROUP6_IO1 sampling mode */
+#define TSC_IOSCR_G6_IO2_Pos     (21U)
+#define TSC_IOSCR_G6_IO2_Msk     (0x1UL << TSC_IOSCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOSCR_G6_IO2         TSC_IOSCR_G6_IO2_Msk                          /*!< GROUP6_IO2 sampling mode */
+#define TSC_IOSCR_G6_IO3_Pos     (22U)
+#define TSC_IOSCR_G6_IO3_Msk     (0x1UL << TSC_IOSCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOSCR_G6_IO3         TSC_IOSCR_G6_IO3_Msk                          /*!< GROUP6_IO3 sampling mode */
+#define TSC_IOSCR_G6_IO4_Pos     (23U)
+#define TSC_IOSCR_G6_IO4_Msk     (0x1UL << TSC_IOSCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOSCR_G6_IO4         TSC_IOSCR_G6_IO4_Msk                          /*!< GROUP6_IO4 sampling mode */
+#define TSC_IOSCR_G7_IO1_Pos     (24U)
+#define TSC_IOSCR_G7_IO1_Msk     (0x1UL << TSC_IOSCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOSCR_G7_IO1         TSC_IOSCR_G7_IO1_Msk                          /*!< GROUP7_IO1 sampling mode */
+#define TSC_IOSCR_G7_IO2_Pos     (25U)
+#define TSC_IOSCR_G7_IO2_Msk     (0x1UL << TSC_IOSCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOSCR_G7_IO2         TSC_IOSCR_G7_IO2_Msk                          /*!< GROUP7_IO2 sampling mode */
+#define TSC_IOSCR_G7_IO3_Pos     (26U)
+#define TSC_IOSCR_G7_IO3_Msk     (0x1UL << TSC_IOSCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOSCR_G7_IO3         TSC_IOSCR_G7_IO3_Msk                          /*!< GROUP7_IO3 sampling mode */
+#define TSC_IOSCR_G7_IO4_Pos     (27U)
+#define TSC_IOSCR_G7_IO4_Msk     (0x1UL << TSC_IOSCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOSCR_G7_IO4         TSC_IOSCR_G7_IO4_Msk                          /*!< GROUP7_IO4 sampling mode */
+
+/*******************  Bit definition for TSC_IOCCR register  ******************/
+#define TSC_IOCCR_G1_IO1_Pos     (0U)
+#define TSC_IOCCR_G1_IO1_Msk     (0x1UL << TSC_IOCCR_G1_IO1_Pos)               /*!< 0x00000001 */
+#define TSC_IOCCR_G1_IO1         TSC_IOCCR_G1_IO1_Msk                          /*!< GROUP1_IO1 channel mode */
+#define TSC_IOCCR_G1_IO2_Pos     (1U)
+#define TSC_IOCCR_G1_IO2_Msk     (0x1UL << TSC_IOCCR_G1_IO2_Pos)               /*!< 0x00000002 */
+#define TSC_IOCCR_G1_IO2         TSC_IOCCR_G1_IO2_Msk                          /*!< GROUP1_IO2 channel mode */
+#define TSC_IOCCR_G1_IO3_Pos     (2U)
+#define TSC_IOCCR_G1_IO3_Msk     (0x1UL << TSC_IOCCR_G1_IO3_Pos)               /*!< 0x00000004 */
+#define TSC_IOCCR_G1_IO3         TSC_IOCCR_G1_IO3_Msk                          /*!< GROUP1_IO3 channel mode */
+#define TSC_IOCCR_G1_IO4_Pos     (3U)
+#define TSC_IOCCR_G1_IO4_Msk     (0x1UL << TSC_IOCCR_G1_IO4_Pos)               /*!< 0x00000008 */
+#define TSC_IOCCR_G1_IO4         TSC_IOCCR_G1_IO4_Msk                          /*!< GROUP1_IO4 channel mode */
+#define TSC_IOCCR_G2_IO1_Pos     (4U)
+#define TSC_IOCCR_G2_IO1_Msk     (0x1UL << TSC_IOCCR_G2_IO1_Pos)               /*!< 0x00000010 */
+#define TSC_IOCCR_G2_IO1         TSC_IOCCR_G2_IO1_Msk                          /*!< GROUP2_IO1 channel mode */
+#define TSC_IOCCR_G2_IO2_Pos     (5U)
+#define TSC_IOCCR_G2_IO2_Msk     (0x1UL << TSC_IOCCR_G2_IO2_Pos)               /*!< 0x00000020 */
+#define TSC_IOCCR_G2_IO2         TSC_IOCCR_G2_IO2_Msk                          /*!< GROUP2_IO2 channel mode */
+#define TSC_IOCCR_G2_IO3_Pos     (6U)
+#define TSC_IOCCR_G2_IO3_Msk     (0x1UL << TSC_IOCCR_G2_IO3_Pos)               /*!< 0x00000040 */
+#define TSC_IOCCR_G2_IO3         TSC_IOCCR_G2_IO3_Msk                          /*!< GROUP2_IO3 channel mode */
+#define TSC_IOCCR_G2_IO4_Pos     (7U)
+#define TSC_IOCCR_G2_IO4_Msk     (0x1UL << TSC_IOCCR_G2_IO4_Pos)               /*!< 0x00000080 */
+#define TSC_IOCCR_G2_IO4         TSC_IOCCR_G2_IO4_Msk                          /*!< GROUP2_IO4 channel mode */
+#define TSC_IOCCR_G3_IO1_Pos     (8U)
+#define TSC_IOCCR_G3_IO1_Msk     (0x1UL << TSC_IOCCR_G3_IO1_Pos)               /*!< 0x00000100 */
+#define TSC_IOCCR_G3_IO1         TSC_IOCCR_G3_IO1_Msk                          /*!< GROUP3_IO1 channel mode */
+#define TSC_IOCCR_G3_IO2_Pos     (9U)
+#define TSC_IOCCR_G3_IO2_Msk     (0x1UL << TSC_IOCCR_G3_IO2_Pos)               /*!< 0x00000200 */
+#define TSC_IOCCR_G3_IO2         TSC_IOCCR_G3_IO2_Msk                          /*!< GROUP3_IO2 channel mode */
+#define TSC_IOCCR_G3_IO3_Pos     (10U)
+#define TSC_IOCCR_G3_IO3_Msk     (0x1UL << TSC_IOCCR_G3_IO3_Pos)               /*!< 0x00000400 */
+#define TSC_IOCCR_G3_IO3         TSC_IOCCR_G3_IO3_Msk                          /*!< GROUP3_IO3 channel mode */
+#define TSC_IOCCR_G3_IO4_Pos     (11U)
+#define TSC_IOCCR_G3_IO4_Msk     (0x1UL << TSC_IOCCR_G3_IO4_Pos)               /*!< 0x00000800 */
+#define TSC_IOCCR_G3_IO4         TSC_IOCCR_G3_IO4_Msk                          /*!< GROUP3_IO4 channel mode */
+#define TSC_IOCCR_G4_IO1_Pos     (12U)
+#define TSC_IOCCR_G4_IO1_Msk     (0x1UL << TSC_IOCCR_G4_IO1_Pos)               /*!< 0x00001000 */
+#define TSC_IOCCR_G4_IO1         TSC_IOCCR_G4_IO1_Msk                          /*!< GROUP4_IO1 channel mode */
+#define TSC_IOCCR_G4_IO2_Pos     (13U)
+#define TSC_IOCCR_G4_IO2_Msk     (0x1UL << TSC_IOCCR_G4_IO2_Pos)               /*!< 0x00002000 */
+#define TSC_IOCCR_G4_IO2         TSC_IOCCR_G4_IO2_Msk                          /*!< GROUP4_IO2 channel mode */
+#define TSC_IOCCR_G4_IO3_Pos     (14U)
+#define TSC_IOCCR_G4_IO3_Msk     (0x1UL << TSC_IOCCR_G4_IO3_Pos)               /*!< 0x00004000 */
+#define TSC_IOCCR_G4_IO3         TSC_IOCCR_G4_IO3_Msk                          /*!< GROUP4_IO3 channel mode */
+#define TSC_IOCCR_G4_IO4_Pos     (15U)
+#define TSC_IOCCR_G4_IO4_Msk     (0x1UL << TSC_IOCCR_G4_IO4_Pos)               /*!< 0x00008000 */
+#define TSC_IOCCR_G4_IO4         TSC_IOCCR_G4_IO4_Msk                          /*!< GROUP4_IO4 channel mode */
+#define TSC_IOCCR_G5_IO1_Pos     (16U)
+#define TSC_IOCCR_G5_IO1_Msk     (0x1UL << TSC_IOCCR_G5_IO1_Pos)               /*!< 0x00010000 */
+#define TSC_IOCCR_G5_IO1         TSC_IOCCR_G5_IO1_Msk                          /*!< GROUP5_IO1 channel mode */
+#define TSC_IOCCR_G5_IO2_Pos     (17U)
+#define TSC_IOCCR_G5_IO2_Msk     (0x1UL << TSC_IOCCR_G5_IO2_Pos)               /*!< 0x00020000 */
+#define TSC_IOCCR_G5_IO2         TSC_IOCCR_G5_IO2_Msk                          /*!< GROUP5_IO2 channel mode */
+#define TSC_IOCCR_G5_IO3_Pos     (18U)
+#define TSC_IOCCR_G5_IO3_Msk     (0x1UL << TSC_IOCCR_G5_IO3_Pos)               /*!< 0x00040000 */
+#define TSC_IOCCR_G5_IO3         TSC_IOCCR_G5_IO3_Msk                          /*!< GROUP5_IO3 channel mode */
+#define TSC_IOCCR_G5_IO4_Pos     (19U)
+#define TSC_IOCCR_G5_IO4_Msk     (0x1UL << TSC_IOCCR_G5_IO4_Pos)               /*!< 0x00080000 */
+#define TSC_IOCCR_G5_IO4         TSC_IOCCR_G5_IO4_Msk                          /*!< GROUP5_IO4 channel mode */
+#define TSC_IOCCR_G6_IO1_Pos     (20U)
+#define TSC_IOCCR_G6_IO1_Msk     (0x1UL << TSC_IOCCR_G6_IO1_Pos)               /*!< 0x00100000 */
+#define TSC_IOCCR_G6_IO1         TSC_IOCCR_G6_IO1_Msk                          /*!< GROUP6_IO1 channel mode */
+#define TSC_IOCCR_G6_IO2_Pos     (21U)
+#define TSC_IOCCR_G6_IO2_Msk     (0x1UL << TSC_IOCCR_G6_IO2_Pos)               /*!< 0x00200000 */
+#define TSC_IOCCR_G6_IO2         TSC_IOCCR_G6_IO2_Msk                          /*!< GROUP6_IO2 channel mode */
+#define TSC_IOCCR_G6_IO3_Pos     (22U)
+#define TSC_IOCCR_G6_IO3_Msk     (0x1UL << TSC_IOCCR_G6_IO3_Pos)               /*!< 0x00400000 */
+#define TSC_IOCCR_G6_IO3         TSC_IOCCR_G6_IO3_Msk                          /*!< GROUP6_IO3 channel mode */
+#define TSC_IOCCR_G6_IO4_Pos     (23U)
+#define TSC_IOCCR_G6_IO4_Msk     (0x1UL << TSC_IOCCR_G6_IO4_Pos)               /*!< 0x00800000 */
+#define TSC_IOCCR_G6_IO4         TSC_IOCCR_G6_IO4_Msk                          /*!< GROUP6_IO4 channel mode */
+#define TSC_IOCCR_G7_IO1_Pos     (24U)
+#define TSC_IOCCR_G7_IO1_Msk     (0x1UL << TSC_IOCCR_G7_IO1_Pos)               /*!< 0x01000000 */
+#define TSC_IOCCR_G7_IO1         TSC_IOCCR_G7_IO1_Msk                          /*!< GROUP7_IO1 channel mode */
+#define TSC_IOCCR_G7_IO2_Pos     (25U)
+#define TSC_IOCCR_G7_IO2_Msk     (0x1UL << TSC_IOCCR_G7_IO2_Pos)               /*!< 0x02000000 */
+#define TSC_IOCCR_G7_IO2         TSC_IOCCR_G7_IO2_Msk                          /*!< GROUP7_IO2 channel mode */
+#define TSC_IOCCR_G7_IO3_Pos     (26U)
+#define TSC_IOCCR_G7_IO3_Msk     (0x1UL << TSC_IOCCR_G7_IO3_Pos)               /*!< 0x04000000 */
+#define TSC_IOCCR_G7_IO3         TSC_IOCCR_G7_IO3_Msk                          /*!< GROUP7_IO3 channel mode */
+#define TSC_IOCCR_G7_IO4_Pos     (27U)
+#define TSC_IOCCR_G7_IO4_Msk     (0x1UL << TSC_IOCCR_G7_IO4_Pos)               /*!< 0x08000000 */
+#define TSC_IOCCR_G7_IO4         TSC_IOCCR_G7_IO4_Msk                          /*!< GROUP7_IO4 channel mode */
+
+/*******************  Bit definition for TSC_IOGCSR register  *****************/
+#define TSC_IOGCSR_G1E_Pos       (0U)
+#define TSC_IOGCSR_G1E_Msk       (0x1UL << TSC_IOGCSR_G1E_Pos)                 /*!< 0x00000001 */
+#define TSC_IOGCSR_G1E           TSC_IOGCSR_G1E_Msk                            /*!< Analog IO GROUP1 enable */
+#define TSC_IOGCSR_G2E_Pos       (1U)
+#define TSC_IOGCSR_G2E_Msk       (0x1UL << TSC_IOGCSR_G2E_Pos)                 /*!< 0x00000002 */
+#define TSC_IOGCSR_G2E           TSC_IOGCSR_G2E_Msk                            /*!< Analog IO GROUP2 enable */
+#define TSC_IOGCSR_G3E_Pos       (2U)
+#define TSC_IOGCSR_G3E_Msk       (0x1UL << TSC_IOGCSR_G3E_Pos)                 /*!< 0x00000004 */
+#define TSC_IOGCSR_G3E           TSC_IOGCSR_G3E_Msk                            /*!< Analog IO GROUP3 enable */
+#define TSC_IOGCSR_G4E_Pos       (3U)
+#define TSC_IOGCSR_G4E_Msk       (0x1UL << TSC_IOGCSR_G4E_Pos)                 /*!< 0x00000008 */
+#define TSC_IOGCSR_G4E           TSC_IOGCSR_G4E_Msk                            /*!< Analog IO GROUP4 enable */
+#define TSC_IOGCSR_G5E_Pos       (4U)
+#define TSC_IOGCSR_G5E_Msk       (0x1UL << TSC_IOGCSR_G5E_Pos)                 /*!< 0x00000010 */
+#define TSC_IOGCSR_G5E           TSC_IOGCSR_G5E_Msk                            /*!< Analog IO GROUP5 enable */
+#define TSC_IOGCSR_G6E_Pos       (5U)
+#define TSC_IOGCSR_G6E_Msk       (0x1UL << TSC_IOGCSR_G6E_Pos)                 /*!< 0x00000020 */
+#define TSC_IOGCSR_G6E           TSC_IOGCSR_G6E_Msk                            /*!< Analog IO GROUP6 enable */
+#define TSC_IOGCSR_G7E_Pos       (6U)
+#define TSC_IOGCSR_G7E_Msk       (0x1UL << TSC_IOGCSR_G7E_Pos)                 /*!< 0x00000040 */
+#define TSC_IOGCSR_G7E           TSC_IOGCSR_G7E_Msk                            /*!< Analog IO GROUP7 enable */
+#define TSC_IOGCSR_G1S_Pos       (16U)
+#define TSC_IOGCSR_G1S_Msk       (0x1UL << TSC_IOGCSR_G1S_Pos)                 /*!< 0x00010000 */
+#define TSC_IOGCSR_G1S           TSC_IOGCSR_G1S_Msk                            /*!< Analog IO GROUP1 status */
+#define TSC_IOGCSR_G2S_Pos       (17U)
+#define TSC_IOGCSR_G2S_Msk       (0x1UL << TSC_IOGCSR_G2S_Pos)                 /*!< 0x00020000 */
+#define TSC_IOGCSR_G2S           TSC_IOGCSR_G2S_Msk                            /*!< Analog IO GROUP2 status */
+#define TSC_IOGCSR_G3S_Pos       (18U)
+#define TSC_IOGCSR_G3S_Msk       (0x1UL << TSC_IOGCSR_G3S_Pos)                 /*!< 0x00040000 */
+#define TSC_IOGCSR_G3S           TSC_IOGCSR_G3S_Msk                            /*!< Analog IO GROUP3 status */
+#define TSC_IOGCSR_G4S_Pos       (19U)
+#define TSC_IOGCSR_G4S_Msk       (0x1UL << TSC_IOGCSR_G4S_Pos)                 /*!< 0x00080000 */
+#define TSC_IOGCSR_G4S           TSC_IOGCSR_G4S_Msk                            /*!< Analog IO GROUP4 status */
+#define TSC_IOGCSR_G5S_Pos       (20U)
+#define TSC_IOGCSR_G5S_Msk       (0x1UL << TSC_IOGCSR_G5S_Pos)                 /*!< 0x00100000 */
+#define TSC_IOGCSR_G5S           TSC_IOGCSR_G5S_Msk                            /*!< Analog IO GROUP5 status */
+#define TSC_IOGCSR_G6S_Pos       (21U)
+#define TSC_IOGCSR_G6S_Msk       (0x1UL << TSC_IOGCSR_G6S_Pos)                 /*!< 0x00200000 */
+#define TSC_IOGCSR_G6S           TSC_IOGCSR_G6S_Msk                            /*!< Analog IO GROUP6 status */
+#define TSC_IOGCSR_G7S_Pos       (22U)
+#define TSC_IOGCSR_G7S_Msk       (0x1UL << TSC_IOGCSR_G7S_Pos)                 /*!< 0x00400000 */
+#define TSC_IOGCSR_G7S           TSC_IOGCSR_G7S_Msk                            /*!< Analog IO GROUP7 status */
+
+/*******************  Bit definition for TSC_IOGXCR register  *****************/
+#define TSC_IOGXCR_CNT_Pos       (0U)
+#define TSC_IOGXCR_CNT_Msk       (0x3FFFUL << TSC_IOGXCR_CNT_Pos)              /*!< 0x00003FFF */
+#define TSC_IOGXCR_CNT           TSC_IOGXCR_CNT_Msk                            /*!< CNT[13:0] bits (Counter value) */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                 SYSCFG                                     */
+/*                                                                            */
+/******************************************************************************/
+/*****************  Bit definition for SYSCFG_MEMRMP register  (SYSCFG memory remap register) ***********************************/
+#define SYSCFG_MEMRMP_MEM_MODE_Pos              (0U)
+#define SYSCFG_MEMRMP_MEM_MODE_Msk              (0x7UL << SYSCFG_MEMRMP_MEM_MODE_Pos)           /*!< 0x00000007 */
+#define SYSCFG_MEMRMP_MEM_MODE                  SYSCFG_MEMRMP_MEM_MODE_Msk                      /*!< SYSCFG_Memory Remap Config */
+#define SYSCFG_MEMRMP_MEM_MODE_0                (0x1U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000001 */
+#define SYSCFG_MEMRMP_MEM_MODE_1                (0x2U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000002 */
+#define SYSCFG_MEMRMP_MEM_MODE_2                (0x4U << SYSCFG_MEMRMP_MEM_MODE_Pos)            /*!< 0x00000004 */
+
+/*****************  Bit definition for SYSCFG_CFGR1 register  (SYSCFG configuration register 1) ****************************************************************/
+#define SYSCFG_CFGR1_BOOSTEN_Pos                (8U)
+#define SYSCFG_CFGR1_BOOSTEN_Msk                (0x1UL << SYSCFG_CFGR1_BOOSTEN_Pos)             /*!< 0x00000100 */
+#define SYSCFG_CFGR1_BOOSTEN                    SYSCFG_CFGR1_BOOSTEN_Msk                        /*!< I/O analog switch voltage booster enable                  */
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Pos            (16U)
+#define SYSCFG_CFGR1_I2C_PB6_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB6_FMP_Pos)         /*!< 0x00010000 */
+#define SYSCFG_CFGR1_I2C_PB6_FMP                SYSCFG_CFGR1_I2C_PB6_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB6 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Pos            (17U)
+#define SYSCFG_CFGR1_I2C_PB7_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB7_FMP_Pos)         /*!< 0x00020000 */
+#define SYSCFG_CFGR1_I2C_PB7_FMP                SYSCFG_CFGR1_I2C_PB7_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB7 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Pos            (18U)
+#define SYSCFG_CFGR1_I2C_PB8_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB8_FMP_Pos)         /*!< 0x00040000 */
+#define SYSCFG_CFGR1_I2C_PB8_FMP                SYSCFG_CFGR1_I2C_PB8_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB8 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Pos            (19U)
+#define SYSCFG_CFGR1_I2C_PB9_FMP_Msk            (0x1UL << SYSCFG_CFGR1_I2C_PB9_FMP_Pos)         /*!< 0x00080000 */
+#define SYSCFG_CFGR1_I2C_PB9_FMP                SYSCFG_CFGR1_I2C_PB9_FMP_Msk                    /*!< Fast-mode Plus (Fm+) driving capability activation on PB9 */
+#define SYSCFG_CFGR1_I2C1_FMP_Pos               (20U)
+#define SYSCFG_CFGR1_I2C1_FMP_Msk               (0x1UL << SYSCFG_CFGR1_I2C1_FMP_Pos)            /*!< 0x00100000 */
+#define SYSCFG_CFGR1_I2C1_FMP                   SYSCFG_CFGR1_I2C1_FMP_Msk                       /*!< I2C1 Fast-mode Plus (Fm+) driving capability activation   */
+#define SYSCFG_CFGR1_FPU_IE_Pos                 (26U)
+#define SYSCFG_CFGR1_FPU_IE_Msk                 (0x3FUL << SYSCFG_CFGR1_FPU_IE_Pos)             /*!< 0xFC000000 */
+#define SYSCFG_CFGR1_FPU_IE                     SYSCFG_CFGR1_FPU_IE_Msk                         /*!< Cortex M4 Floating Point Unit interrupts enable bits      */
+#define SYSCFG_CFGR1_FPU_IE_0                   (0x01U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x04000000 */
+#define SYSCFG_CFGR1_FPU_IE_1                   (0x02U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x08000000 */
+#define SYSCFG_CFGR1_FPU_IE_2                   (0x04U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x10000000 */
+#define SYSCFG_CFGR1_FPU_IE_3                   (0x08U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x20000000 */
+#define SYSCFG_CFGR1_FPU_IE_4                   (0x10U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x40000000 */
+#define SYSCFG_CFGR1_FPU_IE_5                   (0x20U << SYSCFG_CFGR1_FPU_IE_Pos)              /*!< 0x80000000 */
+
+/*****************  Bit definition for SYSCFG_EXTICR1 register  (External interrupt configuration register 1) ********************************/
+#define SYSCFG_EXTICR1_EXTI0_Pos                (0U)
+#define SYSCFG_EXTICR1_EXTI0_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI0_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR1_EXTI0                    SYSCFG_EXTICR1_EXTI0_Msk                        /*!< External Interrupt Line 0 configuration */
+#define SYSCFG_EXTICR1_EXTI1_Pos                (4U)
+#define SYSCFG_EXTICR1_EXTI1_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI1_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR1_EXTI1                    SYSCFG_EXTICR1_EXTI1_Msk                        /*!< External Interrupt Line 1 configuration */
+#define SYSCFG_EXTICR1_EXTI2_Pos                (8U)
+#define SYSCFG_EXTICR1_EXTI2_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI2_Pos)             /*!< 0x00000700 */
+#define SYSCFG_EXTICR1_EXTI2                    SYSCFG_EXTICR1_EXTI2_Msk                        /*!< External Interrupt Line 2 configuration */
+#define SYSCFG_EXTICR1_EXTI3_Pos                (12U)
+#define SYSCFG_EXTICR1_EXTI3_Msk                (0x7UL << SYSCFG_EXTICR1_EXTI3_Pos)             /*!< 0x00007000 */
+#define SYSCFG_EXTICR1_EXTI3                    SYSCFG_EXTICR1_EXTI3_Msk                        /*!< External Interrupt Line 3 configuration */
+
+/**
+  * @brief  External Interrupt Line 0 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI0_PA                 (0x00000000UL)  /*!< PA[0] pin */
+#define SYSCFG_EXTICR1_EXTI0_PB                 (0x00000001UL)  /*!< PB[0] pin */
+
+/**
+  * @brief  External Interrupt Line 1 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI1_PA                 (0x00000000UL)  /*!< PA[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PB                 (0x00000010UL)  /*!< PB[1] pin */
+#define SYSCFG_EXTICR1_EXTI1_PC                 (0x00000020UL)  /*!< PC[1] pin */
+
+/**
+  * @brief  External Interrupt Line 2 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI2_PA                 (0x00000000UL)  /*!< PA[2] pin */
+#define SYSCFG_EXTICR1_EXTI2_PB                 (0x00000100UL)  /*!< PB[2] pin */
+
+/**
+  * @brief  External Interrupt Line 3 Source Input configuration
+  */
+#define SYSCFG_EXTICR1_EXTI3_PA                 (0x00000000UL)  /*!< PA[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PB                 (0x00001000UL)  /*!< PB[3] pin */
+#define SYSCFG_EXTICR1_EXTI3_PH                 (0x00007000UL)  /*!< PH[3] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR2 register  (External interrupt configuration register 2) ********************************/
+#define SYSCFG_EXTICR2_EXTI4_Pos                (0U)
+#define SYSCFG_EXTICR2_EXTI4_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI4_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR2_EXTI4                    SYSCFG_EXTICR2_EXTI4_Msk                        /*!< External Interrupt Line 4 configuration */
+#define SYSCFG_EXTICR2_EXTI5_Pos                (4U)
+#define SYSCFG_EXTICR2_EXTI5_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI5_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR2_EXTI5                    SYSCFG_EXTICR2_EXTI5_Msk                        /*!< External Interrupt Line 5 configuration */
+#define SYSCFG_EXTICR2_EXTI6_Pos                (8U)
+#define SYSCFG_EXTICR2_EXTI6_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI6_Pos)             /*!< 0x00000700 */
+#define SYSCFG_EXTICR2_EXTI6                    SYSCFG_EXTICR2_EXTI6_Msk                        /*!< External Interrupt Line 6 configuration */
+#define SYSCFG_EXTICR2_EXTI7_Pos                (12U)
+#define SYSCFG_EXTICR2_EXTI7_Msk                (0x7UL << SYSCFG_EXTICR2_EXTI7_Pos)             /*!< 0x00007000 */
+#define SYSCFG_EXTICR2_EXTI7                    SYSCFG_EXTICR2_EXTI7_Msk                        /*!< External Interrupt Line 7 configuration */
+
+/**
+  * @brief  External Interrupt Line 4 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI4_PA                 (0x00000000UL)  /*!< PA[4] pin  */
+#define SYSCFG_EXTICR2_EXTI4_PB                 (0x00000001UL)  /*!< PB[4] pin  */
+#define SYSCFG_EXTICR2_EXTI4_PE                 (0x00000004UL)  /*!< PE[4] pin  */
+
+/**
+  * @brief  External Interrupt Line 5 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI5_PA                 (0x00000000UL)  /*!< PA[5] pin  */
+#define SYSCFG_EXTICR2_EXTI5_PB                 (0x00000010UL)  /*!< PB[5] pin  */
+
+/**
+  * @brief  External Interrupt Line 6 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI6_PA                 (0x00000000UL)  /*!< PA[6] pin  */
+#define SYSCFG_EXTICR2_EXTI6_PB                 (0x00000100UL)  /*!< PB[6] pin  */
+
+/**
+  * @brief  External Interrupt Line 7 Source Input configuration
+  */
+#define SYSCFG_EXTICR2_EXTI7_PA                 (0x00000000UL)  /*!< PA[7] pin  */
+#define SYSCFG_EXTICR2_EXTI7_PB                 (0x00001000UL)  /*!< PB[7] pin  */
+
+/*****************  Bit definition for SYSCFG_EXTICR3 register  (External interrupt configuration register 3) ********************************/
+#define SYSCFG_EXTICR3_EXTI8_Pos                (0U)
+#define SYSCFG_EXTICR3_EXTI8_Msk                (0x7UL << SYSCFG_EXTICR3_EXTI8_Pos)             /*!< 0x00000007 */
+#define SYSCFG_EXTICR3_EXTI8                    SYSCFG_EXTICR3_EXTI8_Msk                        /*!< External Interrupt Line 8 configuration */
+#define SYSCFG_EXTICR3_EXTI9_Pos                (4U)
+#define SYSCFG_EXTICR3_EXTI9_Msk                (0x7UL << SYSCFG_EXTICR3_EXTI9_Pos)             /*!< 0x00000070 */
+#define SYSCFG_EXTICR3_EXTI9                    SYSCFG_EXTICR3_EXTI9_Msk                        /*!< External Interrupt Line 9 configuration */
+#define SYSCFG_EXTICR3_EXTI10_Pos               (8U)
+#define SYSCFG_EXTICR3_EXTI10_Msk               (0x7UL << SYSCFG_EXTICR3_EXTI10_Pos)            /*!< 0x00000700 */
+#define SYSCFG_EXTICR3_EXTI10                   SYSCFG_EXTICR3_EXTI10_Msk                       /*!< External Interrupt Line 10 configuration */
+#define SYSCFG_EXTICR3_EXTI11_Pos               (12U)
+#define SYSCFG_EXTICR3_EXTI11_Msk               (0xFUL << SYSCFG_EXTICR3_EXTI11_Pos)            /*!< 0x0000F000 */
+#define SYSCFG_EXTICR3_EXTI11                   SYSCFG_EXTICR3_EXTI11_Msk                       /*!< External Interrupt Line 11 configuration */
+
+/**
+  * @brief  External Interrupt Line 8 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI8_PA                 (0x00000000UL)  /*!< PA[8] pin  */
+#define SYSCFG_EXTICR3_EXTI8_PB                 (0x00000001UL)  /*!< PB[8] pin  */
+
+/**
+  * @brief  External Interrupt Line 9 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI9_PA                 (0x00000000UL)  /*!< PA[9] pin  */
+#define SYSCFG_EXTICR3_EXTI9_PB                 (0x00000010UL)  /*!< PB[9] pin  */
+
+/**
+  * @brief  External Interrupt Line 10 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI10_PA                (0x00000000UL)  /*!< PA[10] pin */
+#define SYSCFG_EXTICR3_EXTI10_PB                (0x00000100UL)  /*!< PB[10] pin */
+
+/**
+  * @brief  External Interrupt Line 11 Source Input configuration
+  */
+#define SYSCFG_EXTICR3_EXTI11_PA                (0x00000000UL)  /*!< PA[11] pin */
+#define SYSCFG_EXTICR3_EXTI11_PB                (0x00001000UL)  /*!< PB[11] pin */
+
+/*****************  Bit definition for SYSCFG_EXTICR4 register  (External interrupt configuration register 4) *********************************/
+#define SYSCFG_EXTICR4_EXTI12_Pos               (0U)
+#define SYSCFG_EXTICR4_EXTI12_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI12_Pos)            /*!< 0x00000007 */
+#define SYSCFG_EXTICR4_EXTI12                   SYSCFG_EXTICR4_EXTI12_Msk                       /*!< External Interrupt Line 12 configuration */
+#define SYSCFG_EXTICR4_EXTI13_Pos               (4U)
+#define SYSCFG_EXTICR4_EXTI13_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI13_Pos)            /*!< 0x00000070 */
+#define SYSCFG_EXTICR4_EXTI13                   SYSCFG_EXTICR4_EXTI13_Msk                       /*!< External Interrupt Line 13 configuration */
+#define SYSCFG_EXTICR4_EXTI14_Pos               (8U)
+#define SYSCFG_EXTICR4_EXTI14_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI14_Pos)            /*!< 0x00000700 */
+#define SYSCFG_EXTICR4_EXTI14                   SYSCFG_EXTICR4_EXTI14_Msk                       /*!< External Interrupt Line 14 configuration */
+#define SYSCFG_EXTICR4_EXTI15_Pos               (12U)
+#define SYSCFG_EXTICR4_EXTI15_Msk               (0x7UL << SYSCFG_EXTICR4_EXTI15_Pos)            /*!< 0x00007000 */
+#define SYSCFG_EXTICR4_EXTI15                   SYSCFG_EXTICR4_EXTI15_Msk                       /*!< External Interrupt Line 15 configuration */
+
+/**
+  * @brief  External Interrupt Line 12 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI12_PA                (0x00000000UL)  /*!< PA[12] pin */
+#define SYSCFG_EXTICR4_EXTI12_PB                (0x00000001UL)  /*!< PB[12] pin */
+
+/**
+  * @brief  External Interrupt Line 13 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI13_PA                (0x00000000UL)  /*!< PA[13] pin */
+#define SYSCFG_EXTICR4_EXTI13_PB                (0x00000010UL)  /*!< PB[13] pin */
+
+/**
+  * @brief  External Interrupt Line 14 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI14_PA                (0x00000000UL)  /*!< PA[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PB                (0x00000100UL)  /*!< PB[14] pin */
+#define SYSCFG_EXTICR4_EXTI14_PC                (0x00000200UL)  /*!< PC[14] pin */
+
+/**
+  * @brief  External Interrupt Line 15 Source Input configuration
+  */
+#define SYSCFG_EXTICR4_EXTI15_PA                (0x00000000UL)  /*!< PA[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PB                (0x00001000UL)  /*!< PB[15] pin */
+#define SYSCFG_EXTICR4_EXTI15_PC                (0x00002000UL)  /*!< PC[15] pin */
+
+/*****************  Bit definition for SYSCFG_SCSR register  (SYSCFG SRAM2 control and status register) *********************************************************/
+#define SYSCFG_SCSR_SRAM2ER_Pos                 (0U)
+#define SYSCFG_SCSR_SRAM2ER_Msk                 (0x1UL << SYSCFG_SCSR_SRAM2ER_Pos)              /*!< 0x00000001 */
+#define SYSCFG_SCSR_SRAM2ER                     SYSCFG_SCSR_SRAM2ER_Msk                         /*!< SRAM2 and PKA RAM Erase                                    */
+#define SYSCFG_SCSR_SRAM2BSY_Pos                (1U)
+#define SYSCFG_SCSR_SRAM2BSY_Msk                (0x1UL << SYSCFG_SCSR_SRAM2BSY_Pos)             /*!< 0x00000002 */
+#define SYSCFG_SCSR_SRAM2BSY                    SYSCFG_SCSR_SRAM2BSY_Msk                        /*!< SRAM2 and PKA RAM busy by erase operation                  */
+#define SYSCFG_SCSR_C2RFD_Pos                   (31U)
+#define SYSCFG_SCSR_C2RFD_Msk                   (0x1UL << SYSCFG_SCSR_C2RFD_Pos)                /*!< 0x80000000 */
+#define SYSCFG_SCSR_C2RFD                       SYSCFG_SCSR_C2RFD_Msk                           /*!< CPU2 SRAM fetch (execution) disable                        */
+
+/*****************  Bit definition for SYSCFG_CFGR2 register  (SYSCFG configuration register 2) *****************************************************************/
+#define SYSCFG_CFGR2_CLL_Pos                    (0U)
+#define SYSCFG_CFGR2_CLL_Msk                    (0x1UL << SYSCFG_CFGR2_CLL_Pos)                 /*!< 0x00000001 */
+#define SYSCFG_CFGR2_CLL                        SYSCFG_CFGR2_CLL_Msk                            /*!< Cortex M4 LOCKUP (hardfault) output enable                 */
+#define SYSCFG_CFGR2_SPL_Pos                    (1U)
+#define SYSCFG_CFGR2_SPL_Msk                    (0x1UL << SYSCFG_CFGR2_SPL_Pos)                 /*!< 0x00000002 */
+#define SYSCFG_CFGR2_SPL                        SYSCFG_CFGR2_SPL_Msk                            /*!< SRAM2 Parity Lock                                          */
+#define SYSCFG_CFGR2_PVDL_Pos                   (2U)
+#define SYSCFG_CFGR2_PVDL_Msk                   (0x1UL << SYSCFG_CFGR2_PVDL_Pos)                /*!< 0x00000004 */
+#define SYSCFG_CFGR2_PVDL                       SYSCFG_CFGR2_PVDL_Msk                           /*!< PVD Lock                                                   */
+#define SYSCFG_CFGR2_ECCL_Pos                   (3U)
+#define SYSCFG_CFGR2_ECCL_Msk                   (0x1UL << SYSCFG_CFGR2_ECCL_Pos)                /*!< 0x00000008 */
+#define SYSCFG_CFGR2_ECCL                       SYSCFG_CFGR2_ECCL_Msk                           /*!< ECC Lock                                                   */
+#define SYSCFG_CFGR2_SPF_Pos                    (8U)
+#define SYSCFG_CFGR2_SPF_Msk                    (0x1UL << SYSCFG_CFGR2_SPF_Pos)                 /*!< 0x00000100 */
+#define SYSCFG_CFGR2_SPF                        SYSCFG_CFGR2_SPF_Msk                            /*!< SRAM2 Parity Lock                                          */
+
+/*****************  Bit definition for SYSCFG_SWPR1 register  (SYSCFG SRAM2A write protection register) *********************************************************/
+#define SYSCFG_SWPR1_PAGE0_Pos                  (0U)
+#define SYSCFG_SWPR1_PAGE0_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE0_Pos)               /*!< 0x00000001 */
+#define SYSCFG_SWPR1_PAGE0                      SYSCFG_SWPR1_PAGE0_Msk                          /*!< SRAM2A Write protection page 0 (0x20030000 - 0x200303FF)   */
+#define SYSCFG_SWPR1_PAGE1_Pos                  (1U)
+#define SYSCFG_SWPR1_PAGE1_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE1_Pos)               /*!< 0x00000002 */
+#define SYSCFG_SWPR1_PAGE1                      SYSCFG_SWPR1_PAGE1_Msk                          /*!< SRAM2A Write protection page 1 (0x20030400 - 0x200307FF)   */
+#define SYSCFG_SWPR1_PAGE2_Pos                  (2U)
+#define SYSCFG_SWPR1_PAGE2_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE2_Pos)               /*!< 0x00000004 */
+#define SYSCFG_SWPR1_PAGE2                      SYSCFG_SWPR1_PAGE2_Msk                          /*!< SRAM2A Write protection page 2 (0x20030800 - 0x20030BFF)   */
+#define SYSCFG_SWPR1_PAGE3_Pos                  (3U)
+#define SYSCFG_SWPR1_PAGE3_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE3_Pos)               /*!< 0x00000008 */
+#define SYSCFG_SWPR1_PAGE3                      SYSCFG_SWPR1_PAGE3_Msk                          /*!< SRAM2A Write protection page 3 (0x20030C00 - 0x20030FFF)   */
+#define SYSCFG_SWPR1_PAGE4_Pos                  (4U)
+#define SYSCFG_SWPR1_PAGE4_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE4_Pos)               /*!< 0x00000010 */
+#define SYSCFG_SWPR1_PAGE4                      SYSCFG_SWPR1_PAGE4_Msk                          /*!< SRAM2A Write protection page 4 (0x20031000 - 0x200313FF)   */
+#define SYSCFG_SWPR1_PAGE5_Pos                  (5U)
+#define SYSCFG_SWPR1_PAGE5_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE5_Pos)               /*!< 0x00000020 */
+#define SYSCFG_SWPR1_PAGE5                      SYSCFG_SWPR1_PAGE5_Msk                          /*!< SRAM2A Write protection page 5 (0x20031400 - 0x200317FF)   */
+#define SYSCFG_SWPR1_PAGE6_Pos                  (6U)
+#define SYSCFG_SWPR1_PAGE6_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE6_Pos)               /*!< 0x00000040 */
+#define SYSCFG_SWPR1_PAGE6                      SYSCFG_SWPR1_PAGE6_Msk                          /*!< SRAM2A Write protection page 6 (0x20031800 - 0x20031BFF)   */
+#define SYSCFG_SWPR1_PAGE7_Pos                  (7U)
+#define SYSCFG_SWPR1_PAGE7_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE7_Pos)               /*!< 0x00000080 */
+#define SYSCFG_SWPR1_PAGE7                      SYSCFG_SWPR1_PAGE7_Msk                          /*!< SRAM2A Write protection page 7 (0x20031C00 - 0x20031FFF)   */
+#define SYSCFG_SWPR1_PAGE8_Pos                  (8U)
+#define SYSCFG_SWPR1_PAGE8_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE8_Pos)               /*!< 0x00000100 */
+#define SYSCFG_SWPR1_PAGE8                      SYSCFG_SWPR1_PAGE8_Msk                          /*!< SRAM2A Write protection page 8 (0x20032000 - 0x200323FF)   */
+#define SYSCFG_SWPR1_PAGE9_Pos                  (9U)
+#define SYSCFG_SWPR1_PAGE9_Msk                  (0x1UL << SYSCFG_SWPR1_PAGE9_Pos)               /*!< 0x00000200 */
+#define SYSCFG_SWPR1_PAGE9                      SYSCFG_SWPR1_PAGE9_Msk                          /*!< SRAM2A Write protection page 9 (0x20032400 - 0x200327FF)   */
+#define SYSCFG_SWPR1_PAGE10_Pos                 (10U)
+#define SYSCFG_SWPR1_PAGE10_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE10_Pos)              /*!< 0x00000400 */
+#define SYSCFG_SWPR1_PAGE10                     SYSCFG_SWPR1_PAGE10_Msk                         /*!< SRAM2A Write protection page 10 (0x20032800 - 0x20032BFF)  */
+#define SYSCFG_SWPR1_PAGE11_Pos                 (11U)
+#define SYSCFG_SWPR1_PAGE11_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE11_Pos)              /*!< 0x00000800 */
+#define SYSCFG_SWPR1_PAGE11                     SYSCFG_SWPR1_PAGE11_Msk                         /*!< SRAM2A Write protection page 11 (0x20032C00 - 0x20032FFF)  */
+#define SYSCFG_SWPR1_PAGE12_Pos                 (12U)
+#define SYSCFG_SWPR1_PAGE12_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE12_Pos)              /*!< 0x00001000 */
+#define SYSCFG_SWPR1_PAGE12                     SYSCFG_SWPR1_PAGE12_Msk                         /*!< SRAM2A Write protection page 12 (0x20033000 - 0x200333FF)  */
+#define SYSCFG_SWPR1_PAGE13_Pos                 (13U)
+#define SYSCFG_SWPR1_PAGE13_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE13_Pos)              /*!< 0x00002000 */
+#define SYSCFG_SWPR1_PAGE13                     SYSCFG_SWPR1_PAGE13_Msk                         /*!< SRAM2A Write protection page 13 (0x20033400 - 0x200337FF)  */
+#define SYSCFG_SWPR1_PAGE14_Pos                 (14U)
+#define SYSCFG_SWPR1_PAGE14_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE14_Pos)              /*!< 0x00004000 */
+#define SYSCFG_SWPR1_PAGE14                     SYSCFG_SWPR1_PAGE14_Msk                         /*!< SRAM2A Write protection page 14 (0x20033800 - 0x20033BFF)  */
+#define SYSCFG_SWPR1_PAGE15_Pos                 (15U)
+#define SYSCFG_SWPR1_PAGE15_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE15_Pos)              /*!< 0x00008000 */
+#define SYSCFG_SWPR1_PAGE15                     SYSCFG_SWPR1_PAGE15_Msk                         /*!< SRAM2A Write protection page 15 (0x20033C00 - 0x20033FFF)  */
+#define SYSCFG_SWPR1_PAGE16_Pos                 (16U)
+#define SYSCFG_SWPR1_PAGE16_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE16_Pos)              /*!< 0x00010000 */
+#define SYSCFG_SWPR1_PAGE16                     SYSCFG_SWPR1_PAGE16_Msk                         /*!< SRAM2A Write protection page 16 (0x20034000 - 0x200343FF)  */
+#define SYSCFG_SWPR1_PAGE17_Pos                 (17U)
+#define SYSCFG_SWPR1_PAGE17_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE17_Pos)              /*!< 0x00020000 */
+#define SYSCFG_SWPR1_PAGE17                     SYSCFG_SWPR1_PAGE17_Msk                         /*!< SRAM2A Write protection page 17 (0x20034400 - 0x200347FF)  */
+#define SYSCFG_SWPR1_PAGE18_Pos                 (18U)
+#define SYSCFG_SWPR1_PAGE18_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE18_Pos)              /*!< 0x00040000 */
+#define SYSCFG_SWPR1_PAGE18                     SYSCFG_SWPR1_PAGE18_Msk                         /*!< SRAM2A Write protection page 18 (0x20034800 - 0x20034BFF)  */
+#define SYSCFG_SWPR1_PAGE19_Pos                 (19U)
+#define SYSCFG_SWPR1_PAGE19_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE19_Pos)              /*!< 0x00080000 */
+#define SYSCFG_SWPR1_PAGE19                     SYSCFG_SWPR1_PAGE19_Msk                         /*!< SRAM2A Write protection page 19 (0x20034C00 - 0x20034FFF)  */
+#define SYSCFG_SWPR1_PAGE20_Pos                 (20U)
+#define SYSCFG_SWPR1_PAGE20_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE20_Pos)              /*!< 0x00100000 */
+#define SYSCFG_SWPR1_PAGE20                     SYSCFG_SWPR1_PAGE20_Msk                         /*!< SRAM2A Write protection page 20 (0x20035000 - 0x200353FF)  */
+#define SYSCFG_SWPR1_PAGE21_Pos                 (21U)
+#define SYSCFG_SWPR1_PAGE21_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE21_Pos)              /*!< 0x00200000 */
+#define SYSCFG_SWPR1_PAGE21                     SYSCFG_SWPR1_PAGE21_Msk                         /*!< SRAM2A Write protection page 21 (0x20035400 - 0x200357FF)  */
+#define SYSCFG_SWPR1_PAGE22_Pos                 (22U)
+#define SYSCFG_SWPR1_PAGE22_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE22_Pos)              /*!< 0x00400000 */
+#define SYSCFG_SWPR1_PAGE22                     SYSCFG_SWPR1_PAGE22_Msk                         /*!< SRAM2A Write protection page 22 (0x20035800 - 0x20035BFF)  */
+#define SYSCFG_SWPR1_PAGE23_Pos                 (23U)
+#define SYSCFG_SWPR1_PAGE23_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE23_Pos)              /*!< 0x00800000 */
+#define SYSCFG_SWPR1_PAGE23                     SYSCFG_SWPR1_PAGE23_Msk                         /*!< SRAM2A Write protection page 23 (0x20035C00 - 0x20035FFF)  */
+#define SYSCFG_SWPR1_PAGE24_Pos                 (24U)
+#define SYSCFG_SWPR1_PAGE24_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE24_Pos)              /*!< 0x01000000 */
+#define SYSCFG_SWPR1_PAGE24                     SYSCFG_SWPR1_PAGE24_Msk                         /*!< SRAM2A Write protection page 24 (0x20036000 - 0x200363FF)  */
+#define SYSCFG_SWPR1_PAGE25_Pos                 (25U)
+#define SYSCFG_SWPR1_PAGE25_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE25_Pos)              /*!< 0x02000000 */
+#define SYSCFG_SWPR1_PAGE25                     SYSCFG_SWPR1_PAGE25_Msk                         /*!< SRAM2A Write protection page 25 (0x20036400 - 0x200367FF)  */
+#define SYSCFG_SWPR1_PAGE26_Pos                 (26U)
+#define SYSCFG_SWPR1_PAGE26_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE26_Pos)              /*!< 0x04000000 */
+#define SYSCFG_SWPR1_PAGE26                     SYSCFG_SWPR1_PAGE26_Msk                         /*!< SRAM2A Write protection page 26 (0x20036800 - 0x20036BFF)  */
+#define SYSCFG_SWPR1_PAGE27_Pos                 (27U)
+#define SYSCFG_SWPR1_PAGE27_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE27_Pos)              /*!< 0x08000000 */
+#define SYSCFG_SWPR1_PAGE27                     SYSCFG_SWPR1_PAGE27_Msk                         /*!< SRAM2A Write protection page 27 (0x20036C00 - 0x20036FFF)  */
+#define SYSCFG_SWPR1_PAGE28_Pos                 (28U)
+#define SYSCFG_SWPR1_PAGE28_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE28_Pos)              /*!< 0x10000000 */
+#define SYSCFG_SWPR1_PAGE28                     SYSCFG_SWPR1_PAGE28_Msk                         /*!< SRAM2A Write protection page 28 (0x20037000 - 0x200373FF)  */
+#define SYSCFG_SWPR1_PAGE29_Pos                 (29U)
+#define SYSCFG_SWPR1_PAGE29_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE29_Pos)              /*!< 0x20000000 */
+#define SYSCFG_SWPR1_PAGE29                     SYSCFG_SWPR1_PAGE29_Msk                         /*!< SRAM2A Write protection page 29 (0x20037400 - 0x200377FF)  */
+#define SYSCFG_SWPR1_PAGE30_Pos                 (30U)
+#define SYSCFG_SWPR1_PAGE30_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE30_Pos)              /*!< 0x40000000 */
+#define SYSCFG_SWPR1_PAGE30                     SYSCFG_SWPR1_PAGE30_Msk                         /*!< SRAM2A Write protection page 30 (0x20037800 - 0x20037BFF)  */
+#define SYSCFG_SWPR1_PAGE31_Pos                 (31U)
+#define SYSCFG_SWPR1_PAGE31_Msk                 (0x1UL << SYSCFG_SWPR1_PAGE31_Pos)              /*!< 0x80000000 */
+#define SYSCFG_SWPR1_PAGE31                     SYSCFG_SWPR1_PAGE31_Msk                         /*!< SRAM2A Write protection page 31 (0x20037C00 - 0x20037FFF)  */
+
+/*****************  Bit definition for SYSCFG_SKR register  (SYSCFG SRAM2 key register) *************************************************************************/
+#define SYSCFG_SKR_KEY_Pos                      (0U)
+#define SYSCFG_SKR_KEY_Msk                      (0xFFUL << SYSCFG_SKR_KEY_Pos)                  /*!< 0x000000FF */
+#define SYSCFG_SKR_KEY                          SYSCFG_SKR_KEY_Msk                              /*!< SRAM2 write protection key for software erase              */
+
+/*****************  Bit definition for SYSCFG_SWPR2 register  (SYSCFG SRAM2 write protection register) **********************************************************/
+#define SYSCFG_SWPR2_PAGE32_Pos                 (0U)
+#define SYSCFG_SWPR2_PAGE32_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE32_Pos)              /*!< 0x00000001 */
+#define SYSCFG_SWPR2_PAGE32                     SYSCFG_SWPR2_PAGE32_Msk                         /*!< SRAM2B Write protection page 0 (0x20038000 - 0x200383FF)   */
+#define SYSCFG_SWPR2_PAGE33_Pos                 (1U)
+#define SYSCFG_SWPR2_PAGE33_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE33_Pos)              /*!< 0x00000002 */
+#define SYSCFG_SWPR2_PAGE33                     SYSCFG_SWPR2_PAGE33_Msk                         /*!< SRAM2B Write protection page 1 (0x20038400 - 0x200387FF)   */
+#define SYSCFG_SWPR2_PAGE34_Pos                 (2U)
+#define SYSCFG_SWPR2_PAGE34_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE34_Pos)              /*!< 0x00000004 */
+#define SYSCFG_SWPR2_PAGE34                     SYSCFG_SWPR2_PAGE34_Msk                         /*!< SRAM2B Write protection page 2 (0x20038800 - 0x20038bFF)   */
+#define SYSCFG_SWPR2_PAGE35_Pos                 (3U)
+#define SYSCFG_SWPR2_PAGE35_Msk                 (0x1UL << SYSCFG_SWPR2_PAGE35_Pos)              /*!< 0x00000008 */
+#define SYSCFG_SWPR2_PAGE35                     SYSCFG_SWPR2_PAGE35_Msk                         /*!< SRAM2B Write protection page 3 (0x20038C00 - 0x20038FFF)   */
+
+/*****************  Bit definition for SYSCFG_IMR1 register (Interrupt masks control and status register on CPU1 - part 1) *******************************************/
+#define SYSCFG_IMR1_TIM1IM_Pos                  (13U)
+#define SYSCFG_IMR1_TIM1IM_Msk                  (0x1UL << SYSCFG_IMR1_TIM1IM_Pos)             /*!< 0x00002000 */
+#define SYSCFG_IMR1_TIM1IM                      SYSCFG_IMR1_TIM1IM_Msk                        /*!< Enabling of interrupt from Timer 1 to CPU1                        */
+#define SYSCFG_IMR1_EXTI5IM_Pos                 (21U)
+#define SYSCFG_IMR1_EXTI5IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI5IM_Pos)            /*!< 0x00200000 */
+#define SYSCFG_IMR1_EXTI5IM                     SYSCFG_IMR1_EXTI5IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 5 to CPU1      */
+#define SYSCFG_IMR1_EXTI6IM_Pos                 (22U)
+#define SYSCFG_IMR1_EXTI6IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI6IM_Pos)            /*!< 0x00400000 */
+#define SYSCFG_IMR1_EXTI6IM                     SYSCFG_IMR1_EXTI6IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 6 to CPU1      */
+#define SYSCFG_IMR1_EXTI7IM_Pos                 (23U)
+#define SYSCFG_IMR1_EXTI7IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI7IM_Pos)            /*!< 0x00800000 */
+#define SYSCFG_IMR1_EXTI7IM                     SYSCFG_IMR1_EXTI7IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 7 to CPU1      */
+#define SYSCFG_IMR1_EXTI8IM_Pos                 (24U)
+#define SYSCFG_IMR1_EXTI8IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI8IM_Pos)            /*!< 0x01000000 */
+#define SYSCFG_IMR1_EXTI8IM                     SYSCFG_IMR1_EXTI8IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 8 to CPU1      */
+#define SYSCFG_IMR1_EXTI9IM_Pos                 (25U)
+#define SYSCFG_IMR1_EXTI9IM_Msk                 (0x1UL << SYSCFG_IMR1_EXTI9IM_Pos)            /*!< 0x02000000 */
+#define SYSCFG_IMR1_EXTI9IM                     SYSCFG_IMR1_EXTI9IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 9 to CPU1      */
+#define SYSCFG_IMR1_EXTI10IM_Pos                (26U)
+#define SYSCFG_IMR1_EXTI10IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI10IM_Pos)           /*!< 0x04000000 */
+#define SYSCFG_IMR1_EXTI10IM                    SYSCFG_IMR1_EXTI10IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 10 to CPU1     */
+#define SYSCFG_IMR1_EXTI11IM_Pos                (27U)
+#define SYSCFG_IMR1_EXTI11IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI11IM_Pos)           /*!< 0x08000000 */
+#define SYSCFG_IMR1_EXTI11IM                    SYSCFG_IMR1_EXTI11IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 11 to CPU1     */
+#define SYSCFG_IMR1_EXTI12IM_Pos                (28U)
+#define SYSCFG_IMR1_EXTI12IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI12IM_Pos)           /*!< 0x10000000 */
+#define SYSCFG_IMR1_EXTI12IM                    SYSCFG_IMR1_EXTI12IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 12 to CPU1     */
+#define SYSCFG_IMR1_EXTI13IM_Pos                (29U)
+#define SYSCFG_IMR1_EXTI13IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI13IM_Pos)           /*!< 0x20000000 */
+#define SYSCFG_IMR1_EXTI13IM                    SYSCFG_IMR1_EXTI13IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 13 to CPU1     */
+#define SYSCFG_IMR1_EXTI14IM_Pos                (30U)
+#define SYSCFG_IMR1_EXTI14IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI14IM_Pos)           /*!< 0x40000000 */
+#define SYSCFG_IMR1_EXTI14IM                    SYSCFG_IMR1_EXTI14IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 14 to CPU1     */
+#define SYSCFG_IMR1_EXTI15IM_Pos                (31U)
+#define SYSCFG_IMR1_EXTI15IM_Msk                (0x1UL << SYSCFG_IMR1_EXTI15IM_Pos)           /*!< 0x80000000 */
+#define SYSCFG_IMR1_EXTI15IM                    SYSCFG_IMR1_EXTI15IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 15 to CPU1     */
+
+/*****************  Bit definition for SYSCFG_IMR2 register (Interrupt masks control and status register on CPU1 - part 2) *******************************************/
+#define SYSCFG_IMR2_PVM3IM_Pos                  (18U)
+#define SYSCFG_IMR2_PVM3IM_Msk                  (0x1UL << SYSCFG_IMR2_PVM3IM_Pos)             /*!< 0x00040000 */
+#define SYSCFG_IMR2_PVM3IM                      SYSCFG_IMR2_PVM3IM_Msk                        /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU1     */
+#define SYSCFG_IMR2_PVDIM_Pos                   (20U)
+#define SYSCFG_IMR2_PVDIM_Msk                   (0x1UL << SYSCFG_IMR2_PVDIM_Pos)              /*!< 0x00100000 */
+#define SYSCFG_IMR2_PVDIM                       SYSCFG_IMR2_PVDIM_Msk                         /*!< Enabling of interrupt from Power Voltage Detector to CPU1         */
+
+/*****************  Bit definition for SYSCFG_C2IMR1 register (Interrupt masks control and status register on CPU2 - part 1) *******************************************/
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Pos    (0U)
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Msk    (0x1UL << SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Pos) /*!< 0x00000001 */
+#define SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM        SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM_Msk            /* !< Enabling of interrupt from RTC TimeStamp, RTC Tampers
+                                                                                                      and LSE Clock Security System to CPU2                            */
+#define SYSCFG_C2IMR1_RTCWKUPIM_Pos             (3U)
+#define SYSCFG_C2IMR1_RTCWKUPIM_Msk             (0x1UL << SYSCFG_C2IMR1_RTCWKUPIM_Pos)          /*!< 0x00000008 */
+#define SYSCFG_C2IMR1_RTCWKUPIM                 SYSCFG_C2IMR1_RTCWKUPIM_Msk                     /*!< Enabling of interrupt from RTC Wakeup to CPU2                     */
+#define SYSCFG_C2IMR1_RTCALARMIM_Pos            (4U)
+#define SYSCFG_C2IMR1_RTCALARMIM_Msk            (0x1UL << SYSCFG_C2IMR1_RTCALARMIM_Pos)         /*!< 0x00000010 */
+#define SYSCFG_C2IMR1_RTCALARMIM                SYSCFG_C2IMR1_RTCALARMIM_Msk                    /*!< Enabling of interrupt from RTC Alarms to CPU2                     */
+#define SYSCFG_C2IMR1_RCCIM_Pos                 (5U)
+#define SYSCFG_C2IMR1_RCCIM_Msk                 (0x1UL << SYSCFG_C2IMR1_RCCIM_Pos)              /*!< 0x00000020 */
+#define SYSCFG_C2IMR1_RCCIM                     SYSCFG_C2IMR1_RCCIM_Msk                         /*!< Enabling of interrupt from RCC to CPU2                            */
+#define SYSCFG_C2IMR1_FLASHIM_Pos               (6U)
+#define SYSCFG_C2IMR1_FLASHIM_Msk               (0x1UL << SYSCFG_C2IMR1_FLASHIM_Pos)            /*!< 0x00000040 */
+#define SYSCFG_C2IMR1_FLASHIM                   SYSCFG_C2IMR1_FLASHIM_Msk                       /*!< Enabling of interrupt from FLASH to CPU2                          */
+#define SYSCFG_C2IMR1_PKAIM_Pos                 (8U)
+#define SYSCFG_C2IMR1_PKAIM_Msk                 (0x1UL << SYSCFG_C2IMR1_PKAIM_Pos)              /*!< 0x00000100 */
+#define SYSCFG_C2IMR1_PKAIM                     SYSCFG_C2IMR1_PKAIM_Msk                         /*!< Enabling of interrupt from Public Key Accelerator to CPU2         */
+#define SYSCFG_C2IMR1_RNGIM_Pos                 (9U)
+#define SYSCFG_C2IMR1_RNGIM_Msk                 (0x1UL << SYSCFG_C2IMR1_RNGIM_Pos)              /*!< 0x00000200 */
+#define SYSCFG_C2IMR1_RNGIM                     SYSCFG_C2IMR1_RNGIM_Msk                         /*!< Enabling of interrupt from Random Number Generator to CPU2        */
+#define SYSCFG_C2IMR1_COMPIM_Pos                (11U)
+#define SYSCFG_C2IMR1_COMPIM_Msk                (0x1UL << SYSCFG_C2IMR1_COMPIM_Pos)             /*!< 0x00000800 */
+#define SYSCFG_C2IMR1_COMPIM                    SYSCFG_C2IMR1_COMPIM_Msk                        /*!< Enabling of interrupt from Comparator to CPU2                     */
+#define SYSCFG_C2IMR1_ADCIM_Pos                 (12U)
+#define SYSCFG_C2IMR1_ADCIM_Msk                 (0x1UL << SYSCFG_C2IMR1_ADCIM_Pos)              /*!< 0x00001000 */
+#define SYSCFG_C2IMR1_ADCIM                     SYSCFG_C2IMR1_ADCIM_Msk                         /*!< Enabling of interrupt from Analog Digital Converter to CPU2       */
+#define SYSCFG_C2IMR1_EXTI0IM_Pos               (16U)
+#define SYSCFG_C2IMR1_EXTI0IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI0IM_Pos)            /*!< 0x00010000 */
+#define SYSCFG_C2IMR1_EXTI0IM                   SYSCFG_C2IMR1_EXTI0IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 0 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI1IM_Pos               (17U)
+#define SYSCFG_C2IMR1_EXTI1IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI1IM_Pos)            /*!< 0x00020000 */
+#define SYSCFG_C2IMR1_EXTI1IM                   SYSCFG_C2IMR1_EXTI1IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 1 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI2IM_Pos               (18U)
+#define SYSCFG_C2IMR1_EXTI2IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI2IM_Pos)            /*!< 0x00040000 */
+#define SYSCFG_C2IMR1_EXTI2IM                   SYSCFG_C2IMR1_EXTI2IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 2 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI3IM_Pos               (19U)
+#define SYSCFG_C2IMR1_EXTI3IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI3IM_Pos)            /*!< 0x00080000 */
+#define SYSCFG_C2IMR1_EXTI3IM                   SYSCFG_C2IMR1_EXTI3IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 3 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI4IM_Pos               (20U)
+#define SYSCFG_C2IMR1_EXTI4IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI4IM_Pos)            /*!< 0x00100000 */
+#define SYSCFG_C2IMR1_EXTI4IM                   SYSCFG_C2IMR1_EXTI4IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 4 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI5IM_Pos               (21U)
+#define SYSCFG_C2IMR1_EXTI5IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI5IM_Pos)            /*!< 0x00200000 */
+#define SYSCFG_C2IMR1_EXTI5IM                   SYSCFG_C2IMR1_EXTI5IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 5 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI6IM_Pos               (22U)
+#define SYSCFG_C2IMR1_EXTI6IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI6IM_Pos)            /*!< 0x00400000 */
+#define SYSCFG_C2IMR1_EXTI6IM                   SYSCFG_C2IMR1_EXTI6IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 6 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI7IM_Pos               (23U)
+#define SYSCFG_C2IMR1_EXTI7IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI7IM_Pos)            /*!< 0x00800000 */
+#define SYSCFG_C2IMR1_EXTI7IM                   SYSCFG_C2IMR1_EXTI7IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 7 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI8IM_Pos               (24U)
+#define SYSCFG_C2IMR1_EXTI8IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI8IM_Pos)            /*!< 0x01000000 */
+#define SYSCFG_C2IMR1_EXTI8IM                   SYSCFG_C2IMR1_EXTI8IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 8 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI9IM_Pos               (25U)
+#define SYSCFG_C2IMR1_EXTI9IM_Msk               (0x1UL << SYSCFG_C2IMR1_EXTI9IM_Pos)            /*!< 0x02000000 */
+#define SYSCFG_C2IMR1_EXTI9IM                   SYSCFG_C2IMR1_EXTI9IM_Msk                       /*!< Enabling of interrupt from External Interrupt Line 9 to CPU2      */
+#define SYSCFG_C2IMR1_EXTI10IM_Pos              (26U)
+#define SYSCFG_C2IMR1_EXTI10IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI10IM_Pos)           /*!< 0x04000000 */
+#define SYSCFG_C2IMR1_EXTI10IM                  SYSCFG_C2IMR1_EXTI10IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 10 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI11IM_Pos              (27U)
+#define SYSCFG_C2IMR1_EXTI11IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI11IM_Pos)           /*!< 0x08000000 */
+#define SYSCFG_C2IMR1_EXTI11IM                  SYSCFG_C2IMR1_EXTI11IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 11 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI12IM_Pos              (28U)
+#define SYSCFG_C2IMR1_EXTI12IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI12IM_Pos)           /*!< 0x10000000 */
+#define SYSCFG_C2IMR1_EXTI12IM                  SYSCFG_C2IMR1_EXTI12IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 12 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI13IM_Pos              (29U)
+#define SYSCFG_C2IMR1_EXTI13IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI13IM_Pos)           /*!< 0x20000000 */
+#define SYSCFG_C2IMR1_EXTI13IM                  SYSCFG_C2IMR1_EXTI13IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 13 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI14IM_Pos              (30U)
+#define SYSCFG_C2IMR1_EXTI14IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI14IM_Pos)           /*!< 0x40000000 */
+#define SYSCFG_C2IMR1_EXTI14IM                  SYSCFG_C2IMR1_EXTI14IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 14 to CPU2     */
+#define SYSCFG_C2IMR1_EXTI15IM_Pos              (31U)
+#define SYSCFG_C2IMR1_EXTI15IM_Msk              (0x1UL << SYSCFG_C2IMR1_EXTI15IM_Pos)           /*!< 0x80000000 */
+#define SYSCFG_C2IMR1_EXTI15IM                  SYSCFG_C2IMR1_EXTI15IM_Msk                      /*!< Enabling of interrupt from External Interrupt Line 15 to CPU2     */
+
+/*****************  Bit definition for SYSCFG_C2IMR2 register (Interrupt masks control and status register on CPU2 - part 2) *******************************************/
+#define SYSCFG_C2IMR2_DMA1CH1IM_Pos             (0U)
+#define SYSCFG_C2IMR2_DMA1CH1IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH1IM_Pos)          /*!< 0x00000001 */
+#define SYSCFG_C2IMR2_DMA1CH1IM                 SYSCFG_C2IMR2_DMA1CH1IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 1 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH2IM_Pos             (1U)
+#define SYSCFG_C2IMR2_DMA1CH2IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH2IM_Pos)          /*!< 0x00000002 */
+#define SYSCFG_C2IMR2_DMA1CH2IM                 SYSCFG_C2IMR2_DMA1CH2IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 2 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH3IM_Pos             (2U)
+#define SYSCFG_C2IMR2_DMA1CH3IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH3IM_Pos)          /*!< 0x00000004 */
+#define SYSCFG_C2IMR2_DMA1CH3IM                 SYSCFG_C2IMR2_DMA1CH3IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 3 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH4IM_Pos             (3U)
+#define SYSCFG_C2IMR2_DMA1CH4IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH4IM_Pos)          /*!< 0x00000008 */
+#define SYSCFG_C2IMR2_DMA1CH4IM                 SYSCFG_C2IMR2_DMA1CH4IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 4 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH5IM_Pos             (4U)
+#define SYSCFG_C2IMR2_DMA1CH5IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH5IM_Pos)          /*!< 0x00000010 */
+#define SYSCFG_C2IMR2_DMA1CH5IM                 SYSCFG_C2IMR2_DMA1CH5IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 5 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH6IM_Pos             (5U)
+#define SYSCFG_C2IMR2_DMA1CH6IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH6IM_Pos)          /*!< 0x00000020 */
+#define SYSCFG_C2IMR2_DMA1CH6IM                 SYSCFG_C2IMR2_DMA1CH6IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 6 to CPU2                 */
+#define SYSCFG_C2IMR2_DMA1CH7IM_Pos             (6U)
+#define SYSCFG_C2IMR2_DMA1CH7IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMA1CH7IM_Pos)          /*!< 0x00000040 */
+#define SYSCFG_C2IMR2_DMA1CH7IM                 SYSCFG_C2IMR2_DMA1CH7IM_Msk                     /*!< Enabling of interrupt from DMA1 Channel 7 to CPU2                 */
+#define SYSCFG_C2IMR2_DMAMUX1IM_Pos             (15U)
+#define SYSCFG_C2IMR2_DMAMUX1IM_Msk             (0x1UL << SYSCFG_C2IMR2_DMAMUX1IM_Pos)          /*!< 0x00008000 */
+#define SYSCFG_C2IMR2_DMAMUX1IM                 SYSCFG_C2IMR2_DMAMUX1IM_Msk                     /*!< Enabling of interrupt from DMAMUX1 to CPU2                        */
+#define SYSCFG_C2IMR2_PVM3IM_Pos                (18U)
+#define SYSCFG_C2IMR2_PVM3IM_Msk                (0x1UL << SYSCFG_C2IMR2_PVM3IM_Pos)             /*!< 0x00040000 */
+#define SYSCFG_C2IMR2_PVM3IM                    SYSCFG_C2IMR2_PVM3IM_Msk                        /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU2     */
+#define SYSCFG_C2IMR2_PVDIM_Pos                 (20U)
+#define SYSCFG_C2IMR2_PVDIM_Msk                 (0x1UL << SYSCFG_C2IMR2_PVDIM_Pos)              /*!< 0x00100000 */
+#define SYSCFG_C2IMR2_PVDIM                     SYSCFG_C2IMR2_PVDIM_Msk                         /*!< Enabling of interrupt from Power Voltage Detector to CPU2         */
+#define SYSCFG_C2IMR2_TSCIM_Pos                 (21U)
+#define SYSCFG_C2IMR2_TSCIM_Msk                 (0x1UL << SYSCFG_C2IMR2_TSCIM_Pos)              /*!< 0x00200000 */
+#define SYSCFG_C2IMR2_TSCIM                     SYSCFG_C2IMR2_TSCIM_Msk                         /*!< Enabling of interrupt from Touch Sensing Controller to CPU2       */
+
+/*****************  Bit definition for SYSCFG_SIPCR register (SYSCFG secure IP control register) *****************************************************************************/
+#define SYSCFG_SIPCR_SAES2_Pos                  (1U)
+#define SYSCFG_SIPCR_SAES2_Msk                  (0x1UL << SYSCFG_SIPCR_SAES2_Pos)               /*!< 0x00000002 */
+#define SYSCFG_SIPCR_SAES2                      SYSCFG_SIPCR_SAES2_Msk                          /*!< Enabling the security access of Advanced Encryption Standard 2          */
+#define SYSCFG_SIPCR_SPKA_Pos                   (2U)
+#define SYSCFG_SIPCR_SPKA_Msk                   (0x1UL << SYSCFG_SIPCR_SPKA_Pos)                /*!< 0x00000004 */
+#define SYSCFG_SIPCR_SPKA                       SYSCFG_SIPCR_SPKA_Msk                           /*!< Enabling the security access of Public Key Accelerator                  */
+#define SYSCFG_SIPCR_SRNG_Pos                   (3U)
+#define SYSCFG_SIPCR_SRNG_Msk                   (0x1UL << SYSCFG_SIPCR_SRNG_Pos)                /*!< 0x00000008 */
+#define SYSCFG_SIPCR_SRNG                       SYSCFG_SIPCR_SRNG_Msk                           /*!< Enabling the security access of Random Number Generator                 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                    TIM                                     */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for TIM_CR1 register  ********************/
+#define TIM_CR1_CEN_Pos           (0U)
+#define TIM_CR1_CEN_Msk           (0x1UL << TIM_CR1_CEN_Pos)                   /*!< 0x00000001 */
+#define TIM_CR1_CEN               TIM_CR1_CEN_Msk                              /*!<Counter enable */
+#define TIM_CR1_UDIS_Pos          (1U)
+#define TIM_CR1_UDIS_Msk          (0x1UL << TIM_CR1_UDIS_Pos)                  /*!< 0x00000002 */
+#define TIM_CR1_UDIS              TIM_CR1_UDIS_Msk                             /*!<Update disable */
+#define TIM_CR1_URS_Pos           (2U)
+#define TIM_CR1_URS_Msk           (0x1UL << TIM_CR1_URS_Pos)                   /*!< 0x00000004 */
+#define TIM_CR1_URS               TIM_CR1_URS_Msk                              /*!<Update request source */
+#define TIM_CR1_OPM_Pos           (3U)
+#define TIM_CR1_OPM_Msk           (0x1UL << TIM_CR1_OPM_Pos)                   /*!< 0x00000008 */
+#define TIM_CR1_OPM               TIM_CR1_OPM_Msk                              /*!<One pulse mode */
+#define TIM_CR1_DIR_Pos           (4U)
+#define TIM_CR1_DIR_Msk           (0x1UL << TIM_CR1_DIR_Pos)                   /*!< 0x00000010 */
+#define TIM_CR1_DIR               TIM_CR1_DIR_Msk                              /*!<Direction */
+
+#define TIM_CR1_CMS_Pos           (5U)
+#define TIM_CR1_CMS_Msk           (0x3UL << TIM_CR1_CMS_Pos)                   /*!< 0x00000060 */
+#define TIM_CR1_CMS               TIM_CR1_CMS_Msk                              /*!<CMS[1:0] bits (Center-aligned mode selection) */
+#define TIM_CR1_CMS_0             (0x1U << TIM_CR1_CMS_Pos)                    /*!< 0x00000020 */
+#define TIM_CR1_CMS_1             (0x2U << TIM_CR1_CMS_Pos)                    /*!< 0x00000040 */
+
+#define TIM_CR1_ARPE_Pos          (7U)
+#define TIM_CR1_ARPE_Msk          (0x1UL << TIM_CR1_ARPE_Pos)                  /*!< 0x00000080 */
+#define TIM_CR1_ARPE              TIM_CR1_ARPE_Msk                             /*!<Auto-reload preload enable */
+
+#define TIM_CR1_CKD_Pos           (8U)
+#define TIM_CR1_CKD_Msk           (0x3UL << TIM_CR1_CKD_Pos)                   /*!< 0x00000300 */
+#define TIM_CR1_CKD               TIM_CR1_CKD_Msk                              /*!<CKD[1:0] bits (clock division) */
+#define TIM_CR1_CKD_0             (0x1U << TIM_CR1_CKD_Pos)                    /*!< 0x00000100 */
+#define TIM_CR1_CKD_1             (0x2U << TIM_CR1_CKD_Pos)                    /*!< 0x00000200 */
+
+#define TIM_CR1_UIFREMAP_Pos      (11U)
+#define TIM_CR1_UIFREMAP_Msk      (0x1UL << TIM_CR1_UIFREMAP_Pos)              /*!< 0x00000800 */
+#define TIM_CR1_UIFREMAP          TIM_CR1_UIFREMAP_Msk                         /*!<Update interrupt flag remap */
+
+/*******************  Bit definition for TIM_CR2 register  ********************/
+#define TIM_CR2_CCPC_Pos          (0U)
+#define TIM_CR2_CCPC_Msk          (0x1UL << TIM_CR2_CCPC_Pos)                  /*!< 0x00000001 */
+#define TIM_CR2_CCPC              TIM_CR2_CCPC_Msk                             /*!<Capture/Compare Preloaded Control */
+#define TIM_CR2_CCUS_Pos          (2U)
+#define TIM_CR2_CCUS_Msk          (0x1UL << TIM_CR2_CCUS_Pos)                  /*!< 0x00000004 */
+#define TIM_CR2_CCUS              TIM_CR2_CCUS_Msk                             /*!<Capture/Compare Control Update Selection */
+#define TIM_CR2_CCDS_Pos          (3U)
+#define TIM_CR2_CCDS_Msk          (0x1UL << TIM_CR2_CCDS_Pos)                  /*!< 0x00000008 */
+#define TIM_CR2_CCDS              TIM_CR2_CCDS_Msk                             /*!<Capture/Compare DMA Selection */
+
+#define TIM_CR2_MMS_Pos           (4U)
+#define TIM_CR2_MMS_Msk           (0x7UL << TIM_CR2_MMS_Pos)                   /*!< 0x00000070 */
+#define TIM_CR2_MMS               TIM_CR2_MMS_Msk                              /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS_0             (0x1U << TIM_CR2_MMS_Pos)                    /*!< 0x00000010 */
+#define TIM_CR2_MMS_1             (0x2U << TIM_CR2_MMS_Pos)                    /*!< 0x00000020 */
+#define TIM_CR2_MMS_2             (0x4U << TIM_CR2_MMS_Pos)                    /*!< 0x00000040 */
+
+#define TIM_CR2_TI1S_Pos          (7U)
+#define TIM_CR2_TI1S_Msk          (0x1UL << TIM_CR2_TI1S_Pos)                  /*!< 0x00000080 */
+#define TIM_CR2_TI1S              TIM_CR2_TI1S_Msk                             /*!<TI1 Selection */
+#define TIM_CR2_OIS1_Pos          (8U)
+#define TIM_CR2_OIS1_Msk          (0x1UL << TIM_CR2_OIS1_Pos)                  /*!< 0x00000100 */
+#define TIM_CR2_OIS1              TIM_CR2_OIS1_Msk                             /*!<Output Idle state 1 (OC1 output) */
+#define TIM_CR2_OIS1N_Pos         (9U)
+#define TIM_CR2_OIS1N_Msk         (0x1UL << TIM_CR2_OIS1N_Pos)                 /*!< 0x00000200 */
+#define TIM_CR2_OIS1N             TIM_CR2_OIS1N_Msk                            /*!<Output Idle state 1 (OC1N output) */
+#define TIM_CR2_OIS2_Pos          (10U)
+#define TIM_CR2_OIS2_Msk          (0x1UL << TIM_CR2_OIS2_Pos)                  /*!< 0x00000400 */
+#define TIM_CR2_OIS2              TIM_CR2_OIS2_Msk                             /*!<Output Idle state 2 (OC2 output) */
+#define TIM_CR2_OIS2N_Pos         (11U)
+#define TIM_CR2_OIS2N_Msk         (0x1UL << TIM_CR2_OIS2N_Pos)                 /*!< 0x00000800 */
+#define TIM_CR2_OIS2N             TIM_CR2_OIS2N_Msk                            /*!<Output Idle state 2 (OC2N output) */
+#define TIM_CR2_OIS3_Pos          (12U)
+#define TIM_CR2_OIS3_Msk          (0x1UL << TIM_CR2_OIS3_Pos)                  /*!< 0x00001000 */
+#define TIM_CR2_OIS3              TIM_CR2_OIS3_Msk                             /*!<Output Idle state 3 (OC3 output) */
+#define TIM_CR2_OIS3N_Pos         (13U)
+#define TIM_CR2_OIS3N_Msk         (0x1UL << TIM_CR2_OIS3N_Pos)                 /*!< 0x00002000 */
+#define TIM_CR2_OIS3N             TIM_CR2_OIS3N_Msk                            /*!<Output Idle state 3 (OC3N output) */
+#define TIM_CR2_OIS4_Pos          (14U)
+#define TIM_CR2_OIS4_Msk          (0x1UL << TIM_CR2_OIS4_Pos)                  /*!< 0x00004000 */
+#define TIM_CR2_OIS4              TIM_CR2_OIS4_Msk                             /*!<Output Idle state 4 (OC4 output) */
+#define TIM_CR2_OIS5_Pos          (16U)
+#define TIM_CR2_OIS5_Msk          (0x1UL << TIM_CR2_OIS5_Pos)                  /*!< 0x00010000 */
+#define TIM_CR2_OIS5              TIM_CR2_OIS5_Msk                             /*!<Output Idle state 5 (OC5 output) */
+#define TIM_CR2_OIS6_Pos          (18U)
+#define TIM_CR2_OIS6_Msk          (0x1UL << TIM_CR2_OIS6_Pos)                  /*!< 0x00040000 */
+#define TIM_CR2_OIS6              TIM_CR2_OIS6_Msk                             /*!<Output Idle state 6 (OC6 output) */
+
+#define TIM_CR2_MMS2_Pos          (20U)
+#define TIM_CR2_MMS2_Msk          (0xFUL << TIM_CR2_MMS2_Pos)                  /*!< 0x00F00000 */
+#define TIM_CR2_MMS2              TIM_CR2_MMS2_Msk                             /*!<MMS[2:0] bits (Master Mode Selection) */
+#define TIM_CR2_MMS2_0            (0x1U << TIM_CR2_MMS2_Pos)                   /*!< 0x00100000 */
+#define TIM_CR2_MMS2_1            (0x2U << TIM_CR2_MMS2_Pos)                   /*!< 0x00200000 */
+#define TIM_CR2_MMS2_2            (0x4U << TIM_CR2_MMS2_Pos)                   /*!< 0x00400000 */
+#define TIM_CR2_MMS2_3            (0x8U << TIM_CR2_MMS2_Pos)                   /*!< 0x00800000 */
+
+/*******************  Bit definition for TIM_SMCR register  *******************/
+#define TIM_SMCR_SMS_Pos          (0U)
+#define TIM_SMCR_SMS_Msk          (0x10007UL << TIM_SMCR_SMS_Pos)              /*!< 0x00010007 */
+#define TIM_SMCR_SMS              TIM_SMCR_SMS_Msk                             /*!<SMS[2:0] bits (Slave mode selection) */
+#define TIM_SMCR_SMS_0            (0x00001U << TIM_SMCR_SMS_Pos)               /*!< 0x00000001 */
+#define TIM_SMCR_SMS_1            (0x00002U << TIM_SMCR_SMS_Pos)               /*!< 0x00000002 */
+#define TIM_SMCR_SMS_2            (0x00004U << TIM_SMCR_SMS_Pos)               /*!< 0x00000004 */
+#define TIM_SMCR_SMS_3            (0x10000U << TIM_SMCR_SMS_Pos)               /*!< 0x00010000 */
+
+#define TIM_SMCR_OCCS_Pos         (3U)
+#define TIM_SMCR_OCCS_Msk         (0x1UL << TIM_SMCR_OCCS_Pos)                 /*!< 0x00000008 */
+#define TIM_SMCR_OCCS             TIM_SMCR_OCCS_Msk                            /*!< OCREF clear selection */
+
+#define TIM_SMCR_TS_Pos           (4U)
+#define TIM_SMCR_TS_Msk           (0x30007UL << TIM_SMCR_TS_Pos)               /*!< 0x00300070 */
+#define TIM_SMCR_TS               TIM_SMCR_TS_Msk                              /*!<TS[2:0] bits (Trigger selection) */
+#define TIM_SMCR_TS_0             (0x00001U << TIM_SMCR_TS_Pos)                /*!< 0x00000010 */
+#define TIM_SMCR_TS_1             (0x00002U << TIM_SMCR_TS_Pos)                /*!< 0x00000020 */
+#define TIM_SMCR_TS_2             (0x00004U << TIM_SMCR_TS_Pos)                /*!< 0x00000040 */
+#define TIM_SMCR_TS_3             (0x10000U << TIM_SMCR_TS_Pos)                /*!< 0x00100000 */
+#define TIM_SMCR_TS_4             (0x20000U << TIM_SMCR_TS_Pos)                /*!< 0x00200000 */
+
+#define TIM_SMCR_MSM_Pos          (7U)
+#define TIM_SMCR_MSM_Msk          (0x1UL << TIM_SMCR_MSM_Pos)                  /*!< 0x00000080 */
+#define TIM_SMCR_MSM              TIM_SMCR_MSM_Msk                             /*!<Master/slave mode */
+
+#define TIM_SMCR_ETF_Pos          (8U)
+#define TIM_SMCR_ETF_Msk          (0xFUL << TIM_SMCR_ETF_Pos)                  /*!< 0x00000F00 */
+#define TIM_SMCR_ETF              TIM_SMCR_ETF_Msk                             /*!<ETF[3:0] bits (External trigger filter) */
+#define TIM_SMCR_ETF_0            (0x1U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000100 */
+#define TIM_SMCR_ETF_1            (0x2U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000200 */
+#define TIM_SMCR_ETF_2            (0x4U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000400 */
+#define TIM_SMCR_ETF_3            (0x8U << TIM_SMCR_ETF_Pos)                   /*!< 0x00000800 */
+
+#define TIM_SMCR_ETPS_Pos         (12U)
+#define TIM_SMCR_ETPS_Msk         (0x3UL << TIM_SMCR_ETPS_Pos)                 /*!< 0x00003000 */
+#define TIM_SMCR_ETPS             TIM_SMCR_ETPS_Msk                            /*!<ETPS[1:0] bits (External trigger prescaler) */
+#define TIM_SMCR_ETPS_0           (0x1U << TIM_SMCR_ETPS_Pos)                  /*!< 0x00001000 */
+#define TIM_SMCR_ETPS_1           (0x2U << TIM_SMCR_ETPS_Pos)                  /*!< 0x00002000 */
+
+#define TIM_SMCR_ECE_Pos          (14U)
+#define TIM_SMCR_ECE_Msk          (0x1UL << TIM_SMCR_ECE_Pos)                  /*!< 0x00004000 */
+#define TIM_SMCR_ECE              TIM_SMCR_ECE_Msk                             /*!<External clock enable */
+#define TIM_SMCR_ETP_Pos          (15U)
+#define TIM_SMCR_ETP_Msk          (0x1UL << TIM_SMCR_ETP_Pos)                  /*!< 0x00008000 */
+#define TIM_SMCR_ETP              TIM_SMCR_ETP_Msk                             /*!<External trigger polarity */
+
+/*******************  Bit definition for TIM_DIER register  *******************/
+#define TIM_DIER_UIE_Pos          (0U)
+#define TIM_DIER_UIE_Msk          (0x1UL << TIM_DIER_UIE_Pos)                  /*!< 0x00000001 */
+#define TIM_DIER_UIE              TIM_DIER_UIE_Msk                             /*!<Update interrupt enable */
+#define TIM_DIER_CC1IE_Pos        (1U)
+#define TIM_DIER_CC1IE_Msk        (0x1UL << TIM_DIER_CC1IE_Pos)                /*!< 0x00000002 */
+#define TIM_DIER_CC1IE            TIM_DIER_CC1IE_Msk                           /*!<Capture/Compare 1 interrupt enable */
+#define TIM_DIER_CC2IE_Pos        (2U)
+#define TIM_DIER_CC2IE_Msk        (0x1UL << TIM_DIER_CC2IE_Pos)                /*!< 0x00000004 */
+#define TIM_DIER_CC2IE            TIM_DIER_CC2IE_Msk                           /*!<Capture/Compare 2 interrupt enable */
+#define TIM_DIER_CC3IE_Pos        (3U)
+#define TIM_DIER_CC3IE_Msk        (0x1UL << TIM_DIER_CC3IE_Pos)                /*!< 0x00000008 */
+#define TIM_DIER_CC3IE            TIM_DIER_CC3IE_Msk                           /*!<Capture/Compare 3 interrupt enable */
+#define TIM_DIER_CC4IE_Pos        (4U)
+#define TIM_DIER_CC4IE_Msk        (0x1UL << TIM_DIER_CC4IE_Pos)                /*!< 0x00000010 */
+#define TIM_DIER_CC4IE            TIM_DIER_CC4IE_Msk                           /*!<Capture/Compare 4 interrupt enable */
+#define TIM_DIER_COMIE_Pos        (5U)
+#define TIM_DIER_COMIE_Msk        (0x1UL << TIM_DIER_COMIE_Pos)                /*!< 0x00000020 */
+#define TIM_DIER_COMIE            TIM_DIER_COMIE_Msk                           /*!<COM interrupt enable */
+#define TIM_DIER_TIE_Pos          (6U)
+#define TIM_DIER_TIE_Msk          (0x1UL << TIM_DIER_TIE_Pos)                  /*!< 0x00000040 */
+#define TIM_DIER_TIE              TIM_DIER_TIE_Msk                             /*!<Trigger interrupt enable */
+#define TIM_DIER_BIE_Pos          (7U)
+#define TIM_DIER_BIE_Msk          (0x1UL << TIM_DIER_BIE_Pos)                  /*!< 0x00000080 */
+#define TIM_DIER_BIE              TIM_DIER_BIE_Msk                             /*!<Break interrupt enable */
+#define TIM_DIER_UDE_Pos          (8U)
+#define TIM_DIER_UDE_Msk          (0x1UL << TIM_DIER_UDE_Pos)                  /*!< 0x00000100 */
+#define TIM_DIER_UDE              TIM_DIER_UDE_Msk                             /*!<Update DMA request enable */
+#define TIM_DIER_CC1DE_Pos        (9U)
+#define TIM_DIER_CC1DE_Msk        (0x1UL << TIM_DIER_CC1DE_Pos)                /*!< 0x00000200 */
+#define TIM_DIER_CC1DE            TIM_DIER_CC1DE_Msk                           /*!<Capture/Compare 1 DMA request enable */
+#define TIM_DIER_CC2DE_Pos        (10U)
+#define TIM_DIER_CC2DE_Msk        (0x1UL << TIM_DIER_CC2DE_Pos)                /*!< 0x00000400 */
+#define TIM_DIER_CC2DE            TIM_DIER_CC2DE_Msk                           /*!<Capture/Compare 2 DMA request enable */
+#define TIM_DIER_CC3DE_Pos        (11U)
+#define TIM_DIER_CC3DE_Msk        (0x1UL << TIM_DIER_CC3DE_Pos)                /*!< 0x00000800 */
+#define TIM_DIER_CC3DE            TIM_DIER_CC3DE_Msk                           /*!<Capture/Compare 3 DMA request enable */
+#define TIM_DIER_CC4DE_Pos        (12U)
+#define TIM_DIER_CC4DE_Msk        (0x1UL << TIM_DIER_CC4DE_Pos)                /*!< 0x00001000 */
+#define TIM_DIER_CC4DE            TIM_DIER_CC4DE_Msk                           /*!<Capture/Compare 4 DMA request enable */
+#define TIM_DIER_COMDE_Pos        (13U)
+#define TIM_DIER_COMDE_Msk        (0x1UL << TIM_DIER_COMDE_Pos)                /*!< 0x00002000 */
+#define TIM_DIER_COMDE            TIM_DIER_COMDE_Msk                           /*!<COM DMA request enable */
+#define TIM_DIER_TDE_Pos          (14U)
+#define TIM_DIER_TDE_Msk          (0x1UL << TIM_DIER_TDE_Pos)                  /*!< 0x00004000 */
+#define TIM_DIER_TDE              TIM_DIER_TDE_Msk                             /*!<Trigger DMA request enable */
+
+/********************  Bit definition for TIM_SR register  ********************/
+#define TIM_SR_UIF_Pos            (0U)
+#define TIM_SR_UIF_Msk            (0x1UL << TIM_SR_UIF_Pos)                    /*!< 0x00000001 */
+#define TIM_SR_UIF                TIM_SR_UIF_Msk                               /*!<Update interrupt Flag */
+#define TIM_SR_CC1IF_Pos          (1U)
+#define TIM_SR_CC1IF_Msk          (0x1UL << TIM_SR_CC1IF_Pos)                  /*!< 0x00000002 */
+#define TIM_SR_CC1IF              TIM_SR_CC1IF_Msk                             /*!<Capture/Compare 1 interrupt Flag */
+#define TIM_SR_CC2IF_Pos          (2U)
+#define TIM_SR_CC2IF_Msk          (0x1UL << TIM_SR_CC2IF_Pos)                  /*!< 0x00000004 */
+#define TIM_SR_CC2IF              TIM_SR_CC2IF_Msk                             /*!<Capture/Compare 2 interrupt Flag */
+#define TIM_SR_CC3IF_Pos          (3U)
+#define TIM_SR_CC3IF_Msk          (0x1UL << TIM_SR_CC3IF_Pos)                  /*!< 0x00000008 */
+#define TIM_SR_CC3IF              TIM_SR_CC3IF_Msk                             /*!<Capture/Compare 3 interrupt Flag */
+#define TIM_SR_CC4IF_Pos          (4U)
+#define TIM_SR_CC4IF_Msk          (0x1UL << TIM_SR_CC4IF_Pos)                  /*!< 0x00000010 */
+#define TIM_SR_CC4IF              TIM_SR_CC4IF_Msk                             /*!<Capture/Compare 4 interrupt Flag */
+#define TIM_SR_COMIF_Pos          (5U)
+#define TIM_SR_COMIF_Msk          (0x1UL << TIM_SR_COMIF_Pos)                  /*!< 0x00000020 */
+#define TIM_SR_COMIF              TIM_SR_COMIF_Msk                             /*!<COM interrupt Flag */
+#define TIM_SR_TIF_Pos            (6U)
+#define TIM_SR_TIF_Msk            (0x1UL << TIM_SR_TIF_Pos)                    /*!< 0x00000040 */
+#define TIM_SR_TIF                TIM_SR_TIF_Msk                               /*!<Trigger interrupt Flag */
+#define TIM_SR_BIF_Pos            (7U)
+#define TIM_SR_BIF_Msk            (0x1UL << TIM_SR_BIF_Pos)                    /*!< 0x00000080 */
+#define TIM_SR_BIF                TIM_SR_BIF_Msk                               /*!<Break interrupt Flag */
+#define TIM_SR_B2IF_Pos           (8U)
+#define TIM_SR_B2IF_Msk           (0x1UL << TIM_SR_B2IF_Pos)                   /*!< 0x00000100 */
+#define TIM_SR_B2IF               TIM_SR_B2IF_Msk                              /*!<Break 2 interrupt Flag */
+#define TIM_SR_CC1OF_Pos          (9U)
+#define TIM_SR_CC1OF_Msk          (0x1UL << TIM_SR_CC1OF_Pos)                  /*!< 0x00000200 */
+#define TIM_SR_CC1OF              TIM_SR_CC1OF_Msk                             /*!<Capture/Compare 1 Overcapture Flag */
+#define TIM_SR_CC2OF_Pos          (10U)
+#define TIM_SR_CC2OF_Msk          (0x1UL << TIM_SR_CC2OF_Pos)                  /*!< 0x00000400 */
+#define TIM_SR_CC2OF              TIM_SR_CC2OF_Msk                             /*!<Capture/Compare 2 Overcapture Flag */
+#define TIM_SR_CC3OF_Pos          (11U)
+#define TIM_SR_CC3OF_Msk          (0x1UL << TIM_SR_CC3OF_Pos)                  /*!< 0x00000800 */
+#define TIM_SR_CC3OF              TIM_SR_CC3OF_Msk                             /*!<Capture/Compare 3 Overcapture Flag */
+#define TIM_SR_CC4OF_Pos          (12U)
+#define TIM_SR_CC4OF_Msk          (0x1UL << TIM_SR_CC4OF_Pos)                  /*!< 0x00001000 */
+#define TIM_SR_CC4OF              TIM_SR_CC4OF_Msk                             /*!<Capture/Compare 4 Overcapture Flag */
+#define TIM_SR_SBIF_Pos           (13U)
+#define TIM_SR_SBIF_Msk           (0x1UL << TIM_SR_SBIF_Pos)                   /*!< 0x00002000 */
+#define TIM_SR_SBIF               TIM_SR_SBIF_Msk                              /*!<System Break interrupt Flag */
+#define TIM_SR_CC5IF_Pos          (16U)
+#define TIM_SR_CC5IF_Msk          (0x1UL << TIM_SR_CC5IF_Pos)                  /*!< 0x00010000 */
+#define TIM_SR_CC5IF              TIM_SR_CC5IF_Msk                             /*!<Capture/Compare 5 interrupt Flag */
+#define TIM_SR_CC6IF_Pos          (17U)
+#define TIM_SR_CC6IF_Msk          (0x1UL << TIM_SR_CC6IF_Pos)                  /*!< 0x00020000 */
+#define TIM_SR_CC6IF              TIM_SR_CC6IF_Msk                             /*!<Capture/Compare 6 interrupt Flag */
+
+
+/*******************  Bit definition for TIM_EGR register  ********************/
+#define TIM_EGR_UG_Pos            (0U)
+#define TIM_EGR_UG_Msk            (0x1UL << TIM_EGR_UG_Pos)                    /*!< 0x00000001 */
+#define TIM_EGR_UG                TIM_EGR_UG_Msk                               /*!<Update Generation */
+#define TIM_EGR_CC1G_Pos          (1U)
+#define TIM_EGR_CC1G_Msk          (0x1UL << TIM_EGR_CC1G_Pos)                  /*!< 0x00000002 */
+#define TIM_EGR_CC1G              TIM_EGR_CC1G_Msk                             /*!<Capture/Compare 1 Generation */
+#define TIM_EGR_CC2G_Pos          (2U)
+#define TIM_EGR_CC2G_Msk          (0x1UL << TIM_EGR_CC2G_Pos)                  /*!< 0x00000004 */
+#define TIM_EGR_CC2G              TIM_EGR_CC2G_Msk                             /*!<Capture/Compare 2 Generation */
+#define TIM_EGR_CC3G_Pos          (3U)
+#define TIM_EGR_CC3G_Msk          (0x1UL << TIM_EGR_CC3G_Pos)                  /*!< 0x00000008 */
+#define TIM_EGR_CC3G              TIM_EGR_CC3G_Msk                             /*!<Capture/Compare 3 Generation */
+#define TIM_EGR_CC4G_Pos          (4U)
+#define TIM_EGR_CC4G_Msk          (0x1UL << TIM_EGR_CC4G_Pos)                  /*!< 0x00000010 */
+#define TIM_EGR_CC4G              TIM_EGR_CC4G_Msk                             /*!<Capture/Compare 4 Generation */
+#define TIM_EGR_COMG_Pos          (5U)
+#define TIM_EGR_COMG_Msk          (0x1UL << TIM_EGR_COMG_Pos)                  /*!< 0x00000020 */
+#define TIM_EGR_COMG              TIM_EGR_COMG_Msk                             /*!<Capture/Compare Control Update Generation */
+#define TIM_EGR_TG_Pos            (6U)
+#define TIM_EGR_TG_Msk            (0x1UL << TIM_EGR_TG_Pos)                    /*!< 0x00000040 */
+#define TIM_EGR_TG                TIM_EGR_TG_Msk                               /*!<Trigger Generation */
+#define TIM_EGR_BG_Pos            (7U)
+#define TIM_EGR_BG_Msk            (0x1UL << TIM_EGR_BG_Pos)                    /*!< 0x00000080 */
+#define TIM_EGR_BG                TIM_EGR_BG_Msk                               /*!<Break Generation */
+#define TIM_EGR_B2G_Pos           (8U)
+#define TIM_EGR_B2G_Msk           (0x1UL << TIM_EGR_B2G_Pos)                   /*!< 0x00000100 */
+#define TIM_EGR_B2G               TIM_EGR_B2G_Msk                              /*!<Break 2 Generation */
+
+
+/******************  Bit definition for TIM_CCMR1 register  *******************/
+#define TIM_CCMR1_CC1S_Pos        (0U)
+#define TIM_CCMR1_CC1S_Msk        (0x3UL << TIM_CCMR1_CC1S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR1_CC1S            TIM_CCMR1_CC1S_Msk                           /*!<CC1S[1:0] bits (Capture/Compare 1 Selection) */
+#define TIM_CCMR1_CC1S_0          (0x1U << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000001 */
+#define TIM_CCMR1_CC1S_1          (0x2U << TIM_CCMR1_CC1S_Pos)                 /*!< 0x00000002 */
+
+#define TIM_CCMR1_OC1FE_Pos       (2U)
+#define TIM_CCMR1_OC1FE_Msk       (0x1UL << TIM_CCMR1_OC1FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_OC1FE           TIM_CCMR1_OC1FE_Msk                          /*!<Output Compare 1 Fast enable */
+#define TIM_CCMR1_OC1PE_Pos       (3U)
+#define TIM_CCMR1_OC1PE_Msk       (0x1UL << TIM_CCMR1_OC1PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR1_OC1PE           TIM_CCMR1_OC1PE_Msk                          /*!<Output Compare 1 Preload enable */
+
+#define TIM_CCMR1_OC1M_Pos        (4U)
+#define TIM_CCMR1_OC1M_Msk        (0x1007UL << TIM_CCMR1_OC1M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR1_OC1M            TIM_CCMR1_OC1M_Msk                           /*!<OC1M[2:0] bits (Output Compare 1 Mode) */
+#define TIM_CCMR1_OC1M_0          (0x0001U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR1_OC1M_1          (0x0002U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR1_OC1M_2          (0x0004U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR1_OC1M_3          (0x1000U << TIM_CCMR1_OC1M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR1_OC1CE_Pos       (7U)
+#define TIM_CCMR1_OC1CE_Msk       (0x1UL << TIM_CCMR1_OC1CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR1_OC1CE           TIM_CCMR1_OC1CE_Msk                          /*!<Output Compare 1 Clear Enable */
+
+#define TIM_CCMR1_CC2S_Pos        (8U)
+#define TIM_CCMR1_CC2S_Msk        (0x3UL << TIM_CCMR1_CC2S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR1_CC2S            TIM_CCMR1_CC2S_Msk                           /*!<CC2S[1:0] bits (Capture/Compare 2 Selection) */
+#define TIM_CCMR1_CC2S_0          (0x1U << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000100 */
+#define TIM_CCMR1_CC2S_1          (0x2U << TIM_CCMR1_CC2S_Pos)                 /*!< 0x00000200 */
+
+#define TIM_CCMR1_OC2FE_Pos       (10U)
+#define TIM_CCMR1_OC2FE_Msk       (0x1UL << TIM_CCMR1_OC2FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_OC2FE           TIM_CCMR1_OC2FE_Msk                          /*!<Output Compare 2 Fast enable */
+#define TIM_CCMR1_OC2PE_Pos       (11U)
+#define TIM_CCMR1_OC2PE_Msk       (0x1UL << TIM_CCMR1_OC2PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR1_OC2PE           TIM_CCMR1_OC2PE_Msk                          /*!<Output Compare 2 Preload enable */
+
+#define TIM_CCMR1_OC2M_Pos        (12U)
+#define TIM_CCMR1_OC2M_Msk        (0x1007UL << TIM_CCMR1_OC2M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR1_OC2M            TIM_CCMR1_OC2M_Msk                           /*!<OC2M[2:0] bits (Output Compare 2 Mode) */
+#define TIM_CCMR1_OC2M_0          (0x0001U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR1_OC2M_1          (0x0002U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR1_OC2M_2          (0x0004U << TIM_CCMR1_OC2M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR1_OC2M_3          (0x1000U << TIM_CCMR1_OC2M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR1_OC2CE_Pos       (15U)
+#define TIM_CCMR1_OC2CE_Msk       (0x1UL << TIM_CCMR1_OC2CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR1_OC2CE           TIM_CCMR1_OC2CE_Msk                          /*!<Output Compare 2 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR1_IC1PSC_Pos      (2U)
+#define TIM_CCMR1_IC1PSC_Msk      (0x3UL << TIM_CCMR1_IC1PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR1_IC1PSC          TIM_CCMR1_IC1PSC_Msk                         /*!<IC1PSC[1:0] bits (Input Capture 1 Prescaler) */
+#define TIM_CCMR1_IC1PSC_0        (0x1U << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR1_IC1PSC_1        (0x2U << TIM_CCMR1_IC1PSC_Pos)               /*!< 0x00000008 */
+
+#define TIM_CCMR1_IC1F_Pos        (4U)
+#define TIM_CCMR1_IC1F_Msk        (0xFUL << TIM_CCMR1_IC1F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR1_IC1F            TIM_CCMR1_IC1F_Msk                           /*!<IC1F[3:0] bits (Input Capture 1 Filter) */
+#define TIM_CCMR1_IC1F_0          (0x1U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000010 */
+#define TIM_CCMR1_IC1F_1          (0x2U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000020 */
+#define TIM_CCMR1_IC1F_2          (0x4U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000040 */
+#define TIM_CCMR1_IC1F_3          (0x8U << TIM_CCMR1_IC1F_Pos)                 /*!< 0x00000080 */
+
+#define TIM_CCMR1_IC2PSC_Pos      (10U)
+#define TIM_CCMR1_IC2PSC_Msk      (0x3UL << TIM_CCMR1_IC2PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR1_IC2PSC          TIM_CCMR1_IC2PSC_Msk                         /*!<IC2PSC[1:0] bits (Input Capture 2 Prescaler) */
+#define TIM_CCMR1_IC2PSC_0        (0x1U << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR1_IC2PSC_1        (0x2U << TIM_CCMR1_IC2PSC_Pos)               /*!< 0x00000800 */
+
+#define TIM_CCMR1_IC2F_Pos        (12U)
+#define TIM_CCMR1_IC2F_Msk        (0xFUL << TIM_CCMR1_IC2F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR1_IC2F            TIM_CCMR1_IC2F_Msk                           /*!<IC2F[3:0] bits (Input Capture 2 Filter) */
+#define TIM_CCMR1_IC2F_0          (0x1U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00001000 */
+#define TIM_CCMR1_IC2F_1          (0x2U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00002000 */
+#define TIM_CCMR1_IC2F_2          (0x4U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00004000 */
+#define TIM_CCMR1_IC2F_3          (0x8U << TIM_CCMR1_IC2F_Pos)                 /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR2 register  *******************/
+#define TIM_CCMR2_CC3S_Pos        (0U)
+#define TIM_CCMR2_CC3S_Msk        (0x3UL << TIM_CCMR2_CC3S_Pos)                /*!< 0x00000003 */
+#define TIM_CCMR2_CC3S            TIM_CCMR2_CC3S_Msk                           /*!<CC3S[1:0] bits (Capture/Compare 3 Selection) */
+#define TIM_CCMR2_CC3S_0          (0x1U << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000001 */
+#define TIM_CCMR2_CC3S_1          (0x2U << TIM_CCMR2_CC3S_Pos)                 /*!< 0x00000002 */
+
+#define TIM_CCMR2_OC3FE_Pos       (2U)
+#define TIM_CCMR2_OC3FE_Msk       (0x1UL << TIM_CCMR2_OC3FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_OC3FE           TIM_CCMR2_OC3FE_Msk                          /*!<Output Compare 3 Fast enable */
+#define TIM_CCMR2_OC3PE_Pos       (3U)
+#define TIM_CCMR2_OC3PE_Msk       (0x1UL << TIM_CCMR2_OC3PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR2_OC3PE           TIM_CCMR2_OC3PE_Msk                          /*!<Output Compare 3 Preload enable */
+
+#define TIM_CCMR2_OC3M_Pos        (4U)
+#define TIM_CCMR2_OC3M_Msk        (0x1007UL << TIM_CCMR2_OC3M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR2_OC3M            TIM_CCMR2_OC3M_Msk                           /*!<OC3M[2:0] bits (Output Compare 3 Mode) */
+#define TIM_CCMR2_OC3M_0          (0x0001U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR2_OC3M_1          (0x0002U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR2_OC3M_2          (0x0004U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR2_OC3M_3          (0x1000U << TIM_CCMR2_OC3M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR2_OC3CE_Pos       (7U)
+#define TIM_CCMR2_OC3CE_Msk       (0x1UL << TIM_CCMR2_OC3CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR2_OC3CE           TIM_CCMR2_OC3CE_Msk                          /*!<Output Compare 3 Clear Enable */
+
+#define TIM_CCMR2_CC4S_Pos        (8U)
+#define TIM_CCMR2_CC4S_Msk        (0x3UL << TIM_CCMR2_CC4S_Pos)                /*!< 0x00000300 */
+#define TIM_CCMR2_CC4S            TIM_CCMR2_CC4S_Msk                           /*!<CC4S[1:0] bits (Capture/Compare 4 Selection) */
+#define TIM_CCMR2_CC4S_0          (0x1U << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000100 */
+#define TIM_CCMR2_CC4S_1          (0x2U << TIM_CCMR2_CC4S_Pos)                 /*!< 0x00000200 */
+
+#define TIM_CCMR2_OC4FE_Pos       (10U)
+#define TIM_CCMR2_OC4FE_Msk       (0x1UL << TIM_CCMR2_OC4FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_OC4FE           TIM_CCMR2_OC4FE_Msk                          /*!<Output Compare 4 Fast enable */
+#define TIM_CCMR2_OC4PE_Pos       (11U)
+#define TIM_CCMR2_OC4PE_Msk       (0x1UL << TIM_CCMR2_OC4PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR2_OC4PE           TIM_CCMR2_OC4PE_Msk                          /*!<Output Compare 4 Preload enable */
+
+#define TIM_CCMR2_OC4M_Pos        (12U)
+#define TIM_CCMR2_OC4M_Msk        (0x1007UL << TIM_CCMR2_OC4M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR2_OC4M            TIM_CCMR2_OC4M_Msk                           /*!<OC4M[2:0] bits (Output Compare 4 Mode) */
+#define TIM_CCMR2_OC4M_0          (0x0001U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR2_OC4M_1          (0x0002U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR2_OC4M_2          (0x0004U << TIM_CCMR2_OC4M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR2_OC4M_3          (0x1000U << TIM_CCMR2_OC4M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR2_OC4CE_Pos       (15U)
+#define TIM_CCMR2_OC4CE_Msk       (0x1UL << TIM_CCMR2_OC4CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR2_OC4CE           TIM_CCMR2_OC4CE_Msk                          /*!<Output Compare 4 Clear Enable */
+
+/*----------------------------------------------------------------------------*/
+#define TIM_CCMR2_IC3PSC_Pos      (2U)
+#define TIM_CCMR2_IC3PSC_Msk      (0x3UL << TIM_CCMR2_IC3PSC_Pos)              /*!< 0x0000000C */
+#define TIM_CCMR2_IC3PSC          TIM_CCMR2_IC3PSC_Msk                         /*!<IC3PSC[1:0] bits (Input Capture 3 Prescaler) */
+#define TIM_CCMR2_IC3PSC_0        (0x1U << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR2_IC3PSC_1        (0x2U << TIM_CCMR2_IC3PSC_Pos)               /*!< 0x00000008 */
+
+#define TIM_CCMR2_IC3F_Pos        (4U)
+#define TIM_CCMR2_IC3F_Msk        (0xFUL << TIM_CCMR2_IC3F_Pos)                /*!< 0x000000F0 */
+#define TIM_CCMR2_IC3F            TIM_CCMR2_IC3F_Msk                           /*!<IC3F[3:0] bits (Input Capture 3 Filter) */
+#define TIM_CCMR2_IC3F_0          (0x1U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000010 */
+#define TIM_CCMR2_IC3F_1          (0x2U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000020 */
+#define TIM_CCMR2_IC3F_2          (0x4U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000040 */
+#define TIM_CCMR2_IC3F_3          (0x8U << TIM_CCMR2_IC3F_Pos)                 /*!< 0x00000080 */
+
+#define TIM_CCMR2_IC4PSC_Pos      (10U)
+#define TIM_CCMR2_IC4PSC_Msk      (0x3UL << TIM_CCMR2_IC4PSC_Pos)              /*!< 0x00000C00 */
+#define TIM_CCMR2_IC4PSC          TIM_CCMR2_IC4PSC_Msk                         /*!<IC4PSC[1:0] bits (Input Capture 4 Prescaler) */
+#define TIM_CCMR2_IC4PSC_0        (0x1U << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR2_IC4PSC_1        (0x2U << TIM_CCMR2_IC4PSC_Pos)               /*!< 0x00000800 */
+
+#define TIM_CCMR2_IC4F_Pos        (12U)
+#define TIM_CCMR2_IC4F_Msk        (0xFUL << TIM_CCMR2_IC4F_Pos)                /*!< 0x0000F000 */
+#define TIM_CCMR2_IC4F            TIM_CCMR2_IC4F_Msk                           /*!<IC4F[3:0] bits (Input Capture 4 Filter) */
+#define TIM_CCMR2_IC4F_0          (0x1U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00001000 */
+#define TIM_CCMR2_IC4F_1          (0x2U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00002000 */
+#define TIM_CCMR2_IC4F_2          (0x4U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00004000 */
+#define TIM_CCMR2_IC4F_3          (0x8U << TIM_CCMR2_IC4F_Pos)                 /*!< 0x00008000 */
+
+/******************  Bit definition for TIM_CCMR3 register  *******************/
+#define TIM_CCMR3_OC5FE_Pos       (2U)
+#define TIM_CCMR3_OC5FE_Msk       (0x1UL << TIM_CCMR3_OC5FE_Pos)               /*!< 0x00000004 */
+#define TIM_CCMR3_OC5FE           TIM_CCMR3_OC5FE_Msk                          /*!<Output Compare 5 Fast enable */
+#define TIM_CCMR3_OC5PE_Pos       (3U)
+#define TIM_CCMR3_OC5PE_Msk       (0x1UL << TIM_CCMR3_OC5PE_Pos)               /*!< 0x00000008 */
+#define TIM_CCMR3_OC5PE           TIM_CCMR3_OC5PE_Msk                          /*!<Output Compare 5 Preload enable */
+
+#define TIM_CCMR3_OC5M_Pos        (4U)
+#define TIM_CCMR3_OC5M_Msk        (0x1007UL << TIM_CCMR3_OC5M_Pos)             /*!< 0x00010070 */
+#define TIM_CCMR3_OC5M            TIM_CCMR3_OC5M_Msk                           /*!<OC5M[3:0] bits (Output Compare 5 Mode) */
+#define TIM_CCMR3_OC5M_0          (0x0001U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000010 */
+#define TIM_CCMR3_OC5M_1          (0x0002U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000020 */
+#define TIM_CCMR3_OC5M_2          (0x0004U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00000040 */
+#define TIM_CCMR3_OC5M_3          (0x1000U << TIM_CCMR3_OC5M_Pos)              /*!< 0x00010000 */
+
+#define TIM_CCMR3_OC5CE_Pos       (7U)
+#define TIM_CCMR3_OC5CE_Msk       (0x1UL << TIM_CCMR3_OC5CE_Pos)               /*!< 0x00000080 */
+#define TIM_CCMR3_OC5CE           TIM_CCMR3_OC5CE_Msk                          /*!<Output Compare 5 Clear Enable */
+
+#define TIM_CCMR3_OC6FE_Pos       (10U)
+#define TIM_CCMR3_OC6FE_Msk       (0x1UL << TIM_CCMR3_OC6FE_Pos)               /*!< 0x00000400 */
+#define TIM_CCMR3_OC6FE           TIM_CCMR3_OC6FE_Msk                          /*!<Output Compare 6 Fast enable */
+#define TIM_CCMR3_OC6PE_Pos       (11U)
+#define TIM_CCMR3_OC6PE_Msk       (0x1UL << TIM_CCMR3_OC6PE_Pos)               /*!< 0x00000800 */
+#define TIM_CCMR3_OC6PE           TIM_CCMR3_OC6PE_Msk                          /*!<Output Compare 6 Preload enable */
+
+#define TIM_CCMR3_OC6M_Pos        (12U)
+#define TIM_CCMR3_OC6M_Msk        (0x1007UL << TIM_CCMR3_OC6M_Pos)             /*!< 0x01007000 */
+#define TIM_CCMR3_OC6M            TIM_CCMR3_OC6M_Msk                           /*!<OC6M[3:0] bits (Output Compare 6 Mode) */
+#define TIM_CCMR3_OC6M_0          (0x0001U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00001000 */
+#define TIM_CCMR3_OC6M_1          (0x0002U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00002000 */
+#define TIM_CCMR3_OC6M_2          (0x0004U << TIM_CCMR3_OC6M_Pos)              /*!< 0x00004000 */
+#define TIM_CCMR3_OC6M_3          (0x1000U << TIM_CCMR3_OC6M_Pos)              /*!< 0x01000000 */
+
+#define TIM_CCMR3_OC6CE_Pos       (15U)
+#define TIM_CCMR3_OC6CE_Msk       (0x1UL << TIM_CCMR3_OC6CE_Pos)               /*!< 0x00008000 */
+#define TIM_CCMR3_OC6CE           TIM_CCMR3_OC6CE_Msk                          /*!<Output Compare 6 Clear Enable */
+
+/*******************  Bit definition for TIM_CCER register  *******************/
+#define TIM_CCER_CC1E_Pos         (0U)
+#define TIM_CCER_CC1E_Msk         (0x1UL << TIM_CCER_CC1E_Pos)                 /*!< 0x00000001 */
+#define TIM_CCER_CC1E             TIM_CCER_CC1E_Msk                            /*!<Capture/Compare 1 output enable */
+#define TIM_CCER_CC1P_Pos         (1U)
+#define TIM_CCER_CC1P_Msk         (0x1UL << TIM_CCER_CC1P_Pos)                 /*!< 0x00000002 */
+#define TIM_CCER_CC1P             TIM_CCER_CC1P_Msk                            /*!<Capture/Compare 1 output Polarity */
+#define TIM_CCER_CC1NE_Pos        (2U)
+#define TIM_CCER_CC1NE_Msk        (0x1UL << TIM_CCER_CC1NE_Pos)                /*!< 0x00000004 */
+#define TIM_CCER_CC1NE            TIM_CCER_CC1NE_Msk                           /*!<Capture/Compare 1 Complementary output enable */
+#define TIM_CCER_CC1NP_Pos        (3U)
+#define TIM_CCER_CC1NP_Msk        (0x1UL << TIM_CCER_CC1NP_Pos)                /*!< 0x00000008 */
+#define TIM_CCER_CC1NP            TIM_CCER_CC1NP_Msk                           /*!<Capture/Compare 1 Complementary output Polarity */
+#define TIM_CCER_CC2E_Pos         (4U)
+#define TIM_CCER_CC2E_Msk         (0x1UL << TIM_CCER_CC2E_Pos)                 /*!< 0x00000010 */
+#define TIM_CCER_CC2E             TIM_CCER_CC2E_Msk                            /*!<Capture/Compare 2 output enable */
+#define TIM_CCER_CC2P_Pos         (5U)
+#define TIM_CCER_CC2P_Msk         (0x1UL << TIM_CCER_CC2P_Pos)                 /*!< 0x00000020 */
+#define TIM_CCER_CC2P             TIM_CCER_CC2P_Msk                            /*!<Capture/Compare 2 output Polarity */
+#define TIM_CCER_CC2NE_Pos        (6U)
+#define TIM_CCER_CC2NE_Msk        (0x1UL << TIM_CCER_CC2NE_Pos)                /*!< 0x00000040 */
+#define TIM_CCER_CC2NE            TIM_CCER_CC2NE_Msk                           /*!<Capture/Compare 2 Complementary output enable */
+#define TIM_CCER_CC2NP_Pos        (7U)
+#define TIM_CCER_CC2NP_Msk        (0x1UL << TIM_CCER_CC2NP_Pos)                /*!< 0x00000080 */
+#define TIM_CCER_CC2NP            TIM_CCER_CC2NP_Msk                           /*!<Capture/Compare 2 Complementary output Polarity */
+#define TIM_CCER_CC3E_Pos         (8U)
+#define TIM_CCER_CC3E_Msk         (0x1UL << TIM_CCER_CC3E_Pos)                 /*!< 0x00000100 */
+#define TIM_CCER_CC3E             TIM_CCER_CC3E_Msk                            /*!<Capture/Compare 3 output enable */
+#define TIM_CCER_CC3P_Pos         (9U)
+#define TIM_CCER_CC3P_Msk         (0x1UL << TIM_CCER_CC3P_Pos)                 /*!< 0x00000200 */
+#define TIM_CCER_CC3P             TIM_CCER_CC3P_Msk                            /*!<Capture/Compare 3 output Polarity */
+#define TIM_CCER_CC3NE_Pos        (10U)
+#define TIM_CCER_CC3NE_Msk        (0x1UL << TIM_CCER_CC3NE_Pos)                /*!< 0x00000400 */
+#define TIM_CCER_CC3NE            TIM_CCER_CC3NE_Msk                           /*!<Capture/Compare 3 Complementary output enable */
+#define TIM_CCER_CC3NP_Pos        (11U)
+#define TIM_CCER_CC3NP_Msk        (0x1UL << TIM_CCER_CC3NP_Pos)                /*!< 0x00000800 */
+#define TIM_CCER_CC3NP            TIM_CCER_CC3NP_Msk                           /*!<Capture/Compare 3 Complementary output Polarity */
+#define TIM_CCER_CC4E_Pos         (12U)
+#define TIM_CCER_CC4E_Msk         (0x1UL << TIM_CCER_CC4E_Pos)                 /*!< 0x00001000 */
+#define TIM_CCER_CC4E             TIM_CCER_CC4E_Msk                            /*!<Capture/Compare 4 output enable */
+#define TIM_CCER_CC4P_Pos         (13U)
+#define TIM_CCER_CC4P_Msk         (0x1UL << TIM_CCER_CC4P_Pos)                 /*!< 0x00002000 */
+#define TIM_CCER_CC4P             TIM_CCER_CC4P_Msk                            /*!<Capture/Compare 4 output Polarity */
+#define TIM_CCER_CC4NP_Pos        (15U)
+#define TIM_CCER_CC4NP_Msk        (0x1UL << TIM_CCER_CC4NP_Pos)                /*!< 0x00008000 */
+#define TIM_CCER_CC4NP            TIM_CCER_CC4NP_Msk                           /*!<Capture/Compare 4 Complementary output Polarity */
+#define TIM_CCER_CC5E_Pos         (16U)
+#define TIM_CCER_CC5E_Msk         (0x1UL << TIM_CCER_CC5E_Pos)                 /*!< 0x00010000 */
+#define TIM_CCER_CC5E             TIM_CCER_CC5E_Msk                            /*!<Capture/Compare 5 output enable */
+#define TIM_CCER_CC5P_Pos         (17U)
+#define TIM_CCER_CC5P_Msk         (0x1UL << TIM_CCER_CC5P_Pos)                 /*!< 0x00020000 */
+#define TIM_CCER_CC5P             TIM_CCER_CC5P_Msk                            /*!<Capture/Compare 5 output Polarity */
+#define TIM_CCER_CC6E_Pos         (20U)
+#define TIM_CCER_CC6E_Msk         (0x1UL << TIM_CCER_CC6E_Pos)                 /*!< 0x00100000 */
+#define TIM_CCER_CC6E             TIM_CCER_CC6E_Msk                            /*!<Capture/Compare 6 output enable */
+#define TIM_CCER_CC6P_Pos         (21U)
+#define TIM_CCER_CC6P_Msk         (0x1UL << TIM_CCER_CC6P_Pos)                 /*!< 0x00200000 */
+#define TIM_CCER_CC6P             TIM_CCER_CC6P_Msk                            /*!<Capture/Compare 6 output Polarity */
+
+/*******************  Bit definition for TIM_CNT register  ********************/
+#define TIM_CNT_CNT_Pos           (0U)
+#define TIM_CNT_CNT_Msk           (0xFFFFFFFFUL << TIM_CNT_CNT_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_CNT_CNT               TIM_CNT_CNT_Msk                              /*!<Counter Value */
+#define TIM_CNT_UIFCPY_Pos        (31U)
+#define TIM_CNT_UIFCPY_Msk        (0x1UL << TIM_CNT_UIFCPY_Pos)                /*!< 0x80000000 */
+#define TIM_CNT_UIFCPY            TIM_CNT_UIFCPY_Msk                           /*!<Update interrupt flag copy (if UIFREMAP=1) */
+
+/*******************  Bit definition for TIM_PSC register  ********************/
+#define TIM_PSC_PSC_Pos           (0U)
+#define TIM_PSC_PSC_Msk           (0xFFFFUL << TIM_PSC_PSC_Pos)                /*!< 0x0000FFFF */
+#define TIM_PSC_PSC               TIM_PSC_PSC_Msk                              /*!<Prescaler Value */
+
+/*******************  Bit definition for TIM_ARR register  ********************/
+#define TIM_ARR_ARR_Pos           (0U)
+#define TIM_ARR_ARR_Msk           (0xFFFFFFFFUL << TIM_ARR_ARR_Pos)            /*!< 0xFFFFFFFF */
+#define TIM_ARR_ARR               TIM_ARR_ARR_Msk                              /*!<Actual auto-reload Value */
+
+/*******************  Bit definition for TIM_RCR register  ********************/
+#define TIM_RCR_REP_Pos           (0U)
+#define TIM_RCR_REP_Msk           (0xFFFFUL << TIM_RCR_REP_Pos)                /*!< 0x0000FFFF */
+#define TIM_RCR_REP               TIM_RCR_REP_Msk                              /*!<Repetition Counter Value */
+
+/*******************  Bit definition for TIM_CCR1 register  *******************/
+#define TIM_CCR1_CCR1_Pos         (0U)
+#define TIM_CCR1_CCR1_Msk         (0xFFFFUL << TIM_CCR1_CCR1_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR1_CCR1             TIM_CCR1_CCR1_Msk                            /*!<Capture/Compare 1 Value */
+
+/*******************  Bit definition for TIM_CCR2 register  *******************/
+#define TIM_CCR2_CCR2_Pos         (0U)
+#define TIM_CCR2_CCR2_Msk         (0xFFFFUL << TIM_CCR2_CCR2_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR2_CCR2             TIM_CCR2_CCR2_Msk                            /*!<Capture/Compare 2 Value */
+
+/*******************  Bit definition for TIM_CCR3 register  *******************/
+#define TIM_CCR3_CCR3_Pos         (0U)
+#define TIM_CCR3_CCR3_Msk         (0xFFFFUL << TIM_CCR3_CCR3_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR3_CCR3             TIM_CCR3_CCR3_Msk                            /*!<Capture/Compare 3 Value */
+
+/*******************  Bit definition for TIM_CCR4 register  *******************/
+#define TIM_CCR4_CCR4_Pos         (0U)
+#define TIM_CCR4_CCR4_Msk         (0xFFFFUL << TIM_CCR4_CCR4_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR4_CCR4             TIM_CCR4_CCR4_Msk                            /*!<Capture/Compare 4 Value */
+
+/*******************  Bit definition for TIM_CCR5 register  *******************/
+#define TIM_CCR5_CCR5_Pos         (0U)
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
+#define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
+#define TIM_CCR5_GC5C1_Pos        (29U)
+#define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
+#define TIM_CCR5_GC5C1            TIM_CCR5_GC5C1_Msk                           /*!<Group Channel 5 and Channel 1 */
+#define TIM_CCR5_GC5C2_Pos        (30U)
+#define TIM_CCR5_GC5C2_Msk        (0x1UL << TIM_CCR5_GC5C2_Pos)                /*!< 0x40000000 */
+#define TIM_CCR5_GC5C2            TIM_CCR5_GC5C2_Msk                           /*!<Group Channel 5 and Channel 2 */
+#define TIM_CCR5_GC5C3_Pos        (31U)
+#define TIM_CCR5_GC5C3_Msk        (0x1UL << TIM_CCR5_GC5C3_Pos)                /*!< 0x80000000 */
+#define TIM_CCR5_GC5C3            TIM_CCR5_GC5C3_Msk                           /*!<Group Channel 5 and Channel 3 */
+
+/*******************  Bit definition for TIM_CCR6 register  *******************/
+#define TIM_CCR6_CCR6_Pos         (0U)
+#define TIM_CCR6_CCR6_Msk         (0xFFFFUL << TIM_CCR6_CCR6_Pos)              /*!< 0x0000FFFF */
+#define TIM_CCR6_CCR6             TIM_CCR6_CCR6_Msk                            /*!<Capture/Compare 6 Value */
+
+/*******************  Bit definition for TIM_BDTR register  *******************/
+#define TIM_BDTR_DTG_Pos          (0U)
+#define TIM_BDTR_DTG_Msk          (0xFFUL << TIM_BDTR_DTG_Pos)                 /*!< 0x000000FF */
+#define TIM_BDTR_DTG              TIM_BDTR_DTG_Msk                             /*!<DTG[0:7] bits (Dead-Time Generator set-up) */
+#define TIM_BDTR_DTG_0            (0x01U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000001 */
+#define TIM_BDTR_DTG_1            (0x02U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000002 */
+#define TIM_BDTR_DTG_2            (0x04U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000004 */
+#define TIM_BDTR_DTG_3            (0x08U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000008 */
+#define TIM_BDTR_DTG_4            (0x10U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000010 */
+#define TIM_BDTR_DTG_5            (0x20U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000020 */
+#define TIM_BDTR_DTG_6            (0x40U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000040 */
+#define TIM_BDTR_DTG_7            (0x80U << TIM_BDTR_DTG_Pos)                  /*!< 0x00000080 */
+
+#define TIM_BDTR_LOCK_Pos         (8U)
+#define TIM_BDTR_LOCK_Msk         (0x3UL << TIM_BDTR_LOCK_Pos)                 /*!< 0x00000300 */
+#define TIM_BDTR_LOCK             TIM_BDTR_LOCK_Msk                            /*!<LOCK[1:0] bits (Lock Configuration) */
+#define TIM_BDTR_LOCK_0           (0x1U << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000100 */
+#define TIM_BDTR_LOCK_1           (0x2U << TIM_BDTR_LOCK_Pos)                  /*!< 0x00000200 */
+
+#define TIM_BDTR_OSSI_Pos         (10U)
+#define TIM_BDTR_OSSI_Msk         (0x1UL << TIM_BDTR_OSSI_Pos)                 /*!< 0x00000400 */
+#define TIM_BDTR_OSSI             TIM_BDTR_OSSI_Msk                            /*!<Off-State Selection for Idle mode */
+#define TIM_BDTR_OSSR_Pos         (11U)
+#define TIM_BDTR_OSSR_Msk         (0x1UL << TIM_BDTR_OSSR_Pos)                 /*!< 0x00000800 */
+#define TIM_BDTR_OSSR             TIM_BDTR_OSSR_Msk                            /*!<Off-State Selection for Run mode */
+#define TIM_BDTR_BKE_Pos          (12U)
+#define TIM_BDTR_BKE_Msk          (0x1UL << TIM_BDTR_BKE_Pos)                  /*!< 0x00001000 */
+#define TIM_BDTR_BKE              TIM_BDTR_BKE_Msk                             /*!<Break enable for Break 1 */
+#define TIM_BDTR_BKP_Pos          (13U)
+#define TIM_BDTR_BKP_Msk          (0x1UL << TIM_BDTR_BKP_Pos)                  /*!< 0x00002000 */
+#define TIM_BDTR_BKP              TIM_BDTR_BKP_Msk                             /*!<Break Polarity for Break 1 */
+#define TIM_BDTR_AOE_Pos          (14U)
+#define TIM_BDTR_AOE_Msk          (0x1UL << TIM_BDTR_AOE_Pos)                  /*!< 0x00004000 */
+#define TIM_BDTR_AOE              TIM_BDTR_AOE_Msk                             /*!<Automatic Output enable */
+#define TIM_BDTR_MOE_Pos          (15U)
+#define TIM_BDTR_MOE_Msk          (0x1UL << TIM_BDTR_MOE_Pos)                  /*!< 0x00008000 */
+#define TIM_BDTR_MOE              TIM_BDTR_MOE_Msk                             /*!<Main Output enable */
+
+#define TIM_BDTR_BKF_Pos          (16U)
+#define TIM_BDTR_BKF_Msk          (0xFUL << TIM_BDTR_BKF_Pos)                  /*!< 0x000F0000 */
+#define TIM_BDTR_BKF              TIM_BDTR_BKF_Msk                             /*!<Break Filter for Break 1 */
+#define TIM_BDTR_BK2F_Pos         (20U)
+#define TIM_BDTR_BK2F_Msk         (0xFUL << TIM_BDTR_BK2F_Pos)                 /*!< 0x00F00000 */
+#define TIM_BDTR_BK2F             TIM_BDTR_BK2F_Msk                            /*!<Break Filter for Break 2 */
+
+#define TIM_BDTR_BK2E_Pos         (24U)
+#define TIM_BDTR_BK2E_Msk         (0x1UL << TIM_BDTR_BK2E_Pos)                 /*!< 0x01000000 */
+#define TIM_BDTR_BK2E             TIM_BDTR_BK2E_Msk                            /*!<Break enable for Break 2 */
+#define TIM_BDTR_BK2P_Pos         (25U)
+#define TIM_BDTR_BK2P_Msk         (0x1UL << TIM_BDTR_BK2P_Pos)                 /*!< 0x02000000 */
+#define TIM_BDTR_BK2P             TIM_BDTR_BK2P_Msk                            /*!<Break Polarity for Break 2 */
+
+#define TIM_BDTR_BKDSRM_Pos       (26U)
+#define TIM_BDTR_BKDSRM_Msk       (0x1UL << TIM_BDTR_BKDSRM_Pos)               /*!< 0x04000000 */
+#define TIM_BDTR_BKDSRM           TIM_BDTR_BKDSRM_Msk                          /*!<Break disarming/re-arming */
+#define TIM_BDTR_BK2DSRM_Pos      (27U)
+#define TIM_BDTR_BK2DSRM_Msk      (0x1UL << TIM_BDTR_BK2DSRM_Pos)              /*!< 0x08000000 */
+#define TIM_BDTR_BK2DSRM          TIM_BDTR_BK2DSRM_Msk                         /*!<Break2 disarming/re-arming */
+
+#define TIM_BDTR_BKBID_Pos        (28U)
+#define TIM_BDTR_BKBID_Msk        (0x1UL << TIM_BDTR_BKBID_Pos)                /*!< 0x10000000 */
+#define TIM_BDTR_BKBID            TIM_BDTR_BKBID_Msk                           /*!<Break BIDirectional */
+#define TIM_BDTR_BK2BID_Pos       (29U)
+#define TIM_BDTR_BK2BID_Msk       (0x1UL << TIM_BDTR_BK2BID_Pos)               /*!< 0x20000000 */
+#define TIM_BDTR_BK2BID           TIM_BDTR_BK2BID_Msk                          /*!<Break2 BIDirectional */
+
+/*******************  Bit definition for TIM_DCR register  ********************/
+#define TIM_DCR_DBA_Pos           (0U)
+#define TIM_DCR_DBA_Msk           (0x1FUL << TIM_DCR_DBA_Pos)                  /*!< 0x0000001F */
+#define TIM_DCR_DBA               TIM_DCR_DBA_Msk                              /*!<DBA[4:0] bits (DMA Base Address) */
+#define TIM_DCR_DBA_0             (0x01U << TIM_DCR_DBA_Pos)                   /*!< 0x00000001 */
+#define TIM_DCR_DBA_1             (0x02U << TIM_DCR_DBA_Pos)                   /*!< 0x00000002 */
+#define TIM_DCR_DBA_2             (0x04U << TIM_DCR_DBA_Pos)                   /*!< 0x00000004 */
+#define TIM_DCR_DBA_3             (0x08U << TIM_DCR_DBA_Pos)                   /*!< 0x00000008 */
+#define TIM_DCR_DBA_4             (0x10U << TIM_DCR_DBA_Pos)                   /*!< 0x00000010 */
+
+#define TIM_DCR_DBL_Pos           (8U)
+#define TIM_DCR_DBL_Msk           (0x1FUL << TIM_DCR_DBL_Pos)                  /*!< 0x00001F00 */
+#define TIM_DCR_DBL               TIM_DCR_DBL_Msk                              /*!<DBL[4:0] bits (DMA Burst Length) */
+#define TIM_DCR_DBL_0             (0x01U << TIM_DCR_DBL_Pos)                   /*!< 0x00000100 */
+#define TIM_DCR_DBL_1             (0x02U << TIM_DCR_DBL_Pos)                   /*!< 0x00000200 */
+#define TIM_DCR_DBL_2             (0x04U << TIM_DCR_DBL_Pos)                   /*!< 0x00000400 */
+#define TIM_DCR_DBL_3             (0x08U << TIM_DCR_DBL_Pos)                   /*!< 0x00000800 */
+#define TIM_DCR_DBL_4             (0x10U << TIM_DCR_DBL_Pos)                   /*!< 0x00001000 */
+
+/*******************  Bit definition for TIM_DMAR register  *******************/
+#define TIM_DMAR_DMAB_Pos         (0U)
+#define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)              /*!< 0x0000FFFF */
+#define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses */
+
+/*******************  Bit definition for TIM1_OR register  *******************/
+#define TIM1_OR_ETR_ADC1_RMP_Pos      (0U)
+#define TIM1_OR_ETR_ADC1_RMP_Msk      (0x3UL << TIM1_OR_ETR_ADC1_RMP_Pos)    /*!< 0x00000003 */
+#define TIM1_OR_ETR_ADC1_RMP          TIM1_OR_ETR_ADC1_RMP_Msk               /*!< TIM1_ETR_ADC1 remapping capability*/
+#define TIM1_OR_ETR_ADC1_RMP_0        (0x1U << TIM1_OR_ETR_ADC1_RMP_Pos)     /*!< 0x00000001 */
+#define TIM1_OR_ETR_ADC1_RMP_1        (0x2U << TIM1_OR_ETR_ADC1_RMP_Pos)     /*!< 0x00000002 */
+#define TIM1_OR_TI1_RMP_Pos            (4U)
+#define TIM1_OR_TI1_RMP_Msk            (0x1UL << TIM1_OR_TI1_RMP_Pos)          /*!< 0x00000010 */
+#define TIM1_OR_TI1_RMP                TIM1_OR_TI1_RMP_Msk                     /*!< Input Capture 1 remap*/
+
+/*******************  Bit definition for TIM2_OR register  *******************/
+#define TIM2_OR_TI4_RMP_Pos      (2U)
+#define TIM2_OR_TI4_RMP_Msk      (0x3UL << TIM2_OR_TI4_RMP_Pos)              /*!< 0x0000000C */
+#define TIM2_OR_TI4_RMP          TIM2_OR_TI4_RMP_Msk                         /*!< TI4 Input capture 4 remap*/
+#define TIM2_OR_TI4_RMP_0        (0x1U << TIM2_OR_TI4_RMP_Pos)               /*!< 0x00000004 */
+#define TIM2_OR_ETR_RMP_Pos      (1U)
+#define TIM2_OR_ETR_RMP_Msk      (0x1UL << TIM2_OR_ETR_RMP_Pos)              /*!< 0x00000002 */
+#define TIM2_OR_ETR_RMP          TIM2_OR_ETR_RMP_Msk                         /*!< External trigger remap*/
+
+/*******************  Bit definition for TIM1_AF1 register  *******************/
+#define TIM1_AF1_BKINE_Pos             (0U)
+#define TIM1_AF1_BKINE_Msk             (0x1UL << TIM1_AF1_BKINE_Pos)           /*!< 0x00000001 */
+#define TIM1_AF1_BKINE                 TIM1_AF1_BKINE_Msk                      /*!<BRK BKIN input enable */
+#define TIM1_AF1_BKCMP1E_Pos           (1U)
+#define TIM1_AF1_BKCMP1E_Msk           (0x1UL << TIM1_AF1_BKCMP1E_Pos)         /*!< 0x00000002 */
+#define TIM1_AF1_BKCMP1E               TIM1_AF1_BKCMP1E_Msk                    /*!<BRK COMP1 enable */
+#define TIM1_AF1_BKINP_Pos             (9U)
+#define TIM1_AF1_BKINP_Msk             (0x1UL << TIM1_AF1_BKINP_Pos)           /*!< 0x00000200 */
+#define TIM1_AF1_BKINP                 TIM1_AF1_BKINP_Msk                      /*!<BRK BKIN input polarity */
+#define TIM1_AF1_BKCMP1P_Pos           (10U)
+#define TIM1_AF1_BKCMP1P_Msk           (0x1UL << TIM1_AF1_BKCMP1P_Pos)         /*!< 0x00000400 */
+#define TIM1_AF1_BKCMP1P               TIM1_AF1_BKCMP1P_Msk                    /*!<BRK COMP1 input polarity */
+#define TIM1_AF1_ETRSEL_Pos            (14U)
+#define TIM1_AF1_ETRSEL_Msk            (0x7UL << TIM1_AF1_ETRSEL_Pos)          /*!< 0x0001C000 */
+#define TIM1_AF1_ETRSEL                TIM1_AF1_ETRSEL_Msk                     /*!<ETRSEL[2:0] bits (TIM1 ETR source selection) */
+#define TIM1_AF1_ETRSEL_0              (0x1U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00004000 */
+#define TIM1_AF1_ETRSEL_1              (0x2U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00008000 */
+#define TIM1_AF1_ETRSEL_2              (0x4U << TIM1_AF1_ETRSEL_Pos)           /*!< 0x00010000 */
+
+/*******************  Bit definition for TIM2_AF1 register  *******************/
+#define TIM2_AF1_ETRSEL_Pos       (14U)
+#define TIM2_AF1_ETRSEL_Msk       (0x7UL << TIM2_AF1_ETRSEL_Pos)               /*!< 0x0001C000 */
+#define TIM2_AF1_ETRSEL           (0x00001C000)                                /*!< External trigger source selection */
+#define TIM2_AF1_ETRSEL_0         (0x000004000)                                /*!< Bit_0 */
+#define TIM2_AF1_ETRSEL_1         (0x000008000)                                /*!< Bit_1 */
+#define TIM2_AF1_ETRSEL_2         (0x000010000)                                /*!< Bit_2 */
+
+/*******************  Bit definition for TIM17_AF1 register  *******************/
+#define TIM17_AF1_BKINE_Pos             (0U)
+#define TIM17_AF1_BKINE_Msk             (0x1UL << TIM17_AF1_BKINE_Pos)           /*!< 0x00000001 */
+#define TIM17_AF1_BKINE                 TIM17_AF1_BKINE_Msk                      /*!<BRK BKIN input enable */
+#define TIM17_AF1_BKINP_Pos            (9U)
+#define TIM17_AF1_BKINP_Msk            (0x1UL << TIM17_AF1_BKINP_Pos)          /*!< 0x00000200 */
+#define TIM17_AF1_BKINP                TIM17_AF1_BKINP_Msk                     /*!<BRK BKIN2 input polarity */
+
+/*******************  Bit definition for TIM1_AF2 register  *******************/
+#define TIM1_AF2_BK2INE_Pos            (0U)
+#define TIM1_AF2_BK2INE_Msk            (0x1UL << TIM1_AF2_BK2INE_Pos)          /*!< 0x00000001 */
+#define TIM1_AF2_BK2INE                TIM1_AF2_BK2INE_Msk                     /*!<BRK2 BKIN2 input enable */
+#define TIM1_AF2_BK2CMP1E_Pos          (1U)
+#define TIM1_AF2_BK2CMP1E_Msk          (0x1UL << TIM1_AF2_BK2CMP1E_Pos)        /*!< 0x00000002 */
+#define TIM1_AF2_BK2CMP1E              TIM1_AF2_BK2CMP1E_Msk                   /*!<BRK2 COMP1 enable */
+#define TIM1_AF2_BK2INP_Pos            (9U)
+#define TIM1_AF2_BK2INP_Msk            (0x1UL << TIM1_AF2_BK2INP_Pos)          /*!< 0x00000200 */
+#define TIM1_AF2_BK2INP                TIM1_AF2_BK2INP_Msk                     /*!<BRK2 BKIN2 input polarity */
+#define TIM1_AF2_BK2CMP1P_Pos          (10U)
+#define TIM1_AF2_BK2CMP1P_Msk          (0x1UL << TIM1_AF2_BK2CMP1P_Pos)        /*!< 0x00000400 */
+#define TIM1_AF2_BK2CMP1P              TIM1_AF2_BK2CMP1P_Msk                   /*!<BRK2 COMP1 input polarity */
+
+/******************************************************************************/
+/*                                                                            */
+/*                         Low Power Timer (LPTIM)                            */
+/*                                                                            */
+/******************************************************************************/
+
+/******************  Bit definition for LPTIM_ISR register  *******************/
+#define LPTIM_ISR_CMPM_Pos          (0U)
+#define LPTIM_ISR_CMPM_Msk          (0x1UL << LPTIM_ISR_CMPM_Pos)              /*!< 0x00000001 */
+#define LPTIM_ISR_CMPM              LPTIM_ISR_CMPM_Msk                         /*!< Compare match */
+#define LPTIM_ISR_ARRM_Pos          (1U)
+#define LPTIM_ISR_ARRM_Msk          (0x1UL << LPTIM_ISR_ARRM_Pos)              /*!< 0x00000002 */
+#define LPTIM_ISR_ARRM              LPTIM_ISR_ARRM_Msk                         /*!< Autoreload match */
+#define LPTIM_ISR_EXTTRIG_Pos       (2U)
+#define LPTIM_ISR_EXTTRIG_Msk       (0x1UL << LPTIM_ISR_EXTTRIG_Pos)           /*!< 0x00000004 */
+#define LPTIM_ISR_EXTTRIG           LPTIM_ISR_EXTTRIG_Msk                      /*!< External trigger edge event */
+#define LPTIM_ISR_CMPOK_Pos         (3U)
+#define LPTIM_ISR_CMPOK_Msk         (0x1UL << LPTIM_ISR_CMPOK_Pos)             /*!< 0x00000008 */
+#define LPTIM_ISR_CMPOK             LPTIM_ISR_CMPOK_Msk                        /*!< Compare register update OK */
+#define LPTIM_ISR_ARROK_Pos         (4U)
+#define LPTIM_ISR_ARROK_Msk         (0x1UL << LPTIM_ISR_ARROK_Pos)             /*!< 0x00000010 */
+#define LPTIM_ISR_ARROK             LPTIM_ISR_ARROK_Msk                        /*!< Autoreload register update OK */
+#define LPTIM_ISR_UP_Pos            (5U)
+#define LPTIM_ISR_UP_Msk            (0x1UL << LPTIM_ISR_UP_Pos)                /*!< 0x00000020 */
+#define LPTIM_ISR_UP                LPTIM_ISR_UP_Msk                           /*!< Counter direction change down to up */
+#define LPTIM_ISR_DOWN_Pos          (6U)
+#define LPTIM_ISR_DOWN_Msk          (0x1UL << LPTIM_ISR_DOWN_Pos)              /*!< 0x00000040 */
+#define LPTIM_ISR_DOWN              LPTIM_ISR_DOWN_Msk                         /*!< Counter direction change up to down */
+
+/******************  Bit definition for LPTIM_ICR register  *******************/
+#define LPTIM_ICR_CMPMCF_Pos        (0U)
+#define LPTIM_ICR_CMPMCF_Msk        (0x1UL << LPTIM_ICR_CMPMCF_Pos)            /*!< 0x00000001 */
+#define LPTIM_ICR_CMPMCF            LPTIM_ICR_CMPMCF_Msk                       /*!< Compare match Clear Flag */
+#define LPTIM_ICR_ARRMCF_Pos        (1U)
+#define LPTIM_ICR_ARRMCF_Msk        (0x1UL << LPTIM_ICR_ARRMCF_Pos)            /*!< 0x00000002 */
+#define LPTIM_ICR_ARRMCF            LPTIM_ICR_ARRMCF_Msk                       /*!< Autoreload match Clear Flag */
+#define LPTIM_ICR_EXTTRIGCF_Pos     (2U)
+#define LPTIM_ICR_EXTTRIGCF_Msk     (0x1UL << LPTIM_ICR_EXTTRIGCF_Pos)         /*!< 0x00000004 */
+#define LPTIM_ICR_EXTTRIGCF         LPTIM_ICR_EXTTRIGCF_Msk                    /*!< External trigger edge event Clear Flag */
+#define LPTIM_ICR_CMPOKCF_Pos       (3U)
+#define LPTIM_ICR_CMPOKCF_Msk       (0x1UL << LPTIM_ICR_CMPOKCF_Pos)           /*!< 0x00000008 */
+#define LPTIM_ICR_CMPOKCF           LPTIM_ICR_CMPOKCF_Msk                      /*!< Compare register update OK Clear Flag */
+#define LPTIM_ICR_ARROKCF_Pos       (4U)
+#define LPTIM_ICR_ARROKCF_Msk       (0x1UL << LPTIM_ICR_ARROKCF_Pos)           /*!< 0x00000010 */
+#define LPTIM_ICR_ARROKCF           LPTIM_ICR_ARROKCF_Msk                      /*!< Autoreload register update OK Clear Flag */
+#define LPTIM_ICR_UPCF_Pos          (5U)
+#define LPTIM_ICR_UPCF_Msk          (0x1UL << LPTIM_ICR_UPCF_Pos)              /*!< 0x00000020 */
+#define LPTIM_ICR_UPCF              LPTIM_ICR_UPCF_Msk                         /*!< Counter direction change down to up Clear Flag */
+#define LPTIM_ICR_DOWNCF_Pos        (6U)
+#define LPTIM_ICR_DOWNCF_Msk        (0x1UL << LPTIM_ICR_DOWNCF_Pos)            /*!< 0x00000040 */
+#define LPTIM_ICR_DOWNCF            LPTIM_ICR_DOWNCF_Msk                       /*!< Counter direction change up to down Clear Flag */
+
+/******************  Bit definition for LPTIM_IER register ********************/
+#define LPTIM_IER_CMPMIE_Pos        (0U)
+#define LPTIM_IER_CMPMIE_Msk        (0x1UL << LPTIM_IER_CMPMIE_Pos)            /*!< 0x00000001 */
+#define LPTIM_IER_CMPMIE            LPTIM_IER_CMPMIE_Msk                       /*!< Compare match Interrupt Enable */
+#define LPTIM_IER_ARRMIE_Pos        (1U)
+#define LPTIM_IER_ARRMIE_Msk        (0x1UL << LPTIM_IER_ARRMIE_Pos)            /*!< 0x00000002 */
+#define LPTIM_IER_ARRMIE            LPTIM_IER_ARRMIE_Msk                       /*!< Autoreload match Interrupt Enable */
+#define LPTIM_IER_EXTTRIGIE_Pos     (2U)
+#define LPTIM_IER_EXTTRIGIE_Msk     (0x1UL << LPTIM_IER_EXTTRIGIE_Pos)         /*!< 0x00000004 */
+#define LPTIM_IER_EXTTRIGIE         LPTIM_IER_EXTTRIGIE_Msk                    /*!< External trigger edge event Interrupt Enable */
+#define LPTIM_IER_CMPOKIE_Pos       (3U)
+#define LPTIM_IER_CMPOKIE_Msk       (0x1UL << LPTIM_IER_CMPOKIE_Pos)           /*!< 0x00000008 */
+#define LPTIM_IER_CMPOKIE           LPTIM_IER_CMPOKIE_Msk                      /*!< Compare register update OK Interrupt Enable */
+#define LPTIM_IER_ARROKIE_Pos       (4U)
+#define LPTIM_IER_ARROKIE_Msk       (0x1UL << LPTIM_IER_ARROKIE_Pos)           /*!< 0x00000010 */
+#define LPTIM_IER_ARROKIE           LPTIM_IER_ARROKIE_Msk                      /*!< Autoreload register update OK Interrupt Enable */
+#define LPTIM_IER_UPIE_Pos          (5U)
+#define LPTIM_IER_UPIE_Msk          (0x1UL << LPTIM_IER_UPIE_Pos)              /*!< 0x00000020 */
+#define LPTIM_IER_UPIE              LPTIM_IER_UPIE_Msk                         /*!< Counter direction change down to up Interrupt Enable */
+#define LPTIM_IER_DOWNIE_Pos        (6U)
+#define LPTIM_IER_DOWNIE_Msk        (0x1UL << LPTIM_IER_DOWNIE_Pos)            /*!< 0x00000040 */
+#define LPTIM_IER_DOWNIE            LPTIM_IER_DOWNIE_Msk                       /*!< Counter direction change up to down Interrupt Enable */
+
+/******************  Bit definition for LPTIM_CFGR register *******************/
+#define LPTIM_CFGR_CKSEL_Pos        (0U)
+#define LPTIM_CFGR_CKSEL_Msk        (0x1UL << LPTIM_CFGR_CKSEL_Pos)            /*!< 0x00000001 */
+#define LPTIM_CFGR_CKSEL            LPTIM_CFGR_CKSEL_Msk                       /*!< Clock selector */
+
+#define LPTIM_CFGR_CKPOL_Pos        (1U)
+#define LPTIM_CFGR_CKPOL_Msk        (0x3UL << LPTIM_CFGR_CKPOL_Pos)            /*!< 0x00000006 */
+#define LPTIM_CFGR_CKPOL            LPTIM_CFGR_CKPOL_Msk                       /*!< CKPOL[1:0] bits (Clock polarity) */
+#define LPTIM_CFGR_CKPOL_0          (0x1U << LPTIM_CFGR_CKPOL_Pos)             /*!< 0x00000002 */
+#define LPTIM_CFGR_CKPOL_1          (0x2U << LPTIM_CFGR_CKPOL_Pos)             /*!< 0x00000004 */
+
+#define LPTIM_CFGR_CKFLT_Pos        (3U)
+#define LPTIM_CFGR_CKFLT_Msk        (0x3UL << LPTIM_CFGR_CKFLT_Pos)            /*!< 0x00000018 */
+#define LPTIM_CFGR_CKFLT            LPTIM_CFGR_CKFLT_Msk                       /*!< CKFLT[1:0] bits (Configurable digital filter for external clock) */
+#define LPTIM_CFGR_CKFLT_0          (0x1U << LPTIM_CFGR_CKFLT_Pos)             /*!< 0x00000008 */
+#define LPTIM_CFGR_CKFLT_1          (0x2U << LPTIM_CFGR_CKFLT_Pos)             /*!< 0x00000010 */
+
+#define LPTIM_CFGR_TRGFLT_Pos       (6U)
+#define LPTIM_CFGR_TRGFLT_Msk       (0x3UL << LPTIM_CFGR_TRGFLT_Pos)           /*!< 0x000000C0 */
+#define LPTIM_CFGR_TRGFLT           LPTIM_CFGR_TRGFLT_Msk                      /*!< TRGFLT[1:0] bits (Configurable digital filter for trigger) */
+#define LPTIM_CFGR_TRGFLT_0         (0x1U << LPTIM_CFGR_TRGFLT_Pos)            /*!< 0x00000040 */
+#define LPTIM_CFGR_TRGFLT_1         (0x2U << LPTIM_CFGR_TRGFLT_Pos)            /*!< 0x00000080 */
+
+#define LPTIM_CFGR_PRESC_Pos        (9U)
+#define LPTIM_CFGR_PRESC_Msk        (0x7UL << LPTIM_CFGR_PRESC_Pos)            /*!< 0x00000E00 */
+#define LPTIM_CFGR_PRESC            LPTIM_CFGR_PRESC_Msk                       /*!< PRESC[2:0] bits (Clock prescaler) */
+#define LPTIM_CFGR_PRESC_0          (0x1U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000200 */
+#define LPTIM_CFGR_PRESC_1          (0x2U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000400 */
+#define LPTIM_CFGR_PRESC_2          (0x4U << LPTIM_CFGR_PRESC_Pos)             /*!< 0x00000800 */
+
+#define LPTIM_CFGR_TRIGSEL_Pos      (13U)
+#define LPTIM_CFGR_TRIGSEL_Msk      (0x7UL << LPTIM_CFGR_TRIGSEL_Pos)          /*!< 0x0000E000 */
+#define LPTIM_CFGR_TRIGSEL          LPTIM_CFGR_TRIGSEL_Msk                     /*!< TRIGSEL[2:0]] bits (Trigger selector) */
+#define LPTIM_CFGR_TRIGSEL_0        (0x1U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00002000 */
+#define LPTIM_CFGR_TRIGSEL_1        (0x2U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00004000 */
+#define LPTIM_CFGR_TRIGSEL_2        (0x4U << LPTIM_CFGR_TRIGSEL_Pos)           /*!< 0x00008000 */
+
+#define LPTIM_CFGR_TRIGEN_Pos       (17U)
+#define LPTIM_CFGR_TRIGEN_Msk       (0x3UL << LPTIM_CFGR_TRIGEN_Pos)           /*!< 0x00060000 */
+#define LPTIM_CFGR_TRIGEN           LPTIM_CFGR_TRIGEN_Msk                      /*!< TRIGEN[1:0] bits (Trigger enable and polarity) */
+#define LPTIM_CFGR_TRIGEN_0         (0x1U << LPTIM_CFGR_TRIGEN_Pos)            /*!< 0x00020000 */
+#define LPTIM_CFGR_TRIGEN_1         (0x2U << LPTIM_CFGR_TRIGEN_Pos)            /*!< 0x00040000 */
+
+#define LPTIM_CFGR_TIMOUT_Pos       (19U)
+#define LPTIM_CFGR_TIMOUT_Msk       (0x1UL << LPTIM_CFGR_TIMOUT_Pos)           /*!< 0x00080000 */
+#define LPTIM_CFGR_TIMOUT           LPTIM_CFGR_TIMOUT_Msk                      /*!< Timeout enable */
+#define LPTIM_CFGR_WAVE_Pos         (20U)
+#define LPTIM_CFGR_WAVE_Msk         (0x1UL << LPTIM_CFGR_WAVE_Pos)             /*!< 0x00100000 */
+#define LPTIM_CFGR_WAVE             LPTIM_CFGR_WAVE_Msk                        /*!< Waveform shape */
+#define LPTIM_CFGR_WAVPOL_Pos       (21U)
+#define LPTIM_CFGR_WAVPOL_Msk       (0x1UL << LPTIM_CFGR_WAVPOL_Pos)           /*!< 0x00200000 */
+#define LPTIM_CFGR_WAVPOL           LPTIM_CFGR_WAVPOL_Msk                      /*!< Waveform shape polarity */
+#define LPTIM_CFGR_PRELOAD_Pos      (22U)
+#define LPTIM_CFGR_PRELOAD_Msk      (0x1UL << LPTIM_CFGR_PRELOAD_Pos)          /*!< 0x00400000 */
+#define LPTIM_CFGR_PRELOAD          LPTIM_CFGR_PRELOAD_Msk                     /*!< Reg update mode */
+#define LPTIM_CFGR_COUNTMODE_Pos    (23U)
+#define LPTIM_CFGR_COUNTMODE_Msk    (0x1UL << LPTIM_CFGR_COUNTMODE_Pos)        /*!< 0x00800000 */
+#define LPTIM_CFGR_COUNTMODE        LPTIM_CFGR_COUNTMODE_Msk                   /*!< Counter mode enable */
+#define LPTIM_CFGR_ENC_Pos          (24U)
+#define LPTIM_CFGR_ENC_Msk          (0x1UL << LPTIM_CFGR_ENC_Pos)              /*!< 0x01000000 */
+#define LPTIM_CFGR_ENC              LPTIM_CFGR_ENC_Msk                         /*!< Encoder mode enable */
+
+/******************  Bit definition for LPTIM_CR register  ********************/
+#define LPTIM_CR_ENABLE_Pos         (0U)
+#define LPTIM_CR_ENABLE_Msk         (0x1UL << LPTIM_CR_ENABLE_Pos)             /*!< 0x00000001 */
+#define LPTIM_CR_ENABLE             LPTIM_CR_ENABLE_Msk                        /*!< LPTIMer enable */
+#define LPTIM_CR_SNGSTRT_Pos        (1U)
+#define LPTIM_CR_SNGSTRT_Msk        (0x1UL << LPTIM_CR_SNGSTRT_Pos)            /*!< 0x00000002 */
+#define LPTIM_CR_SNGSTRT            LPTIM_CR_SNGSTRT_Msk                       /*!< Timer start in single mode */
+#define LPTIM_CR_CNTSTRT_Pos        (2U)
+#define LPTIM_CR_CNTSTRT_Msk        (0x1UL << LPTIM_CR_CNTSTRT_Pos)            /*!< 0x00000004 */
+#define LPTIM_CR_CNTSTRT            LPTIM_CR_CNTSTRT_Msk                       /*!< Timer start in continuous mode */
+#define LPTIM_CR_COUNTRST_Pos       (3U)
+#define LPTIM_CR_COUNTRST_Msk       (0x1UL << LPTIM_CR_COUNTRST_Pos)           /*!< 0x00000008 */
+#define LPTIM_CR_COUNTRST           LPTIM_CR_COUNTRST_Msk                      /*!< Counter reset */
+#define LPTIM_CR_RSTARE_Pos         (4U)
+#define LPTIM_CR_RSTARE_Msk         (0x1UL << LPTIM_CR_RSTARE_Pos)             /*!< 0x00000010 */
+#define LPTIM_CR_RSTARE             LPTIM_CR_RSTARE_Msk                        /*!< Reset after read enable */
+
+/******************  Bit definition for LPTIM_CMP register  *******************/
+#define LPTIM_CMP_CMP_Pos           (0U)
+#define LPTIM_CMP_CMP_Msk           (0xFFFFUL << LPTIM_CMP_CMP_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CMP_CMP               LPTIM_CMP_CMP_Msk                          /*!< Compare register */
+
+/******************  Bit definition for LPTIM_ARR register  *******************/
+#define LPTIM_ARR_ARR_Pos           (0U)
+#define LPTIM_ARR_ARR_Msk           (0xFFFFUL << LPTIM_ARR_ARR_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_ARR_ARR               LPTIM_ARR_ARR_Msk                          /*!< Auto reload register */
+
+/******************  Bit definition for LPTIM_CNT register  *******************/
+#define LPTIM_CNT_CNT_Pos           (0U)
+#define LPTIM_CNT_CNT_Msk           (0xFFFFUL << LPTIM_CNT_CNT_Pos)            /*!< 0x0000FFFF */
+#define LPTIM_CNT_CNT               LPTIM_CNT_CNT_Msk                          /*!< Counter register */
+
+/******************  Bit definition for LPTIM_OR register  *******************/
+#define LPTIM_OR_OR_Pos             (0U)
+#define LPTIM_OR_OR_Msk             (0x1UL << LPTIM_OR_OR_Pos)                 /*!< 0x00000001 */
+#define LPTIM_OR_OR                 LPTIM_OR_OR_Msk                            /*!< OR[1:0] bits (Remap selection) */
+#define LPTIM_OR_OR_0               (0x1U << LPTIM_OR_OR_Pos)                  /*!< 0x00000001 */
+
+/******************************************************************************/
+/*                                                                            */
+/*         Inter-Processor Communication Controller (IPCC)                    */
+/*                                                                            */
+/******************************************************************************/
+
+/**********************  Bit definition for IPCC_C1CR register  ***************/
+#define IPCC_C1CR_RXOIE_Pos      (0U)
+#define IPCC_C1CR_RXOIE_Msk      (0x1UL << IPCC_C1CR_RXOIE_Pos)                /*!< 0x00000001 */
+#define IPCC_C1CR_RXOIE          IPCC_C1CR_RXOIE_Msk                           /*!< Processor M4 Receive channel occupied interrupt enable */
+#define IPCC_C1CR_TXFIE_Pos      (16U)
+#define IPCC_C1CR_TXFIE_Msk      (0x1UL << IPCC_C1CR_TXFIE_Pos)                /*!< 0x00010000 */
+#define IPCC_C1CR_TXFIE          IPCC_C1CR_TXFIE_Msk                           /*!< Processor M4 Transmit channel free interrupt enable */
+
+/**********************  Bit definition for IPCC_C1MR register  **************/
+#define IPCC_C1MR_CH1OM_Pos      (0U)
+#define IPCC_C1MR_CH1OM_Msk      (0x1UL << IPCC_C1MR_CH1OM_Pos)                /*!< 0x00000001 */
+#define IPCC_C1MR_CH1OM          IPCC_C1MR_CH1OM_Msk                           /*!< M4 Channel1 occupied interrupt mask */
+#define IPCC_C1MR_CH2OM_Pos      (1U)
+#define IPCC_C1MR_CH2OM_Msk      (0x1UL << IPCC_C1MR_CH2OM_Pos)                /*!< 0x00000002 */
+#define IPCC_C1MR_CH2OM          IPCC_C1MR_CH2OM_Msk                           /*!< M4 Channel2 occupied interrupt mask */
+#define IPCC_C1MR_CH3OM_Pos      (2U)
+#define IPCC_C1MR_CH3OM_Msk      (0x1UL << IPCC_C1MR_CH3OM_Pos)                /*!< 0x00000004 */
+#define IPCC_C1MR_CH3OM          IPCC_C1MR_CH3OM_Msk                           /*!< M4 Channel3 occupied interrupt mask */
+#define IPCC_C1MR_CH4OM_Pos      (3U)
+#define IPCC_C1MR_CH4OM_Msk      (0x1UL << IPCC_C1MR_CH4OM_Pos)                /*!< 0x00000008 */
+#define IPCC_C1MR_CH4OM          IPCC_C1MR_CH4OM_Msk                           /*!< M4 Channel4 occupied interrupt mask */
+#define IPCC_C1MR_CH5OM_Pos      (4U)
+#define IPCC_C1MR_CH5OM_Msk      (0x1UL << IPCC_C1MR_CH5OM_Pos)                /*!< 0x00000010 */
+#define IPCC_C1MR_CH5OM          IPCC_C1MR_CH5OM_Msk                           /*!< M4 Channel5 occupied interrupt mask */
+#define IPCC_C1MR_CH6OM_Pos      (5U)
+#define IPCC_C1MR_CH6OM_Msk      (0x1UL << IPCC_C1MR_CH6OM_Pos)                /*!< 0x00000020 */
+#define IPCC_C1MR_CH6OM          IPCC_C1MR_CH6OM_Msk                           /*!< M4 Channel6 occupied interrupt mask */
+
+#define IPCC_C1MR_CH1FM_Pos      (16U)
+#define IPCC_C1MR_CH1FM_Msk      (0x1UL << IPCC_C1MR_CH1FM_Pos)                /*!< 0x00010000 */
+#define IPCC_C1MR_CH1FM          IPCC_C1MR_CH1FM_Msk                           /*!< M4 Transmit Channel1 free interrupt mask */
+#define IPCC_C1MR_CH2FM_Pos      (17U)
+#define IPCC_C1MR_CH2FM_Msk      (0x1UL << IPCC_C1MR_CH2FM_Pos)                /*!< 0x00020000 */
+#define IPCC_C1MR_CH2FM          IPCC_C1MR_CH2FM_Msk                           /*!< M4 Transmit Channel2 free interrupt mask */
+#define IPCC_C1MR_CH3FM_Pos      (18U)
+#define IPCC_C1MR_CH3FM_Msk      (0x1UL << IPCC_C1MR_CH3FM_Pos)                /*!< 0x00040000 */
+#define IPCC_C1MR_CH3FM          IPCC_C1MR_CH3FM_Msk                           /*!< M4 Transmit Channel3 free interrupt mask */
+#define IPCC_C1MR_CH4FM_Pos      (19U)
+#define IPCC_C1MR_CH4FM_Msk      (0x1UL << IPCC_C1MR_CH4FM_Pos)                /*!< 0x00080000 */
+#define IPCC_C1MR_CH4FM          IPCC_C1MR_CH4FM_Msk                           /*!< M4 Transmit Channel4 free interrupt mask */
+#define IPCC_C1MR_CH5FM_Pos      (20U)
+#define IPCC_C1MR_CH5FM_Msk      (0x1UL << IPCC_C1MR_CH5FM_Pos)                /*!< 0x00100000 */
+#define IPCC_C1MR_CH5FM          IPCC_C1MR_CH5FM_Msk                           /*!< M4 Transmit Channel5 free interrupt mask */
+#define IPCC_C1MR_CH6FM_Pos      (21U)
+#define IPCC_C1MR_CH6FM_Msk      (0x1UL << IPCC_C1MR_CH6FM_Pos)                /*!< 0x00200000 */
+#define IPCC_C1MR_CH6FM          IPCC_C1MR_CH6FM_Msk                           /*!< M4 Transmit Channel6 free interrupt mask */
+
+/**********************  Bit definition for IPCC_C1SCR register  ***************/
+#define IPCC_C1SCR_CH1C_Pos      (0U)
+#define IPCC_C1SCR_CH1C_Msk      (0x1UL << IPCC_C1SCR_CH1C_Pos)                /*!< 0x00000001 */
+#define IPCC_C1SCR_CH1C          IPCC_C1SCR_CH1C_Msk                           /*!< M4 receive Channel1 status clear */
+#define IPCC_C1SCR_CH2C_Pos      (1U)
+#define IPCC_C1SCR_CH2C_Msk      (0x1UL << IPCC_C1SCR_CH2C_Pos)                /*!< 0x00000002 */
+#define IPCC_C1SCR_CH2C          IPCC_C1SCR_CH2C_Msk                           /*!< M4 receive Channel2 status clear */
+#define IPCC_C1SCR_CH3C_Pos      (2U)
+#define IPCC_C1SCR_CH3C_Msk      (0x1UL << IPCC_C1SCR_CH3C_Pos)                /*!< 0x00000004 */
+#define IPCC_C1SCR_CH3C          IPCC_C1SCR_CH3C_Msk                           /*!< M4 receive Channel3 status clear */
+#define IPCC_C1SCR_CH4C_Pos      (3U)
+#define IPCC_C1SCR_CH4C_Msk      (0x1UL << IPCC_C1SCR_CH4C_Pos)                /*!< 0x00000008 */
+#define IPCC_C1SCR_CH4C          IPCC_C1SCR_CH4C_Msk                           /*!< M4 receive Channel4 status clear */
+#define IPCC_C1SCR_CH5C_Pos      (4U)
+#define IPCC_C1SCR_CH5C_Msk      (0x1UL << IPCC_C1SCR_CH5C_Pos)                /*!< 0x00000010 */
+#define IPCC_C1SCR_CH5C          IPCC_C1SCR_CH5C_Msk                           /*!< M4 receive Channel5 status clear */
+#define IPCC_C1SCR_CH6C_Pos      (5U)
+#define IPCC_C1SCR_CH6C_Msk      (0x1UL << IPCC_C1SCR_CH6C_Pos)                /*!< 0x00000020 */
+#define IPCC_C1SCR_CH6C          IPCC_C1SCR_CH6C_Msk                           /*!< M4 receive Channel6 status clear */
+
+#define IPCC_C1SCR_CH1S_Pos      (16U)
+#define IPCC_C1SCR_CH1S_Msk      (0x1UL << IPCC_C1SCR_CH1S_Pos)                /*!< 0x00010000 */
+#define IPCC_C1SCR_CH1S          IPCC_C1SCR_CH1S_Msk                           /*!< M4 transmit Channel1 status set */
+#define IPCC_C1SCR_CH2S_Pos      (17U)
+#define IPCC_C1SCR_CH2S_Msk      (0x1UL << IPCC_C1SCR_CH2S_Pos)                /*!< 0x00020000 */
+#define IPCC_C1SCR_CH2S          IPCC_C1SCR_CH2S_Msk                           /*!< M4 transmit Channel2 status set  */
+#define IPCC_C1SCR_CH3S_Pos      (18U)
+#define IPCC_C1SCR_CH3S_Msk      (0x1UL << IPCC_C1SCR_CH3S_Pos)                /*!< 0x00040000 */
+#define IPCC_C1SCR_CH3S          IPCC_C1SCR_CH3S_Msk                           /*!< M4 transmit Channel3 status set  */
+#define IPCC_C1SCR_CH4S_Pos      (19U)
+#define IPCC_C1SCR_CH4S_Msk      (0x1UL << IPCC_C1SCR_CH4S_Pos)                /*!< 0x00080000 */
+#define IPCC_C1SCR_CH4S          IPCC_C1SCR_CH4S_Msk                           /*!< M4 transmit Channel4 status set  */
+#define IPCC_C1SCR_CH5S_Pos      (20U)
+#define IPCC_C1SCR_CH5S_Msk      (0x1UL << IPCC_C1SCR_CH5S_Pos)                /*!< 0x00100000 */
+#define IPCC_C1SCR_CH5S          IPCC_C1SCR_CH5S_Msk                           /*!< M4 transmit Channel5 status set  */
+#define IPCC_C1SCR_CH6S_Pos      (21U)
+#define IPCC_C1SCR_CH6S_Msk      (0x1UL << IPCC_C1SCR_CH6S_Pos)                /*!< 0x00200000 */
+#define IPCC_C1SCR_CH6S          IPCC_C1SCR_CH6S_Msk                           /*!< M4 transmit Channel6 status set  */
+
+/**********************  Bit definition for IPCC_C1TOC2SR register  ***************/
+#define IPCC_C1TOC2SR_CH1F_Pos    (0U)
+#define IPCC_C1TOC2SR_CH1F_Msk    (0x1UL << IPCC_C1TOC2SR_CH1F_Pos)            /*!< 0x00000001 */
+#define IPCC_C1TOC2SR_CH1F        IPCC_C1TOC2SR_CH1F_Msk                       /*!< M4 transmit to M4 receive Channel1 status flag before masking */
+#define IPCC_C1TOC2SR_CH2F_Pos    (1U)
+#define IPCC_C1TOC2SR_CH2F_Msk    (0x1UL << IPCC_C1TOC2SR_CH2F_Pos)            /*!< 0x00000002 */
+#define IPCC_C1TOC2SR_CH2F        IPCC_C1TOC2SR_CH2F_Msk                       /*!< M4 transmit to M4 receive Channel2 status flag before masking */
+#define IPCC_C1TOC2SR_CH3F_Pos    (2U)
+#define IPCC_C1TOC2SR_CH3F_Msk    (0x1UL << IPCC_C1TOC2SR_CH3F_Pos)            /*!< 0x00000004 */
+#define IPCC_C1TOC2SR_CH3F        IPCC_C1TOC2SR_CH3F_Msk                       /*!< M4 transmit to M4 receive Channel3 status flag before masking */
+#define IPCC_C1TOC2SR_CH4F_Pos    (3U)
+#define IPCC_C1TOC2SR_CH4F_Msk    (0x1UL << IPCC_C1TOC2SR_CH4F_Pos)            /*!< 0x00000008 */
+#define IPCC_C1TOC2SR_CH4F        IPCC_C1TOC2SR_CH4F_Msk                       /*!< M4 transmit to M4 receive Channel4 status flag before masking */
+#define IPCC_C1TOC2SR_CH5F_Pos    (4U)
+#define IPCC_C1TOC2SR_CH5F_Msk    (0x1UL << IPCC_C1TOC2SR_CH5F_Pos)            /*!< 0x00000010 */
+#define IPCC_C1TOC2SR_CH5F        IPCC_C1TOC2SR_CH5F_Msk                       /*!< M4 transmit to M4 receive Channel5 status flag before masking */
+#define IPCC_C1TOC2SR_CH6F_Pos    (5U)
+#define IPCC_C1TOC2SR_CH6F_Msk    (0x1UL << IPCC_C1TOC2SR_CH6F_Pos)            /*!< 0x00000020 */
+#define IPCC_C1TOC2SR_CH6F        IPCC_C1TOC2SR_CH6F_Msk                       /*!< M4 transmit to M4 receive Channel6 status flag before masking */
+
+/**********************  Bit definition for IPCC_C2CR register  ***************/
+#define IPCC_C2CR_RXOIE_Pos      (0U)
+#define IPCC_C2CR_RXOIE_Msk      (0x1UL << IPCC_C2CR_RXOIE_Pos)                /*!< 0x00000001 */
+#define IPCC_C2CR_RXOIE          IPCC_C2CR_RXOIE_Msk                           /*!< Processor M0+ Receive channel occupied interrupt enable */
+#define IPCC_C2CR_TXFIE_Pos      (16U)
+#define IPCC_C2CR_TXFIE_Msk      (0x1UL << IPCC_C2CR_TXFIE_Pos)                /*!< 0x00010000 */
+#define IPCC_C2CR_TXFIE          IPCC_C2CR_TXFIE_Msk                           /*!< Processor M0+ Transmit channel free interrupt enable */
+
+/**********************  Bit definition for IPCC_C2MR register  ***************/
+#define IPCC_C2MR_CH1OM_Pos      (0U)
+#define IPCC_C2MR_CH1OM_Msk      (0x1UL << IPCC_C2MR_CH1OM_Pos)                /*!< 0x00000001 */
+#define IPCC_C2MR_CH1OM          IPCC_C2MR_CH1OM_Msk                           /*!< M0+ Channel1 occupied interrupt mask */
+#define IPCC_C2MR_CH2OM_Pos      (1U)
+#define IPCC_C2MR_CH2OM_Msk      (0x1UL << IPCC_C2MR_CH2OM_Pos)                /*!< 0x00000002 */
+#define IPCC_C2MR_CH2OM          IPCC_C2MR_CH2OM_Msk                           /*!< M0+ Channel2 occupied interrupt mask */
+#define IPCC_C2MR_CH3OM_Pos      (2U)
+#define IPCC_C2MR_CH3OM_Msk      (0x1UL << IPCC_C2MR_CH3OM_Pos)                /*!< 0x00000004 */
+#define IPCC_C2MR_CH3OM          IPCC_C2MR_CH3OM_Msk                           /*!< M0+ Channel3 occupied interrupt mask */
+#define IPCC_C2MR_CH4OM_Pos      (3U)
+#define IPCC_C2MR_CH4OM_Msk      (0x1UL << IPCC_C2MR_CH4OM_Pos)                /*!< 0x00000008 */
+#define IPCC_C2MR_CH4OM          IPCC_C2MR_CH4OM_Msk                           /*!< M0+ Channel4 occupied interrupt mask */
+#define IPCC_C2MR_CH5OM_Pos      (4U)
+#define IPCC_C2MR_CH5OM_Msk      (0x1UL << IPCC_C2MR_CH5OM_Pos)                /*!< 0x00000010 */
+#define IPCC_C2MR_CH5OM          IPCC_C2MR_CH5OM_Msk                           /*!< M0+ Channel5 occupied interrupt mask */
+#define IPCC_C2MR_CH6OM_Pos      (5U)
+#define IPCC_C2MR_CH6OM_Msk      (0x1UL << IPCC_C2MR_CH6OM_Pos)                /*!< 0x00000020 */
+#define IPCC_C2MR_CH6OM          IPCC_C2MR_CH6OM_Msk                           /*!< M0+ Channel6 occupied interrupt mask */
+
+#define IPCC_C2MR_CH1FM_Pos      (16U)
+#define IPCC_C2MR_CH1FM_Msk      (0x1UL << IPCC_C2MR_CH1FM_Pos)                /*!< 0x00010000 */
+#define IPCC_C2MR_CH1FM          IPCC_C2MR_CH1FM_Msk                           /*!< M0+ Transmit Channel1 free interrupt mask */
+#define IPCC_C2MR_CH2FM_Pos      (17U)
+#define IPCC_C2MR_CH2FM_Msk      (0x1UL << IPCC_C2MR_CH2FM_Pos)                /*!< 0x00020000 */
+#define IPCC_C2MR_CH2FM          IPCC_C2MR_CH2FM_Msk                           /*!< M0+ Transmit Channel2 free interrupt mask */
+#define IPCC_C2MR_CH3FM_Pos      (18U)
+#define IPCC_C2MR_CH3FM_Msk      (0x1UL << IPCC_C2MR_CH3FM_Pos)                /*!< 0x00040000 */
+#define IPCC_C2MR_CH3FM          IPCC_C2MR_CH3FM_Msk                           /*!< M0+ Transmit Channel3 free interrupt mask */
+#define IPCC_C2MR_CH4FM_Pos      (19U)
+#define IPCC_C2MR_CH4FM_Msk      (0x1UL << IPCC_C2MR_CH4FM_Pos)                /*!< 0x00080000 */
+#define IPCC_C2MR_CH4FM          IPCC_C2MR_CH4FM_Msk                           /*!< M0+ Transmit Channel4 free interrupt mask */
+#define IPCC_C2MR_CH5FM_Pos      (20U)
+#define IPCC_C2MR_CH5FM_Msk      (0x1UL << IPCC_C2MR_CH5FM_Pos)                /*!< 0x00100000 */
+#define IPCC_C2MR_CH5FM          IPCC_C2MR_CH5FM_Msk                           /*!< M0+ Transmit Channel5 free interrupt mask */
+#define IPCC_C2MR_CH6FM_Pos      (21U)
+#define IPCC_C2MR_CH6FM_Msk      (0x1UL << IPCC_C2MR_CH6FM_Pos)                /*!< 0x00200000 */
+#define IPCC_C2MR_CH6FM          IPCC_C2MR_CH6FM_Msk                           /*!< M0+ Transmit Channel6 free interrupt mask */
+
+/**********************  Bit definition for IPCC_C2SCR register  ***************/
+#define IPCC_C2SCR_CH1C_Pos      (0U)
+#define IPCC_C2SCR_CH1C_Msk      (0x1UL << IPCC_C2SCR_CH1C_Pos)                /*!< 0x00000001 */
+#define IPCC_C2SCR_CH1C          IPCC_C2SCR_CH1C_Msk                           /*!< M0+ receive Channel1 status clear */
+#define IPCC_C2SCR_CH2C_Pos      (1U)
+#define IPCC_C2SCR_CH2C_Msk      (0x1UL << IPCC_C2SCR_CH2C_Pos)                /*!< 0x00000002 */
+#define IPCC_C2SCR_CH2C          IPCC_C2SCR_CH2C_Msk                           /*!< M0+ receive Channel2 status clear */
+#define IPCC_C2SCR_CH3C_Pos      (2U)
+#define IPCC_C2SCR_CH3C_Msk      (0x1UL << IPCC_C2SCR_CH3C_Pos)                /*!< 0x00000004 */
+#define IPCC_C2SCR_CH3C          IPCC_C2SCR_CH3C_Msk                           /*!< M0+ receive Channel3 status clear */
+#define IPCC_C2SCR_CH4C_Pos      (3U)
+#define IPCC_C2SCR_CH4C_Msk      (0x1UL << IPCC_C2SCR_CH4C_Pos)                /*!< 0x00000008 */
+#define IPCC_C2SCR_CH4C          IPCC_C2SCR_CH4C_Msk                           /*!< M0+ receive Channel4 status clear */
+#define IPCC_C2SCR_CH5C_Pos      (4U)
+#define IPCC_C2SCR_CH5C_Msk      (0x1UL << IPCC_C2SCR_CH5C_Pos)                /*!< 0x00000010 */
+#define IPCC_C2SCR_CH5C          IPCC_C2SCR_CH5C_Msk                           /*!< M0+ receive Channel5 status clear */
+#define IPCC_C2SCR_CH6C_Pos      (5U)
+#define IPCC_C2SCR_CH6C_Msk      (0x1UL << IPCC_C2SCR_CH6C_Pos)                /*!< 0x00000020 */
+#define IPCC_C2SCR_CH6C          IPCC_C2SCR_CH6C_Msk                           /*!< M0+ receive Channel6 status clear */
+
+#define IPCC_C2SCR_CH1S_Pos      (16U)
+#define IPCC_C2SCR_CH1S_Msk      (0x1UL << IPCC_C2SCR_CH1S_Pos)                /*!< 0x00010000 */
+#define IPCC_C2SCR_CH1S          IPCC_C2SCR_CH1S_Msk                           /*!< M0+ transmit Channel1 status set  */
+#define IPCC_C2SCR_CH2S_Pos      (17U)
+#define IPCC_C2SCR_CH2S_Msk      (0x1UL << IPCC_C2SCR_CH2S_Pos)                /*!< 0x00020000 */
+#define IPCC_C2SCR_CH2S          IPCC_C2SCR_CH2S_Msk                           /*!< M0+ transmit Channel2 status set  */
+#define IPCC_C2SCR_CH3S_Pos      (18U)
+#define IPCC_C2SCR_CH3S_Msk      (0x1UL << IPCC_C2SCR_CH3S_Pos)                /*!< 0x00040000 */
+#define IPCC_C2SCR_CH3S          IPCC_C2SCR_CH3S_Msk                           /*!< M0+ transmit Channel3 status set  */
+#define IPCC_C2SCR_CH4S_Pos      (19U)
+#define IPCC_C2SCR_CH4S_Msk      (0x1UL << IPCC_C2SCR_CH4S_Pos)                /*!< 0x00080000 */
+#define IPCC_C2SCR_CH4S          IPCC_C2SCR_CH4S_Msk                           /*!< M0+ transmit Channel4 status set  */
+#define IPCC_C2SCR_CH5S_Pos      (20U)
+#define IPCC_C2SCR_CH5S_Msk      (0x1UL << IPCC_C2SCR_CH5S_Pos)                /*!< 0x00100000 */
+#define IPCC_C2SCR_CH5S          IPCC_C2SCR_CH5S_Msk                           /*!< M0+ transmit Channel5 status set  */
+#define IPCC_C2SCR_CH6S_Pos      (21U)
+#define IPCC_C2SCR_CH6S_Msk      (0x1UL << IPCC_C2SCR_CH6S_Pos)                /*!< 0x00200000 */
+#define IPCC_C2SCR_CH6S          IPCC_C2SCR_CH6S_Msk                           /*!< M0+ transmit Channel6 status set  */
+
+/**********************  Bit definition for IPCC_C2TOC1SR register  ***************/
+#define IPCC_C2TOC1SR_CH1F_Pos    (0U)
+#define IPCC_C2TOC1SR_CH1F_Msk    (0x1UL << IPCC_C2TOC1SR_CH1F_Pos)            /*!< 0x00000001 */
+#define IPCC_C2TOC1SR_CH1F        IPCC_C2TOC1SR_CH1F_Msk                       /*!< M0+ transmit to M0 receive Channel1 status flag before masking */
+#define IPCC_C2TOC1SR_CH2F_Pos    (1U)
+#define IPCC_C2TOC1SR_CH2F_Msk    (0x1UL << IPCC_C2TOC1SR_CH2F_Pos)            /*!< 0x00000002 */
+#define IPCC_C2TOC1SR_CH2F        IPCC_C2TOC1SR_CH2F_Msk                       /*!< M0+ transmit to M0 receive Channel2 status flag before masking */
+#define IPCC_C2TOC1SR_CH3F_Pos    (2U)
+#define IPCC_C2TOC1SR_CH3F_Msk    (0x1UL << IPCC_C2TOC1SR_CH3F_Pos)            /*!< 0x00000004 */
+#define IPCC_C2TOC1SR_CH3F        IPCC_C2TOC1SR_CH3F_Msk                       /*!< M0+ transmit to M0 receive Channel3 status flag before masking */
+#define IPCC_C2TOC1SR_CH4F_Pos    (3U)
+#define IPCC_C2TOC1SR_CH4F_Msk    (0x1UL << IPCC_C2TOC1SR_CH4F_Pos)            /*!< 0x00000008 */
+#define IPCC_C2TOC1SR_CH4F        IPCC_C2TOC1SR_CH4F_Msk                       /*!< M0+ transmit to M0 receive Channel4 status flag before masking */
+#define IPCC_C2TOC1SR_CH5F_Pos    (4U)
+#define IPCC_C2TOC1SR_CH5F_Msk    (0x1UL << IPCC_C2TOC1SR_CH5F_Pos)            /*!< 0x00000010 */
+#define IPCC_C2TOC1SR_CH5F        IPCC_C2TOC1SR_CH5F_Msk                       /*!< M0+ transmit to M0 receive Channel5 status flag before masking */
+#define IPCC_C2TOC1SR_CH6F_Pos    (5U)
+#define IPCC_C2TOC1SR_CH6F_Msk    (0x1UL << IPCC_C2TOC1SR_CH6F_Pos)            /*!< 0x00000020 */
+#define IPCC_C2TOC1SR_CH6F        IPCC_C2TOC1SR_CH6F_Msk                       /*!< M0+ transmit to M0 receive Channel6 status flag before masking */
+
+/**********************  Bit definition for IPCC_C1CR register  ***************/
+#define IPCC_CR_RXOIE_Pos         IPCC_C1CR_RXOIE_Pos
+#define IPCC_CR_RXOIE_Msk         IPCC_C1CR_RXOIE_Msk
+#define IPCC_CR_RXOIE             IPCC_C1CR_RXOIE
+#define IPCC_CR_TXFIE_Pos         IPCC_C1CR_TXFIE_Pos
+#define IPCC_CR_TXFIE_Msk         IPCC_C1CR_TXFIE_Msk
+#define IPCC_CR_TXFIE             IPCC_C1CR_TXFIE
+
+/**********************  Bit definition for IPCC_C1MR register  **************/
+#define IPCC_MR_CH1OM_Pos         IPCC_C1MR_CH1OM_Pos
+#define IPCC_MR_CH1OM_Msk         IPCC_C1MR_CH1OM_Msk
+#define IPCC_MR_CH1OM             IPCC_C1MR_CH1OM
+#define IPCC_MR_CH2OM_Pos         IPCC_C1MR_CH2OM_Pos
+#define IPCC_MR_CH2OM_Msk         IPCC_C1MR_CH2OM_Msk
+#define IPCC_MR_CH2OM             IPCC_C1MR_CH2OM
+#define IPCC_MR_CH3OM_Pos         IPCC_C1MR_CH3OM_Pos
+#define IPCC_MR_CH3OM_Msk         IPCC_C1MR_CH3OM_Msk
+#define IPCC_MR_CH3OM             IPCC_C1MR_CH3OM
+#define IPCC_MR_CH4OM_Pos         IPCC_C1MR_CH4OM_Pos
+#define IPCC_MR_CH4OM_Msk         IPCC_C1MR_CH4OM_Msk
+#define IPCC_MR_CH4OM             IPCC_C1MR_CH4OM
+#define IPCC_MR_CH5OM_Pos         IPCC_C1MR_CH5OM_Pos
+#define IPCC_MR_CH5OM_Msk         IPCC_C1MR_CH5OM_Msk
+#define IPCC_MR_CH5OM             IPCC_C1MR_CH5OM
+#define IPCC_MR_CH6OM_Pos         IPCC_C1MR_CH6OM_Pos
+#define IPCC_MR_CH6OM_Msk         IPCC_C1MR_CH6OM_Msk
+#define IPCC_MR_CH6OM             IPCC_C1MR_CH6OM
+
+#define IPCC_MR_CH1FM_Pos         IPCC_C1MR_CH1FM_Pos
+#define IPCC_MR_CH1FM_Msk         IPCC_C1MR_CH1FM_Msk
+#define IPCC_MR_CH1FM             IPCC_C1MR_CH1FM
+#define IPCC_MR_CH2FM_Pos         IPCC_C1MR_CH2FM_Pos
+#define IPCC_MR_CH2FM_Msk         IPCC_C1MR_CH2FM_Msk
+#define IPCC_MR_CH2FM             IPCC_C1MR_CH2FM
+#define IPCC_MR_CH3FM_Pos         IPCC_C1MR_CH3FM_Pos
+#define IPCC_MR_CH3FM_Msk         IPCC_C1MR_CH3FM_Msk
+#define IPCC_MR_CH3FM             IPCC_C1MR_CH3FM
+#define IPCC_MR_CH4FM_Pos         IPCC_C1MR_CH4FM_Pos
+#define IPCC_MR_CH4FM_Msk         IPCC_C1MR_CH4FM_Msk
+#define IPCC_MR_CH4FM             IPCC_C1MR_CH4FM
+#define IPCC_MR_CH5FM_Pos         IPCC_C1MR_CH5FM_Pos
+#define IPCC_MR_CH5FM_Msk         IPCC_C1MR_CH5FM_Msk
+#define IPCC_MR_CH5FM             IPCC_C1MR_CH5FM
+#define IPCC_MR_CH6FM_Pos         IPCC_C1MR_CH6FM_Pos
+#define IPCC_MR_CH6FM_Msk         IPCC_C1MR_CH6FM_Msk
+#define IPCC_MR_CH6FM             IPCC_C1MR_CH6FM
+
+/**********************  Bit definition for IPCC_C1SCR register  ***************/
+#define IPCC_SCR_CH1C_Pos         IPCC_C1SCR_CH1C_Pos
+#define IPCC_SCR_CH1C_Msk         IPCC_C1SCR_CH1C_Msk
+#define IPCC_SCR_CH1C             IPCC_C1SCR_CH1C
+#define IPCC_SCR_CH2C_Pos         IPCC_C1SCR_CH2C_Pos
+#define IPCC_SCR_CH2C_Msk         IPCC_C1SCR_CH2C_Msk
+#define IPCC_SCR_CH2C             IPCC_C1SCR_CH2C
+#define IPCC_SCR_CH3C_Pos         IPCC_C1SCR_CH3C_Pos
+#define IPCC_SCR_CH3C_Msk         IPCC_C1SCR_CH3C_Msk
+#define IPCC_SCR_CH3C             IPCC_C1SCR_CH3C
+#define IPCC_SCR_CH4C_Pos         IPCC_C1SCR_CH4C_Pos
+#define IPCC_SCR_CH4C_Msk         IPCC_C1SCR_CH4C_Msk
+#define IPCC_SCR_CH4C             IPCC_C1SCR_CH4C
+#define IPCC_SCR_CH5C_Pos         IPCC_C1SCR_CH5C_Pos
+#define IPCC_SCR_CH5C_Msk         IPCC_C1SCR_CH5C_Msk
+#define IPCC_SCR_CH5C             IPCC_C1SCR_CH5C
+#define IPCC_SCR_CH6C_Pos         IPCC_C1SCR_CH6C_Pos
+#define IPCC_SCR_CH6C_Msk         IPCC_C1SCR_CH6C_Msk
+#define IPCC_SCR_CH6C             IPCC_C1SCR_CH6C
+
+#define IPCC_SCR_CH1S_Pos         IPCC_C1SCR_CH1S_Pos
+#define IPCC_SCR_CH1S_Msk         IPCC_C1SCR_CH1S_Msk
+#define IPCC_SCR_CH1S             IPCC_C1SCR_CH1S
+#define IPCC_SCR_CH2S_Pos         IPCC_C1SCR_CH2S_Pos
+#define IPCC_SCR_CH2S_Msk         IPCC_C1SCR_CH2S_Msk
+#define IPCC_SCR_CH2S             IPCC_C1SCR_CH2S
+#define IPCC_SCR_CH3S_Pos         IPCC_C1SCR_CH3S_Pos
+#define IPCC_SCR_CH3S_Msk         IPCC_C1SCR_CH3S_Msk
+#define IPCC_SCR_CH3S             IPCC_C1SCR_CH3S
+#define IPCC_SCR_CH4S_Pos         IPCC_C1SCR_CH4S_Pos
+#define IPCC_SCR_CH4S_Msk         IPCC_C1SCR_CH4S_Msk
+#define IPCC_SCR_CH4S             IPCC_C1SCR_CH4S
+#define IPCC_SCR_CH5S_Pos         IPCC_C1SCR_CH5S_Pos
+#define IPCC_SCR_CH5S_Msk         IPCC_C1SCR_CH5S_Msk
+#define IPCC_SCR_CH5S             IPCC_C1SCR_CH5S
+#define IPCC_SCR_CH6S_Pos         IPCC_C1SCR_CH6S_Pos
+#define IPCC_SCR_CH6S_Msk         IPCC_C1SCR_CH6S_Msk
+#define IPCC_SCR_CH6S             IPCC_C1SCR_CH6S
+
+/**********************  Bit definition for IPCC_C1TOC2SR register  ***************/
+#define IPCC_SR_CH1F_Pos          IPCC_C1TOC2SR_CH1F_Pos
+#define IPCC_SR_CH1F_Msk          IPCC_C1TOC2SR_CH1F_Msk
+#define IPCC_SR_CH1F              IPCC_C1TOC2SR_CH1F
+#define IPCC_SR_CH2F_Pos          IPCC_C1TOC2SR_CH2F_Pos
+#define IPCC_SR_CH2F_Msk          IPCC_C1TOC2SR_CH2F_Msk
+#define IPCC_SR_CH2F              IPCC_C1TOC2SR_CH2F
+#define IPCC_SR_CH3F_Pos          IPCC_C1TOC2SR_CH3F_Pos
+#define IPCC_SR_CH3F_Msk          IPCC_C1TOC2SR_CH3F_Msk
+#define IPCC_SR_CH3F              IPCC_C1TOC2SR_CH3F
+#define IPCC_SR_CH4F_Pos          IPCC_C1TOC2SR_CH4F_Pos
+#define IPCC_SR_CH4F_Msk          IPCC_C1TOC2SR_CH4F_Msk
+#define IPCC_SR_CH4F              IPCC_C1TOC2SR_CH4F
+#define IPCC_SR_CH5F_Pos          IPCC_C1TOC2SR_CH5F_Pos
+#define IPCC_SR_CH5F_Msk          IPCC_C1TOC2SR_CH5F_Msk
+#define IPCC_SR_CH5F              IPCC_C1TOC2SR_CH5F
+#define IPCC_SR_CH6F_Pos          IPCC_C1TOC2SR_CH6F_Pos
+#define IPCC_SR_CH6F_Msk          IPCC_C1TOC2SR_CH6F_Msk
+#define IPCC_SR_CH6F              IPCC_C1TOC2SR_CH6F
+
+/******************** Number of IPCC channels ******************************/
+#define IPCC_CHANNEL_NUMBER       6U
+
+/******************************************************************************/
+/*                                                                            */
+/*      Universal Synchronous Asynchronous Receiver Transmitter (USART)       */
+/*                                                                            */
+/******************************************************************************/
+/******************  Bit definition for USART_CR1 register  *******************/
+#define USART_CR1_UE_Pos                (0U)
+#define USART_CR1_UE_Msk                (0x1UL << USART_CR1_UE_Pos)            /*!< 0x00000001 */
+#define USART_CR1_UE                    USART_CR1_UE_Msk                        /*!< USART Enable */
+#define USART_CR1_UESM_Pos              (1U)
+#define USART_CR1_UESM_Msk              (0x1UL << USART_CR1_UESM_Pos)           /*!< 0x00000002 */
+#define USART_CR1_UESM                  USART_CR1_UESM_Msk                      /*!< USART Enable in STOP Mode */
+#define USART_CR1_RE_Pos                (2U)
+#define USART_CR1_RE_Msk                (0x1UL << USART_CR1_RE_Pos)             /*!< 0x00000004 */
+#define USART_CR1_RE                    USART_CR1_RE_Msk                        /*!< Receiver Enable */
+#define USART_CR1_TE_Pos                (3U)
+#define USART_CR1_TE_Msk                (0x1UL << USART_CR1_TE_Pos)             /*!< 0x00000008 */
+#define USART_CR1_TE                    USART_CR1_TE_Msk                        /*!< Transmitter Enable */
+#define USART_CR1_IDLEIE_Pos            (4U)
+#define USART_CR1_IDLEIE_Msk            (0x1UL << USART_CR1_IDLEIE_Pos)         /*!< 0x00000010 */
+#define USART_CR1_IDLEIE                USART_CR1_IDLEIE_Msk                    /*!< IDLE Interrupt Enable */
+#define USART_CR1_RXNEIE_Pos            (5U)
+#define USART_CR1_RXNEIE_Msk            (0x1UL << USART_CR1_RXNEIE_Pos)         /*!< 0x00000020 */
+#define USART_CR1_RXNEIE                USART_CR1_RXNEIE_Msk                    /*!< RXNE Interrupt Enable */
+#define USART_CR1_RXNEIE_RXFNEIE_Pos    USART_CR1_RXNEIE_Pos
+#define USART_CR1_RXNEIE_RXFNEIE_Msk    USART_CR1_RXNEIE_Msk                    /*!< 0x00000020 */
+#define USART_CR1_RXNEIE_RXFNEIE        USART_CR1_RXNEIE_Msk                    /*!< RXNE and RX FIFO Not Empty Interrupt Enable */
+#define USART_CR1_TCIE_Pos              (6U)
+#define USART_CR1_TCIE_Msk              (0x1UL << USART_CR1_TCIE_Pos)           /*!< 0x00000040 */
+#define USART_CR1_TCIE                  USART_CR1_TCIE_Msk                      /*!< Transmission Complete Interrupt Enable */
+#define USART_CR1_TXEIE_Pos             (7U)
+#define USART_CR1_TXEIE_Msk             (0x1UL << USART_CR1_TXEIE_Pos)          /*!< 0x00000080 */
+#define USART_CR1_TXEIE                 USART_CR1_TXEIE_Msk                     /*!< TXE Interrupt Enable */
+#define USART_CR1_TXEIE_TXFNFIE_Pos     (7U)
+#define USART_CR1_TXEIE_TXFNFIE_Msk     (0x1UL << USART_CR1_TXEIE_Pos)          /*!< 0x00000080 */
+#define USART_CR1_TXEIE_TXFNFIE         USART_CR1_TXEIE                         /*!< TXE and TX FIFO Not Full Interrupt Enable */
+#define USART_CR1_PEIE_Pos              (8U)
+#define USART_CR1_PEIE_Msk              (0x1UL << USART_CR1_PEIE_Pos)           /*!< 0x00000100 */
+#define USART_CR1_PEIE                  USART_CR1_PEIE_Msk                      /*!< PE Interrupt Enable */
+#define USART_CR1_PS_Pos                (9U)
+#define USART_CR1_PS_Msk                (0x1UL << USART_CR1_PS_Pos)             /*!< 0x00000200 */
+#define USART_CR1_PS                    USART_CR1_PS_Msk                        /*!< Parity Selection */
+#define USART_CR1_PCE_Pos               (10U)
+#define USART_CR1_PCE_Msk               (0x1UL << USART_CR1_PCE_Pos)            /*!< 0x00000400 */
+#define USART_CR1_PCE                   USART_CR1_PCE_Msk                       /*!< Parity Control Enable */
+#define USART_CR1_WAKE_Pos              (11U)
+#define USART_CR1_WAKE_Msk              (0x1UL << USART_CR1_WAKE_Pos)           /*!< 0x00000800 */
+#define USART_CR1_WAKE                  USART_CR1_WAKE_Msk                      /*!< Receiver Wakeup method */
+#define USART_CR1_M0_Pos                (12U)
+#define USART_CR1_M0_Msk                (0x1UL << USART_CR1_M0_Pos)             /*!< 0x00001000 */
+#define USART_CR1_M0                    USART_CR1_M0_Msk                        /*!< Word length - Bit 0 */
+#define USART_CR1_MME_Pos               (13U)
+#define USART_CR1_MME_Msk               (0x1UL << USART_CR1_MME_Pos)            /*!< 0x00002000 */
+#define USART_CR1_MME                   USART_CR1_MME_Msk                       /*!< Mute Mode Enable */
+#define USART_CR1_CMIE_Pos              (14U)
+#define USART_CR1_CMIE_Msk              (0x1UL << USART_CR1_CMIE_Pos)           /*!< 0x00004000 */
+#define USART_CR1_CMIE                  USART_CR1_CMIE_Msk                      /*!< Character match interrupt enable */
+#define USART_CR1_OVER8_Pos             (15U)
+#define USART_CR1_OVER8_Msk             (0x1UL << USART_CR1_OVER8_Pos)          /*!< 0x00008000 */
+#define USART_CR1_OVER8                 USART_CR1_OVER8_Msk                     /*!< Oversampling by 8-bit or 16-bit mode */
+#define USART_CR1_DEDT_Pos              (16U)
+#define USART_CR1_DEDT_Msk              (0x1FUL << USART_CR1_DEDT_Pos)          /*!< 0x001F0000 */
+#define USART_CR1_DEDT                  USART_CR1_DEDT_Msk                      /*!< DEDT[4:0] bits (Driver Enable Deassertion Time) */
+#define USART_CR1_DEDT_0                (0x01U << USART_CR1_DEDT_Pos)           /*!< 0x00010000 */
+#define USART_CR1_DEDT_1                (0x02U << USART_CR1_DEDT_Pos)           /*!< 0x00020000 */
+#define USART_CR1_DEDT_2                (0x04U << USART_CR1_DEDT_Pos)           /*!< 0x00040000 */
+#define USART_CR1_DEDT_3                (0x08U << USART_CR1_DEDT_Pos)           /*!< 0x00080000 */
+#define USART_CR1_DEDT_4                (0x10U << USART_CR1_DEDT_Pos)           /*!< 0x00100000 */
+#define USART_CR1_DEAT_Pos              (21U)
+#define USART_CR1_DEAT_Msk              (0x1FUL << USART_CR1_DEAT_Pos)          /*!< 0x03E00000 */
+#define USART_CR1_DEAT                  USART_CR1_DEAT_Msk                      /*!< DEAT[4:0] bits (Driver Enable Assertion Time) */
+#define USART_CR1_DEAT_0                (0x01U << USART_CR1_DEAT_Pos)           /*!< 0x00200000 */
+#define USART_CR1_DEAT_1                (0x02U << USART_CR1_DEAT_Pos)           /*!< 0x00400000 */
+#define USART_CR1_DEAT_2                (0x04U << USART_CR1_DEAT_Pos)           /*!< 0x00800000 */
+#define USART_CR1_DEAT_3                (0x08U << USART_CR1_DEAT_Pos)           /*!< 0x01000000 */
+#define USART_CR1_DEAT_4                (0x10U << USART_CR1_DEAT_Pos)           /*!< 0x02000000 */
+#define USART_CR1_RTOIE_Pos             (26U)
+#define USART_CR1_RTOIE_Msk             (0x1UL << USART_CR1_RTOIE_Pos)          /*!< 0x04000000 */
+#define USART_CR1_RTOIE                 USART_CR1_RTOIE_Msk                     /*!< Receive Time Out Interrupt Enable */
+#define USART_CR1_EOBIE_Pos             (27U)
+#define USART_CR1_EOBIE_Msk             (0x1UL << USART_CR1_EOBIE_Pos)          /*!< 0x08000000 */
+#define USART_CR1_EOBIE                 USART_CR1_EOBIE_Msk                     /*!< End of Block Interrupt Enable */
+#define USART_CR1_M1_Pos                (28U)
+#define USART_CR1_M1_Msk                (0x1UL << USART_CR1_M1_Pos)             /*!< 0x10000000 */
+#define USART_CR1_M1                    USART_CR1_M1_Msk                        /*!< Word length - Bit 1 */
+#define USART_CR1_M                     (uint32_t)(USART_CR1_M1 | USART_CR1_M0) /*!< Word length */
+#define USART_CR1_FIFOEN_Pos            (29U)
+#define USART_CR1_FIFOEN_Msk            (0x1UL << USART_CR1_FIFOEN_Pos)         /*!< 0x20000000 */
+#define USART_CR1_FIFOEN                USART_CR1_FIFOEN_Msk                    /*!< FIFO mode enable */
+#define USART_CR1_TXFEIE_Pos            (30U)
+#define USART_CR1_TXFEIE_Msk            (0x1UL << USART_CR1_TXFEIE_Pos)         /*!< 0x40000000 */
+#define USART_CR1_TXFEIE                USART_CR1_TXFEIE_Msk                    /*!< TX FIFO Empty Interrupt Enable */
+#define USART_CR1_RXFFIE_Pos            (31U)
+#define USART_CR1_RXFFIE_Msk            (0x1UL << USART_CR1_RXFFIE_Pos)         /*!< 0x80000000 */
+#define USART_CR1_RXFFIE                USART_CR1_RXFFIE_Msk                    /*!< RX FIFO Full Interrupt Enable */
+
+/******************  Bit definition for USART_CR2 register  *******************/
+#define USART_CR2_SLVEN_Pos             (0U)
+#define USART_CR2_SLVEN_Msk             (0x1UL << USART_CR2_SLVEN_Pos)          /*!< 0x00000001 */
+#define USART_CR2_SLVEN                 USART_CR2_SLVEN_Msk                     /*!< Synchronous Slave mode enable */
+#define USART_CR2_DIS_NSS_Pos           (3U)
+#define USART_CR2_DIS_NSS_Msk           (0x1UL << USART_CR2_DIS_NSS_Pos)        /*!< 0x00000008 */
+#define USART_CR2_DIS_NSS               USART_CR2_DIS_NSS_Msk                   /*!< Slave Select (NSS) pin management */
+#define USART_CR2_ADDM7_Pos             (4U)
+#define USART_CR2_ADDM7_Msk             (0x1UL << USART_CR2_ADDM7_Pos)          /*!< 0x00000010 */
+#define USART_CR2_ADDM7                 USART_CR2_ADDM7_Msk                     /*!< 7-bit or 4-bit Address Detection */
+#define USART_CR2_LBDL_Pos              (5U)
+#define USART_CR2_LBDL_Msk              (0x1UL << USART_CR2_LBDL_Pos)           /*!< 0x00000020 */
+#define USART_CR2_LBDL                  USART_CR2_LBDL_Msk                      /*!< LIN Break Detection Length */
+#define USART_CR2_LBDIE_Pos             (6U)
+#define USART_CR2_LBDIE_Msk             (0x1UL << USART_CR2_LBDIE_Pos)          /*!< 0x00000040 */
+#define USART_CR2_LBDIE                 USART_CR2_LBDIE_Msk                     /*!< LIN Break Detection Interrupt Enable */
+#define USART_CR2_LBCL_Pos              (8U)
+#define USART_CR2_LBCL_Msk              (0x1UL << USART_CR2_LBCL_Pos)           /*!< 0x00000100 */
+#define USART_CR2_LBCL                  USART_CR2_LBCL_Msk                      /*!< Last Bit Clock pulse */
+#define USART_CR2_CPHA_Pos              (9U)
+#define USART_CR2_CPHA_Msk              (0x1UL << USART_CR2_CPHA_Pos)           /*!< 0x00000200 */
+#define USART_CR2_CPHA                  USART_CR2_CPHA_Msk                      /*!< Clock Phase */
+#define USART_CR2_CPOL_Pos              (10U)
+#define USART_CR2_CPOL_Msk              (0x1UL << USART_CR2_CPOL_Pos)           /*!< 0x00000400 */
+#define USART_CR2_CPOL                  USART_CR2_CPOL_Msk                      /*!< Clock Polarity */
+#define USART_CR2_CLKEN_Pos             (11U)
+#define USART_CR2_CLKEN_Msk             (0x1UL << USART_CR2_CLKEN_Pos)          /*!< 0x00000800 */
+#define USART_CR2_CLKEN                 USART_CR2_CLKEN_Msk                     /*!< Clock Enable */
+#define USART_CR2_STOP_Pos              (12U)
+#define USART_CR2_STOP_Msk              (0x3UL << USART_CR2_STOP_Pos)           /*!< 0x00003000 */
+#define USART_CR2_STOP                  USART_CR2_STOP_Msk                      /*!< STOP[1:0] bits (STOP bits) */
+#define USART_CR2_STOP_0                (0x1U << USART_CR2_STOP_Pos)            /*!< 0x00001000 */
+#define USART_CR2_STOP_1                (0x2U << USART_CR2_STOP_Pos)            /*!< 0x00002000 */
+#define USART_CR2_LINEN_Pos             (14U)
+#define USART_CR2_LINEN_Msk             (0x1UL << USART_CR2_LINEN_Pos)          /*!< 0x00004000 */
+#define USART_CR2_LINEN                 USART_CR2_LINEN_Msk                     /*!< LIN mode enable */
+#define USART_CR2_SWAP_Pos              (15U)
+#define USART_CR2_SWAP_Msk              (0x1UL << USART_CR2_SWAP_Pos)           /*!< 0x00008000 */
+#define USART_CR2_SWAP                  USART_CR2_SWAP_Msk                      /*!< SWAP TX/RX pins */
+#define USART_CR2_RXINV_Pos             (16U)
+#define USART_CR2_RXINV_Msk             (0x1UL << USART_CR2_RXINV_Pos)          /*!< 0x00010000 */
+#define USART_CR2_RXINV                 USART_CR2_RXINV_Msk                     /*!< RX pin active level inversion */
+#define USART_CR2_TXINV_Pos             (17U)
+#define USART_CR2_TXINV_Msk             (0x1UL << USART_CR2_TXINV_Pos)          /*!< 0x00020000 */
+#define USART_CR2_TXINV                 USART_CR2_TXINV_Msk                     /*!< TX pin active level inversion */
+#define USART_CR2_DATAINV_Pos           (18U)
+#define USART_CR2_DATAINV_Msk           (0x1UL << USART_CR2_DATAINV_Pos)        /*!< 0x00040000 */
+#define USART_CR2_DATAINV               USART_CR2_DATAINV_Msk                   /*!< Binary data inversion */
+#define USART_CR2_MSBFIRST_Pos          (19U)
+#define USART_CR2_MSBFIRST_Msk          (0x1UL << USART_CR2_MSBFIRST_Pos)       /*!< 0x00080000 */
+#define USART_CR2_MSBFIRST              USART_CR2_MSBFIRST_Msk                  /*!< Most Significant Bit First */
+#define USART_CR2_ABREN_Pos             (20U)
+#define USART_CR2_ABREN_Msk             (0x1UL << USART_CR2_ABREN_Pos)          /*!< 0x00100000 */
+#define USART_CR2_ABREN                 USART_CR2_ABREN_Msk                     /*!< Auto Baud-Rate Enable*/
+#define USART_CR2_ABRMODE_Pos           (21U)
+#define USART_CR2_ABRMODE_Msk           (0x3UL << USART_CR2_ABRMODE_Pos)        /*!< 0x00600000 */
+#define USART_CR2_ABRMODE               USART_CR2_ABRMODE_Msk                   /*!< ABRMOD[1:0] bits (Auto Baud-Rate Mode) */
+#define USART_CR2_ABRMODE_0             (0x1U << USART_CR2_ABRMODE_Pos)         /*!< 0x00200000 */
+#define USART_CR2_ABRMODE_1             (0x2U << USART_CR2_ABRMODE_Pos)         /*!< 0x00400000 */
+#define USART_CR2_RTOEN_Pos             (23U)
+#define USART_CR2_RTOEN_Msk             (0x1UL << USART_CR2_RTOEN_Pos)          /*!< 0x00800000 */
+#define USART_CR2_RTOEN                 USART_CR2_RTOEN_Msk                     /*!< Receiver Time-Out enable */
+#define USART_CR2_ADD_Pos               (24U)
+#define USART_CR2_ADD_Msk               (0xFFUL << USART_CR2_ADD_Pos)           /*!< 0xFF000000 */
+#define USART_CR2_ADD                   USART_CR2_ADD_Msk                       /*!< Address of the USART node */
+
+/******************  Bit definition for USART_CR3 register  *******************/
+#define USART_CR3_EIE_Pos               (0U)
+#define USART_CR3_EIE_Msk               (0x1UL << USART_CR3_EIE_Pos)            /*!< 0x00000001 */
+#define USART_CR3_EIE                   USART_CR3_EIE_Msk                       /*!< Error Interrupt Enable */
+#define USART_CR3_IREN_Pos              (1U)
+#define USART_CR3_IREN_Msk              (0x1UL << USART_CR3_IREN_Pos)           /*!< 0x00000002 */
+#define USART_CR3_IREN                  USART_CR3_IREN_Msk                      /*!< IrDA mode Enable */
+#define USART_CR3_IRLP_Pos              (2U)
+#define USART_CR3_IRLP_Msk              (0x1UL << USART_CR3_IRLP_Pos)           /*!< 0x00000004 */
+#define USART_CR3_IRLP                  USART_CR3_IRLP_Msk                      /*!< IrDA Low-Power */
+#define USART_CR3_HDSEL_Pos             (3U)
+#define USART_CR3_HDSEL_Msk             (0x1UL << USART_CR3_HDSEL_Pos)          /*!< 0x00000008 */
+#define USART_CR3_HDSEL                 USART_CR3_HDSEL_Msk                     /*!< Half-Duplex Selection */
+#define USART_CR3_NACK_Pos              (4U)
+#define USART_CR3_NACK_Msk              (0x1UL << USART_CR3_NACK_Pos)           /*!< 0x00000010 */
+#define USART_CR3_NACK                  USART_CR3_NACK_Msk                      /*!< SmartCard NACK enable */
+#define USART_CR3_SCEN_Pos              (5U)
+#define USART_CR3_SCEN_Msk              (0x1UL << USART_CR3_SCEN_Pos)           /*!< 0x00000020 */
+#define USART_CR3_SCEN                  USART_CR3_SCEN_Msk                      /*!< SmartCard mode enable */
+#define USART_CR3_DMAR_Pos              (6U)
+#define USART_CR3_DMAR_Msk              (0x1UL << USART_CR3_DMAR_Pos)           /*!< 0x00000040 */
+#define USART_CR3_DMAR                  USART_CR3_DMAR_Msk                      /*!< DMA Enable Receiver */
+#define USART_CR3_DMAT_Pos              (7U)
+#define USART_CR3_DMAT_Msk              (0x1UL << USART_CR3_DMAT_Pos)           /*!< 0x00000080 */
+#define USART_CR3_DMAT                  USART_CR3_DMAT_Msk                      /*!< DMA Enable Transmitter */
+#define USART_CR3_RTSE_Pos              (8U)
+#define USART_CR3_RTSE_Msk              (0x1UL << USART_CR3_RTSE_Pos)           /*!< 0x00000100 */
+#define USART_CR3_RTSE                  USART_CR3_RTSE_Msk                      /*!< RTS Enable */
+#define USART_CR3_CTSE_Pos              (9U)
+#define USART_CR3_CTSE_Msk              (0x1UL << USART_CR3_CTSE_Pos)           /*!< 0x00000200 */
+#define USART_CR3_CTSE                  USART_CR3_CTSE_Msk
+#define USART_CR3_CTSIE_Pos             (10U)
+#define USART_CR3_CTSIE_Msk             (0x1UL << USART_CR3_CTSIE_Pos)          /*!< 0x00000400 */
+#define USART_CR3_CTSIE                 USART_CR3_CTSIE_Msk                     /*!< CTS Interrupt Enable */
+#define USART_CR3_ONEBIT_Pos            (11U)
+#define USART_CR3_ONEBIT_Msk            (0x1UL << USART_CR3_ONEBIT_Pos)         /*!< 0x00000800 */
+#define USART_CR3_ONEBIT                USART_CR3_ONEBIT_Msk                    /*!< One sample bit method enable */
+#define USART_CR3_OVRDIS_Pos            (12U)
+#define USART_CR3_OVRDIS_Msk            (0x1UL << USART_CR3_OVRDIS_Pos)         /*!< 0x00001000 */
+#define USART_CR3_OVRDIS                USART_CR3_OVRDIS_Msk                    /*!< Overrun Disable */
+#define USART_CR3_DDRE_Pos              (13U)
+#define USART_CR3_DDRE_Msk              (0x1UL << USART_CR3_DDRE_Pos)           /*!< 0x00002000 */
+#define USART_CR3_DDRE                  USART_CR3_DDRE_Msk                      /*!< DMA Disable on Reception Error */
+#define USART_CR3_DEM_Pos               (14U)
+#define USART_CR3_DEM_Msk               (0x1UL << USART_CR3_DEM_Pos)            /*!< 0x00004000 */
+#define USART_CR3_DEM                   USART_CR3_DEM_Msk                       /*!< Driver Enable Mode */
+#define USART_CR3_DEP_Pos               (15U)
+#define USART_CR3_DEP_Msk               (0x1UL << USART_CR3_DEP_Pos)            /*!< 0x00008000 */
+#define USART_CR3_DEP                   USART_CR3_DEP_Msk                       /*!< Driver Enable Polarity Selection */
+#define USART_CR3_SCARCNT_Pos           (17U)
+#define USART_CR3_SCARCNT_Msk           (0x7UL << USART_CR3_SCARCNT_Pos)        /*!< 0x000E0000 */
+#define USART_CR3_SCARCNT               USART_CR3_SCARCNT_Msk                   /*!< SCARCNT[2:0] bits (SmartCard Auto-Retry Count) */
+#define USART_CR3_SCARCNT_0             (0x1U << USART_CR3_SCARCNT_Pos)         /*!< 0x00020000 */
+#define USART_CR3_SCARCNT_1             (0x2U << USART_CR3_SCARCNT_Pos)         /*!< 0x00040000 */
+#define USART_CR3_SCARCNT_2             (0x4U << USART_CR3_SCARCNT_Pos)         /*!< 0x00080000 */
+#define USART_CR3_WUS_Pos               (20U)
+#define USART_CR3_WUS_Msk               (0x3UL << USART_CR3_WUS_Pos)            /*!< 0x00300000 */
+#define USART_CR3_WUS                   USART_CR3_WUS_Msk                       /*!< WUS[1:0] bits (Wake UP Interrupt Flag Selection) */
+#define USART_CR3_WUS_0                 (0x1U << USART_CR3_WUS_Pos)             /*!< 0x00100000 */
+#define USART_CR3_WUS_1                 (0x2U << USART_CR3_WUS_Pos)             /*!< 0x00200000 */
+#define USART_CR3_WUFIE_Pos             (22U)
+#define USART_CR3_WUFIE_Msk             (0x1UL << USART_CR3_WUFIE_Pos)          /*!< 0x00400000 */
+#define USART_CR3_WUFIE                 USART_CR3_WUFIE_Msk                     /*!< Wake Up Interrupt Enable */
+#define USART_CR3_TXFTIE_Pos            (23U)
+#define USART_CR3_TXFTIE_Msk            (0x1UL << USART_CR3_TXFTIE_Pos)         /*!< 0x00800000 */
+#define USART_CR3_TXFTIE                USART_CR3_TXFTIE_Msk                    /*!< TX FIFO Threshold Interrupt Enable */
+#define USART_CR3_TCBGTIE_Pos           (24U)
+#define USART_CR3_TCBGTIE_Msk           (0x1UL << USART_CR3_TCBGTIE_Pos)        /*!< 0x01000000 */
+#define USART_CR3_TCBGTIE               USART_CR3_TCBGTIE_Msk                   /*!< Transmission Complete Before Guard Time Interrupt Enable */
+#define USART_CR3_RXFTCFG_Pos           (25U)
+#define USART_CR3_RXFTCFG_Msk           (0x7UL << USART_CR3_RXFTCFG_Pos)        /*!< 0x0E000000 */
+#define USART_CR3_RXFTCFG               USART_CR3_RXFTCFG_Msk                   /*!< RX FIFO Threshold Configuration */
+#define USART_CR3_RXFTCFG_0             (0x1U << USART_CR3_RXFTCFG_Pos)         /*!< 0x02000000 */
+#define USART_CR3_RXFTCFG_1             (0x2U << USART_CR3_RXFTCFG_Pos)         /*!< 0x04000000 */
+#define USART_CR3_RXFTCFG_2             (0x4U << USART_CR3_RXFTCFG_Pos)         /*!< 0x08000000 */
+#define USART_CR3_RXFTIE_Pos            (28U)
+#define USART_CR3_RXFTIE_Msk            (0x1UL << USART_CR3_RXFTIE_Pos)         /*!< 0x10000000 */
+#define USART_CR3_RXFTIE                USART_CR3_RXFTIE_Msk                    /*!< RX FIFO Threshold Interrupt Enable */
+#define USART_CR3_TXFTCFG_Pos           (29U)
+#define USART_CR3_TXFTCFG_Msk           (0x7UL << USART_CR3_TXFTCFG_Pos)        /*!< 0xE0000000 */
+#define USART_CR3_TXFTCFG               USART_CR3_TXFTCFG_Msk                   /*!< TX FIFO Threshold configuration */
+#define USART_CR3_TXFTCFG_0             (0x1U << USART_CR3_TXFTCFG_Pos)         /*!< 0x20000000 */
+#define USART_CR3_TXFTCFG_1             (0x2U << USART_CR3_TXFTCFG_Pos)         /*!< 0x40000000 */
+#define USART_CR3_TXFTCFG_2             (0x4U << USART_CR3_TXFTCFG_Pos)         /*!< 0x80000000 */
+
+/******************  Bit definition for USART_BRR register  *******************/
+#define USART_BRR_BRR                   ((uint16_t)0xFFFF)                      /*!< USART  Baud rate register [15:0] */
+
+/******************  Bit definition for USART_GTPR register  ******************/
+#define USART_GTPR_PSC_Pos              (0U)
+#define USART_GTPR_PSC_Msk              (0xFFUL << USART_GTPR_PSC_Pos)          /*!< 0x000000FF */
+#define USART_GTPR_PSC                  USART_GTPR_PSC_Msk                      /*!< PSC[7:0] bits (Prescaler value) */
+#define USART_GTPR_GT_Pos               (8U)
+#define USART_GTPR_GT_Msk               (0xFFUL << USART_GTPR_GT_Pos)           /*!< 0x0000FF00 */
+#define USART_GTPR_GT                   USART_GTPR_GT_Msk                       /*!< GT[7:0] bits (Guard time value) */
+
+/*******************  Bit definition for USART_RTOR register  *****************/
+#define USART_RTOR_RTO_Pos              (0U)
+#define USART_RTOR_RTO_Msk              (0xFFFFFFUL << USART_RTOR_RTO_Pos)      /*!< 0x00FFFFFF */
+#define USART_RTOR_RTO                  USART_RTOR_RTO_Msk                      /*!< Receiver Timeout Value */
+#define USART_RTOR_BLEN_Pos             (24U)
+#define USART_RTOR_BLEN_Msk             (0xFFUL << USART_RTOR_BLEN_Pos)         /*!< 0xFF000000 */
+#define USART_RTOR_BLEN                 USART_RTOR_BLEN_Msk                     /*!< Block Length */
+
+/*******************  Bit definition for USART_RQR register  ******************/
+#define USART_RQR_ABRRQ_Pos             (0U)
+#define USART_RQR_ABRRQ_Msk             (0x1UL << USART_RQR_ABRRQ_Pos)          /*!< 0x00000001 */
+#define USART_RQR_ABRRQ                 USART_RQR_ABRRQ_Msk                     /*!< Auto-Baud Rate Request */
+#define USART_RQR_SBKRQ_Pos             (1U)
+#define USART_RQR_SBKRQ_Msk             (0x1UL << USART_RQR_SBKRQ_Pos)          /*!< 0x00000002 */
+#define USART_RQR_SBKRQ                 USART_RQR_SBKRQ_Msk                     /*!< Send Break Request */
+#define USART_RQR_MMRQ_Pos              (2U)
+#define USART_RQR_MMRQ_Msk              (0x1UL << USART_RQR_MMRQ_Pos)           /*!< 0x00000004 */
+#define USART_RQR_MMRQ                  USART_RQR_MMRQ_Msk                      /*!< Mute Mode Request */
+#define USART_RQR_RXFRQ_Pos             (3U)
+#define USART_RQR_RXFRQ_Msk             (0x1UL << USART_RQR_RXFRQ_Pos)          /*!< 0x00000008 */
+#define USART_RQR_RXFRQ                 USART_RQR_RXFRQ_Msk                     /*!< Receive Data flush Request */
+#define USART_RQR_TXFRQ_Pos             (4U)
+#define USART_RQR_TXFRQ_Msk             (0x1UL << USART_RQR_TXFRQ_Pos)          /*!< 0x00000010 */
+#define USART_RQR_TXFRQ                 USART_RQR_TXFRQ_Msk                     /*!< Transmit Data flush Request */
+
+/*******************  Bit definition for USART_ISR register  ******************/
+#define USART_ISR_PE_Pos                (0U)
+#define USART_ISR_PE_Msk                (0x1UL << USART_ISR_PE_Pos)             /*!< 0x00000001 */
+#define USART_ISR_PE                    USART_ISR_PE_Msk                        /*!< Parity Error */
+#define USART_ISR_FE_Pos                (1U)
+#define USART_ISR_FE_Msk                (0x1UL << USART_ISR_FE_Pos)             /*!< 0x00000002 */
+#define USART_ISR_FE                    USART_ISR_FE_Msk                        /*!< Framing Error */
+#define USART_ISR_NE_Pos                (2U)
+#define USART_ISR_NE_Msk                (0x1UL << USART_ISR_NE_Pos)             /*!< 0x00000004 */
+#define USART_ISR_NE                    USART_ISR_NE_Msk                        /*!< START bit Noise Error detection Flag */
+#define USART_ISR_ORE_Pos               (3U)
+#define USART_ISR_ORE_Msk               (0x1UL << USART_ISR_ORE_Pos)            /*!< 0x00000008 */
+#define USART_ISR_ORE                   USART_ISR_ORE_Msk                       /*!< OverRun Error */
+#define USART_ISR_IDLE_Pos              (4U)
+#define USART_ISR_IDLE_Msk              (0x1UL << USART_ISR_IDLE_Pos)           /*!< 0x00000010 */
+#define USART_ISR_IDLE                  USART_ISR_IDLE_Msk                      /*!< IDLE line detected */
+#define USART_ISR_RXNE_Pos              (5U)
+#define USART_ISR_RXNE_Msk              (0x1UL << USART_ISR_RXNE_Pos)           /*!< 0x00000020 */
+#define USART_ISR_RXNE                  USART_ISR_RXNE_Msk                      /*!< Read Data Register Not Empty */
+#define USART_ISR_RXNE_RXFNE_Pos        USART_ISR_RXNE_Pos
+#define USART_ISR_RXNE_RXFNE_Msk        USART_ISR_RXNE_Msk                      /*!< 0x00000020 */
+#define USART_ISR_RXNE_RXFNE            USART_ISR_RXNE_Msk                      /*!< Read Data Register or RX FIFO Not Empty */
+#define USART_ISR_TC_Pos                (6U)
+#define USART_ISR_TC_Msk                (0x1UL << USART_ISR_TC_Pos)             /*!< 0x00000040 */
+#define USART_ISR_TC                    USART_ISR_TC_Msk                        /*!< Transmission Complete */
+#define USART_ISR_TXE_Pos               (7U)
+#define USART_ISR_TXE_Msk               (0x1UL << USART_ISR_TXE_Pos)            /*!< 0x00000080 */
+#define USART_ISR_TXE                   USART_ISR_TXE_Msk                       /*!< Transmit Data Register Empty */
+#define USART_ISR_TXE_TXFNF_Pos         USART_ISR_TXE_Pos
+#define USART_ISR_TXE_TXFNF_Msk         USART_ISR_TXE_Msk                       /*!< 0x00000080 */
+#define USART_ISR_TXE_TXFNF             USART_ISR_TXE_Msk                       /*!< Transmit Data Register Empty or TX FIFO Not Full Flag */
+#define USART_ISR_LBDF_Pos              (8U)
+#define USART_ISR_LBDF_Msk              (0x1UL << USART_ISR_LBDF_Pos)           /*!< 0x00000100 */
+#define USART_ISR_LBDF                  USART_ISR_LBDF_Msk                      /*!< LIN Break Detection Flag */
+#define USART_ISR_CTSIF_Pos             (9U)
+#define USART_ISR_CTSIF_Msk             (0x1UL << USART_ISR_CTSIF_Pos)          /*!< 0x00000200 */
+#define USART_ISR_CTSIF                 USART_ISR_CTSIF_Msk                     /*!< CTS interrupt Flag */
+#define USART_ISR_CTS_Pos               (10U)
+#define USART_ISR_CTS_Msk               (0x1UL << USART_ISR_CTS_Pos)            /*!< 0x00000400 */
+#define USART_ISR_CTS                   USART_ISR_CTS_Msk                       /*!< CTS Flag */
+#define USART_ISR_RTOF_Pos              (11U)
+#define USART_ISR_RTOF_Msk              (0x1UL << USART_ISR_RTOF_Pos)           /*!< 0x00000800 */
+#define USART_ISR_RTOF                  USART_ISR_RTOF_Msk                      /*!< Receiver Timeout */
+#define USART_ISR_EOBF_Pos              (12U)
+#define USART_ISR_EOBF_Msk              (0x1UL << USART_ISR_EOBF_Pos)           /*!< 0x00001000 */
+#define USART_ISR_EOBF                  USART_ISR_EOBF_Msk                      /*!< End Of Block Flag */
+#define USART_ISR_UDR_Pos               (13U)
+#define USART_ISR_UDR_Msk               (0x1UL << USART_ISR_UDR_Pos)            /*!< 0x00002000 */
+#define USART_ISR_UDR                   USART_ISR_UDR_Msk                       /*!< SPI Slave Underrun error Flag */
+#define USART_ISR_ABRE_Pos              (14U)
+#define USART_ISR_ABRE_Msk              (0x1UL << USART_ISR_ABRE_Pos)           /*!< 0x00004000 */
+#define USART_ISR_ABRE                  USART_ISR_ABRE_Msk                      /*!< Auto-Baud Rate Error */
+#define USART_ISR_ABRF_Pos              (15U)
+#define USART_ISR_ABRF_Msk              (0x1UL << USART_ISR_ABRF_Pos)           /*!< 0x00008000 */
+#define USART_ISR_ABRF                  USART_ISR_ABRF_Msk                      /*!< Auto-Baud Rate Flag */
+#define USART_ISR_BUSY_Pos              (16U)
+#define USART_ISR_BUSY_Msk              (0x1UL << USART_ISR_BUSY_Pos)           /*!< 0x00010000 */
+#define USART_ISR_BUSY                  USART_ISR_BUSY_Msk                      /*!< Busy Flag */
+#define USART_ISR_CMF_Pos               (17U)
+#define USART_ISR_CMF_Msk               (0x1UL << USART_ISR_CMF_Pos)            /*!< 0x00020000 */
+#define USART_ISR_CMF                   USART_ISR_CMF_Msk                       /*!< Character Match Flag */
+#define USART_ISR_SBKF_Pos              (18U)
+#define USART_ISR_SBKF_Msk              (0x1UL << USART_ISR_SBKF_Pos)           /*!< 0x00040000 */
+#define USART_ISR_SBKF                  USART_ISR_SBKF_Msk                      /*!< Send Break Flag */
+#define USART_ISR_RWU_Pos               (19U)
+#define USART_ISR_RWU_Msk               (0x1UL << USART_ISR_RWU_Pos)            /*!< 0x00080000 */
+#define USART_ISR_RWU                   USART_ISR_RWU_Msk                       /*!< Receive Wake Up from mute mode Flag */
+#define USART_ISR_WUF_Pos               (20U)
+#define USART_ISR_WUF_Msk               (0x1UL << USART_ISR_WUF_Pos)            /*!< 0x00100000 */
+#define USART_ISR_WUF                   USART_ISR_WUF_Msk                       /*!< Wake Up from stop mode Flag */
+#define USART_ISR_TEACK_Pos             (21U)
+#define USART_ISR_TEACK_Msk             (0x1UL << USART_ISR_TEACK_Pos)          /*!< 0x00200000 */
+#define USART_ISR_TEACK                 USART_ISR_TEACK_Msk                     /*!< Transmit Enable Acknowledge Flag */
+#define USART_ISR_REACK_Pos             (22U)
+#define USART_ISR_REACK_Msk             (0x1UL << USART_ISR_REACK_Pos)          /*!< 0x00400000 */
+#define USART_ISR_REACK                 USART_ISR_REACK_Msk                     /*!< Receive Enable Acknowledge Flag */
+#define USART_ISR_TXFE_Pos              (23U)
+#define USART_ISR_TXFE_Msk              (0x1UL << USART_ISR_TXFE_Pos)           /*!< 0x00800000 */
+#define USART_ISR_TXFE                  USART_ISR_TXFE_Msk                      /*!< TX FIFO Empty Flag */
+#define USART_ISR_RXFF_Pos              (24U)
+#define USART_ISR_RXFF_Msk              (0x1UL << USART_ISR_RXFF_Pos)           /*!< 0x01000000 */
+#define USART_ISR_RXFF                  USART_ISR_RXFF_Msk                      /*!< RX FIFO Full Flag */
+#define USART_ISR_TCBGT_Pos             (25U)
+#define USART_ISR_TCBGT_Msk             (0x1UL << USART_ISR_TCBGT_Pos)          /*!< 0x02000000 */
+#define USART_ISR_TCBGT                 USART_ISR_TCBGT_Msk                     /*!< Transmission Complete Before Guard Time completion */
+#define USART_ISR_RXFT_Pos              (26U)
+#define USART_ISR_RXFT_Msk              (0x1UL << USART_ISR_RXFT_Pos)           /*!< 0x04000000 */
+#define USART_ISR_RXFT                  USART_ISR_RXFT_Msk                      /*!< RX FIFO Threshold Flag */
+#define USART_ISR_TXFT_Pos              (27U)
+#define USART_ISR_TXFT_Msk              (0x1UL << USART_ISR_TXFT_Pos)           /*!< 0x08000000 */
+#define USART_ISR_TXFT                  USART_ISR_TXFT_Msk                      /*!< TX FIFO Threshold Flag */
+
+/*******************  Bit definition for USART_ICR register  ******************/
+#define USART_ICR_PECF_Pos              (0U)
+#define USART_ICR_PECF_Msk              (0x1UL << USART_ICR_PECF_Pos)           /*!< 0x00000001 */
+#define USART_ICR_PECF                  USART_ICR_PECF_Msk                      /*!< Parity Error Clear Flag */
+#define USART_ICR_FECF_Pos              (1U)
+#define USART_ICR_FECF_Msk              (0x1UL << USART_ICR_FECF_Pos)           /*!< 0x00000002 */
+#define USART_ICR_FECF                  USART_ICR_FECF_Msk                      /*!< Framing Error Clear Flag */
+#define USART_ICR_NECF_Pos              (2U)
+#define USART_ICR_NECF_Msk              (0x1UL << USART_ICR_NECF_Pos)           /*!< 0x00000004 */
+#define USART_ICR_NECF                  USART_ICR_NECF_Msk                      /*!< Noise Error detected Clear Flag */
+#define USART_ICR_ORECF_Pos             (3U)
+#define USART_ICR_ORECF_Msk             (0x1UL << USART_ICR_ORECF_Pos)          /*!< 0x00000008 */
+#define USART_ICR_ORECF                 USART_ICR_ORECF_Msk                     /*!< OverRun Error Clear Flag */
+#define USART_ICR_IDLECF_Pos            (4U)
+#define USART_ICR_IDLECF_Msk            (0x1UL << USART_ICR_IDLECF_Pos)         /*!< 0x00000010 */
+#define USART_ICR_IDLECF                USART_ICR_IDLECF_Msk                    /*!< IDLE line detected Clear Flag */
+#define USART_ICR_TXFECF_Pos            (5U)
+#define USART_ICR_TXFECF_Msk            (0x1UL << USART_ICR_TXFECF_Pos)         /*!< 0x00000020 */
+#define USART_ICR_TXFECF                USART_ICR_TXFECF_Msk                    /*!< TX FIFO Empty Clear Flag */
+#define USART_ICR_TCCF_Pos              (6U)
+#define USART_ICR_TCCF_Msk              (0x1UL << USART_ICR_TCCF_Pos)           /*!< 0x00000040 */
+#define USART_ICR_TCCF                  USART_ICR_TCCF_Msk                      /*!< Transmission Complete Clear Flag */
+#define USART_ICR_TCBGTCF_Pos           (7U)
+#define USART_ICR_TCBGTCF_Msk           (0x1UL << USART_ICR_TCBGTCF_Pos)        /*!< 0x00000080 */
+#define USART_ICR_TCBGTCF               USART_ICR_TCBGTCF_Msk                   /*!< Transmission Complete Before Guard Time Clear Flag */
+#define USART_ICR_LBDCF_Pos             (8U)
+#define USART_ICR_LBDCF_Msk             (0x1UL << USART_ICR_LBDCF_Pos)          /*!< 0x00000100 */
+#define USART_ICR_LBDCF                 USART_ICR_LBDCF_Msk                     /*!< LIN Break Detection Clear Flag */
+#define USART_ICR_CTSCF_Pos             (9U)
+#define USART_ICR_CTSCF_Msk             (0x1UL << USART_ICR_CTSCF_Pos)          /*!< 0x00000200 */
+#define USART_ICR_CTSCF                 USART_ICR_CTSCF_Msk                     /*!< CTS Interrupt Clear Flag */
+#define USART_ICR_RTOCF_Pos             (11U)
+#define USART_ICR_RTOCF_Msk             (0x1UL << USART_ICR_RTOCF_Pos)          /*!< 0x00000800 */
+#define USART_ICR_RTOCF                 USART_ICR_RTOCF_Msk                     /*!< Receiver Time Out Clear Flag */
+#define USART_ICR_EOBCF_Pos             (12U)
+#define USART_ICR_EOBCF_Msk             (0x1UL << USART_ICR_EOBCF_Pos)          /*!< 0x00001000 */
+#define USART_ICR_EOBCF                 USART_ICR_EOBCF_Msk                     /*!< End Of Block Clear Flag */
+#define USART_ICR_UDRCF_Pos             (13U)
+#define USART_ICR_UDRCF_Msk             (0x1UL << USART_ICR_UDRCF_Pos)          /*!< 0x00002000 */
+#define USART_ICR_UDRCF                 USART_ICR_UDRCF_Msk                     /*!< SPI Slave Underrun Clear Flag */
+#define USART_ICR_CMCF_Pos              (17U)
+#define USART_ICR_CMCF_Msk              (0x1UL << USART_ICR_CMCF_Pos)           /*!< 0x00020000 */
+#define USART_ICR_CMCF                  USART_ICR_CMCF_Msk                      /*!< Character Match Clear Flag */
+#define USART_ICR_WUCF_Pos              (20U)
+#define USART_ICR_WUCF_Msk              (0x1UL << USART_ICR_WUCF_Pos)           /*!< 0x00100000 */
+#define USART_ICR_WUCF                  USART_ICR_WUCF_Msk                      /*!< Wake Up from stop mode Clear Flag */
+
+/*******************  Bit definition for USART_RDR register  ******************/
+#define USART_RDR_RDR_Pos               (0U)
+#define USART_RDR_RDR_Msk               (0x01FFUL << USART_RDR_RDR_Pos)         /*!< 0x000001FF */
+#define USART_RDR_RDR                   USART_RDR_RDR_Msk                       /*!< RDR[8:0] bits (Receive Data value) */
+
+/*******************  Bit definition for USART_TDR register  ******************/
+#define USART_TDR_TDR_Pos               (0U)
+#define USART_TDR_TDR_Msk               (0x01FFUL << USART_TDR_TDR_Pos)         /*!< 0x000001FF */
+#define USART_TDR_TDR                   USART_TDR_TDR_Msk                       /*!< TDR[8:0] bits (Transmit Data value) */
+
+/*******************  Bit definition for USART_PRESC register  ******************/
+#define USART_PRESC_PRESCALER_Pos       (0U)
+#define USART_PRESC_PRESCALER_Msk       (0xFUL << USART_PRESC_PRESCALER_Pos)    /*!< 0x0000000F */
+#define USART_PRESC_PRESCALER           USART_PRESC_PRESCALER_Msk               /*!< PRESCALER[3:0] bits (Clock prescaler) */
+#define USART_PRESC_PRESCALER_0         (0x1U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000001 */
+#define USART_PRESC_PRESCALER_1         (0x2U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000002 */
+#define USART_PRESC_PRESCALER_2         (0x4U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000004 */
+#define USART_PRESC_PRESCALER_3         (0x8U << USART_PRESC_PRESCALER_Pos)     /*!< 0x00000008 */
+
+/******************************************************************************/
+/*                                                                            */
+/*                            Window WATCHDOG                                 */
+/*                                                                            */
+/******************************************************************************/
+/*******************  Bit definition for WWDG_CR register  ********************/
+#define WWDG_CR_T_Pos           (0U)
+#define WWDG_CR_T_Msk           (0x7FUL << WWDG_CR_T_Pos)                      /*!< 0x0000007F */
+#define WWDG_CR_T               WWDG_CR_T_Msk                                  /*!<T[6:0] bits (7-Bit counter (MSB to LSB)) */
+#define WWDG_CR_T_0             (0x01U << WWDG_CR_T_Pos)                       /*!< 0x00000001 */
+#define WWDG_CR_T_1             (0x02U << WWDG_CR_T_Pos)                       /*!< 0x00000002 */
+#define WWDG_CR_T_2             (0x04U << WWDG_CR_T_Pos)                       /*!< 0x00000004 */
+#define WWDG_CR_T_3             (0x08U << WWDG_CR_T_Pos)                       /*!< 0x00000008 */
+#define WWDG_CR_T_4             (0x10U << WWDG_CR_T_Pos)                       /*!< 0x00000010 */
+#define WWDG_CR_T_5             (0x20U << WWDG_CR_T_Pos)                       /*!< 0x00000020 */
+#define WWDG_CR_T_6             (0x40U << WWDG_CR_T_Pos)                       /*!< 0x00000040 */
+
+#define WWDG_CR_WDGA_Pos        (7U)
+#define WWDG_CR_WDGA_Msk        (0x1UL << WWDG_CR_WDGA_Pos)                    /*!< 0x00000080 */
+#define WWDG_CR_WDGA            WWDG_CR_WDGA_Msk                               /*!<Activation bit */
+
+/*******************  Bit definition for WWDG_CFR register  *******************/
+#define WWDG_CFR_W_Pos          (0U)
+#define WWDG_CFR_W_Msk          (0x7FUL << WWDG_CFR_W_Pos)                     /*!< 0x0000007F */
+#define WWDG_CFR_W              WWDG_CFR_W_Msk                                 /*!<W[6:0] bits (7-bit window value) */
+#define WWDG_CFR_W_0            (0x01U << WWDG_CFR_W_Pos)                      /*!< 0x00000001 */
+#define WWDG_CFR_W_1            (0x02U << WWDG_CFR_W_Pos)                      /*!< 0x00000002 */
+#define WWDG_CFR_W_2            (0x04U << WWDG_CFR_W_Pos)                      /*!< 0x00000004 */
+#define WWDG_CFR_W_3            (0x08U << WWDG_CFR_W_Pos)                      /*!< 0x00000008 */
+#define WWDG_CFR_W_4            (0x10U << WWDG_CFR_W_Pos)                      /*!< 0x00000010 */
+#define WWDG_CFR_W_5            (0x20U << WWDG_CFR_W_Pos)                      /*!< 0x00000020 */
+#define WWDG_CFR_W_6            (0x40U << WWDG_CFR_W_Pos)                      /*!< 0x00000040 */
+
+#define WWDG_CFR_WDGTB_Pos      (11U)
+#define WWDG_CFR_WDGTB_Msk      (0x7UL << WWDG_CFR_WDGTB_Pos)                  /*!< 0x00003800 */
+#define WWDG_CFR_WDGTB          WWDG_CFR_WDGTB_Msk                             /*!<WDGTB[2:0] bits (Timer Base) */
+#define WWDG_CFR_WDGTB_0        (0x1U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00000800 */
+#define WWDG_CFR_WDGTB_1        (0x2U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00001000 */
+#define WWDG_CFR_WDGTB_2        (0x4U << WWDG_CFR_WDGTB_Pos)                   /*!< 0x00002000 */
+
+#define WWDG_CFR_EWI_Pos        (9U)
+#define WWDG_CFR_EWI_Msk        (0x1UL << WWDG_CFR_EWI_Pos)                    /*!< 0x00000200 */
+#define WWDG_CFR_EWI            WWDG_CFR_EWI_Msk                               /*!<Early Wakeup Interrupt */
+
+/*******************  Bit definition for WWDG_SR register  ********************/
+#define WWDG_SR_EWIF_Pos        (0U)
+#define WWDG_SR_EWIF_Msk        (0x1UL << WWDG_SR_EWIF_Pos)                    /*!< 0x00000001 */
+#define WWDG_SR_EWIF            WWDG_SR_EWIF_Msk                               /*!<Early Wakeup Interrupt Flag */
+
+/******************************************************************************/
+/*                                                                            */
+/*                                Debug MCU                                   */
+/*                                                                            */
+/******************************************************************************/
+/********************  Bit definition for DBGMCU_IDCODE register  *************/
+#define DBGMCU_IDCODE_DEV_ID_Pos                          (0U)
+#define DBGMCU_IDCODE_DEV_ID_Msk                          (0xFFFUL << DBGMCU_IDCODE_DEV_ID_Pos) /*!< 0x00000FFF */
+#define DBGMCU_IDCODE_DEV_ID                              DBGMCU_IDCODE_DEV_ID_Msk
+#define DBGMCU_IDCODE_REV_ID_Pos                          (16U)
+#define DBGMCU_IDCODE_REV_ID_Msk                          (0xFFFFUL << DBGMCU_IDCODE_REV_ID_Pos) /*!< 0xFFFF0000 */
+#define DBGMCU_IDCODE_REV_ID                              DBGMCU_IDCODE_REV_ID_Msk
+
+/********************  Bit definition for DBGMCU_CR register  *****************/
+#define DBGMCU_CR_DBG_SLEEP_Pos                           (0U)
+#define DBGMCU_CR_DBG_SLEEP_Msk                           (0x1UL << DBGMCU_CR_DBG_SLEEP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_CR_DBG_SLEEP                               DBGMCU_CR_DBG_SLEEP_Msk
+#define DBGMCU_CR_DBG_STOP_Pos                            (1U)
+#define DBGMCU_CR_DBG_STOP_Msk                            (0x1UL << DBGMCU_CR_DBG_STOP_Pos)   /*!< 0x00000002 */
+#define DBGMCU_CR_DBG_STOP                                DBGMCU_CR_DBG_STOP_Msk
+#define DBGMCU_CR_DBG_STANDBY_Pos                         (2U)
+#define DBGMCU_CR_DBG_STANDBY_Msk                         (0x1UL << DBGMCU_CR_DBG_STANDBY_Pos) /*!< 0x00000004 */
+#define DBGMCU_CR_DBG_STANDBY                             DBGMCU_CR_DBG_STANDBY_Msk
+#define DBGMCU_CR_TRACE_IOEN_Pos                          (5U)
+#define DBGMCU_CR_TRACE_IOEN_Msk                          (0x1UL << DBGMCU_CR_TRACE_IOEN_Pos) /*!< 0x00000020 */
+#define DBGMCU_CR_TRACE_IOEN                              DBGMCU_CR_TRACE_IOEN_Msk
+#define DBGMCU_CR_TRGOEN_Pos                              (28U)
+#define DBGMCU_CR_TRGOEN_Msk                              (0x1UL << DBGMCU_CR_TRGOEN_Pos)      /*!< 0x10000000 */
+#define DBGMCU_CR_TRGOEN                                  DBGMCU_CR_TRGOEN_Msk
+
+/********************  Bit definition for DBGMCU_APB1FZR1 register  ***********/
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP_Pos                 (0U)
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_TIM2_STOP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_APB1FZR1_DBG_TIM2_STOP                     DBGMCU_APB1FZR1_DBG_TIM2_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP_Pos                  (10U)
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP_Msk                  (0x1UL << DBGMCU_APB1FZR1_DBG_RTC_STOP_Pos)   /*!< 0x00000400 */
+#define DBGMCU_APB1FZR1_DBG_RTC_STOP                      DBGMCU_APB1FZR1_DBG_RTC_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos                 (11U)
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_WWDG_STOP_Pos)  /*!< 0x00000800 */
+#define DBGMCU_APB1FZR1_DBG_WWDG_STOP                     DBGMCU_APB1FZR1_DBG_WWDG_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP_Pos                 (12U)
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_IWDG_STOP_Pos)  /*!< 0x00001000 */
+#define DBGMCU_APB1FZR1_DBG_IWDG_STOP                     DBGMCU_APB1FZR1_DBG_IWDG_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP_Pos                 (21U)
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP_Msk                 (0x1UL << DBGMCU_APB1FZR1_DBG_I2C1_STOP_Pos)  /*!< 0x00200000 */
+#define DBGMCU_APB1FZR1_DBG_I2C1_STOP                     DBGMCU_APB1FZR1_DBG_I2C1_STOP_Msk
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Pos               (31U)
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Msk               (0x1UL << DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBGMCU_APB1FZR1_DBG_LPTIM1_STOP                   DBGMCU_APB1FZR1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB1FZR1 register  ***********/
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Pos               (0U)
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Pos)  /*!< 0x00000001 */
+#define DBGMCU_C2APB1FZR1_DBG_TIM2_STOP                   DBGMCU_C2APB1FZR1_DBG_TIM2_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Pos                (10U)
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Msk                (0x1UL << DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Pos)   /*!< 0x00000400 */
+#define DBGMCU_C2APB1FZR1_DBG_RTC_STOP                    DBGMCU_C2APB1FZR1_DBG_RTC_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Pos               (12U)
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Pos)  /*!< 0x00001000 */
+#define DBGMCU_C2APB1FZR1_DBG_IWDG_STOP                   DBGMCU_C2APB1FZR1_DBG_IWDG_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Pos               (21U)
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Msk               (0x1UL << DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Pos)  /*!< 0x00200000 */
+#define DBGMCU_C2APB1FZR1_DBG_I2C1_STOP                   DBGMCU_C2APB1FZR1_DBG_I2C1_STOP_Msk
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Pos             (31U)
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Msk             (0x1UL << DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Pos) /*!< 0x80000000 */
+#define DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP                 DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_APB1FZR2 register  ***********/
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Pos               (5U)
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Msk               (0x1UL << DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Pos) /*!< 0x00000020 */
+#define DBGMCU_APB1FZR2_DBG_LPTIM2_STOP                   DBGMCU_APB1FZR2_DBG_LPTIM2_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB1FZR2 register  ***********/
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Pos             (5U)
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Msk             (0x1UL << DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Pos) /*!< 0x00000020 */
+#define DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP                 DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP_Msk
+
+/********************  Bit definition for DBGMCU_APB2FZR register  ************/
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP_Pos                  (11U)
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP_Msk                  (0x1UL << DBGMCU_APB2FZR_DBG_TIM1_STOP_Pos) /*!< 0x000000800 */
+#define DBGMCU_APB2FZR_DBG_TIM1_STOP                      DBGMCU_APB2FZR_DBG_TIM1_STOP_Msk
+
+/********************  Bit definition for DBGMCU_C2APB2FZR register  ************/
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Pos                (11U)
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Msk                (0x1UL << DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Pos) /*!< 0x000000800 */
+#define DBGMCU_C2APB2FZR_DBG_TIM1_STOP                    DBGMCU_C2APB2FZR_DBG_TIM1_STOP_Msk
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+
+
+/*********************** UART Instances : Asynchronous mode *******************/
+#define IS_UART_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : FIFO mode ***************************/
+#define IS_UART_FIFO_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                         ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : SPI Slave mode **********************/
+#define IS_UART_SPI_SLAVE_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** USART Instances : Synchronous mode *******************/
+#define IS_USART_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** USART Instances : Auto Baud Rate detection ***********/
+
+#define IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Half-Duplex mode ********************/
+#define IS_UART_HALFDUPLEX_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                 ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : LIN mode ****************************/
+#define IS_UART_LIN_INSTANCE(INSTANCE)    ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Wake-up from Stop mode **************/
+#define IS_UART_WAKEUP_FROMSTOP_INSTANCE(INSTANCE)   (((INSTANCE) == USART1) || \
+                                                      ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : Hardware Flow control ***************/
+#define IS_UART_HWFLOW_INSTANCE(INSTANCE) (((INSTANCE) == USART1) || \
+                                           ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : Smard card mode *********************/
+#define IS_SMARTCARD_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/*********************** UART Instances : Driver Enable ***********************/
+#define IS_UART_DRIVER_ENABLE_INSTANCE(INSTANCE) (((INSTANCE) == USART1)|| \
+                                                  ((INSTANCE) == LPUART1))
+
+/*********************** UART Instances : IRDA mode ***************************/
+#define IS_IRDA_INSTANCE(INSTANCE) ((INSTANCE) == USART1)
+
+/******************** LPUART Instance *****************************************/
+#define IS_LPUART_INSTANCE(INSTANCE)    ((INSTANCE) == LPUART1)
+
+/******************************* ADC Instances ********************************/
+#define IS_ADC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == ADC1)
+
+#define IS_ADC_COMMON_INSTANCE(INSTANCE) ((INSTANCE) == ADC1_COMMON)
+
+/******************************* AES Instances ********************************/
+#define IS_AES_ALL_INSTANCE(INSTANCE) ((INSTANCE) == AES2)
+
+/******************************** COMP Instances ******************************/
+#define IS_COMP_ALL_INSTANCE(INSTANCE) (((INSTANCE) == COMP1))
+
+#define IS_COMP_COMMON_INSTANCE(INSTANCE) (0U)
+
+/******************** COMP Instances with window mode capability **************/
+#define IS_COMP_WINDOWMODE_INSTANCE(INSTANCE) (0U)
+
+/******************************* CRC Instances ********************************/
+#define IS_CRC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == CRC)
+
+/******************************** DMA Instances *******************************/
+#define IS_DMA_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMA1_Channel1) || \
+                                       ((INSTANCE) == DMA1_Channel2) || \
+                                       ((INSTANCE) == DMA1_Channel3) || \
+                                       ((INSTANCE) == DMA1_Channel4) || \
+                                       ((INSTANCE) == DMA1_Channel5) || \
+                                       ((INSTANCE) == DMA1_Channel6) || \
+                                       ((INSTANCE) == DMA1_Channel7))
+
+/******************************** DMAMUX Instances ****************************/
+#define IS_DMAMUX_ALL_INSTANCE(INSTANCE) ((INSTANCE) == DMAMUX1)
+
+#define IS_DMAMUX_REQUEST_GEN_ALL_INSTANCE(INSTANCE) (((INSTANCE) == DMAMUX1_RequestGenerator0) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator1) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator2) || \
+                                                      ((INSTANCE) == DMAMUX1_RequestGenerator3))
+
+/******************************* GPIO Instances *******************************/
+#define IS_GPIO_ALL_INSTANCE(INSTANCE) (((INSTANCE) == GPIOA) || \
+                                        ((INSTANCE) == GPIOB) || \
+                                        ((INSTANCE) == GPIOC) || \
+                                        ((INSTANCE) == GPIOE) || \
+                                        ((INSTANCE) == GPIOH))
+
+/******************************* GPIO AF Instances ****************************/
+#define IS_GPIO_AF_INSTANCE(INSTANCE)   IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/**************************** GPIO Lock Instances *****************************/
+#define IS_GPIO_LOCK_INSTANCE(INSTANCE) IS_GPIO_ALL_INSTANCE(INSTANCE)
+
+/******************************** I2C Instances *******************************/
+#define IS_I2C_ALL_INSTANCE(INSTANCE) ((INSTANCE) == I2C1)
+
+/****************** I2C Instances : wakeup capability from stop modes *********/
+#define IS_I2C_WAKEUP_FROMSTOP_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
+
+/******************************* SMBUS Instances ******************************/
+#define IS_SMBUS_ALL_INSTANCE(INSTANCE) IS_I2C_ALL_INSTANCE(INSTANCE)
+
+/******************************* IPCC Instances ********************************/
+#define IS_IPCC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IPCC)
+
+/******************************** HSEM Instances *******************************/
+#define IS_HSEM_ALL_INSTANCE(INSTANCE) ((INSTANCE) == HSEM)
+
+#define HSEM_CPU1_COREID        (0x00000004UL)/* Semaphore Core ID */
+#define HSEM_CPU2_COREID        (0x00000008UL)/* Semaphore Core ID */
+
+#define HSEM_SEMID_MIN     (0U)       /* HSEM ID Min*/
+#define HSEM_SEMID_MAX     (31U)      /* HSEM ID Max */
+
+#define HSEM_PROCESSID_MIN (0U)       /* HSEM Process ID Min */
+#define HSEM_PROCESSID_MAX (255U)     /* HSEM Process ID Max */
+
+#define HSEM_CLEAR_KEY_MIN (0U)       /* HSEM clear Key Min value */
+#define HSEM_CLEAR_KEY_MAX (0xFFFFU)  /* HSEM clear Key Max value */
+
+/******************************** PKA Instances *******************************/
+#define IS_PKA_ALL_INSTANCE(INSTANCE) ((INSTANCE) == PKA)
+
+/******************************* RNG Instances ********************************/
+#define IS_RNG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RNG)
+
+/****************************** RTC Instances *********************************/
+#define IS_RTC_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == RTC)
+
+/******************************** SPI Instances *******************************/
+#define IS_SPI_ALL_INSTANCE(INSTANCE) ((INSTANCE) == SPI1)
+
+/****************** LPTIM Instances : All supported instances *****************/
+#define IS_LPTIM_INSTANCE(INSTANCE)     (((INSTANCE) == LPTIM1) || \
+                                         ((INSTANCE) == LPTIM2))
+
+/****************** LPTIM Instances : Encoder mode ****************************/
+#define IS_LPTIM_ENCODER_INTERFACE_INSTANCE(INSTANCE) ((INSTANCE) == LPTIM1)
+
+/****************** TIM Instances : All supported instances *******************/
+#define IS_TIM_INSTANCE(INSTANCE)       (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/****************************** IWDG Instances ********************************/
+#define IS_IWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == IWDG)
+
+/****************************** WWDG Instances ********************************/
+#define IS_WWDG_ALL_INSTANCE(INSTANCE)  ((INSTANCE) == WWDG)
+
+/****************** TIM Instances : supporting 32 bits counter ****************/
+#define IS_TIM_32B_COUNTER_INSTANCE(INSTANCE) ((INSTANCE) == TIM2)
+
+/****************** TIM Instances : supporting the break function *************/
+#define IS_TIM_BREAK_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/************** TIM Instances : supporting Break source selection *************/
+#define IS_TIM_BREAKSOURCE_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting 2 break inputs *****************/
+#define IS_TIM_BKIN2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/************* TIM Instances : at least 1 capture/compare channel *************/
+#define IS_TIM_CC1_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 2 capture/compare channels *************/
+#define IS_TIM_CC2_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 3 capture/compare channels *************/
+#define IS_TIM_CC3_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/************ TIM Instances : at least 4 capture/compare channels *************/
+#define IS_TIM_CC4_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : at least 5 capture/compare channels *******/
+#define IS_TIM_CC5_INSTANCE(INSTANCE)      ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : at least 6 capture/compare channels *******/
+#define IS_TIM_CC6_INSTANCE(INSTANCE)      ((INSTANCE) == TIM1)
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.COMDE) *******/
+#define IS_TIM_CCDMA_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : DMA requests generation (TIMx_DIER.UDE) ***/
+#define IS_TIM_DMA_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/************ TIM Instances : DMA requests generation (TIMx_DIER.CCxDE) *******/
+#define IS_TIM_DMA_CC_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/******************** TIM Instances : DMA burst feature ***********************/
+#define IS_TIM_DMABURST_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/******************* TIM Instances : Timer input selection ********************/
+#define IS_TIM_TISEL_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)   || \
+                                         ((INSTANCE) == TIM2))
+
+/******************* TIM Instances : output(s) available **********************/
+#define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4))))
+
+/****************** TIM Instances : supporting complementary output(s) ********/
+#define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
+  (((INSTANCE) == TIM1) &&                    \
+   (((CHANNEL) == TIM_CHANNEL_1) ||           \
+    ((CHANNEL) == TIM_CHANNEL_2) ||           \
+    ((CHANNEL) == TIM_CHANNEL_3)))
+
+/****************** TIM Instances : supporting clock division *****************/
+#define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
+                                                    ((INSTANCE) == TIM2))
+
+/****** TIM Instances : supporting external clock mode 1 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE1_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****** TIM Instances : supporting external clock mode 2 for ETRF input *******/
+#define IS_TIM_CLOCKSOURCE_ETRMODE2_INSTANCE(INSTANCE) (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting external clock mode 1 for TIX inputs*/
+#define IS_TIM_CLOCKSOURCE_TIX_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+#define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)     (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting combined 3-phase PWM mode ******/
+#define IS_TIM_COMBINED3PHASEPWM_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting commutation event generation ***/
+#define IS_TIM_COMMUTATION_EVENT_INSTANCE(INSTANCE) ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting counting mode selection ********/
+#define IS_TIM_COUNTER_MODE_SELECT_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1) || \
+                                                        ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting encoder interface **************/
+#define IS_TIM_ENCODER_INTERFACE_INSTANCE(INSTANCE)  (((INSTANCE) == TIM1)  || \
+                                                      ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting Hall sensor interface **********/
+#define IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(INSTANCE) (((INSTANCE) == TIM1)  || \
+                                                         ((INSTANCE) == TIM2))
+
+/**************** TIM Instances : external trigger input available ************/
+#define IS_TIM_ETR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/************* TIM Instances : supporting ETR source selection ***************/
+#define IS_TIM_ETRSEL_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                             ((INSTANCE) == TIM2))
+
+/****** TIM Instances : Master mode available (TIMx_CR2.MMS available )********/
+#define IS_TIM_MASTER_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/*********** TIM Instances : Slave mode available (TIMx_SMCR available )*******/
+#define IS_TIM_SLAVE_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting OCxREF clear *******************/
+#define IS_TIM_OCXREF_CLEAR_INSTANCE(INSTANCE)        (((INSTANCE) == TIM1) || \
+                                                       ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : remapping capability **********************/
+#define IS_TIM_REMAP_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1)  || \
+                                            ((INSTANCE) == TIM2))
+
+/****************** TIM Instances : supporting repetition counter *************/
+#define IS_TIM_REPETITION_COUNTER_INSTANCE(INSTANCE)  ((INSTANCE) == TIM1)
+
+/****************** TIM Instances : supporting ADC triggering through TRGO2 ***/
+#define IS_TIM_TRGO2_INSTANCE(INSTANCE)    ((INSTANCE) == TIM1)
+
+/******************* TIM Instances : Timer input XOR function *****************/
+#define IS_TIM_XOR_INSTANCE(INSTANCE)      (((INSTANCE) == TIM1)   || \
+                                            ((INSTANCE) == TIM2))
+
+/************ TIM Instances : Advanced timers  ********************************/
+#define IS_TIM_ADVANCED_INSTANCE(INSTANCE)    (((INSTANCE) == TIM1))
+
+/****************************** TSC Instances *********************************/
+#define IS_TSC_ALL_INSTANCE(INSTANCE) ((INSTANCE) == TSC)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+ */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32WB1Mxx_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb30xx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb30xx.h
@@ -14,13 +14,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -37,7 +36,7 @@
 #define __STM32WB30xx_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif /* __cplusplus */
 
 /** @addtogroup Configuration_section_for_CMSIS
@@ -61,13 +60,13 @@
   */
 
 /**
- * @brief stm32wb30xx Interrupt Number Definition, according to the selected device
- *        in @ref Library_configuration_section
- */
+  * @brief stm32wb30xx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
 /*!< Interrupt Number Definition for M4 */
 typedef enum
 {
-/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
   NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
   HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
   MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
@@ -78,7 +77,7 @@ typedef enum
   PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
   SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
 
-/*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
   WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
   PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
   TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
@@ -244,24 +243,24 @@ typedef struct
 typedef struct
 {
   __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
-}DMAMUX_Channel_TypeDef;
+} DMAMUX_Channel_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
   __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
-}DMAMUX_ChannelStatus_TypeDef;
+} DMAMUX_ChannelStatus_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
-}DMAMUX_RequestGen_TypeDef;
+} DMAMUX_RequestGen_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
   __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
-}DMAMUX_RequestGenStatus_TypeDef;
+} DMAMUX_RequestGenStatus_TypeDef;
 
 /**
   * @brief FLASH Registers
@@ -395,15 +394,15 @@ typedef struct
   __IO uint32_t ICSCR;         /*!< RCC Internal Clock Sources Calibration Register,                                Address offset: 0x04 */
   __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
   __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
-uint32_t RESERVED0[2];         /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
+       uint32_t RESERVED0[2];  /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
   __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
   __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
   __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
-uint32_t RESERVED11;           /*!< Reserved,                                                                       Address offset: 0x24 */
+       uint32_t RESERVED11;    /*!< Reserved,                                                                       Address offset: 0x24 */
   __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
   __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
   __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
-uint32_t RESERVED1;            /*!< Reserved,                                                                       Address offset: 0x34 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
   __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
   __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
   __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
@@ -411,32 +410,32 @@ uint32_t RESERVED1;            /*!< Reserved,                                   
   __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
   __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
   __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
-uint32_t RESERVED2;            /*!< Reserved,                                                                       Address offset: 0x54 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
   __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
   __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
   __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
-uint32_t RESERVED3;            /*!< Reserved,                                                                       Address offset: 0x64 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
   __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
   __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
   __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
-uint32_t RESERVED4;            /*!< Reserved,                                                                       Address offset: 0x74 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
   __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
   __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
   __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
-uint32_t RESERVED5;            /*!< Reserved,                                                                       Address offset: 0x84 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
   __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
-uint32_t RESERVED6;            /*!< Reserved,                                                                       Address offset: 0x8C */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
   __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
   __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
   __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
   __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
-uint32_t RESERVED7[26];        /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
   __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
-uint32_t RESERVED8[15];        /*!< Reserved,                                                                      Address offset: 0x10C-0x144 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
   __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
   __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
   __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
-uint32_t RESERVED9;            /*!< Reserved,                                                                       Address offset: 0x154 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
   __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
   __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
   __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
@@ -444,7 +443,7 @@ uint32_t RESERVED9;            /*!< Reserved,                                   
   __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
   __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
   __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
-uint32_t RESERVED10;           /*!< Reserved,                                                                                             */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
   __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
   __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
   __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
@@ -695,7 +694,7 @@ typedef struct
   __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
   __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
   __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
-}EXTI_TypeDef;
+} EXTI_TypeDef;
 
 /**
   * @brief Public Key Accelerator (PKA)
@@ -714,19 +713,19 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t R[32];      /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
-  __IO uint32_t RLR[32];    /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
-  __IO uint32_t C1IER;      /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
-  __IO uint32_t C1ICR;      /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
-  __IO uint32_t C1ISR;      /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
-  __IO uint32_t C1MISR;     /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
-  __IO uint32_t C2IER;      /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
-  __IO uint32_t C2ICR;      /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
-  __IO uint32_t C2ISR;      /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
-  __IO uint32_t C2MISR;     /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
-   uint32_t  Reserved[8];   /*!< Reserved                                        Address offset: 120h-13Ch*/
-  __IO uint32_t CR;         /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
-  __IO uint32_t KEYR;       /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
 } HSEM_TypeDef;
 
 typedef struct
@@ -957,6 +956,16 @@ typedef struct
   * @{
   */
 
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
 /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
@@ -1091,7 +1100,7 @@ typedef struct
 
 #define ADC_CFGR_ALIGN_Pos             (5U)
 #define ADC_CFGR_ALIGN_Msk             (0x1UL << ADC_CFGR_ALIGN_Pos)           /*!< 0x00000020 */
-#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignement */
+#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignment */
 
 #define ADC_CFGR_EXTSEL_Pos            (6U)
 #define ADC_CFGR_EXTSEL_Msk            (0xFUL << ADC_CFGR_EXTSEL_Pos)          /*!< 0x000003C0 */
@@ -3512,12 +3521,12 @@ typedef struct
 /* Arithmetic addition output data */
 #define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Arithmetic substraction input data */
+/* Arithmetic subtraction input data */
 #define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 
-/* Arithmetic substraction output data */
+/* Arithmetic subtraction output data */
 #define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Arithmetic multiplication input data */
@@ -3553,13 +3562,13 @@ typedef struct
 /* Modular inversion output data */
 #define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Modular substraction input data */
+/* Modular subtraction input data */
 #define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 #define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
 
-/* Modular substraction output data */
+/* Modular subtraction output data */
 #define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Montgomery multiplication input data */
@@ -3614,10 +3623,10 @@ typedef struct
 #define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
 #define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
 
-#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)                                       /*!< FLASH Zero wait state   */
-#define FLASH_ACR_LATENCY_1WS               (FLASH_ACR_LATENCY_0 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH One wait state    */
-#define FLASH_ACR_LATENCY_2WS               (FLASH_ACR_LATENCY_1 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH Two wait states   */
-#define FLASH_ACR_LATENCY_3WS               ((FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) << FLASH_ACR_LATENCY_Pos) /*!< FLASH Three wait states */
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
 
 /*******************  Bits definition for FLASH_SR register  ******************/
 #define FLASH_SR_EOP_Pos                    (0U)
@@ -3720,6 +3729,9 @@ typedef struct
 #define FLASH_ECCR_CPUID_Pos                (26U)
 #define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
 #define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
 #define FLASH_ECCR_ECCC_Pos                 (30U)
 #define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
@@ -6291,8 +6303,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RCC_HSI48_SUPPORT
 #define RCC_802_SUPPORT
 
@@ -7373,8 +7385,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RTC_TAMPER2_SUPPORT
 #define RTC_WAKEUP_SUPPORT
 #define RTC_BACKUP_SUPPORT
@@ -7482,10 +7494,10 @@ typedef struct
 #define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
 #define RTC_CR_POL_Pos                 (20U)
 #define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
-#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Ouput polarity */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
 #define RTC_CR_COSEL_Pos               (19U)
 #define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
-#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration ouput selection */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
 #define RTC_CR_BKP_Pos                 (18U)
 #define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
 #define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
@@ -7754,7 +7766,7 @@ typedef struct
 /********************  Bits definition for RTC_SHIFTR register  ***************/
 #define RTC_SHIFTR_SUBFS_Pos           (0U)
 #define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
-#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Substract a fraction of a second */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
 #define RTC_SHIFTR_ADD1S_Pos           (31U)
 #define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
 #define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
@@ -9399,7 +9411,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos         (0U)
-#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
 #define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos        (29U)
 #define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
@@ -10880,38 +10892,38 @@ typedef struct
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
-        ((((INSTANCE) == TIM1) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4) ||          \
-            ((CHANNEL) == TIM_CHANNEL_5) ||          \
-            ((CHANNEL) == TIM_CHANNEL_6)))           \
-           ||                                        \
-           (((INSTANCE) == TIM2) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4)))           \
-           ||                                        \
-           (((INSTANCE) == TIM16) &&                 \
-           (((CHANNEL) == TIM_CHANNEL_1)))           \
-           ||                                        \
-           (((INSTANCE) == TIM17) &&                 \
-            (((CHANNEL) == TIM_CHANNEL_1))))
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4)))           \
+   ||                                        \
+   (((INSTANCE) == TIM16) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1)))           \
+   ||                                        \
+   (((INSTANCE) == TIM17) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
-   ((((INSTANCE) == TIM1) &&                    \
-     (((CHANNEL) == TIM_CHANNEL_1) ||           \
-      ((CHANNEL) == TIM_CHANNEL_2) ||           \
-      ((CHANNEL) == TIM_CHANNEL_3)))            \
-    ||                                          \
-    (((INSTANCE) == TIM17) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    (((INSTANCE) == TIM16) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1)))
+  ((((INSTANCE) == TIM1) &&                    \
+    (((CHANNEL) == TIM_CHANNEL_1) ||           \
+     ((CHANNEL) == TIM_CHANNEL_2) ||           \
+     ((CHANNEL) == TIM_CHANNEL_3)))            \
+   ||                                          \
+   (((INSTANCE) == TIM17) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1))              \
+   ||                                          \
+   (((INSTANCE) == TIM16) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
 #define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
@@ -11000,9 +11012,9 @@ typedef struct
   * @}
   */
 
- /**
+/**
   * @}
-  */
+ */
 
 /**
   * @}
@@ -11018,8 +11030,6 @@ typedef struct
   * @}
   */
 
-  /**
+/**
   * @}
-  */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb35xx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb35xx.h
@@ -14,13 +14,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -37,7 +36,7 @@
 #define __STM32WB35xx_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif /* __cplusplus */
 
 /** @addtogroup Configuration_section_for_CMSIS
@@ -61,13 +60,13 @@
   */
 
 /**
- * @brief stm32wb35xx Interrupt Number Definition, according to the selected device
- *        in @ref Library_configuration_section
- */
+  * @brief stm32wb35xx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
 /*!< Interrupt Number Definition for M4 */
 typedef enum
 {
-/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
   NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
   HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
   MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
@@ -78,7 +77,7 @@ typedef enum
   PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
   SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
 
-/*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
   WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
   PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
   TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
@@ -274,24 +273,24 @@ typedef struct
 typedef struct
 {
   __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
-}DMAMUX_Channel_TypeDef;
+} DMAMUX_Channel_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
   __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
-}DMAMUX_ChannelStatus_TypeDef;
+} DMAMUX_ChannelStatus_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
-}DMAMUX_RequestGen_TypeDef;
+} DMAMUX_RequestGen_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
   __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
-}DMAMUX_RequestGenStatus_TypeDef;
+} DMAMUX_RequestGenStatus_TypeDef;
 
 /**
   * @brief FLASH Registers
@@ -447,7 +446,7 @@ typedef struct
   __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
   __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
   __IO uint32_t PLLSAI1CFGR;   /*!< RCC  PLL SAI1 configuration Register,                                           Address offset: 0x10 */
-uint32_t RESERVED0;            /*!< Reserved,                                                                       Address offset: 0x14 */
+       uint32_t RESERVED0;     /*!< Reserved,                                                                       Address offset: 0x14 */
   __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
   __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
   __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
@@ -455,7 +454,7 @@ uint32_t RESERVED0;            /*!< Reserved,                                   
   __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
   __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
   __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
-uint32_t RESERVED1;            /*!< Reserved,                                                                       Address offset: 0x34 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
   __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
   __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
   __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
@@ -463,32 +462,32 @@ uint32_t RESERVED1;            /*!< Reserved,                                   
   __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
   __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
   __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
-uint32_t RESERVED2;            /*!< Reserved,                                                                       Address offset: 0x54 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
   __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
   __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
   __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
-uint32_t RESERVED3;            /*!< Reserved,                                                                       Address offset: 0x64 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
   __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
   __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
   __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
-uint32_t RESERVED4;            /*!< Reserved,                                                                       Address offset: 0x74 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
   __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
   __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
   __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
-uint32_t RESERVED5;            /*!< Reserved,                                                                       Address offset: 0x84 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
   __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
-uint32_t RESERVED6;            /*!< Reserved,                                                                       Address offset: 0x8C */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
   __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
   __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
   __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
   __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
-uint32_t RESERVED7[26];        /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
   __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
-uint32_t RESERVED8[15];        /*!< Reserved,                                                                      Address offset: 0x10C-0x144 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
   __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
   __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
   __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
-uint32_t RESERVED9;            /*!< Reserved,                                                                       Address offset: 0x154 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
   __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
   __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
   __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
@@ -496,7 +495,7 @@ uint32_t RESERVED9;            /*!< Reserved,                                   
   __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
   __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
   __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
-uint32_t RESERVED10;           /*!< Reserved,                                                                                             */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
   __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
   __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
   __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
@@ -804,7 +803,7 @@ typedef struct
   __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
   __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
   __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
-}EXTI_TypeDef;
+} EXTI_TypeDef;
 
 /**
   * @brief Serial Audio Interface
@@ -846,19 +845,19 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t R[32];      /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
-  __IO uint32_t RLR[32];    /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
-  __IO uint32_t C1IER;      /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
-  __IO uint32_t C1ICR;      /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
-  __IO uint32_t C1ISR;      /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
-  __IO uint32_t C1MISR;     /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
-  __IO uint32_t C2IER;      /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
-  __IO uint32_t C2ICR;      /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
-  __IO uint32_t C2ISR;      /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
-  __IO uint32_t C2MISR;     /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
-   uint32_t  Reserved[8];   /*!< Reserved                                        Address offset: 120h-13Ch*/
-  __IO uint32_t CR;         /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
-  __IO uint32_t KEYR;       /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
 } HSEM_TypeDef;
 
 typedef struct
@@ -1149,6 +1148,16 @@ typedef struct
   * @{
   */
 
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
 /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
@@ -1283,7 +1292,7 @@ typedef struct
 
 #define ADC_CFGR_ALIGN_Pos             (5U)
 #define ADC_CFGR_ALIGN_Msk             (0x1UL << ADC_CFGR_ALIGN_Pos)           /*!< 0x00000020 */
-#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignement */
+#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignment */
 
 #define ADC_CFGR_EXTSEL_Pos            (6U)
 #define ADC_CFGR_EXTSEL_Msk            (0xFUL << ADC_CFGR_EXTSEL_Pos)          /*!< 0x000003C0 */
@@ -3890,12 +3899,12 @@ typedef struct
 /* Arithmetic addition output data */
 #define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Arithmetic substraction input data */
+/* Arithmetic subtraction input data */
 #define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 
-/* Arithmetic substraction output data */
+/* Arithmetic subtraction output data */
 #define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Arithmetic multiplication input data */
@@ -3931,13 +3940,13 @@ typedef struct
 /* Modular inversion output data */
 #define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Modular substraction input data */
+/* Modular subtraction input data */
 #define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 #define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
 
-/* Modular substraction output data */
+/* Modular subtraction output data */
 #define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Montgomery multiplication input data */
@@ -3992,10 +4001,10 @@ typedef struct
 #define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
 #define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
 
-#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)                                       /*!< FLASH Zero wait state   */
-#define FLASH_ACR_LATENCY_1WS               (FLASH_ACR_LATENCY_0 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH One wait state    */
-#define FLASH_ACR_LATENCY_2WS               (FLASH_ACR_LATENCY_1 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH Two wait states   */
-#define FLASH_ACR_LATENCY_3WS               ((FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) << FLASH_ACR_LATENCY_Pos) /*!< FLASH Three wait states */
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
 
 /*******************  Bits definition for FLASH_SR register  ******************/
 #define FLASH_SR_EOP_Pos                    (0U)
@@ -4098,6 +4107,9 @@ typedef struct
 #define FLASH_ECCR_CPUID_Pos                (26U)
 #define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
 #define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
 #define FLASH_ECCR_ECCC_Pos                 (30U)
 #define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
@@ -7076,8 +7088,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RCC_SMPS_SUPPORT
 #define RCC_MCO3_SUPPORT
 #define RCC_LSCO3_SUPPORT
@@ -8372,8 +8384,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RTC_TAMPER1_SUPPORT
 #define RTC_TAMPER2_SUPPORT
 #define RTC_TAMPER3_SUPPORT
@@ -8483,10 +8495,10 @@ typedef struct
 #define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
 #define RTC_CR_POL_Pos                 (20U)
 #define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
-#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Ouput polarity */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
 #define RTC_CR_COSEL_Pos               (19U)
 #define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
-#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration ouput selection */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
 #define RTC_CR_BKP_Pos                 (18U)
 #define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
 #define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
@@ -8761,7 +8773,7 @@ typedef struct
 /********************  Bits definition for RTC_SHIFTR register  ***************/
 #define RTC_SHIFTR_SUBFS_Pos           (0U)
 #define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
-#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Substract a fraction of a second */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
 #define RTC_SHIFTR_ADD1S_Pos           (31U)
 #define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
 #define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
@@ -10784,7 +10796,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos         (0U)
-#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
 #define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos        (29U)
 #define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
@@ -12150,10 +12162,8 @@ typedef struct
 /*                         USB Device General registers                       */
 /*                                                                            */
 /******************************************************************************/
-#define USB_BASE                              (0x40005C00UL)                   /*!< USB_IP Peripheral Registers base address */
-#define USB_PMAADDR_Pos           (13U)
-#define USB_PMAADDR_Msk           (0x20003UL << USB_PMAADDR_Pos)               /*!< 0x40006000 */
-#define USB_PMAADDR               USB_PMAADDR_Msk                              /*!< USB_IP Packet Memory Area base address */
+#define USB_BASE                             (USB1_BASE)               /*!< USB_IP Peripheral Registers base address */
+#define USB_PMAADDR                          (USB1_PMAADDR)            /*!< USB_IP Packet Memory Area base address */
 
 #define USB_CNTR                             (USB_BASE + 0x40)           /*!< Control register */
 #define USB_ISTR                             (USB_BASE + 0x44)           /*!< Interrupt status register */
@@ -12248,7 +12258,7 @@ typedef struct
 
 /* EndPoint REGister MASK (no toggle fields) */
 #define USB_EPREG_MASK     (USB_EP_CTR_RX|USB_EP_SETUP|USB_EP_T_FIELD|USB_EP_KIND|USB_EP_CTR_TX|USB_EPADDR_FIELD)
-                                                                         /*!< EP_TYPE[1:0] EndPoint TYPE */
+/*!< EP_TYPE[1:0] EndPoint TYPE */
 #define USB_EP_TYPE_MASK                      ((uint16_t)0x0600U)              /*!< EndPoint TYPE Mask */
 #define USB_EP_BULK                           ((uint16_t)0x0000U)              /*!< EndPoint BULK */
 #define USB_EP_CONTROL                        ((uint16_t)0x0200U)              /*!< EndPoint CONTROL */
@@ -12257,7 +12267,7 @@ typedef struct
 #define USB_EP_T_MASK                        ((uint16_t) ~USB_EP_T_FIELD & USB_EPREG_MASK)
 
 #define USB_EPKIND_MASK                      ((uint16_t)~USB_EP_KIND & USB_EPREG_MASK) /*!< EP_KIND EndPoint KIND */
-                                                                         /*!< STAT_TX[1:0] STATus for TX transfer */
+/*!< STAT_TX[1:0] STATus for TX transfer */
 #define USB_EP_TX_DIS                         ((uint16_t)0x0000U)              /*!< EndPoint TX DISabled */
 #define USB_EP_TX_STALL                       ((uint16_t)0x0010U)              /*!< EndPoint TX STALLed */
 #define USB_EP_TX_NAK                         ((uint16_t)0x0020U)              /*!< EndPoint TX NAKed */
@@ -12265,7 +12275,7 @@ typedef struct
 #define USB_EPTX_DTOG1                        ((uint16_t)0x0010U)              /*!< EndPoint TX Data TOGgle bit1 */
 #define USB_EPTX_DTOG2                        ((uint16_t)0x0020U)              /*!< EndPoint TX Data TOGgle bit2 */
 #define USB_EPTX_DTOGMASK  (USB_EPTX_STAT|USB_EPREG_MASK)
-                                                                         /*!< STAT_RX[1:0] STATus for RX transfer */
+/*!< STAT_RX[1:0] STATus for RX transfer */
 #define USB_EP_RX_DIS                         ((uint16_t)0x0000U)              /*!< EndPoint RX DISabled */
 #define USB_EP_RX_STALL                       ((uint16_t)0x1000U)              /*!< EndPoint RX STALLed */
 #define USB_EP_RX_NAK                         ((uint16_t)0x2000U)              /*!< EndPoint RX NAKed */
@@ -12624,38 +12634,38 @@ typedef struct
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
-        ((((INSTANCE) == TIM1) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4) ||          \
-            ((CHANNEL) == TIM_CHANNEL_5) ||          \
-            ((CHANNEL) == TIM_CHANNEL_6)))           \
-           ||                                        \
-           (((INSTANCE) == TIM2) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4)))           \
-           ||                                        \
-           (((INSTANCE) == TIM16) &&                 \
-           (((CHANNEL) == TIM_CHANNEL_1)))           \
-           ||                                        \
-           (((INSTANCE) == TIM17) &&                 \
-            (((CHANNEL) == TIM_CHANNEL_1))))
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4)))           \
+   ||                                        \
+   (((INSTANCE) == TIM16) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1)))           \
+   ||                                        \
+   (((INSTANCE) == TIM17) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
-   ((((INSTANCE) == TIM1) &&                    \
-     (((CHANNEL) == TIM_CHANNEL_1) ||           \
-      ((CHANNEL) == TIM_CHANNEL_2) ||           \
-      ((CHANNEL) == TIM_CHANNEL_3)))            \
-    ||                                          \
-    (((INSTANCE) == TIM17) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    (((INSTANCE) == TIM16) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1)))
+  ((((INSTANCE) == TIM1) &&                    \
+    (((CHANNEL) == TIM_CHANNEL_1) ||           \
+     ((CHANNEL) == TIM_CHANNEL_2) ||           \
+     ((CHANNEL) == TIM_CHANNEL_3)))            \
+   ||                                          \
+   (((INSTANCE) == TIM17) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1))              \
+   ||                                          \
+   (((INSTANCE) == TIM16) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
 #define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
@@ -12744,9 +12754,9 @@ typedef struct
   * @}
   */
 
- /**
+/**
   * @}
-  */
+ */
 
 /**
   * @}
@@ -12762,8 +12772,6 @@ typedef struct
   * @}
   */
 
-  /**
+/**
   * @}
-  */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb50xx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb50xx.h
@@ -14,13 +14,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -37,7 +36,7 @@
 #define __STM32WB50xx_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif /* __cplusplus */
 
 /** @addtogroup Configuration_section_for_CMSIS
@@ -61,13 +60,13 @@
   */
 
 /**
- * @brief stm32wb50xx Interrupt Number Definition, according to the selected device
- *        in @ref Library_configuration_section
- */
+  * @brief stm32wb50xx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
 /*!< Interrupt Number Definition for M4 */
 typedef enum
 {
-/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
   NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
   HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
   MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
@@ -78,7 +77,7 @@ typedef enum
   PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
   SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
 
-/*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
   WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
   PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
   TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
@@ -245,24 +244,24 @@ typedef struct
 typedef struct
 {
   __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
-}DMAMUX_Channel_TypeDef;
+} DMAMUX_Channel_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
   __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
-}DMAMUX_ChannelStatus_TypeDef;
+} DMAMUX_ChannelStatus_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
-}DMAMUX_RequestGen_TypeDef;
+} DMAMUX_RequestGen_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
   __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
-}DMAMUX_RequestGenStatus_TypeDef;
+} DMAMUX_RequestGenStatus_TypeDef;
 
 /**
   * @brief FLASH Registers
@@ -396,15 +395,15 @@ typedef struct
   __IO uint32_t ICSCR;         /*!< RCC Internal Clock Sources Calibration Register,                                Address offset: 0x04 */
   __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
   __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
-uint32_t RESERVED0[2];         /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
+       uint32_t RESERVED0[2];  /*!< Reserved,                                                                       Address offset: 0x10-0x14 */
   __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
   __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
   __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
-uint32_t RESERVED11;           /*!< Reserved,                                                                       Address offset: 0x24 */
+       uint32_t RESERVED11;    /*!< Reserved,                                                                       Address offset: 0x24 */
   __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
   __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
   __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
-uint32_t RESERVED1;            /*!< Reserved,                                                                       Address offset: 0x34 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
   __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
   __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
   __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
@@ -412,32 +411,32 @@ uint32_t RESERVED1;            /*!< Reserved,                                   
   __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
   __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
   __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
-uint32_t RESERVED2;            /*!< Reserved,                                                                       Address offset: 0x54 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
   __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
   __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
   __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
-uint32_t RESERVED3;            /*!< Reserved,                                                                       Address offset: 0x64 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
   __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
   __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
   __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
-uint32_t RESERVED4;            /*!< Reserved,                                                                       Address offset: 0x74 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
   __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
   __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
   __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
-uint32_t RESERVED5;            /*!< Reserved,                                                                       Address offset: 0x84 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
   __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
-uint32_t RESERVED6;            /*!< Reserved,                                                                       Address offset: 0x8C */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
   __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
   __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
   __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
   __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
-uint32_t RESERVED7[26];        /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
   __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
-uint32_t RESERVED8[15];        /*!< Reserved,                                                                      Address offset: 0x10C-0x144 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
   __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
   __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
   __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
-uint32_t RESERVED9;            /*!< Reserved,                                                                       Address offset: 0x154 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
   __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
   __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
   __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
@@ -445,7 +444,7 @@ uint32_t RESERVED9;            /*!< Reserved,                                   
   __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
   __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
   __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
-uint32_t RESERVED10;           /*!< Reserved,                                                                                             */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
   __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
   __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
   __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
@@ -696,7 +695,7 @@ typedef struct
   __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
   __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
   __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
-}EXTI_TypeDef;
+} EXTI_TypeDef;
 
 /**
   * @brief Public Key Accelerator (PKA)
@@ -715,19 +714,19 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t R[32];      /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
-  __IO uint32_t RLR[32];    /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
-  __IO uint32_t C1IER;      /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
-  __IO uint32_t C1ICR;      /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
-  __IO uint32_t C1ISR;      /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
-  __IO uint32_t C1MISR;     /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
-  __IO uint32_t C2IER;      /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
-  __IO uint32_t C2ICR;      /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
-  __IO uint32_t C2ISR;      /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
-  __IO uint32_t C2MISR;     /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
-   uint32_t  Reserved[8];   /*!< Reserved                                        Address offset: 120h-13Ch*/
-  __IO uint32_t CR;         /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
-  __IO uint32_t KEYR;       /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
 } HSEM_TypeDef;
 
 typedef struct
@@ -958,6 +957,16 @@ typedef struct
   * @{
   */
 
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
 /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
@@ -1092,7 +1101,7 @@ typedef struct
 
 #define ADC_CFGR_ALIGN_Pos             (5U)
 #define ADC_CFGR_ALIGN_Msk             (0x1UL << ADC_CFGR_ALIGN_Pos)           /*!< 0x00000020 */
-#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignement */
+#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignment */
 
 #define ADC_CFGR_EXTSEL_Pos            (6U)
 #define ADC_CFGR_EXTSEL_Msk            (0xFUL << ADC_CFGR_EXTSEL_Pos)          /*!< 0x000003C0 */
@@ -3513,12 +3522,12 @@ typedef struct
 /* Arithmetic addition output data */
 #define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Arithmetic substraction input data */
+/* Arithmetic subtraction input data */
 #define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 
-/* Arithmetic substraction output data */
+/* Arithmetic subtraction output data */
 #define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Arithmetic multiplication input data */
@@ -3554,13 +3563,13 @@ typedef struct
 /* Modular inversion output data */
 #define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Modular substraction input data */
+/* Modular subtraction input data */
 #define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 #define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
 
-/* Modular substraction output data */
+/* Modular subtraction output data */
 #define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Montgomery multiplication input data */
@@ -3615,10 +3624,10 @@ typedef struct
 #define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
 #define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
 
-#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)                                       /*!< FLASH Zero wait state   */
-#define FLASH_ACR_LATENCY_1WS               (FLASH_ACR_LATENCY_0 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH One wait state    */
-#define FLASH_ACR_LATENCY_2WS               (FLASH_ACR_LATENCY_1 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH Two wait states   */
-#define FLASH_ACR_LATENCY_3WS               ((FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) << FLASH_ACR_LATENCY_Pos) /*!< FLASH Three wait states */
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
 
 /*******************  Bits definition for FLASH_SR register  ******************/
 #define FLASH_SR_EOP_Pos                    (0U)
@@ -3721,6 +3730,9 @@ typedef struct
 #define FLASH_ECCR_CPUID_Pos                (26U)
 #define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
 #define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
 #define FLASH_ECCR_ECCC_Pos                 (30U)
 #define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
@@ -6292,8 +6304,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RCC_HSI48_SUPPORT
 #define RCC_802_SUPPORT
 
@@ -7374,8 +7386,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RTC_TAMPER2_SUPPORT
 #define RTC_WAKEUP_SUPPORT
 #define RTC_BACKUP_SUPPORT
@@ -7483,10 +7495,10 @@ typedef struct
 #define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
 #define RTC_CR_POL_Pos                 (20U)
 #define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
-#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Ouput polarity */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
 #define RTC_CR_COSEL_Pos               (19U)
 #define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
-#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration ouput selection */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
 #define RTC_CR_BKP_Pos                 (18U)
 #define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
 #define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
@@ -7755,7 +7767,7 @@ typedef struct
 /********************  Bits definition for RTC_SHIFTR register  ***************/
 #define RTC_SHIFTR_SUBFS_Pos           (0U)
 #define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
-#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Substract a fraction of a second */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
 #define RTC_SHIFTR_ADD1S_Pos           (31U)
 #define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
 #define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
@@ -9403,7 +9415,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos         (0U)
-#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
 #define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos        (29U)
 #define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
@@ -10884,38 +10896,38 @@ typedef struct
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
-        ((((INSTANCE) == TIM1) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4) ||          \
-            ((CHANNEL) == TIM_CHANNEL_5) ||          \
-            ((CHANNEL) == TIM_CHANNEL_6)))           \
-           ||                                        \
-           (((INSTANCE) == TIM2) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4)))           \
-           ||                                        \
-           (((INSTANCE) == TIM16) &&                 \
-           (((CHANNEL) == TIM_CHANNEL_1)))           \
-           ||                                        \
-           (((INSTANCE) == TIM17) &&                 \
-            (((CHANNEL) == TIM_CHANNEL_1))))
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4)))           \
+   ||                                        \
+   (((INSTANCE) == TIM16) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1)))           \
+   ||                                        \
+   (((INSTANCE) == TIM17) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
-   ((((INSTANCE) == TIM1) &&                    \
-     (((CHANNEL) == TIM_CHANNEL_1) ||           \
-      ((CHANNEL) == TIM_CHANNEL_2) ||           \
-      ((CHANNEL) == TIM_CHANNEL_3)))            \
-    ||                                          \
-    (((INSTANCE) == TIM17) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    (((INSTANCE) == TIM16) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1)))
+  ((((INSTANCE) == TIM1) &&                    \
+    (((CHANNEL) == TIM_CHANNEL_1) ||           \
+     ((CHANNEL) == TIM_CHANNEL_2) ||           \
+     ((CHANNEL) == TIM_CHANNEL_3)))            \
+   ||                                          \
+   (((INSTANCE) == TIM17) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1))              \
+   ||                                          \
+   (((INSTANCE) == TIM16) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
 #define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
@@ -11004,9 +11016,9 @@ typedef struct
   * @}
   */
 
- /**
+/**
   * @}
-  */
+ */
 
 /**
   * @}
@@ -11022,8 +11034,6 @@ typedef struct
   * @}
   */
 
-  /**
+/**
   * @}
-  */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb55xx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb55xx.h
@@ -14,13 +14,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -37,7 +36,7 @@
 #define __STM32WB55xx_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif /* __cplusplus */
 
 /** @addtogroup Configuration_section_for_CMSIS
@@ -61,13 +60,13 @@
   */
 
 /**
- * @brief stm32wb55xx Interrupt Number Definition, according to the selected device
- *        in @ref Library_configuration_section
- */
+  * @brief stm32wb55xx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
 /*!< Interrupt Number Definition for M4 */
 typedef enum
 {
-/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
   NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
   HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
   MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
@@ -78,7 +77,7 @@ typedef enum
   PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
   SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
 
-/*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
   WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
   PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
   TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
@@ -277,24 +276,24 @@ typedef struct
 typedef struct
 {
   __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
-}DMAMUX_Channel_TypeDef;
+} DMAMUX_Channel_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
   __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
-}DMAMUX_ChannelStatus_TypeDef;
+} DMAMUX_ChannelStatus_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
-}DMAMUX_RequestGen_TypeDef;
+} DMAMUX_RequestGen_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
   __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
-}DMAMUX_RequestGenStatus_TypeDef;
+} DMAMUX_RequestGenStatus_TypeDef;
 
 /**
   * @brief FLASH Registers
@@ -451,7 +450,7 @@ typedef struct
   __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
   __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
   __IO uint32_t PLLSAI1CFGR;   /*!< RCC  PLL SAI1 configuration Register,                                           Address offset: 0x10 */
-uint32_t RESERVED0;            /*!< Reserved,                                                                       Address offset: 0x14 */
+       uint32_t RESERVED0;     /*!< Reserved,                                                                       Address offset: 0x14 */
   __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
   __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
   __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
@@ -459,7 +458,7 @@ uint32_t RESERVED0;            /*!< Reserved,                                   
   __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
   __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
   __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
-uint32_t RESERVED1;            /*!< Reserved,                                                                       Address offset: 0x34 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
   __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
   __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
   __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
@@ -467,32 +466,32 @@ uint32_t RESERVED1;            /*!< Reserved,                                   
   __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
   __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
   __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
-uint32_t RESERVED2;            /*!< Reserved,                                                                       Address offset: 0x54 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
   __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
   __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
   __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
-uint32_t RESERVED3;            /*!< Reserved,                                                                       Address offset: 0x64 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
   __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
   __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
   __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
-uint32_t RESERVED4;            /*!< Reserved,                                                                       Address offset: 0x74 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
   __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
   __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
   __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
-uint32_t RESERVED5;            /*!< Reserved,                                                                       Address offset: 0x84 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
   __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
-uint32_t RESERVED6;            /*!< Reserved,                                                                       Address offset: 0x8C */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
   __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
   __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
   __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
   __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
-uint32_t RESERVED7[26];        /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
   __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
-uint32_t RESERVED8[15];        /*!< Reserved,                                                                      Address offset: 0x10C-0x144 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
   __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
   __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
   __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
-uint32_t RESERVED9;            /*!< Reserved,                                                                       Address offset: 0x154 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
   __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
   __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
   __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
@@ -500,7 +499,7 @@ uint32_t RESERVED9;            /*!< Reserved,                                   
   __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
   __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
   __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
-uint32_t RESERVED10;           /*!< Reserved,                                                                                             */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
   __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
   __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
   __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
@@ -842,7 +841,7 @@ typedef struct
   __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
   __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
   __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
-}EXTI_TypeDef;
+} EXTI_TypeDef;
 
 /**
   * @brief Serial Audio Interface
@@ -884,19 +883,19 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t R[32];      /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
-  __IO uint32_t RLR[32];    /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
-  __IO uint32_t C1IER;      /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
-  __IO uint32_t C1ICR;      /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
-  __IO uint32_t C1ISR;      /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
-  __IO uint32_t C1MISR;     /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
-  __IO uint32_t C2IER;      /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
-  __IO uint32_t C2ICR;      /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
-  __IO uint32_t C2ISR;      /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
-  __IO uint32_t C2MISR;     /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
-   uint32_t  Reserved[8];   /*!< Reserved                                        Address offset: 120h-13Ch*/
-  __IO uint32_t CR;         /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
-  __IO uint32_t KEYR;       /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
 } HSEM_TypeDef;
 
 typedef struct
@@ -1195,6 +1194,16 @@ typedef struct
   * @{
   */
 
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
 /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
@@ -1329,7 +1338,7 @@ typedef struct
 
 #define ADC_CFGR_ALIGN_Pos             (5U)
 #define ADC_CFGR_ALIGN_Msk             (0x1UL << ADC_CFGR_ALIGN_Pos)           /*!< 0x00000020 */
-#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignement */
+#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignment */
 
 #define ADC_CFGR_EXTSEL_Pos            (6U)
 #define ADC_CFGR_EXTSEL_Msk            (0xFUL << ADC_CFGR_EXTSEL_Pos)          /*!< 0x000003C0 */
@@ -3942,12 +3951,12 @@ typedef struct
 /* Arithmetic addition output data */
 #define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Arithmetic substraction input data */
+/* Arithmetic subtraction input data */
 #define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 
-/* Arithmetic substraction output data */
+/* Arithmetic subtraction output data */
 #define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Arithmetic multiplication input data */
@@ -3983,13 +3992,13 @@ typedef struct
 /* Modular inversion output data */
 #define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Modular substraction input data */
+/* Modular subtraction input data */
 #define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 #define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
 
-/* Modular substraction output data */
+/* Modular subtraction output data */
 #define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Montgomery multiplication input data */
@@ -4044,10 +4053,10 @@ typedef struct
 #define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
 #define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
 
-#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)                                       /*!< FLASH Zero wait state   */
-#define FLASH_ACR_LATENCY_1WS               (FLASH_ACR_LATENCY_0 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH One wait state    */
-#define FLASH_ACR_LATENCY_2WS               (FLASH_ACR_LATENCY_1 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH Two wait states   */
-#define FLASH_ACR_LATENCY_3WS               ((FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) << FLASH_ACR_LATENCY_Pos) /*!< FLASH Three wait states */
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
 
 /*******************  Bits definition for FLASH_SR register  ******************/
 #define FLASH_SR_EOP_Pos                    (0U)
@@ -4150,6 +4159,9 @@ typedef struct
 #define FLASH_ECCR_CPUID_Pos                (26U)
 #define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
 #define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
 #define FLASH_ECCR_ECCC_Pos                 (30U)
 #define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
@@ -7267,8 +7279,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RCC_SMPS_SUPPORT
 #define RCC_MCO3_SUPPORT
 #define RCC_LSCO3_SUPPORT
@@ -8623,8 +8635,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RTC_TAMPER1_SUPPORT
 #define RTC_TAMPER2_SUPPORT
 #define RTC_TAMPER3_SUPPORT
@@ -8734,10 +8746,10 @@ typedef struct
 #define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
 #define RTC_CR_POL_Pos                 (20U)
 #define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
-#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Ouput polarity */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
 #define RTC_CR_COSEL_Pos               (19U)
 #define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
-#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration ouput selection */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
 #define RTC_CR_BKP_Pos                 (18U)
 #define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
 #define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
@@ -9012,7 +9024,7 @@ typedef struct
 /********************  Bits definition for RTC_SHIFTR register  ***************/
 #define RTC_SHIFTR_SUBFS_Pos           (0U)
 #define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
-#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Substract a fraction of a second */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
 #define RTC_SHIFTR_ADD1S_Pos           (31U)
 #define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
 #define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
@@ -11689,7 +11701,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos         (0U)
-#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
 #define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos        (29U)
 #define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
@@ -13055,10 +13067,8 @@ typedef struct
 /*                         USB Device General registers                       */
 /*                                                                            */
 /******************************************************************************/
-#define USB_BASE                              (0x40005C00UL)                   /*!< USB_IP Peripheral Registers base address */
-#define USB_PMAADDR_Pos           (13U)
-#define USB_PMAADDR_Msk           (0x20003UL << USB_PMAADDR_Pos)               /*!< 0x40006000 */
-#define USB_PMAADDR               USB_PMAADDR_Msk                              /*!< USB_IP Packet Memory Area base address */
+#define USB_BASE                             (USB1_BASE)               /*!< USB_IP Peripheral Registers base address */
+#define USB_PMAADDR                          (USB1_PMAADDR)            /*!< USB_IP Packet Memory Area base address */
 
 #define USB_CNTR                             (USB_BASE + 0x40)           /*!< Control register */
 #define USB_ISTR                             (USB_BASE + 0x44)           /*!< Interrupt status register */
@@ -13153,7 +13163,7 @@ typedef struct
 
 /* EndPoint REGister MASK (no toggle fields) */
 #define USB_EPREG_MASK     (USB_EP_CTR_RX|USB_EP_SETUP|USB_EP_T_FIELD|USB_EP_KIND|USB_EP_CTR_TX|USB_EPADDR_FIELD)
-                                                                         /*!< EP_TYPE[1:0] EndPoint TYPE */
+/*!< EP_TYPE[1:0] EndPoint TYPE */
 #define USB_EP_TYPE_MASK                      ((uint16_t)0x0600U)              /*!< EndPoint TYPE Mask */
 #define USB_EP_BULK                           ((uint16_t)0x0000U)              /*!< EndPoint BULK */
 #define USB_EP_CONTROL                        ((uint16_t)0x0200U)              /*!< EndPoint CONTROL */
@@ -13162,7 +13172,7 @@ typedef struct
 #define USB_EP_T_MASK                        ((uint16_t) ~USB_EP_T_FIELD & USB_EPREG_MASK)
 
 #define USB_EPKIND_MASK                      ((uint16_t)~USB_EP_KIND & USB_EPREG_MASK) /*!< EP_KIND EndPoint KIND */
-                                                                         /*!< STAT_TX[1:0] STATus for TX transfer */
+/*!< STAT_TX[1:0] STATus for TX transfer */
 #define USB_EP_TX_DIS                         ((uint16_t)0x0000U)              /*!< EndPoint TX DISabled */
 #define USB_EP_TX_STALL                       ((uint16_t)0x0010U)              /*!< EndPoint TX STALLed */
 #define USB_EP_TX_NAK                         ((uint16_t)0x0020U)              /*!< EndPoint TX NAKed */
@@ -13170,7 +13180,7 @@ typedef struct
 #define USB_EPTX_DTOG1                        ((uint16_t)0x0010U)              /*!< EndPoint TX Data TOGgle bit1 */
 #define USB_EPTX_DTOG2                        ((uint16_t)0x0020U)              /*!< EndPoint TX Data TOGgle bit2 */
 #define USB_EPTX_DTOGMASK  (USB_EPTX_STAT|USB_EPREG_MASK)
-                                                                         /*!< STAT_RX[1:0] STATus for RX transfer */
+/*!< STAT_RX[1:0] STATus for RX transfer */
 #define USB_EP_RX_DIS                         ((uint16_t)0x0000U)              /*!< EndPoint RX DISabled */
 #define USB_EP_RX_STALL                       ((uint16_t)0x1000U)              /*!< EndPoint RX STALLed */
 #define USB_EP_RX_NAK                         ((uint16_t)0x2000U)              /*!< EndPoint RX NAKed */
@@ -13534,38 +13544,38 @@ typedef struct
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
-        ((((INSTANCE) == TIM1) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4) ||          \
-            ((CHANNEL) == TIM_CHANNEL_5) ||          \
-            ((CHANNEL) == TIM_CHANNEL_6)))           \
-           ||                                        \
-           (((INSTANCE) == TIM2) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4)))           \
-           ||                                        \
-           (((INSTANCE) == TIM16) &&                 \
-           (((CHANNEL) == TIM_CHANNEL_1)))           \
-           ||                                        \
-           (((INSTANCE) == TIM17) &&                 \
-            (((CHANNEL) == TIM_CHANNEL_1))))
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4)))           \
+   ||                                        \
+   (((INSTANCE) == TIM16) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1)))           \
+   ||                                        \
+   (((INSTANCE) == TIM17) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
-   ((((INSTANCE) == TIM1) &&                    \
-     (((CHANNEL) == TIM_CHANNEL_1) ||           \
-      ((CHANNEL) == TIM_CHANNEL_2) ||           \
-      ((CHANNEL) == TIM_CHANNEL_3)))            \
-    ||                                          \
-    (((INSTANCE) == TIM17) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    (((INSTANCE) == TIM16) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1)))
+  ((((INSTANCE) == TIM1) &&                    \
+    (((CHANNEL) == TIM_CHANNEL_1) ||           \
+     ((CHANNEL) == TIM_CHANNEL_2) ||           \
+     ((CHANNEL) == TIM_CHANNEL_3)))            \
+   ||                                          \
+   (((INSTANCE) == TIM17) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1))              \
+   ||                                          \
+   (((INSTANCE) == TIM16) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
 #define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
@@ -13657,9 +13667,9 @@ typedef struct
   * @}
   */
 
- /**
+/**
   * @}
-  */
+ */
 
 /**
   * @}
@@ -13675,8 +13685,6 @@ typedef struct
   * @}
   */
 
-  /**
+/**
   * @}
-  */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wb5mxx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wb5mxx.h
@@ -14,13 +14,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -37,7 +36,7 @@
 #define __STM32WB5Mxx_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif /* __cplusplus */
 
 /** @addtogroup Configuration_section_for_CMSIS
@@ -61,13 +60,13 @@
   */
 
 /**
- * @brief stm32wb5mxx Interrupt Number Definition, according to the selected device
- *        in @ref Library_configuration_section
- */
+  * @brief stm32wb5mxx Interrupt Number Definition, according to the selected device
+  *        in @ref Library_configuration_section
+  */
 /*!< Interrupt Number Definition for M4 */
 typedef enum
 {
-/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  /******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
   NonMaskableInt_IRQn                 = -14,    /*!< Non Maskable Interrupt                                            */
   HardFault_IRQn                      = -13,    /*!< Cortex-M4 Hard Fault Interrupt                                    */
   MemoryManagement_IRQn               = -12,    /*!< Cortex-M4 Memory Management Interrupt                             */
@@ -78,7 +77,7 @@ typedef enum
   PendSV_IRQn                         = -2,     /*!< Cortex-M4 Pend SV Interrupt                                       */
   SysTick_IRQn                        = -1,     /*!< Cortex-M4 System Tick Interrupt                                   */
 
-/*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
+  /*************  STM32WBxx specific Interrupt Numbers on M4 core ************************************************/
   WWDG_IRQn                           = 0,      /*!< Window WatchDog Interrupt                                         */
   PVD_PVM_IRQn                        = 1,      /*!< PVD and PVM detector                                              */
   TAMP_STAMP_LSECSS_IRQn              = 2,      /*!< RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts         */
@@ -277,24 +276,24 @@ typedef struct
 typedef struct
 {
   __IO uint32_t   CCR;       /*!< DMA Multiplexer Channel x Control Register    Address offset: 0x0004 * (channel x) */
-}DMAMUX_Channel_TypeDef;
+} DMAMUX_Channel_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   CSR;       /*!< DMA Channel Status Register                    Address offset: 0x0080   */
   __IO uint32_t   CFR;       /*!< DMA Channel Clear Flag Register                Address offset: 0x0084   */
-}DMAMUX_ChannelStatus_TypeDef;
+} DMAMUX_ChannelStatus_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGCR;        /*!< DMA Request Generator x Control Register     Address offset: 0x0100 + 0x0004 * (Req Gen x) */
-}DMAMUX_RequestGen_TypeDef;
+} DMAMUX_RequestGen_TypeDef;
 
 typedef struct
 {
   __IO uint32_t   RGSR;        /*!< DMA Request Generator Status Register        Address offset: 0x0140   */
   __IO uint32_t   RGCFR;       /*!< DMA Request Generator Clear Flag Register    Address offset: 0x0144   */
-}DMAMUX_RequestGenStatus_TypeDef;
+} DMAMUX_RequestGenStatus_TypeDef;
 
 /**
   * @brief FLASH Registers
@@ -451,7 +450,7 @@ typedef struct
   __IO uint32_t CFGR;          /*!< RCC Clocks Configuration Register,                                              Address offset: 0x08 */
   __IO uint32_t PLLCFGR;       /*!< RCC System PLL configuration Register,                                          Address offset: 0x0C */
   __IO uint32_t PLLSAI1CFGR;   /*!< RCC  PLL SAI1 configuration Register,                                           Address offset: 0x10 */
-uint32_t RESERVED0;            /*!< Reserved,                                                                       Address offset: 0x14 */
+       uint32_t RESERVED0;     /*!< Reserved,                                                                       Address offset: 0x14 */
   __IO uint32_t CIER;          /*!< RCC Clock Interrupt Enable Register,                                            Address offset: 0x18 */
   __IO uint32_t CIFR;          /*!< RCC Clock Interrupt Flag Register,                                              Address offset: 0x1C */
   __IO uint32_t CICR;          /*!< RCC Clock Interrupt Clear Register,                                             Address offset: 0x20 */
@@ -459,7 +458,7 @@ uint32_t RESERVED0;            /*!< Reserved,                                   
   __IO uint32_t AHB1RSTR;      /*!< RCC AHB1 peripheral reset register,                                             Address offset: 0x28 */
   __IO uint32_t AHB2RSTR;      /*!< RCC AHB2 peripheral reset register,                                             Address offset: 0x2C */
   __IO uint32_t AHB3RSTR;      /*!< RCC AHB3 & AHB4 peripheral reset register,                                      Address offset: 0x30 */
-uint32_t RESERVED1;            /*!< Reserved,                                                                       Address offset: 0x34 */
+       uint32_t RESERVED1;     /*!< Reserved,                                                                       Address offset: 0x34 */
   __IO uint32_t APB1RSTR1;     /*!< RCC APB1 peripheral reset register 1,                                           Address offset: 0x38 */
   __IO uint32_t APB1RSTR2;     /*!< RCC APB1 peripheral reset register 2,                                           Address offset: 0x3C */
   __IO uint32_t APB2RSTR;      /*!< RCC APB2 peripheral reset register,                                             Address offset: 0x40 */
@@ -467,32 +466,32 @@ uint32_t RESERVED1;            /*!< Reserved,                                   
   __IO uint32_t AHB1ENR;       /*!< RCC AHB1 peripheral clocks enable register,                                     Address offset: 0x48 */
   __IO uint32_t AHB2ENR;       /*!< RCC AHB2 peripheral clocks enable register,                                     Address offset: 0x4C */
   __IO uint32_t AHB3ENR;       /*!< RCC AHB3 & AHB4 peripheral clocks enable register,                              Address offset: 0x50 */
-uint32_t RESERVED2;            /*!< Reserved,                                                                       Address offset: 0x54 */
+       uint32_t RESERVED2;     /*!< Reserved,                                                                       Address offset: 0x54 */
   __IO uint32_t APB1ENR1;      /*!< RCC APB1 peripheral clocks enable register 1,                                   Address offset: 0x58 */
   __IO uint32_t APB1ENR2;      /*!< RCC APB1 peripheral clocks enable register 2,                                   Address offset: 0x5C */
   __IO uint32_t APB2ENR;       /*!< RCC APB2 peripheral clocks enable register,                                     Address offset: 0x60 */
-uint32_t RESERVED3;            /*!< Reserved,                                                                       Address offset: 0x64 */
+       uint32_t RESERVED3;     /*!< Reserved,                                                                       Address offset: 0x64 */
   __IO uint32_t AHB1SMENR;     /*!< RCC AHB1 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x68 */
   __IO uint32_t AHB2SMENR;     /*!< RCC AHB2 peripheral clocks enable in sleep and stop modes register,             Address offset: 0x6C */
   __IO uint32_t AHB3SMENR;     /*!< RCC AHB3 & AHB4 peripheral clocks enable in sleep and stop modes register,      Address offset: 0x70 */
-uint32_t RESERVED4;            /*!< Reserved,                                                                       Address offset: 0x74 */
+       uint32_t RESERVED4;     /*!< Reserved,                                                                       Address offset: 0x74 */
   __IO uint32_t APB1SMENR1;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 1,      Address offset: 0x78 */
   __IO uint32_t APB1SMENR2;    /*!< RCC APB1 peripheral clocks enable in sleep mode and stop modes register 2,      Address offset: 0x7C */
   __IO uint32_t APB2SMENR;     /*!< RCC APB2 peripheral clocks enable in sleep mode and stop modes register,        Address offset: 0x80 */
-uint32_t RESERVED5;            /*!< Reserved,                                                                       Address offset: 0x84 */
+       uint32_t RESERVED5;     /*!< Reserved,                                                                       Address offset: 0x84 */
   __IO uint32_t CCIPR;         /*!< RCC Peripherals Clock Configuration Independent Register,                       Address offset: 0x88 */
-uint32_t RESERVED6;            /*!< Reserved,                                                                       Address offset: 0x8C */
+       uint32_t RESERVED6;     /*!< Reserved,                                                                       Address offset: 0x8C */
   __IO uint32_t BDCR;          /*!< RCC Backup Domain Control Register,                                             Address offset: 0x90 */
   __IO uint32_t CSR;           /*!< RCC Control and Status Register,                                                Address offset: 0x94 */
   __IO uint32_t CRRCR;         /*!< RCC Clock Recovery RC Register,                                                 Address offset: 0x98 */
   __IO uint32_t HSECR;         /*!< RCC HSE Clock Register,                                                         Address offset: 0x9C */
-uint32_t RESERVED7[26];        /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
+       uint32_t RESERVED7[26]; /*!< Reserved,                                                                       Address offset: 0xA0-0x104 */
   __IO uint32_t EXTCFGR;       /*!< RCC Extended Clock Recovery Register,                                           Address offset: 0x108 */
-uint32_t RESERVED8[15];        /*!< Reserved,                                                                      Address offset: 0x10C-0x144 */
+       uint32_t RESERVED8[15]; /*!< Reserved,                                                                       Address offset: 0x10C-0x144 */
   __IO uint32_t C2AHB1ENR;     /*!< RRCC AHB1 peripheral CPU2 clocks enable register,                               Address offset: 0x148 */
   __IO uint32_t C2AHB2ENR;     /*!< RCC AHB2 peripheral CPU2 clocks enable register,                                Address offset: 0x14C */
   __IO uint32_t C2AHB3ENR;     /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable register,,                        Address offset: 0x150 */
-uint32_t RESERVED9;            /*!< Reserved,                                                                       Address offset: 0x154 */
+       uint32_t RESERVED9;     /*!< Reserved,                                                                       Address offset: 0x154 */
   __IO uint32_t C2APB1ENR1;    /*!< RCC APB1 peripheral CPU2 clocks enable register 1,                              Address offset: 0x158 */
   __IO uint32_t C2APB1ENR2;    /*!< RCC APB1 peripheral CPU2 clocks enable register 2,                              Address offset: 0x15C */
   __IO uint32_t C2APB2ENR;     /*!< RCC APB2 peripheral CPU2 clocks enable register 1,                              Address offset: 0x160 */
@@ -500,7 +499,7 @@ uint32_t RESERVED9;            /*!< Reserved,                                   
   __IO uint32_t C2AHB1SMENR;   /*!< RCC AHB1 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x168 */
   __IO uint32_t C2AHB2SMENR;   /*!< RCC AHB2 peripheral CPU2 clocks enable in sleep and stop modes register,        Address offset: 0x16C */
   __IO uint32_t C2AHB3SMENR;   /*!< RCC AHB3 & AHB4 peripheral CPU2 clocks enable in sleep and stop modes register, Address offset: 0x170 */
-uint32_t RESERVED10;           /*!< Reserved,                                                                                             */
+       uint32_t RESERVED10;    /*!< Reserved,                                                                                             */
   __IO uint32_t C2APB1SMENR1;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 1, Address offset: 0x178 */
   __IO uint32_t C2APB1SMENR2;  /*!< RCC APB1 peripheral CPU2 clocks enable in sleep mode and stop modes register 2, Address offset: 0x17C */
   __IO uint32_t C2APB2SMENR;   /*!< RCC APB2 peripheral CPU2 clocks enable in sleep mode and stop modes register,   Address offset: 0x180 */
@@ -842,7 +841,7 @@ typedef struct
   __IO uint32_t RESERVED9[2];   /*!< Reserved,                                                 Address offset: 0xC8 - 0xCC */
   __IO uint32_t C2IMR2;         /*!< EXTI wakeup with interrupt mask register for cpu2 [31:0], Address offset: 0xD0 */
   __IO uint32_t C2EMR2;         /*!< EXTI wakeup with event mask register for cpu2 [31:0],     Address offset: 0xD4 */
-}EXTI_TypeDef;
+} EXTI_TypeDef;
 
 /**
   * @brief Serial Audio Interface
@@ -884,19 +883,19 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t R[32];      /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
-  __IO uint32_t RLR[32];    /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
-  __IO uint32_t C1IER;      /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
-  __IO uint32_t C1ICR;      /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
-  __IO uint32_t C1ISR;      /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
-  __IO uint32_t C1MISR;     /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
-  __IO uint32_t C2IER;      /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
-  __IO uint32_t C2ICR;      /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
-  __IO uint32_t C2ISR;      /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
-  __IO uint32_t C2MISR;     /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
-   uint32_t  Reserved[8];   /*!< Reserved                                        Address offset: 120h-13Ch*/
-  __IO uint32_t CR;         /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
-  __IO uint32_t KEYR;       /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
+  __IO uint32_t R[32];        /*!< HSEM 2-step write lock and read back registers, Address offset: 00h-7Ch  */
+  __IO uint32_t RLR[32];      /*!< HSEM 1-step read lock registers,                Address offset: 80h-FCh  */
+  __IO uint32_t C1IER;        /*!< HSEM CPU1 interrupt enable register ,           Address offset: 100h     */
+  __IO uint32_t C1ICR;        /*!< HSEM CPU1 interrupt clear register ,            Address offset: 104h     */
+  __IO uint32_t C1ISR;        /*!< HSEM CPU1 interrupt status register ,           Address offset: 108h     */
+  __IO uint32_t C1MISR;       /*!< HSEM CPU1 masked interrupt status register ,    Address offset: 10Ch     */
+  __IO uint32_t C2IER;        /*!< HSEM CPU2 interrupt enable register ,           Address offset: 110h     */
+  __IO uint32_t C2ICR;        /*!< HSEM CPU2 interrupt clear register ,            Address offset: 114h     */
+  __IO uint32_t C2ISR;        /*!< HSEM CPU2 interrupt status register ,           Address offset: 118h     */
+  __IO uint32_t C2MISR;       /*!< HSEM CPU2 masked interrupt status register ,    Address offset: 11Ch     */
+       uint32_t  Reserved[8]; /*!< Reserved                                        Address offset: 120h-13Ch*/
+  __IO uint32_t CR;           /*!< HSEM Semaphore clear register ,                 Address offset: 140h     */
+  __IO uint32_t KEYR;         /*!< HSEM Semaphore clear key register ,             Address offset: 144h     */
 } HSEM_TypeDef;
 
 typedef struct
@@ -1195,6 +1194,16 @@ typedef struct
   * @{
   */
 
+/** @addtogroup Hardware_Constant_Definition
+  * @{
+  */
+#define LSI_STARTUP_TIME 130U /*!< LSI Maximum startup time in us */
+
+/**
+  * @}
+  */
+
+
 /** @addtogroup Peripheral_Registers_Bits_Definition
   * @{
   */
@@ -1329,7 +1338,7 @@ typedef struct
 
 #define ADC_CFGR_ALIGN_Pos             (5U)
 #define ADC_CFGR_ALIGN_Msk             (0x1UL << ADC_CFGR_ALIGN_Pos)           /*!< 0x00000020 */
-#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignement */
+#define ADC_CFGR_ALIGN                 ADC_CFGR_ALIGN_Msk                      /*!< ADC data alignment */
 
 #define ADC_CFGR_EXTSEL_Pos            (6U)
 #define ADC_CFGR_EXTSEL_Msk            (0xFUL << ADC_CFGR_EXTSEL_Pos)          /*!< 0x000003C0 */
@@ -3942,12 +3951,12 @@ typedef struct
 /* Arithmetic addition output data */
 #define PKA_ARITHMETIC_ADD_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Arithmetic substraction input data */
+/* Arithmetic subtraction input data */
 #define PKA_ARITHMETIC_SUB_NB_BITS                ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_ARITHMETIC_SUB_IN_OP1                 ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_ARITHMETIC_SUB_IN_OP2                 ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 
-/* Arithmetic substraction output data */
+/* Arithmetic subtraction output data */
 #define PKA_ARITHMETIC_SUB_OUT_RESULT             ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Arithmetic multiplication input data */
@@ -3983,13 +3992,13 @@ typedef struct
 /* Modular inversion output data */
 #define PKA_MODULAR_INV_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
-/* Modular substraction input data */
+/* Modular subtraction input data */
 #define PKA_MODULAR_SUB_NB_BITS                   ((0x404U - PKA_RAM_OFFSET)>>2)   /*!< Input operand number of bits */
 #define PKA_MODULAR_SUB_IN_OP1                    ((0x8B4U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op1 */
 #define PKA_MODULAR_SUB_IN_OP2                    ((0xA44U - PKA_RAM_OFFSET)>>2)   /*!< Input operand op2 */
 #define PKA_MODULAR_SUB_IN_OP3_MOD                ((0xD5CU - PKA_RAM_OFFSET)>>2)   /*!< Input operand op3 */
 
-/* Modular substraction output data */
+/* Modular subtraction output data */
 #define PKA_MODULAR_SUB_OUT_RESULT                ((0xBD0U - PKA_RAM_OFFSET)>>2)   /*!< Output result */
 
 /* Montgomery multiplication input data */
@@ -4044,10 +4053,10 @@ typedef struct
 #define FLASH_ACR_EMPTY_Msk                 (0x1UL << FLASH_ACR_EMPTY_Pos)     /*!< 0x00010000 */
 #define FLASH_ACR_EMPTY                     FLASH_ACR_EMPTY_Msk                /*!< Flash use area empty                                */
 
-#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)                                       /*!< FLASH Zero wait state   */
-#define FLASH_ACR_LATENCY_1WS               (FLASH_ACR_LATENCY_0 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH One wait state    */
-#define FLASH_ACR_LATENCY_2WS               (FLASH_ACR_LATENCY_1 << FLASH_ACR_LATENCY_Pos)                         /*!< FLASH Two wait states   */
-#define FLASH_ACR_LATENCY_3WS               ((FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) << FLASH_ACR_LATENCY_Pos) /*!< FLASH Three wait states */
+#define FLASH_ACR_LATENCY_0WS               (0x0UL << FLASH_ACR_LATENCY_Pos)            /*!< FLASH Zero wait state   */
+#define FLASH_ACR_LATENCY_1WS               FLASH_ACR_LATENCY_0                         /*!< FLASH One wait state    */
+#define FLASH_ACR_LATENCY_2WS               FLASH_ACR_LATENCY_1                         /*!< FLASH Two wait states   */
+#define FLASH_ACR_LATENCY_3WS               (FLASH_ACR_LATENCY_1 | FLASH_ACR_LATENCY_0) /*!< FLASH Three wait states */
 
 /*******************  Bits definition for FLASH_SR register  ******************/
 #define FLASH_SR_EOP_Pos                    (0U)
@@ -4150,6 +4159,9 @@ typedef struct
 #define FLASH_ECCR_CPUID_Pos                (26U)
 #define FLASH_ECCR_CPUID_Msk                (0x7UL << FLASH_ECCR_CPUID_Pos)    /*!< 0x1C000000 */
 #define FLASH_ECCR_CPUID                    FLASH_ECCR_CPUID_Msk               /*!< CPU identification                                  */
+#define FLASH_ECCR_CPUID_0                  (0x1U << FLASH_ECCR_CPUID_Pos)     /*!< 0x04000000 */
+#define FLASH_ECCR_CPUID_1                  (0x2U << FLASH_ECCR_CPUID_Pos)     /*!< 0x08000000 */
+#define FLASH_ECCR_CPUID_2                  (0x4U << FLASH_ECCR_CPUID_Pos)     /*!< 0x10000000 */
 #define FLASH_ECCR_ECCC_Pos                 (30U)
 #define FLASH_ECCR_ECCC_Msk                 (0x1UL << FLASH_ECCR_ECCC_Pos)     /*!< 0x40000000 */
 #define FLASH_ECCR_ECCC                     FLASH_ECCR_ECCC_Msk                /*!< ECC correction                                      */
@@ -7267,8 +7279,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RCC_SMPS_SUPPORT
 #define RCC_MCO3_SUPPORT
 #define RCC_LSCO3_SUPPORT
@@ -8623,8 +8635,8 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
-* @brief Specific device feature definitions
-*/
+  * @brief Specific device feature definitions
+  */
 #define RTC_TAMPER1_SUPPORT
 #define RTC_TAMPER2_SUPPORT
 #define RTC_TAMPER3_SUPPORT
@@ -8734,10 +8746,10 @@ typedef struct
 #define RTC_CR_OSEL_1                  (0x2U << RTC_CR_OSEL_Pos)               /*!< 0x00400000 */
 #define RTC_CR_POL_Pos                 (20U)
 #define RTC_CR_POL_Msk                 (0x1UL << RTC_CR_POL_Pos)               /*!< 0x00100000 */
-#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Ouput polarity */
+#define RTC_CR_POL                     RTC_CR_POL_Msk                          /*!< Output polarity */
 #define RTC_CR_COSEL_Pos               (19U)
 #define RTC_CR_COSEL_Msk               (0x1UL << RTC_CR_COSEL_Pos)             /*!< 0x00080000 */
-#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration ouput selection */
+#define RTC_CR_COSEL                   RTC_CR_COSEL_Msk                        /*!< Calibration output selection */
 #define RTC_CR_BKP_Pos                 (18U)
 #define RTC_CR_BKP_Msk                 (0x1UL << RTC_CR_BKP_Pos)               /*!< 0x00040000 */
 #define RTC_CR_BKP                     RTC_CR_BKP_Msk                          /*!< Backup */
@@ -9012,7 +9024,7 @@ typedef struct
 /********************  Bits definition for RTC_SHIFTR register  ***************/
 #define RTC_SHIFTR_SUBFS_Pos           (0U)
 #define RTC_SHIFTR_SUBFS_Msk           (0x7FFFUL << RTC_SHIFTR_SUBFS_Pos)      /*!< 0x00007FFF */
-#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Substract a fraction of a second */
+#define RTC_SHIFTR_SUBFS               RTC_SHIFTR_SUBFS_Msk                    /*!< Subtract a fraction of a second */
 #define RTC_SHIFTR_ADD1S_Pos           (31U)
 #define RTC_SHIFTR_ADD1S_Msk           (0x1UL << RTC_SHIFTR_ADD1S_Pos)         /*!< 0x80000000 */
 #define RTC_SHIFTR_ADD1S               RTC_SHIFTR_ADD1S_Msk                    /*!< Add on second */
@@ -11689,7 +11701,7 @@ typedef struct
 
 /*******************  Bit definition for TIM_CCR5 register  *******************/
 #define TIM_CCR5_CCR5_Pos         (0U)
-#define TIM_CCR5_CCR5_Msk         (0xFFFFFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFFFFFF */
+#define TIM_CCR5_CCR5_Msk         (0xFFFFUL << TIM_CCR5_CCR5_Pos)          /*!< 0xFFFF */
 #define TIM_CCR5_CCR5             TIM_CCR5_CCR5_Msk                            /*!<Capture/Compare 5 Value */
 #define TIM_CCR5_GC5C1_Pos        (29U)
 #define TIM_CCR5_GC5C1_Msk        (0x1UL << TIM_CCR5_GC5C1_Pos)                /*!< 0x20000000 */
@@ -13055,10 +13067,8 @@ typedef struct
 /*                         USB Device General registers                       */
 /*                                                                            */
 /******************************************************************************/
-#define USB_BASE                              (0x40005C00UL)                   /*!< USB_IP Peripheral Registers base address */
-#define USB_PMAADDR_Pos           (13U)
-#define USB_PMAADDR_Msk           (0x20003UL << USB_PMAADDR_Pos)               /*!< 0x40006000 */
-#define USB_PMAADDR               USB_PMAADDR_Msk                              /*!< USB_IP Packet Memory Area base address */
+#define USB_BASE                             (USB1_BASE)               /*!< USB_IP Peripheral Registers base address */
+#define USB_PMAADDR                          (USB1_PMAADDR)            /*!< USB_IP Packet Memory Area base address */
 
 #define USB_CNTR                             (USB_BASE + 0x40)           /*!< Control register */
 #define USB_ISTR                             (USB_BASE + 0x44)           /*!< Interrupt status register */
@@ -13153,7 +13163,7 @@ typedef struct
 
 /* EndPoint REGister MASK (no toggle fields) */
 #define USB_EPREG_MASK     (USB_EP_CTR_RX|USB_EP_SETUP|USB_EP_T_FIELD|USB_EP_KIND|USB_EP_CTR_TX|USB_EPADDR_FIELD)
-                                                                         /*!< EP_TYPE[1:0] EndPoint TYPE */
+/*!< EP_TYPE[1:0] EndPoint TYPE */
 #define USB_EP_TYPE_MASK                      ((uint16_t)0x0600U)              /*!< EndPoint TYPE Mask */
 #define USB_EP_BULK                           ((uint16_t)0x0000U)              /*!< EndPoint BULK */
 #define USB_EP_CONTROL                        ((uint16_t)0x0200U)              /*!< EndPoint CONTROL */
@@ -13162,7 +13172,7 @@ typedef struct
 #define USB_EP_T_MASK                        ((uint16_t) ~USB_EP_T_FIELD & USB_EPREG_MASK)
 
 #define USB_EPKIND_MASK                      ((uint16_t)~USB_EP_KIND & USB_EPREG_MASK) /*!< EP_KIND EndPoint KIND */
-                                                                         /*!< STAT_TX[1:0] STATus for TX transfer */
+/*!< STAT_TX[1:0] STATus for TX transfer */
 #define USB_EP_TX_DIS                         ((uint16_t)0x0000U)              /*!< EndPoint TX DISabled */
 #define USB_EP_TX_STALL                       ((uint16_t)0x0010U)              /*!< EndPoint TX STALLed */
 #define USB_EP_TX_NAK                         ((uint16_t)0x0020U)              /*!< EndPoint TX NAKed */
@@ -13170,7 +13180,7 @@ typedef struct
 #define USB_EPTX_DTOG1                        ((uint16_t)0x0010U)              /*!< EndPoint TX Data TOGgle bit1 */
 #define USB_EPTX_DTOG2                        ((uint16_t)0x0020U)              /*!< EndPoint TX Data TOGgle bit2 */
 #define USB_EPTX_DTOGMASK  (USB_EPTX_STAT|USB_EPREG_MASK)
-                                                                         /*!< STAT_RX[1:0] STATus for RX transfer */
+/*!< STAT_RX[1:0] STATus for RX transfer */
 #define USB_EP_RX_DIS                         ((uint16_t)0x0000U)              /*!< EndPoint RX DISabled */
 #define USB_EP_RX_STALL                       ((uint16_t)0x1000U)              /*!< EndPoint RX STALLed */
 #define USB_EP_RX_NAK                         ((uint16_t)0x2000U)              /*!< EndPoint RX NAKed */
@@ -13534,38 +13544,38 @@ typedef struct
 
 /******************* TIM Instances : output(s) available **********************/
 #define IS_TIM_CCX_INSTANCE(INSTANCE, CHANNEL) \
-        ((((INSTANCE) == TIM1) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4) ||          \
-            ((CHANNEL) == TIM_CHANNEL_5) ||          \
-            ((CHANNEL) == TIM_CHANNEL_6)))           \
-           ||                                        \
-           (((INSTANCE) == TIM2) &&                  \
-           (((CHANNEL) == TIM_CHANNEL_1) ||          \
-            ((CHANNEL) == TIM_CHANNEL_2) ||          \
-            ((CHANNEL) == TIM_CHANNEL_3) ||          \
-            ((CHANNEL) == TIM_CHANNEL_4)))           \
-           ||                                        \
-           (((INSTANCE) == TIM16) &&                 \
-           (((CHANNEL) == TIM_CHANNEL_1)))           \
-           ||                                        \
-           (((INSTANCE) == TIM17) &&                 \
-            (((CHANNEL) == TIM_CHANNEL_1))))
+  ((((INSTANCE) == TIM1) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4) ||          \
+     ((CHANNEL) == TIM_CHANNEL_5) ||          \
+     ((CHANNEL) == TIM_CHANNEL_6)))           \
+   ||                                        \
+   (((INSTANCE) == TIM2) &&                  \
+    (((CHANNEL) == TIM_CHANNEL_1) ||          \
+     ((CHANNEL) == TIM_CHANNEL_2) ||          \
+     ((CHANNEL) == TIM_CHANNEL_3) ||          \
+     ((CHANNEL) == TIM_CHANNEL_4)))           \
+   ||                                        \
+   (((INSTANCE) == TIM16) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1)))           \
+   ||                                        \
+   (((INSTANCE) == TIM17) &&                 \
+    (((CHANNEL) == TIM_CHANNEL_1))))
 
 /****************** TIM Instances : supporting complementary output(s) ********/
 #define IS_TIM_CCXN_INSTANCE(INSTANCE, CHANNEL) \
-   ((((INSTANCE) == TIM1) &&                    \
-     (((CHANNEL) == TIM_CHANNEL_1) ||           \
-      ((CHANNEL) == TIM_CHANNEL_2) ||           \
-      ((CHANNEL) == TIM_CHANNEL_3)))            \
-    ||                                          \
-    (((INSTANCE) == TIM17) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1))              \
-    ||                                          \
-    (((INSTANCE) == TIM16) &&                   \
-     ((CHANNEL) == TIM_CHANNEL_1)))
+  ((((INSTANCE) == TIM1) &&                    \
+    (((CHANNEL) == TIM_CHANNEL_1) ||           \
+     ((CHANNEL) == TIM_CHANNEL_2) ||           \
+     ((CHANNEL) == TIM_CHANNEL_3)))            \
+   ||                                          \
+   (((INSTANCE) == TIM17) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1))              \
+   ||                                          \
+   (((INSTANCE) == TIM16) &&                   \
+    ((CHANNEL) == TIM_CHANNEL_1)))
 
 /****************** TIM Instances : supporting clock division *****************/
 #define IS_TIM_CLOCK_DIVISION_INSTANCE(INSTANCE)   (((INSTANCE) == TIM1)    || \
@@ -13657,9 +13667,9 @@ typedef struct
   * @}
   */
 
- /**
+/**
   * @}
-  */
+ */
 
 /**
   * @}
@@ -13675,8 +13685,6 @@ typedef struct
   * @}
   */
 
-  /**
+/**
   * @}
-  */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+*/

--- a/CMSIS/STM32WBxx/Include/stm32wbxx.h
+++ b/CMSIS/STM32WBxx/Include/stm32wbxx.h
@@ -16,13 +16,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2021 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -39,7 +38,7 @@
 #define __STM32WBxx_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif /* __cplusplus */
 
 /** @addtogroup Library_configuration_section
@@ -58,19 +57,19 @@
   */
 #if !defined  (USE_HAL_DRIVER)
 /**
- * @brief Comment the line below if you will not use the peripherals drivers.
+  * @brief Comment the line below if you will not use the peripherals drivers.
    In this case, these drivers will not be included and the application code will
    be based on direct access to peripherals registers
    */
-  /*#define USE_HAL_DRIVER */
+/*#define USE_HAL_DRIVER */
 #endif /* USE_HAL_DRIVER */
 
 /**
   * @brief CMSIS Device version number
   */
 #define __STM32WBxx_CMSIS_VERSION_MAIN   (0x01U) /*!< [31:24] main version */
-#define __STM32WBxx_CMSIS_VERSION_SUB1   (0x07U) /*!< [23:16] sub1 version */
-#define __STM32WBxx_CMSIS_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
+#define __STM32WBxx_CMSIS_VERSION_SUB1   (0x0CU) /*!< [23:16] sub1 version */
+#define __STM32WBxx_CMSIS_VERSION_SUB2   (0x03U) /*!< [15:8]  sub2 version */
 #define __STM32WBxx_CMSIS_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
 #define __STM32WBxx_CMSIS_DEVICE_VERSION        ((__STM32WBxx_CMSIS_VERSION_MAIN << 24)\
                                                 |(__STM32WBxx_CMSIS_VERSION_SUB1 << 16)\
@@ -86,17 +85,23 @@
   */
 
 #if defined(STM32WB55xx)
-  #include "stm32wb55xx.h"
+#include "stm32wb55xx.h"
 #elif defined(STM32WB5Mxx)
-  #include "stm32wb5mxx.h"
+#include "stm32wb5mxx.h"
 #elif defined(STM32WB50xx)
-  #include "stm32wb50xx.h"
+#include "stm32wb50xx.h"
 #elif defined(STM32WB35xx)
-  #include "stm32wb35xx.h"
+#include "stm32wb35xx.h"
 #elif defined(STM32WB30xx)
-  #include "stm32wb30xx.h"
+#include "stm32wb30xx.h"
+#elif defined(STM32WB15xx)
+#include "stm32wb15xx.h"
+#elif defined(STM32WB10xx)
+#include "stm32wb10xx.h"
+#elif defined(STM32WB1Mxx)
+#include "stm32wb1mxx.h"
 #else
- #error "Please select first the target STM32WBxx device used in your application, for instance xxx (in stm32wbxx.h file)"
+#error "Please select first the target STM32WBxx device used in your application, for instance xxx (in stm32wbxx.h file)"
 #endif
 /**
   * @}
@@ -146,13 +151,69 @@ typedef enum
 
 #define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
 
+/* Use of CMSIS compiler intrinsics for register exclusive access */
+/* Atomic 32-bit register access macro to set one or several bits */
+#define ATOMIC_SET_BIT(REG, BIT)                             \
+  do {                                                       \
+    uint32_t val;                                            \
+    do {                                                     \
+      val = __LDREXW((__IO uint32_t *)&(REG)) | (BIT);       \
+    } while ((__STREXW(val,(__IO uint32_t *)&(REG))) != 0U); \
+  } while(0)
+
+/* Atomic 32-bit register access macro to clear one or several bits */
+#define ATOMIC_CLEAR_BIT(REG, BIT)                           \
+  do {                                                       \
+    uint32_t val;                                            \
+    do {                                                     \
+      val = __LDREXW((__IO uint32_t *)&(REG)) & ~(BIT);      \
+    } while ((__STREXW(val,(__IO uint32_t *)&(REG))) != 0U); \
+  } while(0)
+
+/* Atomic 32-bit register access macro to clear and set one or several bits */
+#define ATOMIC_MODIFY_REG(REG, CLEARMSK, SETMASK)                          \
+  do {                                                                     \
+    uint32_t val;                                                          \
+    do {                                                                   \
+      val = (__LDREXW((__IO uint32_t *)&(REG)) & ~(CLEARMSK)) | (SETMASK); \
+    } while ((__STREXW(val,(__IO uint32_t *)&(REG))) != 0U);               \
+  } while(0)
+
+/* Atomic 16-bit register access macro to set one or several bits */
+#define ATOMIC_SETH_BIT(REG, BIT)                            \
+  do {                                                       \
+    uint16_t val;                                            \
+    do {                                                     \
+      val = __LDREXH((__IO uint16_t *)&(REG)) | (BIT);       \
+    } while ((__STREXH(val,(__IO uint16_t *)&(REG))) != 0U); \
+  } while(0)
+
+/* Atomic 16-bit register access macro to clear one or several bits */
+#define ATOMIC_CLEARH_BIT(REG, BIT)                          \
+  do {                                                       \
+    uint16_t val;                                            \
+    do {                                                     \
+      val = __LDREXH((__IO uint16_t *)&(REG)) & ~(BIT);      \
+    } while ((__STREXH(val,(__IO uint16_t *)&(REG))) != 0U); \
+  } while(0)
+
+/* Atomic 16-bit register access macro to clear and set one or several bits */
+#define ATOMIC_MODIFYH_REG(REG, CLEARMSK, SETMASK)                         \
+  do {                                                                     \
+    uint16_t val;                                                          \
+    do {                                                                   \
+      val = (__LDREXH((__IO uint16_t *)&(REG)) & ~(CLEARMSK)) | (SETMASK); \
+    } while ((__STREXH(val,(__IO uint16_t *)&(REG))) != 0U);               \
+  } while(0)
+
 #define POSITION_VAL(VAL)     (__CLZ(__RBIT(VAL)))
+
 /**
   * @}
   */
 
 #if defined (USE_HAL_DRIVER)
- #include "stm32wbxx_hal.h"
+#include "stm32wbxx_hal.h"
 #endif /* USE_HAL_DRIVER */
 
 #ifdef __cplusplus
@@ -167,8 +228,3 @@ typedef enum
 /**
   * @}
   */
-
-
-
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Include/system_stm32wbxx.h
+++ b/CMSIS/STM32WBxx/Include/system_stm32wbxx.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2021 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -32,7 +31,7 @@
 #define __SYSTEM_STM32WBXX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 #include <stdint.h>
@@ -49,14 +48,14 @@
 /** @addtogroup STM32WBxx_System_Exported_types
   * @{
   */
-  /* The SystemCoreClock variable is updated in three ways:
-      1) by calling CMSIS function SystemCoreClockUpdate()
-      2) by calling HAL API function HAL_RCC_GetSysClockFreq()
-      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
-         Note: If you use this function to configure the system clock; then there
-               is no need to call the 2 first functions listed above, since SystemCoreClock
-               variable is updated automatically.
-  */
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetSysClockFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+       Note: If you use this function to configure the system clock; then there
+             is no need to call the 2 first functions listed above, since SystemCoreClock
+             variable is updated automatically.
+*/
 
 extern uint32_t SystemCoreClock;            /*!< System Clock Frequency */
 
@@ -64,7 +63,7 @@ extern const uint32_t AHBPrescTable[16];    /*!< AHB prescalers table values */
 extern const uint32_t APBPrescTable[8];     /*!< APB prescalers table values */
 extern const uint32_t MSIRangeTable[16];    /*!< MSI ranges table values     */
 
-#if defined(STM32WB55xx) || defined(STM32WB5Mxx) || defined(STM32WB35xx)
+#if defined(STM32WB55xx) || defined(STM32WB5Mxx) || defined(STM32WB35xx) || defined (STM32WB15xx) || defined (STM32WB1Mxx)
 extern const uint32_t SmpsPrescalerTable[4][6];  /*!< SMPS factor ranges table values     */
 #endif
 /**
@@ -110,4 +109,3 @@ extern void SystemCoreClockUpdate(void);
 /**
   * @}
   */
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb10xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb10xx_cm4.s
@@ -1,0 +1,331 @@
+;******************************************************************************
+;* File Name          : startup_stm32wb10xx_cm4.s
+;* Author             : MCD Application Team
+;* Description        : STM32WB10xx devices vector table for MDK-ARM toolchain.
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == Reset_Handler
+;*                      - Set the vector table entries with the exceptions ISR address
+;*                      - Branches to __main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the CortexM4 processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;* <<< Use Configuration Wizard in Context Menu >>>
+;******************************************************************************
+;* @attention
+;*
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
+;*
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
+;*
+;******************************************************************************
+
+; Amount of memory (in bytes) allocated for Stack
+; Tailor this value to your application needs
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000200
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+
+; Vector Table Mapped to Address 0 at Reset
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp              ; Top of Stack
+        DCD     Reset_Handler                     ; Reset Handler
+        DCD     NMI_Handler                       ; NMI Handler
+        DCD     HardFault_Handler                 ; Hard Fault Handler
+        DCD     MemManage_Handler                 ; MPU Fault Handler
+        DCD     BusFault_Handler                  ; Bus Fault Handler
+        DCD     UsageFault_Handler                ; Usage Fault Handler
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SVC_Handler                       ; SVCall Handler
+        DCD     DebugMon_Handler                  ; Debug Monitor Handler
+        DCD     0                                 ; Reserved
+        DCD     PendSV_Handler                    ; PendSV Handler
+        DCD     SysTick_Handler                   ; SysTick Handler
+
+         ; External Interrupts
+        DCD     WWDG_IRQHandler                   ; Window WatchDog
+        DCD     PVD_PVM_IRQHandler                ; PVD and PVM detector
+        DCD     TAMP_STAMP_LSECSS_IRQHandler      ; RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts
+        DCD     RTC_WKUP_IRQHandler               ; RTC Wakeup Interrupt
+        DCD     FLASH_IRQHandler                  ; FLASH global Interrupt
+        DCD     RCC_IRQHandler                    ; RCC Interrupt
+        DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
+        DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
+        DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
+        DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
+        DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
+        DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
+        DCD     DMA1_Channel3_IRQHandler          ; DMA1 Channel 3 Interrupt
+        DCD     DMA1_Channel4_IRQHandler          ; DMA1 Channel 4 Interrupt
+        DCD     DMA1_Channel5_IRQHandler          ; DMA1 Channel 5 Interrupt
+        DCD     DMA1_Channel6_IRQHandler          ; DMA1 Channel 6 Interrupt
+        DCD     DMA1_Channel7_IRQHandler          ; DMA1 Channel 7 Interrupt
+        DCD     ADC1_IRQHandler                   ; ADC1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     C2SEV_PWR_C2H_IRQHandler          ; CPU M0+ SEV Interrupt
+        DCD     0                                 ; Reserved
+        DCD     EXTI9_5_IRQHandler                ; EXTI Lines [9:5] Interrupt
+        DCD     TIM1_BRK_IRQHandler               ; TIM1 Break Interrupt
+        DCD     TIM1_UP_IRQHandler                ; TIM1 Update Interrupt
+        DCD     TIM1_TRG_COM_IRQHandler           ; TIM1 Trigger and Communication Interrupts
+        DCD     TIM1_CC_IRQHandler                ; TIM1 Capture Compare Interrupt
+        DCD     TIM2_IRQHandler                   ; TIM2 Global Interrupt
+        DCD     PKA_IRQHandler                    ; PKA Interrupt
+        DCD     I2C1_EV_IRQHandler                ; I2C1 Event Interrupt
+        DCD     I2C1_ER_IRQHandler                ; I2C1 Error Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SPI1_IRQHandler                   ; SPI1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     USART1_IRQHandler                 ; USART1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     TSC_IRQHandler                    ; TSC Interrupt
+        DCD     EXTI15_10_IRQHandler              ; EXTI Lines1[15:10 ]Interrupts
+        DCD     RTC_Alarm_IRQHandler              ; RTC Alarms (A and B) Interrupt
+        DCD     0                                 ; Reserved
+        DCD     PWR_SOTF_BLEACT_RFPHASE_IRQHandler ; WKUP Interrupt from PWR
+        DCD     IPCC_C1_RX_IRQHandler             ; IPCC CPU1 RX occupied interrupt
+        DCD     IPCC_C1_TX_IRQHandler             ; IPCC CPU1 RX free interrupt
+        DCD     HSEM_IRQHandler                   ; HSEM0 Interrupt
+        DCD     LPTIM1_IRQHandler                 ; LPTIM1 Interrupt
+        DCD     LPTIM2_IRQHandler                 ; LPTIM2 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     AES2_IRQHandler                   ; AES2 Interrupt
+        DCD     RNG_IRQHandler                    ; RNG1 Interrupt
+        DCD     FPU_IRQHandler                    ; FPU Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     DMAMUX1_OVR_IRQHandler            ; DMAMUX overrun Interrupt
+
+__Vectors_End
+
+__Vectors_Size  EQU  __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset handler
+Reset_Handler    PROC
+                 EXPORT  Reset_Handler                 [WEAK]
+        IMPORT  SystemInit
+        IMPORT  __main
+
+                 LDR     R0, =SystemInit
+                 BLX     R0
+                 LDR     R0, =__main
+                 BX      R0
+                 ENDP
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                    [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler              [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler              [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler               [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler             [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                    [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler               [WEAK]
+                B       .
+                ENDP
+PendSV_Handler  PROC
+                EXPORT  PendSV_Handler                 [WEAK]
+                B       .
+                ENDP
+SysTick_Handler PROC
+                EXPORT  SysTick_Handler                [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+
+                EXPORT  WWDG_IRQHandler                   [WEAK]
+                EXPORT  PVD_PVM_IRQHandler                [WEAK]
+                EXPORT  TAMP_STAMP_LSECSS_IRQHandler      [WEAK]
+                EXPORT  RTC_WKUP_IRQHandler               [WEAK]
+                EXPORT  FLASH_IRQHandler                  [WEAK]
+                EXPORT  RCC_IRQHandler                    [WEAK]
+                EXPORT  EXTI0_IRQHandler                  [WEAK]
+                EXPORT  EXTI1_IRQHandler                  [WEAK]
+                EXPORT  EXTI2_IRQHandler                  [WEAK]
+                EXPORT  EXTI3_IRQHandler                  [WEAK]
+                EXPORT  EXTI4_IRQHandler                  [WEAK]
+                EXPORT  DMA1_Channel1_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel2_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel3_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel4_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel5_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel6_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel7_IRQHandler          [WEAK]
+                EXPORT  ADC1_IRQHandler                   [WEAK]
+                EXPORT  C2SEV_PWR_C2H_IRQHandler          [WEAK]
+                EXPORT  EXTI9_5_IRQHandler                [WEAK]
+                EXPORT  TIM1_BRK_IRQHandler               [WEAK]
+                EXPORT  TIM1_UP_IRQHandler                [WEAK]
+                EXPORT  TIM1_TRG_COM_IRQHandler           [WEAK]
+                EXPORT  TIM1_CC_IRQHandler                [WEAK]
+                EXPORT  TIM2_IRQHandler                   [WEAK]
+                EXPORT  PKA_IRQHandler                    [WEAK]
+                EXPORT  I2C1_EV_IRQHandler                [WEAK]
+                EXPORT  I2C1_ER_IRQHandler                [WEAK]
+                EXPORT  SPI1_IRQHandler                   [WEAK]
+                EXPORT  USART1_IRQHandler                 [WEAK]
+                EXPORT  TSC_IRQHandler                    [WEAK]
+                EXPORT  EXTI15_10_IRQHandler              [WEAK]
+                EXPORT  RTC_Alarm_IRQHandler              [WEAK]
+                EXPORT  PWR_SOTF_BLEACT_RFPHASE_IRQHandler [WEAK]
+                EXPORT  IPCC_C1_RX_IRQHandler             [WEAK]
+                EXPORT  IPCC_C1_TX_IRQHandler             [WEAK]
+                EXPORT  HSEM_IRQHandler                   [WEAK]
+                EXPORT  LPTIM1_IRQHandler                 [WEAK]
+                EXPORT  LPTIM2_IRQHandler                 [WEAK]
+                EXPORT  AES1_IRQHandler                   [WEAK]
+                EXPORT  AES2_IRQHandler                   [WEAK]
+                EXPORT  RNG_IRQHandler                    [WEAK]
+                EXPORT  FPU_IRQHandler                    [WEAK]
+                EXPORT  DMAMUX1_OVR_IRQHandler            [WEAK]
+
+WWDG_IRQHandler
+PVD_PVM_IRQHandler
+TAMP_STAMP_LSECSS_IRQHandler
+RTC_WKUP_IRQHandler
+FLASH_IRQHandler
+RCC_IRQHandler
+EXTI0_IRQHandler
+EXTI1_IRQHandler
+EXTI2_IRQHandler
+EXTI3_IRQHandler
+EXTI4_IRQHandler
+DMA1_Channel1_IRQHandler
+DMA1_Channel2_IRQHandler
+DMA1_Channel3_IRQHandler
+DMA1_Channel4_IRQHandler
+DMA1_Channel5_IRQHandler
+DMA1_Channel6_IRQHandler
+DMA1_Channel7_IRQHandler
+ADC1_IRQHandler
+C2SEV_PWR_C2H_IRQHandler
+EXTI9_5_IRQHandler
+TIM1_BRK_IRQHandler
+TIM1_UP_IRQHandler
+TIM1_TRG_COM_IRQHandler
+TIM1_CC_IRQHandler
+TIM2_IRQHandler
+PKA_IRQHandler
+I2C1_EV_IRQHandler
+I2C1_ER_IRQHandler
+SPI1_IRQHandler
+USART1_IRQHandler
+TSC_IRQHandler
+EXTI15_10_IRQHandler
+RTC_Alarm_IRQHandler
+PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+IPCC_C1_RX_IRQHandler
+IPCC_C1_TX_IRQHandler
+HSEM_IRQHandler
+LPTIM1_IRQHandler
+LPTIM2_IRQHandler
+AES1_IRQHandler
+AES2_IRQHandler
+RNG_IRQHandler
+FPU_IRQHandler
+DMAMUX1_OVR_IRQHandler
+
+                B       .
+
+                ENDP
+
+                ALIGN
+
+;*******************************************************************************
+; User Stack and Heap initialization
+;*******************************************************************************
+                 IF      :DEF:__MICROLIB
+
+                 EXPORT  __initial_sp
+                 EXPORT  __heap_base
+                 EXPORT  __heap_limit
+
+                 ELSE
+
+                 IMPORT  __use_two_region_memory
+                 EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap
+
+                 LDR     R0, =  Heap_Mem
+                 LDR     R1, =(Stack_Mem + Stack_Size)
+                 LDR     R2, = (Heap_Mem +  Heap_Size)
+                 LDR     R3, = Stack_Mem
+                 BX      LR
+
+                 ALIGN
+
+                 ENDIF
+
+                 END
+

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb15xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb15xx_cm4.s
@@ -1,0 +1,335 @@
+;******************************************************************************
+;* File Name          : startup_stm32wb15xx_cm4.s
+;* Author             : MCD Application Team
+;* Description        : STM32WB15xx devices vector table for MDK-ARM toolchain.
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == Reset_Handler
+;*                      - Set the vector table entries with the exceptions ISR address
+;*                      - Branches to __main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the CortexM4 processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;* <<< Use Configuration Wizard in Context Menu >>>
+;******************************************************************************
+;* @attention
+;*
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
+;*
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
+;*
+;******************************************************************************
+
+; Amount of memory (in bytes) allocated for Stack
+; Tailor this value to your application needs
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000200
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+
+; Vector Table Mapped to Address 0 at Reset
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp              ; Top of Stack
+        DCD     Reset_Handler                     ; Reset Handler
+        DCD     NMI_Handler                       ; NMI Handler
+        DCD     HardFault_Handler                 ; Hard Fault Handler
+        DCD     MemManage_Handler                 ; MPU Fault Handler
+        DCD     BusFault_Handler                  ; Bus Fault Handler
+        DCD     UsageFault_Handler                ; Usage Fault Handler
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SVC_Handler                       ; SVCall Handler
+        DCD     DebugMon_Handler                  ; Debug Monitor Handler
+        DCD     0                                 ; Reserved
+        DCD     PendSV_Handler                    ; PendSV Handler
+        DCD     SysTick_Handler                   ; SysTick Handler
+
+         ; External Interrupts
+        DCD     WWDG_IRQHandler                   ; Window WatchDog
+        DCD     PVD_PVM_IRQHandler                ; PVD and PVM detector
+        DCD     TAMP_STAMP_LSECSS_IRQHandler      ; RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts
+        DCD     RTC_WKUP_IRQHandler               ; RTC Wakeup Interrupt
+        DCD     FLASH_IRQHandler                  ; FLASH global Interrupt
+        DCD     RCC_IRQHandler                    ; RCC Interrupt
+        DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
+        DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
+        DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
+        DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
+        DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
+        DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
+        DCD     DMA1_Channel3_IRQHandler          ; DMA1 Channel 3 Interrupt
+        DCD     DMA1_Channel4_IRQHandler          ; DMA1 Channel 4 Interrupt
+        DCD     DMA1_Channel5_IRQHandler          ; DMA1 Channel 5 Interrupt
+        DCD     DMA1_Channel6_IRQHandler          ; DMA1 Channel 6 Interrupt
+        DCD     DMA1_Channel7_IRQHandler          ; DMA1 Channel 7 Interrupt
+        DCD     ADC1_IRQHandler                   ; ADC1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     C2SEV_PWR_C2H_IRQHandler          ; CPU M0+ SEV Interrupt
+        DCD     COMP_IRQHandler                   ; COMP1 Interrupts
+        DCD     EXTI9_5_IRQHandler                ; EXTI Lines [9:5] Interrupt
+        DCD     TIM1_BRK_IRQHandler               ; TIM1 Break Interrupt
+        DCD     TIM1_UP_IRQHandler                ; TIM1 Update Interrupt
+        DCD     TIM1_TRG_COM_IRQHandler           ; TIM1 Trigger and Communication Interrupts
+        DCD     TIM1_CC_IRQHandler                ; TIM1 Capture Compare Interrupt
+        DCD     TIM2_IRQHandler                   ; TIM2 Global Interrupt
+        DCD     PKA_IRQHandler                    ; PKA Interrupt
+        DCD     I2C1_EV_IRQHandler                ; I2C1 Event Interrupt
+        DCD     I2C1_ER_IRQHandler                ; I2C1 Error Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SPI1_IRQHandler                   ; SPI1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     USART1_IRQHandler                 ; USART1 Interrupt
+        DCD     LPUART1_IRQHandler                ; LPUART1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     TSC_IRQHandler                    ; TSC Interrupt
+        DCD     EXTI15_10_IRQHandler              ; EXTI Lines1[15:10 ]Interrupts
+        DCD     RTC_Alarm_IRQHandler              ; RTC Alarms (A and B) Interrupt
+        DCD     0                                 ; Reserved
+        DCD     PWR_SOTF_BLEACT_RFPHASE_IRQHandler ; WKUP Interrupt from PWR
+        DCD     IPCC_C1_RX_IRQHandler             ; IPCC CPU1 RX occupied interrupt
+        DCD     IPCC_C1_TX_IRQHandler             ; IPCC CPU1 RX free interrupt
+        DCD     HSEM_IRQHandler                   ; HSEM0 Interrupt
+        DCD     LPTIM1_IRQHandler                 ; LPTIM1 Interrupt
+        DCD     LPTIM2_IRQHandler                 ; LPTIM2 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     AES2_IRQHandler                   ; AES2 Interrupt
+        DCD     RNG_IRQHandler                    ; RNG1 Interrupt
+        DCD     FPU_IRQHandler                    ; FPU Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     DMAMUX1_OVR_IRQHandler            ; DMAMUX overrun Interrupt
+
+__Vectors_End
+
+__Vectors_Size  EQU  __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset handler
+Reset_Handler    PROC
+                 EXPORT  Reset_Handler                 [WEAK]
+        IMPORT  SystemInit
+        IMPORT  __main
+
+                 LDR     R0, =SystemInit
+                 BLX     R0
+                 LDR     R0, =__main
+                 BX      R0
+                 ENDP
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                    [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler              [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler              [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler               [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler             [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                    [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler               [WEAK]
+                B       .
+                ENDP
+PendSV_Handler  PROC
+                EXPORT  PendSV_Handler                 [WEAK]
+                B       .
+                ENDP
+SysTick_Handler PROC
+                EXPORT  SysTick_Handler                [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+
+                EXPORT  WWDG_IRQHandler                   [WEAK]
+                EXPORT  PVD_PVM_IRQHandler                [WEAK]
+                EXPORT  TAMP_STAMP_LSECSS_IRQHandler      [WEAK]
+                EXPORT  RTC_WKUP_IRQHandler               [WEAK]
+                EXPORT  FLASH_IRQHandler                  [WEAK]
+                EXPORT  RCC_IRQHandler                    [WEAK]
+                EXPORT  EXTI0_IRQHandler                  [WEAK]
+                EXPORT  EXTI1_IRQHandler                  [WEAK]
+                EXPORT  EXTI2_IRQHandler                  [WEAK]
+                EXPORT  EXTI3_IRQHandler                  [WEAK]
+                EXPORT  EXTI4_IRQHandler                  [WEAK]
+                EXPORT  DMA1_Channel1_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel2_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel3_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel4_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel5_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel6_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel7_IRQHandler          [WEAK]
+                EXPORT  ADC1_IRQHandler                   [WEAK]
+                EXPORT  C2SEV_PWR_C2H_IRQHandler          [WEAK]
+                EXPORT  COMP_IRQHandler                   [WEAK]
+                EXPORT  EXTI9_5_IRQHandler                [WEAK]
+                EXPORT  TIM1_BRK_IRQHandler               [WEAK]
+                EXPORT  TIM1_UP_IRQHandler                [WEAK]
+                EXPORT  TIM1_TRG_COM_IRQHandler           [WEAK]
+                EXPORT  TIM1_CC_IRQHandler                [WEAK]
+                EXPORT  TIM2_IRQHandler                   [WEAK]
+                EXPORT  PKA_IRQHandler                    [WEAK]
+                EXPORT  I2C1_EV_IRQHandler                [WEAK]
+                EXPORT  I2C1_ER_IRQHandler                [WEAK]
+                EXPORT  SPI1_IRQHandler                   [WEAK]
+                EXPORT  USART1_IRQHandler                 [WEAK]
+                EXPORT  LPUART1_IRQHandler                [WEAK]
+                EXPORT  TSC_IRQHandler                    [WEAK]
+                EXPORT  EXTI15_10_IRQHandler              [WEAK]
+                EXPORT  RTC_Alarm_IRQHandler              [WEAK]
+                EXPORT  PWR_SOTF_BLEACT_RFPHASE_IRQHandler [WEAK]
+                EXPORT  IPCC_C1_RX_IRQHandler             [WEAK]
+                EXPORT  IPCC_C1_TX_IRQHandler             [WEAK]
+                EXPORT  HSEM_IRQHandler                   [WEAK]
+                EXPORT  LPTIM1_IRQHandler                 [WEAK]
+                EXPORT  LPTIM2_IRQHandler                 [WEAK]
+                EXPORT  AES1_IRQHandler                   [WEAK]
+                EXPORT  AES2_IRQHandler                   [WEAK]
+                EXPORT  RNG_IRQHandler                    [WEAK]
+                EXPORT  FPU_IRQHandler                    [WEAK]
+                EXPORT  DMAMUX1_OVR_IRQHandler            [WEAK]
+
+WWDG_IRQHandler
+PVD_PVM_IRQHandler
+TAMP_STAMP_LSECSS_IRQHandler
+RTC_WKUP_IRQHandler
+FLASH_IRQHandler
+RCC_IRQHandler
+EXTI0_IRQHandler
+EXTI1_IRQHandler
+EXTI2_IRQHandler
+EXTI3_IRQHandler
+EXTI4_IRQHandler
+DMA1_Channel1_IRQHandler
+DMA1_Channel2_IRQHandler
+DMA1_Channel3_IRQHandler
+DMA1_Channel4_IRQHandler
+DMA1_Channel5_IRQHandler
+DMA1_Channel6_IRQHandler
+DMA1_Channel7_IRQHandler
+ADC1_IRQHandler
+C2SEV_PWR_C2H_IRQHandler
+COMP_IRQHandler
+EXTI9_5_IRQHandler
+TIM1_BRK_IRQHandler
+TIM1_UP_IRQHandler
+TIM1_TRG_COM_IRQHandler
+TIM1_CC_IRQHandler
+TIM2_IRQHandler
+PKA_IRQHandler
+I2C1_EV_IRQHandler
+I2C1_ER_IRQHandler
+SPI1_IRQHandler
+USART1_IRQHandler
+LPUART1_IRQHandler
+TSC_IRQHandler
+EXTI15_10_IRQHandler
+RTC_Alarm_IRQHandler
+PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+IPCC_C1_RX_IRQHandler
+IPCC_C1_TX_IRQHandler
+HSEM_IRQHandler
+LPTIM1_IRQHandler
+LPTIM2_IRQHandler
+AES1_IRQHandler
+AES2_IRQHandler
+RNG_IRQHandler
+FPU_IRQHandler
+DMAMUX1_OVR_IRQHandler
+
+                B       .
+
+                ENDP
+
+                ALIGN
+
+;*******************************************************************************
+; User Stack and Heap initialization
+;*******************************************************************************
+                 IF      :DEF:__MICROLIB
+
+                 EXPORT  __initial_sp
+                 EXPORT  __heap_base
+                 EXPORT  __heap_limit
+
+                 ELSE
+
+                 IMPORT  __use_two_region_memory
+                 EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap
+
+                 LDR     R0, =  Heap_Mem
+                 LDR     R1, =(Stack_Mem + Stack_Size)
+                 LDR     R2, = (Heap_Mem +  Heap_Size)
+                 LDR     R3, = Stack_Mem
+                 BX      LR
+
+                 ALIGN
+
+                 ENDIF
+
+                 END
+

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb1mxx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb1mxx_cm4.s
@@ -1,0 +1,335 @@
+;******************************************************************************
+;* File Name          : startup_stm32wb1mxx_cm4.s
+;* Author             : MCD Application Team
+;* Description        : STM32WB1Mxx devices vector table for MDK-ARM toolchain.
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == Reset_Handler
+;*                      - Set the vector table entries with the exceptions ISR address
+;*                      - Branches to __main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the CortexM4 processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;* <<< Use Configuration Wizard in Context Menu >>>
+;******************************************************************************
+;* @attention
+;*
+;* Copyright (c) 2022 STMicroelectronics.
+;* All rights reserved.
+;*
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
+;*
+;******************************************************************************
+
+; Amount of memory (in bytes) allocated for Stack
+; Tailor this value to your application needs
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000200
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+
+; Vector Table Mapped to Address 0 at Reset
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp              ; Top of Stack
+        DCD     Reset_Handler                     ; Reset Handler
+        DCD     NMI_Handler                       ; NMI Handler
+        DCD     HardFault_Handler                 ; Hard Fault Handler
+        DCD     MemManage_Handler                 ; MPU Fault Handler
+        DCD     BusFault_Handler                  ; Bus Fault Handler
+        DCD     UsageFault_Handler                ; Usage Fault Handler
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SVC_Handler                       ; SVCall Handler
+        DCD     DebugMon_Handler                  ; Debug Monitor Handler
+        DCD     0                                 ; Reserved
+        DCD     PendSV_Handler                    ; PendSV Handler
+        DCD     SysTick_Handler                   ; SysTick Handler
+
+         ; External Interrupts
+        DCD     WWDG_IRQHandler                   ; Window WatchDog
+        DCD     PVD_PVM_IRQHandler                ; PVD and PVM detector
+        DCD     TAMP_STAMP_LSECSS_IRQHandler      ; RTC Tamper and TimeStamp Interrupts and LSECSS Interrupts
+        DCD     RTC_WKUP_IRQHandler               ; RTC Wakeup Interrupt
+        DCD     FLASH_IRQHandler                  ; FLASH global Interrupt
+        DCD     RCC_IRQHandler                    ; RCC Interrupt
+        DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
+        DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
+        DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
+        DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
+        DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
+        DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
+        DCD     DMA1_Channel3_IRQHandler          ; DMA1 Channel 3 Interrupt
+        DCD     DMA1_Channel4_IRQHandler          ; DMA1 Channel 4 Interrupt
+        DCD     DMA1_Channel5_IRQHandler          ; DMA1 Channel 5 Interrupt
+        DCD     DMA1_Channel6_IRQHandler          ; DMA1 Channel 6 Interrupt
+        DCD     DMA1_Channel7_IRQHandler          ; DMA1 Channel 7 Interrupt
+        DCD     ADC1_IRQHandler                   ; ADC1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     C2SEV_PWR_C2H_IRQHandler          ; CPU M0+ SEV Interrupt
+        DCD     COMP_IRQHandler                   ; COMP1 Interrupts
+        DCD     EXTI9_5_IRQHandler                ; EXTI Lines [9:5] Interrupt
+        DCD     TIM1_BRK_IRQHandler               ; TIM1 Break Interrupt
+        DCD     TIM1_UP_IRQHandler                ; TIM1 Update Interrupt
+        DCD     TIM1_TRG_COM_IRQHandler           ; TIM1 Trigger and Communication Interrupts
+        DCD     TIM1_CC_IRQHandler                ; TIM1 Capture Compare Interrupt
+        DCD     TIM2_IRQHandler                   ; TIM2 Global Interrupt
+        DCD     PKA_IRQHandler                    ; PKA Interrupt
+        DCD     I2C1_EV_IRQHandler                ; I2C1 Event Interrupt
+        DCD     I2C1_ER_IRQHandler                ; I2C1 Error Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SPI1_IRQHandler                   ; SPI1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     USART1_IRQHandler                 ; USART1 Interrupt
+        DCD     LPUART1_IRQHandler                ; LPUART1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     TSC_IRQHandler                    ; TSC Interrupt
+        DCD     EXTI15_10_IRQHandler              ; EXTI Lines1[15:10 ]Interrupts
+        DCD     RTC_Alarm_IRQHandler              ; RTC Alarms (A and B) Interrupt
+        DCD     0                                 ; Reserved
+        DCD     PWR_SOTF_BLEACT_RFPHASE_IRQHandler ; WKUP Interrupt from PWR
+        DCD     IPCC_C1_RX_IRQHandler             ; IPCC CPU1 RX occupied interrupt
+        DCD     IPCC_C1_TX_IRQHandler             ; IPCC CPU1 RX free interrupt
+        DCD     HSEM_IRQHandler                   ; HSEM0 Interrupt
+        DCD     LPTIM1_IRQHandler                 ; LPTIM1 Interrupt
+        DCD     LPTIM2_IRQHandler                 ; LPTIM2 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     AES2_IRQHandler                   ; AES2 Interrupt
+        DCD     RNG_IRQHandler                    ; RNG1 Interrupt
+        DCD     FPU_IRQHandler                    ; FPU Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     DMAMUX1_OVR_IRQHandler            ; DMAMUX overrun Interrupt
+
+__Vectors_End
+
+__Vectors_Size  EQU  __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset handler
+Reset_Handler    PROC
+                 EXPORT  Reset_Handler                 [WEAK]
+        IMPORT  SystemInit
+        IMPORT  __main
+
+                 LDR     R0, =SystemInit
+                 BLX     R0
+                 LDR     R0, =__main
+                 BX      R0
+                 ENDP
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                    [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler              [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler              [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler               [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler             [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                    [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler               [WEAK]
+                B       .
+                ENDP
+PendSV_Handler  PROC
+                EXPORT  PendSV_Handler                 [WEAK]
+                B       .
+                ENDP
+SysTick_Handler PROC
+                EXPORT  SysTick_Handler                [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+
+                EXPORT  WWDG_IRQHandler                   [WEAK]
+                EXPORT  PVD_PVM_IRQHandler                [WEAK]
+                EXPORT  TAMP_STAMP_LSECSS_IRQHandler      [WEAK]
+                EXPORT  RTC_WKUP_IRQHandler               [WEAK]
+                EXPORT  FLASH_IRQHandler                  [WEAK]
+                EXPORT  RCC_IRQHandler                    [WEAK]
+                EXPORT  EXTI0_IRQHandler                  [WEAK]
+                EXPORT  EXTI1_IRQHandler                  [WEAK]
+                EXPORT  EXTI2_IRQHandler                  [WEAK]
+                EXPORT  EXTI3_IRQHandler                  [WEAK]
+                EXPORT  EXTI4_IRQHandler                  [WEAK]
+                EXPORT  DMA1_Channel1_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel2_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel3_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel4_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel5_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel6_IRQHandler          [WEAK]
+                EXPORT  DMA1_Channel7_IRQHandler          [WEAK]
+                EXPORT  ADC1_IRQHandler                   [WEAK]
+                EXPORT  C2SEV_PWR_C2H_IRQHandler          [WEAK]
+                EXPORT  COMP_IRQHandler                   [WEAK]
+                EXPORT  EXTI9_5_IRQHandler                [WEAK]
+                EXPORT  TIM1_BRK_IRQHandler               [WEAK]
+                EXPORT  TIM1_UP_IRQHandler                [WEAK]
+                EXPORT  TIM1_TRG_COM_IRQHandler           [WEAK]
+                EXPORT  TIM1_CC_IRQHandler                [WEAK]
+                EXPORT  TIM2_IRQHandler                   [WEAK]
+                EXPORT  PKA_IRQHandler                    [WEAK]
+                EXPORT  I2C1_EV_IRQHandler                [WEAK]
+                EXPORT  I2C1_ER_IRQHandler                [WEAK]
+                EXPORT  SPI1_IRQHandler                   [WEAK]
+                EXPORT  USART1_IRQHandler                 [WEAK]
+                EXPORT  LPUART1_IRQHandler                [WEAK]
+                EXPORT  TSC_IRQHandler                    [WEAK]
+                EXPORT  EXTI15_10_IRQHandler              [WEAK]
+                EXPORT  RTC_Alarm_IRQHandler              [WEAK]
+                EXPORT  PWR_SOTF_BLEACT_RFPHASE_IRQHandler [WEAK]
+                EXPORT  IPCC_C1_RX_IRQHandler             [WEAK]
+                EXPORT  IPCC_C1_TX_IRQHandler             [WEAK]
+                EXPORT  HSEM_IRQHandler                   [WEAK]
+                EXPORT  LPTIM1_IRQHandler                 [WEAK]
+                EXPORT  LPTIM2_IRQHandler                 [WEAK]
+                EXPORT  AES1_IRQHandler                   [WEAK]
+                EXPORT  AES2_IRQHandler                   [WEAK]
+                EXPORT  RNG_IRQHandler                    [WEAK]
+                EXPORT  FPU_IRQHandler                    [WEAK]
+                EXPORT  DMAMUX1_OVR_IRQHandler            [WEAK]
+
+WWDG_IRQHandler
+PVD_PVM_IRQHandler
+TAMP_STAMP_LSECSS_IRQHandler
+RTC_WKUP_IRQHandler
+FLASH_IRQHandler
+RCC_IRQHandler
+EXTI0_IRQHandler
+EXTI1_IRQHandler
+EXTI2_IRQHandler
+EXTI3_IRQHandler
+EXTI4_IRQHandler
+DMA1_Channel1_IRQHandler
+DMA1_Channel2_IRQHandler
+DMA1_Channel3_IRQHandler
+DMA1_Channel4_IRQHandler
+DMA1_Channel5_IRQHandler
+DMA1_Channel6_IRQHandler
+DMA1_Channel7_IRQHandler
+ADC1_IRQHandler
+C2SEV_PWR_C2H_IRQHandler
+COMP_IRQHandler
+EXTI9_5_IRQHandler
+TIM1_BRK_IRQHandler
+TIM1_UP_IRQHandler
+TIM1_TRG_COM_IRQHandler
+TIM1_CC_IRQHandler
+TIM2_IRQHandler
+PKA_IRQHandler
+I2C1_EV_IRQHandler
+I2C1_ER_IRQHandler
+SPI1_IRQHandler
+USART1_IRQHandler
+LPUART1_IRQHandler
+TSC_IRQHandler
+EXTI15_10_IRQHandler
+RTC_Alarm_IRQHandler
+PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+IPCC_C1_RX_IRQHandler
+IPCC_C1_TX_IRQHandler
+HSEM_IRQHandler
+LPTIM1_IRQHandler
+LPTIM2_IRQHandler
+AES1_IRQHandler
+AES2_IRQHandler
+RNG_IRQHandler
+FPU_IRQHandler
+DMAMUX1_OVR_IRQHandler
+
+                B       .
+
+                ENDP
+
+                ALIGN
+
+;*******************************************************************************
+; User Stack and Heap initialization
+;*******************************************************************************
+                 IF      :DEF:__MICROLIB
+
+                 EXPORT  __initial_sp
+                 EXPORT  __heap_base
+                 EXPORT  __heap_limit
+
+                 ELSE
+
+                 IMPORT  __use_two_region_memory
+                 EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap
+
+                 LDR     R0, =  Heap_Mem
+                 LDR     R1, =(Stack_Mem + Stack_Size)
+                 LDR     R2, = (Heap_Mem +  Heap_Size)
+                 LDR     R3, = Stack_Mem
+                 BX      LR
+
+                 ALIGN
+
+                 ENDIF
+
+                 END
+

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb30xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb30xx_cm4.s
@@ -14,12 +14,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright (c) 2019 STMicroelectronics. All rights reserved.
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 
@@ -84,7 +84,7 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -325,4 +325,3 @@ __user_initial_stackheap
 
                  END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb35xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb35xx_cm4.s
@@ -14,12 +14,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright (c) 2019 STMicroelectronics. All rights reserved.
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 
@@ -84,7 +84,7 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -357,4 +357,3 @@ __user_initial_stackheap
 
                  END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb50xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb50xx_cm4.s
@@ -14,12 +14,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright (c) 2019 STMicroelectronics. All rights reserved.
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 
@@ -84,7 +84,7 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -325,4 +325,3 @@ __user_initial_stackheap
 
                  END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb55xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb55xx_cm4.s
@@ -14,12 +14,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright (c) 2019 STMicroelectronics. All rights reserved.
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 
@@ -84,7 +84,7 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -365,4 +365,3 @@ __user_initial_stackheap
 
                  END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb5mxx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/arm/startup_stm32wb5mxx_cm4.s
@@ -14,12 +14,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* Copyright (c) 2019 STMicroelectronics. All rights reserved.
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 
@@ -84,7 +84,7 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -365,4 +365,3 @@ __user_initial_stackheap
 
                  END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb10xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb10xx_cm4.s
@@ -1,0 +1,390 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32wb10xx_cm4.s
+  * @author    MCD Application Team
+  * @brief     STM32WB10xx devices vector table GCC toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
+
+.global g_pfnVectors
+.global Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word _sidata
+/* start address for the .data section. defined in linker script */
+.word _sdata
+/* end address for the .data section. defined in linker script */
+.word _edata
+/* start address for the .bss section. defined in linker script */
+.word _sbss
+/* end address for the .bss section. defined in linker script */
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
+/* start address for the .MB_MEM2 section. defined in linker script */
+.word _sMB_MEM2
+/* end address for the .MB_MEM2 section. defined in linker script */
+.word _eMB_MEM2
+
+/* INIT_BSS macro is used to fill the specified region [start : end] with zeros */
+.macro INIT_BSS start, end
+  ldr r0, =\start
+  ldr r1, =\end
+  movs r3, #0
+  bl LoopFillZerobss
+.endm
+
+/* INIT_DATA macro is used to copy data in the region [start : end] starting from 'src' */
+.macro INIT_DATA start, end, src
+  ldr r0, =\start
+  ldr r1, =\end
+  ldr r2, =\src
+  movs r3, #0
+  bl LoopCopyDataInit
+.endm
+
+.section  .text.data_initializers
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc  CopyDataInit
+  bx lr
+
+FillZerobss:
+  str  r3, [r0]
+  adds r0, r0, #4
+
+LoopFillZerobss:
+  cmp r0, r1
+  bcc FillZerobss
+  bx lr
+
+  .section .text.Reset_Handler
+  .weak Reset_Handler
+  .type Reset_Handler, %function
+Reset_Handler:
+  ldr   r0, =_estack
+  mov   sp, r0          /* set stack pointer */
+/* Call the clock system initialization function.*/
+  bl  SystemInit
+
+/* Copy the data segment initializers from flash to SRAM */
+  INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
+
+/* Zero fill the bss segments. */
+  INIT_BSS _sbss, _ebss
+
+/* Call static constructors */
+  bl __libc_init_array
+/* Call the application s entry point.*/
+  bl main
+
+LoopForever:
+  b LoopForever
+
+.size Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval None
+*/
+  .section .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex-M4.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
+
+
+g_pfnVectors:
+  .word _estack
+  .word Reset_Handler
+  .word NMI_Handler
+  .word HardFault_Handler
+  .word MemManage_Handler
+  .word BusFault_Handler
+  .word UsageFault_Handler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word SVC_Handler
+  .word DebugMon_Handler
+  .word 0
+  .word PendSV_Handler
+  .word SysTick_Handler
+  .word WWDG_IRQHandler
+  .word PVD_PVM_IRQHandler
+  .word TAMP_STAMP_LSECSS_IRQHandler
+  .word RTC_WKUP_IRQHandler
+  .word FLASH_IRQHandler
+  .word RCC_IRQHandler
+  .word EXTI0_IRQHandler
+  .word EXTI1_IRQHandler
+  .word EXTI2_IRQHandler
+  .word EXTI3_IRQHandler
+  .word EXTI4_IRQHandler
+  .word DMA1_Channel1_IRQHandler
+  .word DMA1_Channel2_IRQHandler
+  .word DMA1_Channel3_IRQHandler
+  .word DMA1_Channel4_IRQHandler
+  .word DMA1_Channel5_IRQHandler
+  .word DMA1_Channel6_IRQHandler
+  .word DMA1_Channel7_IRQHandler
+  .word ADC1_IRQHandler
+  .word 0
+  .word 0
+  .word C2SEV_PWR_C2H_IRQHandler
+  .word 0
+  .word EXTI9_5_IRQHandler
+  .word TIM1_BRK_IRQHandler
+  .word TIM1_UP_IRQHandler
+  .word TIM1_TRG_COM_IRQHandler
+  .word TIM1_CC_IRQHandler
+  .word TIM2_IRQHandler
+  .word PKA_IRQHandler
+  .word I2C1_EV_IRQHandler
+  .word I2C1_ER_IRQHandler
+  .word 0
+  .word 0
+  .word SPI1_IRQHandler
+  .word 0
+  .word USART1_IRQHandler
+  .word 0
+  .word 0
+  .word TSC_IRQHandler
+  .word EXTI15_10_IRQHandler
+  .word RTC_Alarm_IRQHandler
+  .word 0
+  .word PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+  .word IPCC_C1_RX_IRQHandler
+  .word IPCC_C1_TX_IRQHandler
+  .word HSEM_IRQHandler
+  .word LPTIM1_IRQHandler
+  .word LPTIM2_IRQHandler
+  .word 0
+  .word 0
+  .word 0
+  .word AES2_IRQHandler
+  .word RNG_IRQHandler
+  .word FPU_IRQHandler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word DMAMUX1_OVR_IRQHandler
+
+  .size g_pfnVectors, .-g_pfnVectors
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+  .weak  NMI_Handler
+  .thumb_set NMI_Handler,Default_Handler
+
+  .weak  HardFault_Handler
+  .thumb_set HardFault_Handler,Default_Handler
+
+  .weak  MemManage_Handler
+  .thumb_set MemManage_Handler,Default_Handler
+
+  .weak  BusFault_Handler
+  .thumb_set BusFault_Handler,Default_Handler
+
+  .weak  UsageFault_Handler
+  .thumb_set UsageFault_Handler,Default_Handler
+
+  .weak  SVC_Handler
+  .thumb_set SVC_Handler,Default_Handler
+
+  .weak  DebugMon_Handler
+  .thumb_set DebugMon_Handler,Default_Handler
+
+  .weak  PendSV_Handler
+  .thumb_set PendSV_Handler,Default_Handler
+
+  .weak  SysTick_Handler
+  .thumb_set SysTick_Handler,Default_Handler
+
+  .weak  WWDG_IRQHandler
+  .thumb_set WWDG_IRQHandler,Default_Handler
+
+  .weak  PVD_PVM_IRQHandler
+  .thumb_set PVD_PVM_IRQHandler,Default_Handler
+
+  .weak  TAMP_STAMP_LSECSS_IRQHandler
+  .thumb_set TAMP_STAMP_LSECSS_IRQHandler,Default_Handler
+
+  .weak  RTC_WKUP_IRQHandler
+  .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+  .weak  FLASH_IRQHandler
+  .thumb_set FLASH_IRQHandler,Default_Handler
+
+  .weak  RCC_IRQHandler
+  .thumb_set RCC_IRQHandler,Default_Handler
+
+  .weak  EXTI0_IRQHandler
+  .thumb_set EXTI0_IRQHandler,Default_Handler
+
+  .weak  EXTI1_IRQHandler
+  .thumb_set EXTI1_IRQHandler,Default_Handler
+
+  .weak  EXTI2_IRQHandler
+  .thumb_set EXTI2_IRQHandler,Default_Handler
+
+  .weak  EXTI3_IRQHandler
+  .thumb_set EXTI3_IRQHandler,Default_Handler
+
+  .weak  EXTI4_IRQHandler
+  .thumb_set EXTI4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel1_IRQHandler
+  .thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel2_IRQHandler
+  .thumb_set DMA1_Channel2_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel3_IRQHandler
+  .thumb_set DMA1_Channel3_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel4_IRQHandler
+  .thumb_set DMA1_Channel4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel5_IRQHandler
+  .thumb_set DMA1_Channel5_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel6_IRQHandler
+  .thumb_set DMA1_Channel6_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel7_IRQHandler
+  .thumb_set DMA1_Channel7_IRQHandler,Default_Handler
+
+  .weak  ADC1_IRQHandler
+  .thumb_set ADC1_IRQHandler,Default_Handler
+
+  .weak  C2SEV_PWR_C2H_IRQHandler
+  .thumb_set C2SEV_PWR_C2H_IRQHandler,Default_Handler
+
+  .weak  EXTI9_5_IRQHandler
+  .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+  .weak  TIM1_BRK_IRQHandler
+  .thumb_set TIM1_BRK_IRQHandler,Default_Handler
+
+  .weak  TIM1_UP_IRQHandler
+  .thumb_set TIM1_UP_IRQHandler,Default_Handler
+
+  .weak  TIM1_TRG_COM_IRQHandler
+  .thumb_set TIM1_TRG_COM_IRQHandler,Default_Handler
+
+  .weak  TIM1_CC_IRQHandler
+  .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+  .weak  TIM2_IRQHandler
+  .thumb_set TIM2_IRQHandler,Default_Handler
+
+  .weak  PKA_IRQHandler
+  .thumb_set PKA_IRQHandler,Default_Handler
+
+  .weak  I2C1_EV_IRQHandler
+  .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+  .weak  I2C1_ER_IRQHandler
+  .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+  .weak  SPI1_IRQHandler
+  .thumb_set SPI1_IRQHandler,Default_Handler
+
+  .weak  USART1_IRQHandler
+  .thumb_set USART1_IRQHandler,Default_Handler
+
+  .weak  TSC_IRQHandler
+  .thumb_set TSC_IRQHandler,Default_Handler
+
+  .weak  EXTI15_10_IRQHandler
+  .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+  .weak  RTC_Alarm_IRQHandler
+  .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+  .weak  PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+  .thumb_set PWR_SOTF_BLEACT_RFPHASE_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_RX_IRQHandler
+  .thumb_set IPCC_C1_RX_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_TX_IRQHandler
+  .thumb_set IPCC_C1_TX_IRQHandler,Default_Handler
+
+  .weak  HSEM_IRQHandler
+  .thumb_set HSEM_IRQHandler,Default_Handler
+
+  .weak  LPTIM1_IRQHandler
+  .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+  .weak  LPTIM2_IRQHandler
+  .thumb_set LPTIM2_IRQHandler,Default_Handler
+
+  .weak  AES2_IRQHandler
+  .thumb_set AES2_IRQHandler,Default_Handler
+
+  .weak  RNG_IRQHandler
+  .thumb_set RNG_IRQHandler,Default_Handler
+
+  .weak  FPU_IRQHandler
+  .thumb_set FPU_IRQHandler,Default_Handler
+
+  .weak  DMAMUX1_OVR_IRQHandler
+  .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
+

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb15xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb15xx_cm4.s
@@ -1,0 +1,396 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32wb15xx_cm4.s
+  * @author    MCD Application Team
+  * @brief     STM32WB15xx devices vector table GCC toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
+
+.global g_pfnVectors
+.global Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word _sidata
+/* start address for the .data section. defined in linker script */
+.word _sdata
+/* end address for the .data section. defined in linker script */
+.word _edata
+/* start address for the .bss section. defined in linker script */
+.word _sbss
+/* end address for the .bss section. defined in linker script */
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
+/* start address for the .MB_MEM2 section. defined in linker script */
+.word _sMB_MEM2
+/* end address for the .MB_MEM2 section. defined in linker script */
+.word _eMB_MEM2
+
+/* INIT_BSS macro is used to fill the specified region [start : end] with zeros */
+.macro INIT_BSS start, end
+  ldr r0, =\start
+  ldr r1, =\end
+  movs r3, #0
+  bl LoopFillZerobss
+.endm
+
+/* INIT_DATA macro is used to copy data in the region [start : end] starting from 'src' */
+.macro INIT_DATA start, end, src
+  ldr r0, =\start
+  ldr r1, =\end
+  ldr r2, =\src
+  movs r3, #0
+  bl LoopCopyDataInit
+.endm
+
+.section  .text.data_initializers
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc  CopyDataInit
+  bx lr
+
+FillZerobss:
+  str  r3, [r0]
+  adds r0, r0, #4
+
+LoopFillZerobss:
+  cmp r0, r1
+  bcc FillZerobss
+  bx lr
+
+  .section .text.Reset_Handler
+  .weak Reset_Handler
+  .type Reset_Handler, %function
+Reset_Handler:
+  ldr   r0, =_estack
+  mov   sp, r0          /* set stack pointer */
+/* Call the clock system initialization function.*/
+  bl  SystemInit
+
+/* Copy the data segment initializers from flash to SRAM */
+  INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
+
+/* Zero fill the bss segments. */
+  INIT_BSS _sbss, _ebss
+
+/* Call static constructors */
+  bl __libc_init_array
+/* Call the application s entry point.*/
+  bl main
+
+LoopForever:
+  b LoopForever
+
+.size Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval None
+*/
+  .section .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex-M4.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
+
+
+g_pfnVectors:
+  .word _estack
+  .word Reset_Handler
+  .word NMI_Handler
+  .word HardFault_Handler
+  .word MemManage_Handler
+  .word BusFault_Handler
+  .word UsageFault_Handler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word SVC_Handler
+  .word DebugMon_Handler
+  .word 0
+  .word PendSV_Handler
+  .word SysTick_Handler
+  .word WWDG_IRQHandler
+  .word PVD_PVM_IRQHandler
+  .word TAMP_STAMP_LSECSS_IRQHandler
+  .word RTC_WKUP_IRQHandler
+  .word FLASH_IRQHandler
+  .word RCC_IRQHandler
+  .word EXTI0_IRQHandler
+  .word EXTI1_IRQHandler
+  .word EXTI2_IRQHandler
+  .word EXTI3_IRQHandler
+  .word EXTI4_IRQHandler
+  .word DMA1_Channel1_IRQHandler
+  .word DMA1_Channel2_IRQHandler
+  .word DMA1_Channel3_IRQHandler
+  .word DMA1_Channel4_IRQHandler
+  .word DMA1_Channel5_IRQHandler
+  .word DMA1_Channel6_IRQHandler
+  .word DMA1_Channel7_IRQHandler
+  .word ADC1_IRQHandler
+  .word 0
+  .word 0
+  .word C2SEV_PWR_C2H_IRQHandler
+  .word COMP_IRQHandler
+  .word EXTI9_5_IRQHandler
+  .word TIM1_BRK_IRQHandler
+  .word TIM1_UP_IRQHandler
+  .word TIM1_TRG_COM_IRQHandler
+  .word TIM1_CC_IRQHandler
+  .word TIM2_IRQHandler
+  .word PKA_IRQHandler
+  .word I2C1_EV_IRQHandler
+  .word I2C1_ER_IRQHandler
+  .word 0
+  .word 0
+  .word SPI1_IRQHandler
+  .word 0
+  .word USART1_IRQHandler
+  .word LPUART1_IRQHandler
+  .word 0
+  .word TSC_IRQHandler
+  .word EXTI15_10_IRQHandler
+  .word RTC_Alarm_IRQHandler
+  .word 0
+  .word PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+  .word IPCC_C1_RX_IRQHandler
+  .word IPCC_C1_TX_IRQHandler
+  .word HSEM_IRQHandler
+  .word LPTIM1_IRQHandler
+  .word LPTIM2_IRQHandler
+  .word 0
+  .word 0
+  .word 0
+  .word AES2_IRQHandler
+  .word RNG_IRQHandler
+  .word FPU_IRQHandler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word DMAMUX1_OVR_IRQHandler
+
+  .size g_pfnVectors, .-g_pfnVectors
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+  .weak  NMI_Handler
+  .thumb_set NMI_Handler,Default_Handler
+
+  .weak  HardFault_Handler
+  .thumb_set HardFault_Handler,Default_Handler
+
+  .weak  MemManage_Handler
+  .thumb_set MemManage_Handler,Default_Handler
+
+  .weak  BusFault_Handler
+  .thumb_set BusFault_Handler,Default_Handler
+
+  .weak  UsageFault_Handler
+  .thumb_set UsageFault_Handler,Default_Handler
+
+  .weak  SVC_Handler
+  .thumb_set SVC_Handler,Default_Handler
+
+  .weak  DebugMon_Handler
+  .thumb_set DebugMon_Handler,Default_Handler
+
+  .weak  PendSV_Handler
+  .thumb_set PendSV_Handler,Default_Handler
+
+  .weak  SysTick_Handler
+  .thumb_set SysTick_Handler,Default_Handler
+
+  .weak  WWDG_IRQHandler
+  .thumb_set WWDG_IRQHandler,Default_Handler
+
+  .weak  PVD_PVM_IRQHandler
+  .thumb_set PVD_PVM_IRQHandler,Default_Handler
+
+  .weak  TAMP_STAMP_LSECSS_IRQHandler
+  .thumb_set TAMP_STAMP_LSECSS_IRQHandler,Default_Handler
+
+  .weak  RTC_WKUP_IRQHandler
+  .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+  .weak  FLASH_IRQHandler
+  .thumb_set FLASH_IRQHandler,Default_Handler
+
+  .weak  RCC_IRQHandler
+  .thumb_set RCC_IRQHandler,Default_Handler
+
+  .weak  EXTI0_IRQHandler
+  .thumb_set EXTI0_IRQHandler,Default_Handler
+
+  .weak  EXTI1_IRQHandler
+  .thumb_set EXTI1_IRQHandler,Default_Handler
+
+  .weak  EXTI2_IRQHandler
+  .thumb_set EXTI2_IRQHandler,Default_Handler
+
+  .weak  EXTI3_IRQHandler
+  .thumb_set EXTI3_IRQHandler,Default_Handler
+
+  .weak  EXTI4_IRQHandler
+  .thumb_set EXTI4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel1_IRQHandler
+  .thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel2_IRQHandler
+  .thumb_set DMA1_Channel2_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel3_IRQHandler
+  .thumb_set DMA1_Channel3_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel4_IRQHandler
+  .thumb_set DMA1_Channel4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel5_IRQHandler
+  .thumb_set DMA1_Channel5_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel6_IRQHandler
+  .thumb_set DMA1_Channel6_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel7_IRQHandler
+  .thumb_set DMA1_Channel7_IRQHandler,Default_Handler
+
+  .weak  ADC1_IRQHandler
+  .thumb_set ADC1_IRQHandler,Default_Handler
+
+  .weak  C2SEV_PWR_C2H_IRQHandler
+  .thumb_set C2SEV_PWR_C2H_IRQHandler,Default_Handler
+
+  .weak  COMP_IRQHandler
+  .thumb_set COMP_IRQHandler,Default_Handler
+
+  .weak  EXTI9_5_IRQHandler
+  .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+  .weak  TIM1_BRK_IRQHandler
+  .thumb_set TIM1_BRK_IRQHandler,Default_Handler
+
+  .weak  TIM1_UP_IRQHandler
+  .thumb_set TIM1_UP_IRQHandler,Default_Handler
+
+  .weak  TIM1_TRG_COM_IRQHandler
+  .thumb_set TIM1_TRG_COM_IRQHandler,Default_Handler
+
+  .weak  TIM1_CC_IRQHandler
+  .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+  .weak  TIM2_IRQHandler
+  .thumb_set TIM2_IRQHandler,Default_Handler
+
+  .weak  PKA_IRQHandler
+  .thumb_set PKA_IRQHandler,Default_Handler
+
+  .weak  I2C1_EV_IRQHandler
+  .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+  .weak  I2C1_ER_IRQHandler
+  .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+  .weak  SPI1_IRQHandler
+  .thumb_set SPI1_IRQHandler,Default_Handler
+
+  .weak  USART1_IRQHandler
+  .thumb_set USART1_IRQHandler,Default_Handler
+
+  .weak  LPUART1_IRQHandler
+  .thumb_set LPUART1_IRQHandler,Default_Handler
+
+  .weak  TSC_IRQHandler
+  .thumb_set TSC_IRQHandler,Default_Handler
+
+  .weak  EXTI15_10_IRQHandler
+  .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+  .weak  RTC_Alarm_IRQHandler
+  .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+  .weak  PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+  .thumb_set PWR_SOTF_BLEACT_RFPHASE_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_RX_IRQHandler
+  .thumb_set IPCC_C1_RX_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_TX_IRQHandler
+  .thumb_set IPCC_C1_TX_IRQHandler,Default_Handler
+
+  .weak  HSEM_IRQHandler
+  .thumb_set HSEM_IRQHandler,Default_Handler
+
+  .weak  LPTIM1_IRQHandler
+  .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+  .weak  LPTIM2_IRQHandler
+  .thumb_set LPTIM2_IRQHandler,Default_Handler
+
+  .weak  AES2_IRQHandler
+  .thumb_set AES2_IRQHandler,Default_Handler
+
+  .weak  RNG_IRQHandler
+  .thumb_set RNG_IRQHandler,Default_Handler
+
+  .weak  FPU_IRQHandler
+  .thumb_set FPU_IRQHandler,Default_Handler
+
+  .weak  DMAMUX1_OVR_IRQHandler
+  .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
+

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb1mxx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb1mxx_cm4.s
@@ -1,0 +1,396 @@
+/**
+  ******************************************************************************
+  * @file      startup_stm32wb1mxx_cm4.s
+  * @author    MCD Application Team
+  * @brief     STM32WB1Mxx devices vector table GCC toolchain.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2022 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m4
+ .fpu softvfp
+  .thumb
+
+.global g_pfnVectors
+.global Default_Handler
+
+/* start address for the initialization values of the .data section.
+defined in linker script */
+.word _sidata
+/* start address for the .data section. defined in linker script */
+.word _sdata
+/* end address for the .data section. defined in linker script */
+.word _edata
+/* start address for the .bss section. defined in linker script */
+.word _sbss
+/* end address for the .bss section. defined in linker script */
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
+/* start address for the .MB_MEM2 section. defined in linker script */
+.word _sMB_MEM2
+/* end address for the .MB_MEM2 section. defined in linker script */
+.word _eMB_MEM2
+
+/* INIT_BSS macro is used to fill the specified region [start : end] with zeros */
+.macro INIT_BSS start, end
+  ldr r0, =\start
+  ldr r1, =\end
+  movs r3, #0
+  bl LoopFillZerobss
+.endm
+
+/* INIT_DATA macro is used to copy data in the region [start : end] starting from 'src' */
+.macro INIT_DATA start, end, src
+  ldr r0, =\start
+  ldr r1, =\end
+  ldr r2, =\src
+  movs r3, #0
+  bl LoopCopyDataInit
+.endm
+
+.section  .text.data_initializers
+CopyDataInit:
+  ldr r4, [r2, r3]
+  str r4, [r0, r3]
+  adds r3, r3, #4
+
+LoopCopyDataInit:
+  adds r4, r0, r3
+  cmp r4, r1
+  bcc  CopyDataInit
+  bx lr
+
+FillZerobss:
+  str  r3, [r0]
+  adds r0, r0, #4
+
+LoopFillZerobss:
+  cmp r0, r1
+  bcc FillZerobss
+  bx lr
+
+  .section .text.Reset_Handler
+  .weak Reset_Handler
+  .type Reset_Handler, %function
+Reset_Handler:
+  ldr   r0, =_estack
+  mov   sp, r0          /* set stack pointer */
+/* Call the clock system initialization function.*/
+  bl  SystemInit
+
+/* Copy the data segment initializers from flash to SRAM */
+  INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
+
+/* Zero fill the bss segments. */
+  INIT_BSS _sbss, _ebss
+
+/* Call static constructors */
+  bl __libc_init_array
+/* Call the application s entry point.*/
+  bl main
+
+LoopForever:
+  b LoopForever
+
+.size Reset_Handler, .-Reset_Handler
+
+/**
+ * @brief  This is the code that gets called when the processor receives an
+ *         unexpected interrupt.  This simply enters an infinite loop, preserving
+ *         the system state for examination by a debugger.
+ *
+ * @param  None
+ * @retval None
+*/
+  .section .text.Default_Handler,"ax",%progbits
+Default_Handler:
+Infinite_Loop:
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
+/******************************************************************************
+*
+* The minimal vector table for a Cortex-M4.  Note that the proper constructs
+* must be placed on this to ensure that it ends up at physical address
+* 0x0000.0000.
+*
+******************************************************************************/
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
+
+
+g_pfnVectors:
+  .word _estack
+  .word Reset_Handler
+  .word NMI_Handler
+  .word HardFault_Handler
+  .word MemManage_Handler
+  .word BusFault_Handler
+  .word UsageFault_Handler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word SVC_Handler
+  .word DebugMon_Handler
+  .word 0
+  .word PendSV_Handler
+  .word SysTick_Handler
+  .word WWDG_IRQHandler
+  .word PVD_PVM_IRQHandler
+  .word TAMP_STAMP_LSECSS_IRQHandler
+  .word RTC_WKUP_IRQHandler
+  .word FLASH_IRQHandler
+  .word RCC_IRQHandler
+  .word EXTI0_IRQHandler
+  .word EXTI1_IRQHandler
+  .word EXTI2_IRQHandler
+  .word EXTI3_IRQHandler
+  .word EXTI4_IRQHandler
+  .word DMA1_Channel1_IRQHandler
+  .word DMA1_Channel2_IRQHandler
+  .word DMA1_Channel3_IRQHandler
+  .word DMA1_Channel4_IRQHandler
+  .word DMA1_Channel5_IRQHandler
+  .word DMA1_Channel6_IRQHandler
+  .word DMA1_Channel7_IRQHandler
+  .word ADC1_IRQHandler
+  .word 0
+  .word 0
+  .word C2SEV_PWR_C2H_IRQHandler
+  .word COMP_IRQHandler
+  .word EXTI9_5_IRQHandler
+  .word TIM1_BRK_IRQHandler
+  .word TIM1_UP_IRQHandler
+  .word TIM1_TRG_COM_IRQHandler
+  .word TIM1_CC_IRQHandler
+  .word TIM2_IRQHandler
+  .word PKA_IRQHandler
+  .word I2C1_EV_IRQHandler
+  .word I2C1_ER_IRQHandler
+  .word 0
+  .word 0
+  .word SPI1_IRQHandler
+  .word 0
+  .word USART1_IRQHandler
+  .word LPUART1_IRQHandler
+  .word 0
+  .word TSC_IRQHandler
+  .word EXTI15_10_IRQHandler
+  .word RTC_Alarm_IRQHandler
+  .word 0
+  .word PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+  .word IPCC_C1_RX_IRQHandler
+  .word IPCC_C1_TX_IRQHandler
+  .word HSEM_IRQHandler
+  .word LPTIM1_IRQHandler
+  .word LPTIM2_IRQHandler
+  .word 0
+  .word 0
+  .word 0
+  .word AES2_IRQHandler
+  .word RNG_IRQHandler
+  .word FPU_IRQHandler
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word 0
+  .word DMAMUX1_OVR_IRQHandler
+
+  .size g_pfnVectors, .-g_pfnVectors
+
+/*******************************************************************************
+*
+* Provide weak aliases for each Exception handler to the Default_Handler.
+* As they are weak aliases, any function with the same name will override
+* this definition.
+*
+*******************************************************************************/
+  .weak  NMI_Handler
+  .thumb_set NMI_Handler,Default_Handler
+
+  .weak  HardFault_Handler
+  .thumb_set HardFault_Handler,Default_Handler
+
+  .weak  MemManage_Handler
+  .thumb_set MemManage_Handler,Default_Handler
+
+  .weak  BusFault_Handler
+  .thumb_set BusFault_Handler,Default_Handler
+
+  .weak  UsageFault_Handler
+  .thumb_set UsageFault_Handler,Default_Handler
+
+  .weak  SVC_Handler
+  .thumb_set SVC_Handler,Default_Handler
+
+  .weak  DebugMon_Handler
+  .thumb_set DebugMon_Handler,Default_Handler
+
+  .weak  PendSV_Handler
+  .thumb_set PendSV_Handler,Default_Handler
+
+  .weak  SysTick_Handler
+  .thumb_set SysTick_Handler,Default_Handler
+
+  .weak  WWDG_IRQHandler
+  .thumb_set WWDG_IRQHandler,Default_Handler
+
+  .weak  PVD_PVM_IRQHandler
+  .thumb_set PVD_PVM_IRQHandler,Default_Handler
+
+  .weak  TAMP_STAMP_LSECSS_IRQHandler
+  .thumb_set TAMP_STAMP_LSECSS_IRQHandler,Default_Handler
+
+  .weak  RTC_WKUP_IRQHandler
+  .thumb_set RTC_WKUP_IRQHandler,Default_Handler
+
+  .weak  FLASH_IRQHandler
+  .thumb_set FLASH_IRQHandler,Default_Handler
+
+  .weak  RCC_IRQHandler
+  .thumb_set RCC_IRQHandler,Default_Handler
+
+  .weak  EXTI0_IRQHandler
+  .thumb_set EXTI0_IRQHandler,Default_Handler
+
+  .weak  EXTI1_IRQHandler
+  .thumb_set EXTI1_IRQHandler,Default_Handler
+
+  .weak  EXTI2_IRQHandler
+  .thumb_set EXTI2_IRQHandler,Default_Handler
+
+  .weak  EXTI3_IRQHandler
+  .thumb_set EXTI3_IRQHandler,Default_Handler
+
+  .weak  EXTI4_IRQHandler
+  .thumb_set EXTI4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel1_IRQHandler
+  .thumb_set DMA1_Channel1_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel2_IRQHandler
+  .thumb_set DMA1_Channel2_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel3_IRQHandler
+  .thumb_set DMA1_Channel3_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel4_IRQHandler
+  .thumb_set DMA1_Channel4_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel5_IRQHandler
+  .thumb_set DMA1_Channel5_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel6_IRQHandler
+  .thumb_set DMA1_Channel6_IRQHandler,Default_Handler
+
+  .weak  DMA1_Channel7_IRQHandler
+  .thumb_set DMA1_Channel7_IRQHandler,Default_Handler
+
+  .weak  ADC1_IRQHandler
+  .thumb_set ADC1_IRQHandler,Default_Handler
+
+  .weak  C2SEV_PWR_C2H_IRQHandler
+  .thumb_set C2SEV_PWR_C2H_IRQHandler,Default_Handler
+
+  .weak  COMP_IRQHandler
+  .thumb_set COMP_IRQHandler,Default_Handler
+
+  .weak  EXTI9_5_IRQHandler
+  .thumb_set EXTI9_5_IRQHandler,Default_Handler
+
+  .weak  TIM1_BRK_IRQHandler
+  .thumb_set TIM1_BRK_IRQHandler,Default_Handler
+
+  .weak  TIM1_UP_IRQHandler
+  .thumb_set TIM1_UP_IRQHandler,Default_Handler
+
+  .weak  TIM1_TRG_COM_IRQHandler
+  .thumb_set TIM1_TRG_COM_IRQHandler,Default_Handler
+
+  .weak  TIM1_CC_IRQHandler
+  .thumb_set TIM1_CC_IRQHandler,Default_Handler
+
+  .weak  TIM2_IRQHandler
+  .thumb_set TIM2_IRQHandler,Default_Handler
+
+  .weak  PKA_IRQHandler
+  .thumb_set PKA_IRQHandler,Default_Handler
+
+  .weak  I2C1_EV_IRQHandler
+  .thumb_set I2C1_EV_IRQHandler,Default_Handler
+
+  .weak  I2C1_ER_IRQHandler
+  .thumb_set I2C1_ER_IRQHandler,Default_Handler
+
+  .weak  SPI1_IRQHandler
+  .thumb_set SPI1_IRQHandler,Default_Handler
+
+  .weak  USART1_IRQHandler
+  .thumb_set USART1_IRQHandler,Default_Handler
+
+  .weak  LPUART1_IRQHandler
+  .thumb_set LPUART1_IRQHandler,Default_Handler
+
+  .weak  TSC_IRQHandler
+  .thumb_set TSC_IRQHandler,Default_Handler
+
+  .weak  EXTI15_10_IRQHandler
+  .thumb_set EXTI15_10_IRQHandler,Default_Handler
+
+  .weak  RTC_Alarm_IRQHandler
+  .thumb_set RTC_Alarm_IRQHandler,Default_Handler
+
+  .weak  PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+  .thumb_set PWR_SOTF_BLEACT_RFPHASE_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_RX_IRQHandler
+  .thumb_set IPCC_C1_RX_IRQHandler,Default_Handler
+
+  .weak  IPCC_C1_TX_IRQHandler
+  .thumb_set IPCC_C1_TX_IRQHandler,Default_Handler
+
+  .weak  HSEM_IRQHandler
+  .thumb_set HSEM_IRQHandler,Default_Handler
+
+  .weak  LPTIM1_IRQHandler
+  .thumb_set LPTIM1_IRQHandler,Default_Handler
+
+  .weak  LPTIM2_IRQHandler
+  .thumb_set LPTIM2_IRQHandler,Default_Handler
+
+  .weak  AES2_IRQHandler
+  .thumb_set AES2_IRQHandler,Default_Handler
+
+  .weak  RNG_IRQHandler
+  .thumb_set RNG_IRQHandler,Default_Handler
+
+  .weak  FPU_IRQHandler
+  .thumb_set FPU_IRQHandler,Default_Handler
+
+  .weak  DMAMUX1_OVR_IRQHandler
+  .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
+

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb30xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb30xx_cm4.s
@@ -14,36 +14,38 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
 
   .syntax unified
-    .cpu cortex-m4
-    .fpu softvfp
-    .thumb
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
 
 .global g_pfnVectors
 .global Default_Handler
 
 /* start address for the initialization values of the .data section.
 defined in linker script */
-.word   _sidata
+.word _sidata
 /* start address for the .data section. defined in linker script */
-.word   _sdata
+.word _sdata
 /* end address for the .data section. defined in linker script */
-.word   _edata
+.word _edata
 /* start address for the .bss section. defined in linker script */
-.word   _sbss
+.word _sbss
 /* end address for the .bss section. defined in linker script */
-.word   _ebss
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
 /* start address for the .MB_MEM2 section. defined in linker script */
 .word _sMB_MEM2
 /* end address for the .MB_MEM2 section. defined in linker script */
@@ -93,20 +95,20 @@ LoopFillZerobss:
 Reset_Handler:
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
   bl  SystemInit
 
 /* Copy the data segment initializers from flash to SRAM */
   INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
 
 /* Zero fill the bss segments. */
   INIT_BSS _sbss, _ebss
-  INIT_BSS _sMB_MEM2, _eMB_MEM2
 
 /* Call static constructors */
   bl __libc_init_array
 /* Call the application s entry point.*/
-    bl  main
+  bl main
 
 LoopForever:
   b LoopForever
@@ -124,8 +126,8 @@ LoopForever:
   .section .text.Default_Handler,"ax",%progbits
 Default_Handler:
 Infinite_Loop:
-    b   Infinite_Loop
-    .size   Default_Handler, .-Default_Handler
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
 /******************************************************************************
 *
 * The minimal vector table for a Cortex-M4.  Note that the proper constructs
@@ -133,15 +135,14 @@ Infinite_Loop:
 * 0x0000.0000.
 *
 ******************************************************************************/
-    .section    .isr_vector,"a",%progbits
-    .type   g_pfnVectors, %object
-    .size   g_pfnVectors, .-g_pfnVectors
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
 
 
 g_pfnVectors:
   .word _estack
   .word Reset_Handler
-    .word   NMI_Handler
+  .word NMI_Handler
   .word HardFault_Handler
   .word MemManage_Handler
   .word BusFault_Handler
@@ -219,6 +220,8 @@ g_pfnVectors:
   .word 0
   .word DMAMUX1_OVR_IRQHandler
 
+  .size g_pfnVectors, .-g_pfnVectors
+
 /*******************************************************************************
 *
 * Provide weak aliases for each Exception handler to the Default_Handler.
@@ -226,7 +229,7 @@ g_pfnVectors:
 * this definition.
 *
 *******************************************************************************/
-  .weak NMI_Handler
+  .weak  NMI_Handler
   .thumb_set NMI_Handler,Default_Handler
 
   .weak  HardFault_Handler
@@ -382,4 +385,3 @@ g_pfnVectors:
   .weak  DMAMUX1_OVR_IRQHandler
   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb35xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb35xx_cm4.s
@@ -14,36 +14,38 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
 
   .syntax unified
-    .cpu cortex-m4
-    .fpu softvfp
-    .thumb
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
 
 .global g_pfnVectors
 .global Default_Handler
 
 /* start address for the initialization values of the .data section.
 defined in linker script */
-.word   _sidata
+.word _sidata
 /* start address for the .data section. defined in linker script */
-.word   _sdata
+.word _sdata
 /* end address for the .data section. defined in linker script */
-.word   _edata
+.word _edata
 /* start address for the .bss section. defined in linker script */
-.word   _sbss
+.word _sbss
 /* end address for the .bss section. defined in linker script */
 .word   _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
 /* start address for the .MB_MEM2 section. defined in linker script */
 .word _sMB_MEM2
 /* end address for the .MB_MEM2 section. defined in linker script */
@@ -93,25 +95,25 @@ LoopFillZerobss:
 Reset_Handler:
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
   bl  SystemInit
 
 /* Copy the data segment initializers from flash to SRAM */
   INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
 
 /* Zero fill the bss segments. */
   INIT_BSS _sbss, _ebss
-  INIT_BSS _sMB_MEM2, _eMB_MEM2
 
 /* Call static constructors */
   bl __libc_init_array
 /* Call the application s entry point.*/
-    bl  main
+  bl main
 
 LoopForever:
   b LoopForever
 
-.size   Reset_Handler, .-Reset_Handler
+.size Reset_Handler, .-Reset_Handler
 
 /**
  * @brief  This is the code that gets called when the processor receives an
@@ -124,8 +126,8 @@ LoopForever:
   .section .text.Default_Handler,"ax",%progbits
 Default_Handler:
 Infinite_Loop:
-    b   Infinite_Loop
-    .size   Default_Handler, .-Default_Handler
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
 /******************************************************************************
 *
 * The minimal vector table for a Cortex-M4.  Note that the proper constructs
@@ -133,15 +135,14 @@ Infinite_Loop:
 * 0x0000.0000.
 *
 ******************************************************************************/
-    .section    .isr_vector,"a",%progbits
-    .type   g_pfnVectors, %object
-    .size   g_pfnVectors, .-g_pfnVectors
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
 
 
 g_pfnVectors:
   .word _estack
   .word Reset_Handler
-    .word   NMI_Handler
+  .word NMI_Handler
   .word HardFault_Handler
   .word MemManage_Handler
   .word BusFault_Handler
@@ -219,6 +220,8 @@ g_pfnVectors:
   .word DMA2_Channel7_IRQHandler
   .word DMAMUX1_OVR_IRQHandler
 
+  .size g_pfnVectors, .-g_pfnVectors
+
 /*******************************************************************************
 *
 * Provide weak aliases for each Exception handler to the Default_Handler.
@@ -226,7 +229,7 @@ g_pfnVectors:
 * this definition.
 *
 *******************************************************************************/
-  .weak NMI_Handler
+  .weak  NMI_Handler
   .thumb_set NMI_Handler,Default_Handler
 
   .weak  HardFault_Handler
@@ -430,4 +433,3 @@ g_pfnVectors:
   .weak  DMAMUX1_OVR_IRQHandler
   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb50xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb50xx_cm4.s
@@ -14,36 +14,38 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
 
   .syntax unified
-    .cpu cortex-m4
-    .fpu softvfp
-    .thumb
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
 
 .global g_pfnVectors
 .global Default_Handler
 
 /* start address for the initialization values of the .data section.
 defined in linker script */
-.word   _sidata
+.word _sidata
 /* start address for the .data section. defined in linker script */
-.word   _sdata
+.word _sdata
 /* end address for the .data section. defined in linker script */
-.word   _edata
+.word _edata
 /* start address for the .bss section. defined in linker script */
-.word   _sbss
+.word _sbss
 /* end address for the .bss section. defined in linker script */
-.word   _ebss
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
 /* start address for the .MB_MEM2 section. defined in linker script */
 .word _sMB_MEM2
 /* end address for the .MB_MEM2 section. defined in linker script */
@@ -93,11 +95,12 @@ LoopFillZerobss:
 Reset_Handler:
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
   bl  SystemInit
 
 /* Copy the data segment initializers from flash to SRAM */
   INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
 
 /* Zero fill the bss segments. */
   INIT_BSS _sbss, _ebss
@@ -106,12 +109,12 @@ Reset_Handler:
 /* Call static constructors */
   bl __libc_init_array
 /* Call the application s entry point.*/
-    bl  main
+  bl main
 
 LoopForever:
   b LoopForever
 
-.size   Reset_Handler, .-Reset_Handler
+.size Reset_Handler, .-Reset_Handler
 
 /**
  * @brief  This is the code that gets called when the processor receives an
@@ -124,8 +127,8 @@ LoopForever:
   .section .text.Default_Handler,"ax",%progbits
 Default_Handler:
 Infinite_Loop:
-    b   Infinite_Loop
-    .size   Default_Handler, .-Default_Handler
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
 /******************************************************************************
 *
 * The minimal vector table for a Cortex-M4.  Note that the proper constructs
@@ -133,15 +136,14 @@ Infinite_Loop:
 * 0x0000.0000.
 *
 ******************************************************************************/
-    .section    .isr_vector,"a",%progbits
-    .type   g_pfnVectors, %object
-    .size   g_pfnVectors, .-g_pfnVectors
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
 
 
 g_pfnVectors:
   .word _estack
   .word Reset_Handler
-    .word   NMI_Handler
+  .word NMI_Handler
   .word HardFault_Handler
   .word MemManage_Handler
   .word BusFault_Handler
@@ -219,6 +221,8 @@ g_pfnVectors:
   .word 0
   .word DMAMUX1_OVR_IRQHandler
 
+  .size g_pfnVectors, .-g_pfnVectors
+
 /*******************************************************************************
 *
 * Provide weak aliases for each Exception handler to the Default_Handler.
@@ -226,7 +230,7 @@ g_pfnVectors:
 * this definition.
 *
 *******************************************************************************/
-  .weak NMI_Handler
+  .weak  NMI_Handler
   .thumb_set NMI_Handler,Default_Handler
 
   .weak  HardFault_Handler
@@ -385,4 +389,3 @@ g_pfnVectors:
   .weak  DMAMUX1_OVR_IRQHandler
   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb55xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb55xx_cm4.s
@@ -14,36 +14,38 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
 
   .syntax unified
-    .cpu cortex-m4
-    .fpu softvfp
-    .thumb
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
 
 .global g_pfnVectors
 .global Default_Handler
 
 /* start address for the initialization values of the .data section.
 defined in linker script */
-.word   _sidata
+.word _sidata
 /* start address for the .data section. defined in linker script */
-.word   _sdata
+.word _sdata
 /* end address for the .data section. defined in linker script */
-.word   _edata
+.word _edata
 /* start address for the .bss section. defined in linker script */
-.word   _sbss
+.word _sbss
 /* end address for the .bss section. defined in linker script */
-.word   _ebss
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
 /* start address for the .MB_MEM2 section. defined in linker script */
 .word _sMB_MEM2
 /* end address for the .MB_MEM2 section. defined in linker script */
@@ -93,25 +95,25 @@ LoopFillZerobss:
 Reset_Handler:
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
   bl  SystemInit
 
 /* Copy the data segment initializers from flash to SRAM */
   INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
 
 /* Zero fill the bss segments. */
   INIT_BSS _sbss, _ebss
-  INIT_BSS _sMB_MEM2, _eMB_MEM2
 
 /* Call static constructors */
   bl __libc_init_array
 /* Call the application s entry point.*/
-    bl  main
+  bl main
 
 LoopForever:
   b LoopForever
 
-.size   Reset_Handler, .-Reset_Handler
+.size Reset_Handler, .-Reset_Handler
 
 /**
  * @brief  This is the code that gets called when the processor receives an
@@ -124,8 +126,8 @@ LoopForever:
   .section .text.Default_Handler,"ax",%progbits
 Default_Handler:
 Infinite_Loop:
-    b   Infinite_Loop
-    .size   Default_Handler, .-Default_Handler
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
 /******************************************************************************
 *
 * The minimal vector table for a Cortex-M4.  Note that the proper constructs
@@ -133,15 +135,14 @@ Infinite_Loop:
 * 0x0000.0000.
 *
 ******************************************************************************/
-    .section    .isr_vector,"a",%progbits
-    .type   g_pfnVectors, %object
-    .size   g_pfnVectors, .-g_pfnVectors
+  .section  .isr_vector,"a",%progbits
+  .type  g_pfnVectors, %object
 
 
 g_pfnVectors:
   .word _estack
   .word Reset_Handler
-    .word   NMI_Handler
+  .word NMI_Handler
   .word HardFault_Handler
   .word MemManage_Handler
   .word BusFault_Handler
@@ -219,6 +220,8 @@ g_pfnVectors:
   .word DMA2_Channel7_IRQHandler
   .word DMAMUX1_OVR_IRQHandler
 
+  .size  g_pfnVectors, .-g_pfnVectors
+
 /*******************************************************************************
 *
 * Provide weak aliases for each Exception handler to the Default_Handler.
@@ -226,7 +229,7 @@ g_pfnVectors:
 * this definition.
 *
 *******************************************************************************/
-  .weak NMI_Handler
+  .weak  NMI_Handler
   .thumb_set NMI_Handler,Default_Handler
 
   .weak  HardFault_Handler
@@ -442,4 +445,3 @@ g_pfnVectors:
   .weak  DMAMUX1_OVR_IRQHandler
   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb5mxx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/gcc/startup_stm32wb5mxx_cm4.s
@@ -14,36 +14,38 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2022 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
 
   .syntax unified
-    .cpu cortex-m4
-    .fpu softvfp
-    .thumb
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
 
 .global g_pfnVectors
 .global Default_Handler
 
 /* start address for the initialization values of the .data section.
 defined in linker script */
-.word   _sidata
+.word _sidata
 /* start address for the .data section. defined in linker script */
-.word   _sdata
+.word _sdata
 /* end address for the .data section. defined in linker script */
-.word   _edata
+.word _edata
 /* start address for the .bss section. defined in linker script */
-.word   _sbss
+.word _sbss
 /* end address for the .bss section. defined in linker script */
-.word   _ebss
+.word _ebss
+/* start address for the initialization values of the .MB_MEM2 section.
+defined in linker script */
+.word _siMB_MEM2
 /* start address for the .MB_MEM2 section. defined in linker script */
 .word _sMB_MEM2
 /* end address for the .MB_MEM2 section. defined in linker script */
@@ -93,25 +95,25 @@ LoopFillZerobss:
 Reset_Handler:
   ldr   r0, =_estack
   mov   sp, r0          /* set stack pointer */
-/* Call the clock system intitialization function.*/
+/* Call the clock system initialization function.*/
   bl  SystemInit
 
 /* Copy the data segment initializers from flash to SRAM */
   INIT_DATA _sdata, _edata, _sidata
+  INIT_DATA _sMB_MEM2, _eMB_MEM2, _siMB_MEM2
 
 /* Zero fill the bss segments. */
   INIT_BSS _sbss, _ebss
-  INIT_BSS _sMB_MEM2, _eMB_MEM2
 
 /* Call static constructors */
   bl __libc_init_array
 /* Call the application s entry point.*/
-    bl  main
+  bl main
 
 LoopForever:
   b LoopForever
 
-.size   Reset_Handler, .-Reset_Handler
+.size Reset_Handler, .-Reset_Handler
 
 /**
  * @brief  This is the code that gets called when the processor receives an
@@ -124,8 +126,8 @@ LoopForever:
   .section .text.Default_Handler,"ax",%progbits
 Default_Handler:
 Infinite_Loop:
-    b   Infinite_Loop
-    .size   Default_Handler, .-Default_Handler
+  b Infinite_Loop
+  .size Default_Handler, .-Default_Handler
 /******************************************************************************
 *
 * The minimal vector table for a Cortex-M4.  Note that the proper constructs
@@ -133,15 +135,14 @@ Infinite_Loop:
 * 0x0000.0000.
 *
 ******************************************************************************/
-    .section    .isr_vector,"a",%progbits
-    .type   g_pfnVectors, %object
-    .size   g_pfnVectors, .-g_pfnVectors
+  .section .isr_vector,"a",%progbits
+  .type g_pfnVectors, %object
 
 
 g_pfnVectors:
   .word _estack
   .word Reset_Handler
-    .word   NMI_Handler
+  .word NMI_Handler
   .word HardFault_Handler
   .word MemManage_Handler
   .word BusFault_Handler
@@ -219,6 +220,8 @@ g_pfnVectors:
   .word DMA2_Channel7_IRQHandler
   .word DMAMUX1_OVR_IRQHandler
 
+  .size g_pfnVectors, .-g_pfnVectors
+
 /*******************************************************************************
 *
 * Provide weak aliases for each Exception handler to the Default_Handler.
@@ -226,7 +229,7 @@ g_pfnVectors:
 * this definition.
 *
 *******************************************************************************/
-  .weak NMI_Handler
+  .weak  NMI_Handler
   .thumb_set NMI_Handler,Default_Handler
 
   .weak  HardFault_Handler
@@ -442,4 +445,3 @@ g_pfnVectors:
   .weak  DMAMUX1_OVR_IRQHandler
   .thumb_set DMAMUX1_OVR_IRQHandler,Default_Handler
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb10xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb10xx_cm4.s
@@ -1,0 +1,420 @@
+;******************************************************************************
+;* File Name          : startup_stm32wb10xx_cm4.s
+;* Author             : MCD Application Team
+;* Description        : M4 core vector table of the STM32WB10xx devices for the
+;*                      IAR (EWARM) toolchain.
+;*
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == _iar_program_start,
+;*                      - Set the vector table entries with the exceptions ISR
+;*                        address.
+;*                      - Branches to main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the Cortex-M4 processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;******************************************************************************
+;* @attention
+;*
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
+;*
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
+;*
+;******************************************************************************
+;
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+
+        DATA
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler                     ; Reset Handler
+
+        DCD     NMI_Handler                       ; NMI Handler
+        DCD     HardFault_Handler                 ; Hard Fault Handler
+        DCD     MemManage_Handler                 ; MPU Fault Handler
+        DCD     BusFault_Handler                  ; Bus Fault Handler
+        DCD     UsageFault_Handler                ; Usage Fault Handler
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SVC_Handler                       ; SVCall Handler
+        DCD     DebugMon_Handler                  ; Debug Monitor Handler
+        DCD     0                                 ; Reserved
+        DCD     PendSV_Handler                    ; PendSV Handler
+        DCD     SysTick_Handler                   ; SysTick Handler
+
+        ; External Interrupts
+        DCD     WWDG_IRQHandler                   ; Window WatchDog
+        DCD     PVD_PVM_IRQHandler                ; PVD and PVM Interrupt
+        DCD     TAMP_STAMP_LSECSS_IRQHandler      ; RTC Tamper, TimeStamp Interrupts and LSECSS Interrupts
+        DCD     RTC_WKUP_IRQHandler               ; RTC Wakeup Interrupt
+        DCD     FLASH_IRQHandler                  ; FLASH global Interrupt
+        DCD     RCC_IRQHandler                    ; RCC Interrupt
+        DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
+        DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
+        DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
+        DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
+        DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
+        DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
+        DCD     DMA1_Channel3_IRQHandler          ; DMA1 Channel 3 Interrupt
+        DCD     DMA1_Channel4_IRQHandler          ; DMA1 Channel 4 Interrupt
+        DCD     DMA1_Channel5_IRQHandler          ; DMA1 Channel 5 Interrupt
+        DCD     DMA1_Channel6_IRQHandler          ; DMA1 Channel 6 Interrupt
+        DCD     DMA1_Channel7_IRQHandler          ; DMA1 Channel 7 Interrupt
+        DCD     ADC1_IRQHandler                   ; ADC1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     C2SEV_PWR_C2H_IRQHandler          ; CPU M0+ SEV Interrupt
+        DCD     0                                 ; Reserved
+        DCD     EXTI9_5_IRQHandler                ; EXTI Lines [9:5] Interrupt
+        DCD     TIM1_BRK_IRQHandler               ; TIM1 Break Interrupt
+        DCD     TIM1_UP_IRQHandler                ; TIM1 Update Interrupt
+        DCD     TIM1_TRG_COM_IRQHandler           ; TIM1 Trigger and Communication Interrupts
+        DCD     TIM1_CC_IRQHandler                ; TIM1 Capture Compare Interrupt
+        DCD     TIM2_IRQHandler                   ; TIM2 Global Interrupt
+        DCD     PKA_IRQHandler                    ; PKA Interrupt
+        DCD     I2C1_EV_IRQHandler                ; I2C1 Event Interrupt
+        DCD     I2C1_ER_IRQHandler                ; I2C1 Error Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SPI1_IRQHandler                   ; SPI1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     USART1_IRQHandler                 ; USART1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     TSC_IRQHandler                    ; TSC Interrupt
+        DCD     EXTI15_10_IRQHandler              ; EXTI Lines1[15:10 ]Interrupts
+        DCD     RTC_Alarm_IRQHandler              ; RTC Alarms (A and B) Interrupt
+        DCD     0                                 ; Reserved
+        DCD     PWR_SOTF_BLEACT_RFPHASE_IRQHandler ; WKUP Interrupt from PWR
+        DCD     IPCC_C1_RX_IRQHandler             ; IPCC CPU1 RX occupied interrupt
+        DCD     IPCC_C1_TX_IRQHandler             ; IPCC CPU1 RX free interrupt
+        DCD     HSEM_IRQHandler                   ; HSEM0 Interrupt
+        DCD     LPTIM1_IRQHandler                 ; LPTIM1 Interrupt
+        DCD     LPTIM2_IRQHandler                 ; LPTIM2 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     AES2_IRQHandler                   ; AES2 Interrupt
+        DCD     RNG_IRQHandler                    ; RNG1 Interrupt
+        DCD     FPU_IRQHandler                    ; FPU Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     DMAMUX1_OVR_IRQHandler            ; DMAMUX overrun Interrupt
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HardFault_Handler
+        B HardFault_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK WWDG_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+WWDG_IRQHandler
+        B WWDG_IRQHandler
+
+        PUBWEAK PVD_PVM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PVD_PVM_IRQHandler
+        B PVD_PVM_IRQHandler
+
+        PUBWEAK TAMP_STAMP_LSECSS_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TAMP_STAMP_LSECSS_IRQHandler
+        B TAMP_STAMP_LSECSS_IRQHandler
+
+        PUBWEAK RTC_WKUP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_WKUP_IRQHandler
+        B RTC_WKUP_IRQHandler
+
+        PUBWEAK FLASH_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FLASH_IRQHandler
+        B FLASH_IRQHandler
+
+        PUBWEAK RCC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RCC_IRQHandler
+        B RCC_IRQHandler
+
+        PUBWEAK EXTI0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI0_IRQHandler
+        B EXTI0_IRQHandler
+
+        PUBWEAK EXTI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI1_IRQHandler
+        B EXTI1_IRQHandler
+
+        PUBWEAK EXTI2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI2_IRQHandler
+        B EXTI2_IRQHandler
+
+        PUBWEAK EXTI3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI3_IRQHandler
+        B EXTI3_IRQHandler
+
+        PUBWEAK EXTI4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI4_IRQHandler
+        B EXTI4_IRQHandler
+
+        PUBWEAK DMA1_Channel1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel1_IRQHandler
+        B DMA1_Channel1_IRQHandler
+
+        PUBWEAK DMA1_Channel2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel2_IRQHandler
+        B DMA1_Channel2_IRQHandler
+
+        PUBWEAK DMA1_Channel3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel3_IRQHandler
+        B DMA1_Channel3_IRQHandler
+
+        PUBWEAK DMA1_Channel4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel4_IRQHandler
+        B DMA1_Channel4_IRQHandler
+
+        PUBWEAK DMA1_Channel5_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel5_IRQHandler
+        B DMA1_Channel5_IRQHandler
+
+        PUBWEAK DMA1_Channel6_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel6_IRQHandler
+        B DMA1_Channel6_IRQHandler
+
+        PUBWEAK DMA1_Channel7_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel7_IRQHandler
+        B DMA1_Channel7_IRQHandler
+
+        PUBWEAK ADC1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ADC1_IRQHandler
+        B ADC1_IRQHandler
+
+        PUBWEAK C2SEV_PWR_C2H_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+C2SEV_PWR_C2H_IRQHandler
+        B C2SEV_PWR_C2H_IRQHandler
+
+        PUBWEAK EXTI9_5_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI9_5_IRQHandler
+        B EXTI9_5_IRQHandler
+
+        PUBWEAK TIM1_BRK_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_BRK_IRQHandler
+        B TIM1_BRK_IRQHandler
+
+        PUBWEAK TIM1_UP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_UP_IRQHandler
+        B TIM1_UP_IRQHandler
+
+        PUBWEAK TIM1_TRG_COM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_TRG_COM_IRQHandler
+        B TIM1_TRG_COM_IRQHandler
+
+        PUBWEAK TIM1_CC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_CC_IRQHandler
+        B TIM1_CC_IRQHandler
+
+        PUBWEAK TIM2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM2_IRQHandler
+        B TIM2_IRQHandler
+
+        PUBWEAK PKA_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PKA_IRQHandler
+        B PKA_IRQHandler
+
+        PUBWEAK I2C1_EV_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_EV_IRQHandler
+        B I2C1_EV_IRQHandler
+
+        PUBWEAK I2C1_ER_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_ER_IRQHandler
+        B I2C1_ER_IRQHandler
+
+        PUBWEAK SPI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI1_IRQHandler
+        B SPI1_IRQHandler
+
+        PUBWEAK USART1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART1_IRQHandler
+        B USART1_IRQHandler
+
+        PUBWEAK TSC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TSC_IRQHandler
+        B TSC_IRQHandler
+
+        PUBWEAK EXTI15_10_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI15_10_IRQHandler
+        B EXTI15_10_IRQHandler
+
+        PUBWEAK RTC_Alarm_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_Alarm_IRQHandler
+        B RTC_Alarm_IRQHandler
+
+        PUBWEAK PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+        B PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+
+        PUBWEAK IPCC_C1_RX_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPCC_C1_RX_IRQHandler
+        B IPCC_C1_RX_IRQHandler
+
+        PUBWEAK IPCC_C1_TX_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPCC_C1_TX_IRQHandler
+        B IPCC_C1_TX_IRQHandler
+
+        PUBWEAK HSEM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HSEM_IRQHandler
+        B HSEM_IRQHandler
+
+        PUBWEAK LPTIM1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPTIM1_IRQHandler
+        B LPTIM1_IRQHandler
+
+        PUBWEAK LPTIM2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPTIM2_IRQHandler
+        B LPTIM2_IRQHandler
+
+        PUBWEAK AES2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+AES2_IRQHandler
+        B AES2_IRQHandler
+
+        PUBWEAK RNG_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RNG_IRQHandler
+        B RNG_IRQHandler
+
+        PUBWEAK FPU_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FPU_IRQHandler
+        B FPU_IRQHandler
+
+        PUBWEAK DMAMUX1_OVR_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMAMUX1_OVR_IRQHandler
+        B DMAMUX1_OVR_IRQHandler
+
+        END
+

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb15xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb15xx_cm4.s
@@ -1,0 +1,430 @@
+;******************************************************************************
+;* File Name          : startup_stm32wb15xx_cm4.s
+;* Author             : MCD Application Team
+;* Description        : M4 core vector table of the STM32WB15xx devices for the
+;*                      IAR (EWARM) toolchain.
+;*
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == _iar_program_start,
+;*                      - Set the vector table entries with the exceptions ISR
+;*                        address.
+;*                      - Branches to main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the Cortex-M4 processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;******************************************************************************
+;* @attention
+;*
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
+;*
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
+;*
+;******************************************************************************
+;
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+
+        DATA
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler                     ; Reset Handler
+
+        DCD     NMI_Handler                       ; NMI Handler
+        DCD     HardFault_Handler                 ; Hard Fault Handler
+        DCD     MemManage_Handler                 ; MPU Fault Handler
+        DCD     BusFault_Handler                  ; Bus Fault Handler
+        DCD     UsageFault_Handler                ; Usage Fault Handler
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SVC_Handler                       ; SVCall Handler
+        DCD     DebugMon_Handler                  ; Debug Monitor Handler
+        DCD     0                                 ; Reserved
+        DCD     PendSV_Handler                    ; PendSV Handler
+        DCD     SysTick_Handler                   ; SysTick Handler
+
+        ; External Interrupts
+        DCD     WWDG_IRQHandler                   ; Window WatchDog
+        DCD     PVD_PVM_IRQHandler                ; PVD and PVM Interrupt
+        DCD     TAMP_STAMP_LSECSS_IRQHandler      ; RTC Tamper, TimeStamp Interrupts and LSECSS Interrupts
+        DCD     RTC_WKUP_IRQHandler               ; RTC Wakeup Interrupt
+        DCD     FLASH_IRQHandler                  ; FLASH global Interrupt
+        DCD     RCC_IRQHandler                    ; RCC Interrupt
+        DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
+        DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
+        DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
+        DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
+        DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
+        DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
+        DCD     DMA1_Channel3_IRQHandler          ; DMA1 Channel 3 Interrupt
+        DCD     DMA1_Channel4_IRQHandler          ; DMA1 Channel 4 Interrupt
+        DCD     DMA1_Channel5_IRQHandler          ; DMA1 Channel 5 Interrupt
+        DCD     DMA1_Channel6_IRQHandler          ; DMA1 Channel 6 Interrupt
+        DCD     DMA1_Channel7_IRQHandler          ; DMA1 Channel 7 Interrupt
+        DCD     ADC1_IRQHandler                   ; ADC1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     C2SEV_PWR_C2H_IRQHandler          ; CPU M0+ SEV Interrupt
+        DCD     COMP_IRQHandler                   ; COMP1 Interrupts
+        DCD     EXTI9_5_IRQHandler                ; EXTI Lines [9:5] Interrupt
+        DCD     TIM1_BRK_IRQHandler               ; TIM1 Break Interrupt
+        DCD     TIM1_UP_IRQHandler                ; TIM1 Update Interrupt
+        DCD     TIM1_TRG_COM_IRQHandler           ; TIM1 Trigger and Communication Interrupts
+        DCD     TIM1_CC_IRQHandler                ; TIM1 Capture Compare Interrupt
+        DCD     TIM2_IRQHandler                   ; TIM2 Global Interrupt
+        DCD     PKA_IRQHandler                    ; PKA Interrupt
+        DCD     I2C1_EV_IRQHandler                ; I2C1 Event Interrupt
+        DCD     I2C1_ER_IRQHandler                ; I2C1 Error Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SPI1_IRQHandler                   ; SPI1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     USART1_IRQHandler                 ; USART1 Interrupt
+        DCD     LPUART1_IRQHandler                ; LPUART1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     TSC_IRQHandler                    ; TSC Interrupt
+        DCD     EXTI15_10_IRQHandler              ; EXTI Lines1[15:10 ]Interrupts
+        DCD     RTC_Alarm_IRQHandler              ; RTC Alarms (A and B) Interrupt
+        DCD     0                                 ; Reserved
+        DCD     PWR_SOTF_BLEACT_RFPHASE_IRQHandler ; WKUP Interrupt from PWR
+        DCD     IPCC_C1_RX_IRQHandler             ; IPCC CPU1 RX occupied interrupt
+        DCD     IPCC_C1_TX_IRQHandler             ; IPCC CPU1 RX free interrupt
+        DCD     HSEM_IRQHandler                   ; HSEM0 Interrupt
+        DCD     LPTIM1_IRQHandler                 ; LPTIM1 Interrupt
+        DCD     LPTIM2_IRQHandler                 ; LPTIM2 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     AES2_IRQHandler                   ; AES2 Interrupt
+        DCD     RNG_IRQHandler                    ; RNG1 Interrupt
+        DCD     FPU_IRQHandler                    ; FPU Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     DMAMUX1_OVR_IRQHandler            ; DMAMUX overrun Interrupt
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HardFault_Handler
+        B HardFault_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK WWDG_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+WWDG_IRQHandler
+        B WWDG_IRQHandler
+
+        PUBWEAK PVD_PVM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PVD_PVM_IRQHandler
+        B PVD_PVM_IRQHandler
+
+        PUBWEAK TAMP_STAMP_LSECSS_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TAMP_STAMP_LSECSS_IRQHandler
+        B TAMP_STAMP_LSECSS_IRQHandler
+
+        PUBWEAK RTC_WKUP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_WKUP_IRQHandler
+        B RTC_WKUP_IRQHandler
+
+        PUBWEAK FLASH_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FLASH_IRQHandler
+        B FLASH_IRQHandler
+
+        PUBWEAK RCC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RCC_IRQHandler
+        B RCC_IRQHandler
+
+        PUBWEAK EXTI0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI0_IRQHandler
+        B EXTI0_IRQHandler
+
+        PUBWEAK EXTI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI1_IRQHandler
+        B EXTI1_IRQHandler
+
+        PUBWEAK EXTI2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI2_IRQHandler
+        B EXTI2_IRQHandler
+
+        PUBWEAK EXTI3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI3_IRQHandler
+        B EXTI3_IRQHandler
+
+        PUBWEAK EXTI4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI4_IRQHandler
+        B EXTI4_IRQHandler
+
+        PUBWEAK DMA1_Channel1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel1_IRQHandler
+        B DMA1_Channel1_IRQHandler
+
+        PUBWEAK DMA1_Channel2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel2_IRQHandler
+        B DMA1_Channel2_IRQHandler
+
+        PUBWEAK DMA1_Channel3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel3_IRQHandler
+        B DMA1_Channel3_IRQHandler
+
+        PUBWEAK DMA1_Channel4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel4_IRQHandler
+        B DMA1_Channel4_IRQHandler
+
+        PUBWEAK DMA1_Channel5_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel5_IRQHandler
+        B DMA1_Channel5_IRQHandler
+
+        PUBWEAK DMA1_Channel6_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel6_IRQHandler
+        B DMA1_Channel6_IRQHandler
+
+        PUBWEAK DMA1_Channel7_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel7_IRQHandler
+        B DMA1_Channel7_IRQHandler
+
+        PUBWEAK ADC1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ADC1_IRQHandler
+        B ADC1_IRQHandler
+
+        PUBWEAK C2SEV_PWR_C2H_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+C2SEV_PWR_C2H_IRQHandler
+        B C2SEV_PWR_C2H_IRQHandler
+
+        PUBWEAK COMP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+COMP_IRQHandler
+        B COMP_IRQHandler
+
+        PUBWEAK EXTI9_5_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI9_5_IRQHandler
+        B EXTI9_5_IRQHandler
+
+        PUBWEAK TIM1_BRK_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_BRK_IRQHandler
+        B TIM1_BRK_IRQHandler
+
+        PUBWEAK TIM1_UP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_UP_IRQHandler
+        B TIM1_UP_IRQHandler
+
+        PUBWEAK TIM1_TRG_COM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_TRG_COM_IRQHandler
+        B TIM1_TRG_COM_IRQHandler
+
+        PUBWEAK TIM1_CC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_CC_IRQHandler
+        B TIM1_CC_IRQHandler
+
+        PUBWEAK TIM2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM2_IRQHandler
+        B TIM2_IRQHandler
+
+        PUBWEAK PKA_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PKA_IRQHandler
+        B PKA_IRQHandler
+
+        PUBWEAK I2C1_EV_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_EV_IRQHandler
+        B I2C1_EV_IRQHandler
+
+        PUBWEAK I2C1_ER_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_ER_IRQHandler
+        B I2C1_ER_IRQHandler
+
+        PUBWEAK SPI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI1_IRQHandler
+        B SPI1_IRQHandler
+
+        PUBWEAK USART1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART1_IRQHandler
+        B USART1_IRQHandler
+
+        PUBWEAK LPUART1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPUART1_IRQHandler
+        B LPUART1_IRQHandler
+
+        PUBWEAK TSC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TSC_IRQHandler
+        B TSC_IRQHandler
+
+        PUBWEAK EXTI15_10_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI15_10_IRQHandler
+        B EXTI15_10_IRQHandler
+
+        PUBWEAK RTC_Alarm_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_Alarm_IRQHandler
+        B RTC_Alarm_IRQHandler
+
+        PUBWEAK PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+        B PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+
+        PUBWEAK IPCC_C1_RX_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPCC_C1_RX_IRQHandler
+        B IPCC_C1_RX_IRQHandler
+
+        PUBWEAK IPCC_C1_TX_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPCC_C1_TX_IRQHandler
+        B IPCC_C1_TX_IRQHandler
+
+        PUBWEAK HSEM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HSEM_IRQHandler
+        B HSEM_IRQHandler
+
+        PUBWEAK LPTIM1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPTIM1_IRQHandler
+        B LPTIM1_IRQHandler
+
+        PUBWEAK LPTIM2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPTIM2_IRQHandler
+        B LPTIM2_IRQHandler
+
+        PUBWEAK AES2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+AES2_IRQHandler
+        B AES2_IRQHandler
+
+        PUBWEAK RNG_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RNG_IRQHandler
+        B RNG_IRQHandler
+
+        PUBWEAK FPU_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FPU_IRQHandler
+        B FPU_IRQHandler
+
+        PUBWEAK DMAMUX1_OVR_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMAMUX1_OVR_IRQHandler
+        B DMAMUX1_OVR_IRQHandler
+
+        END
+

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb1mxx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb1mxx_cm4.s
@@ -1,0 +1,430 @@
+;******************************************************************************
+;* File Name          : startup_stm32wb1mxx_cm4.s
+;* Author             : MCD Application Team
+;* Description        : M4 core vector table of the STM32WB1Mxx devices for the
+;*                      IAR (EWARM) toolchain.
+;*
+;*                      This module performs:
+;*                      - Set the initial SP
+;*                      - Set the initial PC == _iar_program_start,
+;*                      - Set the vector table entries with the exceptions ISR
+;*                        address.
+;*                      - Branches to main in the C library (which eventually
+;*                        calls main()).
+;*                      After Reset the Cortex-M4 processor is in Thread mode,
+;*                      priority is Privileged, and the Stack is set to Main.
+;******************************************************************************
+;* @attention
+;*
+;* Copyright (c) 2022 STMicroelectronics.
+;* All rights reserved.
+;*
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
+;*
+;******************************************************************************
+;
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+
+        DATA
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler                     ; Reset Handler
+
+        DCD     NMI_Handler                       ; NMI Handler
+        DCD     HardFault_Handler                 ; Hard Fault Handler
+        DCD     MemManage_Handler                 ; MPU Fault Handler
+        DCD     BusFault_Handler                  ; Bus Fault Handler
+        DCD     UsageFault_Handler                ; Usage Fault Handler
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SVC_Handler                       ; SVCall Handler
+        DCD     DebugMon_Handler                  ; Debug Monitor Handler
+        DCD     0                                 ; Reserved
+        DCD     PendSV_Handler                    ; PendSV Handler
+        DCD     SysTick_Handler                   ; SysTick Handler
+
+        ; External Interrupts
+        DCD     WWDG_IRQHandler                   ; Window WatchDog
+        DCD     PVD_PVM_IRQHandler                ; PVD and PVM Interrupt
+        DCD     TAMP_STAMP_LSECSS_IRQHandler      ; RTC Tamper, TimeStamp Interrupts and LSECSS Interrupts
+        DCD     RTC_WKUP_IRQHandler               ; RTC Wakeup Interrupt
+        DCD     FLASH_IRQHandler                  ; FLASH global Interrupt
+        DCD     RCC_IRQHandler                    ; RCC Interrupt
+        DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
+        DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
+        DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
+        DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
+        DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
+        DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
+        DCD     DMA1_Channel3_IRQHandler          ; DMA1 Channel 3 Interrupt
+        DCD     DMA1_Channel4_IRQHandler          ; DMA1 Channel 4 Interrupt
+        DCD     DMA1_Channel5_IRQHandler          ; DMA1 Channel 5 Interrupt
+        DCD     DMA1_Channel6_IRQHandler          ; DMA1 Channel 6 Interrupt
+        DCD     DMA1_Channel7_IRQHandler          ; DMA1 Channel 7 Interrupt
+        DCD     ADC1_IRQHandler                   ; ADC1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     C2SEV_PWR_C2H_IRQHandler          ; CPU M0+ SEV Interrupt
+        DCD     COMP_IRQHandler                   ; COMP1 Interrupts
+        DCD     EXTI9_5_IRQHandler                ; EXTI Lines [9:5] Interrupt
+        DCD     TIM1_BRK_IRQHandler               ; TIM1 Break Interrupt
+        DCD     TIM1_UP_IRQHandler                ; TIM1 Update Interrupt
+        DCD     TIM1_TRG_COM_IRQHandler           ; TIM1 Trigger and Communication Interrupts
+        DCD     TIM1_CC_IRQHandler                ; TIM1 Capture Compare Interrupt
+        DCD     TIM2_IRQHandler                   ; TIM2 Global Interrupt
+        DCD     PKA_IRQHandler                    ; PKA Interrupt
+        DCD     I2C1_EV_IRQHandler                ; I2C1 Event Interrupt
+        DCD     I2C1_ER_IRQHandler                ; I2C1 Error Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     SPI1_IRQHandler                   ; SPI1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     USART1_IRQHandler                 ; USART1 Interrupt
+        DCD     LPUART1_IRQHandler                ; LPUART1 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     TSC_IRQHandler                    ; TSC Interrupt
+        DCD     EXTI15_10_IRQHandler              ; EXTI Lines1[15:10 ]Interrupts
+        DCD     RTC_Alarm_IRQHandler              ; RTC Alarms (A and B) Interrupt
+        DCD     0                                 ; Reserved
+        DCD     PWR_SOTF_BLEACT_RFPHASE_IRQHandler ; WKUP Interrupt from PWR
+        DCD     IPCC_C1_RX_IRQHandler             ; IPCC CPU1 RX occupied interrupt
+        DCD     IPCC_C1_TX_IRQHandler             ; IPCC CPU1 RX free interrupt
+        DCD     HSEM_IRQHandler                   ; HSEM0 Interrupt
+        DCD     LPTIM1_IRQHandler                 ; LPTIM1 Interrupt
+        DCD     LPTIM2_IRQHandler                 ; LPTIM2 Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     AES2_IRQHandler                   ; AES2 Interrupt
+        DCD     RNG_IRQHandler                    ; RNG1 Interrupt
+        DCD     FPU_IRQHandler                    ; FPU Interrupt
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     0                                 ; Reserved
+        DCD     DMAMUX1_OVR_IRQHandler            ; DMAMUX overrun Interrupt
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HardFault_Handler
+        B HardFault_Handler
+
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UsageFault_Handler
+        B UsageFault_Handler
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SVC_Handler
+        B SVC_Handler
+
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DebugMon_Handler
+        B DebugMon_Handler
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PendSV_Handler
+        B PendSV_Handler
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SysTick_Handler
+        B SysTick_Handler
+
+        PUBWEAK WWDG_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+WWDG_IRQHandler
+        B WWDG_IRQHandler
+
+        PUBWEAK PVD_PVM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PVD_PVM_IRQHandler
+        B PVD_PVM_IRQHandler
+
+        PUBWEAK TAMP_STAMP_LSECSS_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TAMP_STAMP_LSECSS_IRQHandler
+        B TAMP_STAMP_LSECSS_IRQHandler
+
+        PUBWEAK RTC_WKUP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_WKUP_IRQHandler
+        B RTC_WKUP_IRQHandler
+
+        PUBWEAK FLASH_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FLASH_IRQHandler
+        B FLASH_IRQHandler
+
+        PUBWEAK RCC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RCC_IRQHandler
+        B RCC_IRQHandler
+
+        PUBWEAK EXTI0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI0_IRQHandler
+        B EXTI0_IRQHandler
+
+        PUBWEAK EXTI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI1_IRQHandler
+        B EXTI1_IRQHandler
+
+        PUBWEAK EXTI2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI2_IRQHandler
+        B EXTI2_IRQHandler
+
+        PUBWEAK EXTI3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI3_IRQHandler
+        B EXTI3_IRQHandler
+
+        PUBWEAK EXTI4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI4_IRQHandler
+        B EXTI4_IRQHandler
+
+        PUBWEAK DMA1_Channel1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel1_IRQHandler
+        B DMA1_Channel1_IRQHandler
+
+        PUBWEAK DMA1_Channel2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel2_IRQHandler
+        B DMA1_Channel2_IRQHandler
+
+        PUBWEAK DMA1_Channel3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel3_IRQHandler
+        B DMA1_Channel3_IRQHandler
+
+        PUBWEAK DMA1_Channel4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel4_IRQHandler
+        B DMA1_Channel4_IRQHandler
+
+        PUBWEAK DMA1_Channel5_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel5_IRQHandler
+        B DMA1_Channel5_IRQHandler
+
+        PUBWEAK DMA1_Channel6_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel6_IRQHandler
+        B DMA1_Channel6_IRQHandler
+
+        PUBWEAK DMA1_Channel7_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel7_IRQHandler
+        B DMA1_Channel7_IRQHandler
+
+        PUBWEAK ADC1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ADC1_IRQHandler
+        B ADC1_IRQHandler
+
+        PUBWEAK C2SEV_PWR_C2H_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+C2SEV_PWR_C2H_IRQHandler
+        B C2SEV_PWR_C2H_IRQHandler
+
+        PUBWEAK COMP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+COMP_IRQHandler
+        B COMP_IRQHandler
+
+        PUBWEAK EXTI9_5_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI9_5_IRQHandler
+        B EXTI9_5_IRQHandler
+
+        PUBWEAK TIM1_BRK_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_BRK_IRQHandler
+        B TIM1_BRK_IRQHandler
+
+        PUBWEAK TIM1_UP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_UP_IRQHandler
+        B TIM1_UP_IRQHandler
+
+        PUBWEAK TIM1_TRG_COM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_TRG_COM_IRQHandler
+        B TIM1_TRG_COM_IRQHandler
+
+        PUBWEAK TIM1_CC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM1_CC_IRQHandler
+        B TIM1_CC_IRQHandler
+
+        PUBWEAK TIM2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIM2_IRQHandler
+        B TIM2_IRQHandler
+
+        PUBWEAK PKA_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PKA_IRQHandler
+        B PKA_IRQHandler
+
+        PUBWEAK I2C1_EV_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_EV_IRQHandler
+        B I2C1_EV_IRQHandler
+
+        PUBWEAK I2C1_ER_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_ER_IRQHandler
+        B I2C1_ER_IRQHandler
+
+        PUBWEAK SPI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI1_IRQHandler
+        B SPI1_IRQHandler
+
+        PUBWEAK USART1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART1_IRQHandler
+        B USART1_IRQHandler
+
+        PUBWEAK LPUART1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPUART1_IRQHandler
+        B LPUART1_IRQHandler
+
+        PUBWEAK TSC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TSC_IRQHandler
+        B TSC_IRQHandler
+
+        PUBWEAK EXTI15_10_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI15_10_IRQHandler
+        B EXTI15_10_IRQHandler
+
+        PUBWEAK RTC_Alarm_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_Alarm_IRQHandler
+        B RTC_Alarm_IRQHandler
+
+        PUBWEAK PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+        B PWR_SOTF_BLEACT_RFPHASE_IRQHandler
+
+        PUBWEAK IPCC_C1_RX_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPCC_C1_RX_IRQHandler
+        B IPCC_C1_RX_IRQHandler
+
+        PUBWEAK IPCC_C1_TX_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPCC_C1_TX_IRQHandler
+        B IPCC_C1_TX_IRQHandler
+
+        PUBWEAK HSEM_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HSEM_IRQHandler
+        B HSEM_IRQHandler
+
+        PUBWEAK LPTIM1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPTIM1_IRQHandler
+        B LPTIM1_IRQHandler
+
+        PUBWEAK LPTIM2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LPTIM2_IRQHandler
+        B LPTIM2_IRQHandler
+
+        PUBWEAK AES2_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+AES2_IRQHandler
+        B AES2_IRQHandler
+
+        PUBWEAK RNG_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RNG_IRQHandler
+        B RNG_IRQHandler
+
+        PUBWEAK FPU_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FPU_IRQHandler
+        B FPU_IRQHandler
+
+        PUBWEAK DMAMUX1_OVR_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMAMUX1_OVR_IRQHandler
+        B DMAMUX1_OVR_IRQHandler
+
+        END
+

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb30xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb30xx_cm4.s
@@ -16,13 +16,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-;* All rights reserved.</center></h2>
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 ;
@@ -83,7 +82,7 @@ __vector_table
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -414,4 +413,3 @@ DMAMUX1_OVR_IRQHandler
 
         END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb35xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb35xx_cm4.s
@@ -16,13 +16,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-;* All rights reserved.</center></h2>
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 ;
@@ -83,7 +82,7 @@ __vector_table
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -494,4 +493,3 @@ DMAMUX1_OVR_IRQHandler
 
         END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb50xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb50xx_cm4.s
@@ -16,13 +16,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-;* All rights reserved.</center></h2>
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 ;
@@ -83,7 +82,7 @@ __vector_table
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -414,4 +413,3 @@ DMAMUX1_OVR_IRQHandler
 
         END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb55xx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb55xx_cm4.s
@@ -16,13 +16,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-;* All rights reserved.</center></h2>
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 ;
@@ -83,7 +82,7 @@ __vector_table
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -514,4 +513,3 @@ DMAMUX1_OVR_IRQHandler
 
         END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb5mxx_cm4.s
+++ b/CMSIS/STM32WBxx/Source/Templates/iar/startup_stm32wb5mxx_cm4.s
@@ -16,13 +16,12 @@
 ;******************************************************************************
 ;* @attention
 ;*
-;* <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-;* All rights reserved.</center></h2>
+;* Copyright (c) 2019-2021 STMicroelectronics.
+;* All rights reserved.
 ;*
-;* This software component is licensed by ST under BSD 3-Clause license,
-;* the "License"; You may not use this file except in compliance with the
-;* License. You may obtain a copy of the License at:
-;*                        opensource.org/licenses/BSD-3-Clause
+;* This software is licensed under terms that can be found in the LICENSE file
+;* in the root directory of this software component.
+;* If no LICENSE file comes with this software, it is provided AS-IS.
 ;*
 ;******************************************************************************
 ;
@@ -83,7 +82,7 @@ __vector_table
         DCD     EXTI0_IRQHandler                  ; EXTI Line 0 Interrupt
         DCD     EXTI1_IRQHandler                  ; EXTI Line 1 Interrupt
         DCD     EXTI2_IRQHandler                  ; EXTI Line 2 Interrupt
-        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrup
+        DCD     EXTI3_IRQHandler                  ; EXTI Line 3 Interrupt
         DCD     EXTI4_IRQHandler                  ; EXTI Line 4 Interrupt
         DCD     DMA1_Channel1_IRQHandler          ; DMA1 Channel 1 Interrupt
         DCD     DMA1_Channel2_IRQHandler          ; DMA1 Channel 2 Interrupt
@@ -514,4 +513,3 @@ DMAMUX1_OVR_IRQHandler
 
         END
 
-;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/CMSIS/STM32WBxx/Source/Templates/system_stm32wbxx.c
+++ b/CMSIS/STM32WBxx/Source/Templates/system_stm32wbxx.c
@@ -60,13 +60,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019-2021 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -86,23 +85,27 @@
 #include "stm32wbxx.h"
 
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    (32000000UL) /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE    (32000000UL) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (MSI_VALUE)
-   #define MSI_VALUE    (4000000UL) /*!< Value of the Internal oscillator in Hz*/
+#define MSI_VALUE    (4000000UL) /*!< Value of the Internal oscillator in Hz*/
 #endif /* MSI_VALUE */
 
 #if !defined  (HSI_VALUE)
-  #define HSI_VALUE    (16000000UL) /*!< Value of the Internal oscillator in Hz*/
+#define HSI_VALUE    (16000000UL) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
 #if !defined  (LSI_VALUE)
- #define LSI_VALUE  (32000UL)       /*!< Value of LSI in Hz*/
+#define LSI_VALUE  (32000UL)       /*!< Value of LSI in Hz*/
 #endif /* LSI_VALUE */
 
 #if !defined  (LSE_VALUE)
-  #define LSE_VALUE    (32768UL)    /*!< Value of LSE in Hz*/
+#if defined(STM32WB5Mxx)
+  #define LSE_VALUE    32774U     /*!< Value of the LSE oscillator in Hz */
+#else
+  #define LSE_VALUE    32768U     /*!< Value of the LSE oscillator in Hz */
+#endif /* STM32WB5Mxx */
 #endif /* LSE_VALUE */
 
 /**
@@ -121,14 +124,35 @@
   * @{
   */
 
-/*!< Uncomment the following line if you need to relocate your vector Table in
-     Internal SRAM. */
+/* Note: Following vector table addresses must be defined in line with linker
+         configuration. */
+/*!< Uncomment the following line if you need to relocate CPU1 CM4 and/or CPU2
+     CM0+ vector table anywhere in Sram or Flash. Else vector table will be kept
+     at address 0x00 which correspond to automatic remap of boot address selected */
+/* #define USER_VECT_TAB_ADDRESS */
+#if defined(USER_VECT_TAB_ADDRESS)
+/*!< Uncomment this line for user vector table remap in Sram else user remap
+     will be done in Flash. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET         0x0U            /*!< Vector Table base offset field.
+#if defined(VECT_TAB_SRAM)
+#define VECT_TAB_BASE_ADDRESS   SRAM1_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
+#if !defined(VECT_TAB_OFFSET)
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* VECT_TAB_OFFSET */
 
-#define VECT_TAB_BASE_ADDRESS   SRAM1_BASE       /*!< Vector Table base offset field.
+#else
+#define VECT_TAB_BASE_ADDRESS   FLASH_BASE      /*!< Vector Table base address field.
                                                      This value must be a multiple of 0x200. */
+#if !defined(VECT_TAB_OFFSET)
+#define VECT_TAB_OFFSET         0x00000000U     /*!< Vector Table offset field.
+                                                     This value must be a multiple of 0x200. */
+#endif /* VECT_TAB_OFFSET */
+
+#endif /* VECT_TAB_SRAM */
+#endif /* USER_VECT_TAB_ADDRESS */
+
 /**
   * @}
   */
@@ -144,29 +168,31 @@
 /** @addtogroup STM32WBxx_System_Private_Variables
   * @{
   */
-  /* The SystemCoreClock variable is updated in three ways:
-      1) by calling CMSIS function SystemCoreClockUpdate()
-      2) by calling HAL API function HAL_RCC_GetHCLKFreq()
-      3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
-         Note: If you use this function to configure the system clock; then there
-               is no need to call the 2 first functions listed above, since SystemCoreClock
-               variable is updated automatically.
-  */
-  uint32_t SystemCoreClock  = 4000000UL ; /*CPU1: M4 on MSI clock after startup (4MHz)*/
+/* The SystemCoreClock variable is updated in three ways:
+    1) by calling CMSIS function SystemCoreClockUpdate()
+    2) by calling HAL API function HAL_RCC_GetHCLKFreq()
+    3) each time HAL_RCC_ClockConfig() is called to configure the system clock frequency
+       Note: If you use this function to configure the system clock; then there
+             is no need to call the 2 first functions listed above, since SystemCoreClock
+             variable is updated automatically.
+*/
+uint32_t SystemCoreClock = 4000000UL ; /*CPU1: M4 on MSI clock after startup (4MHz)*/
 
-  const uint32_t AHBPrescTable[16UL] = {1UL, 3UL, 5UL, 1UL, 1UL, 6UL, 10UL, 32UL, 2UL, 4UL, 8UL, 16UL, 64UL, 128UL, 256UL, 512UL};
+const uint32_t AHBPrescTable[16UL] = {1UL, 3UL, 5UL, 1UL, 1UL, 6UL, 10UL, 32UL, 2UL, 4UL, 8UL, 16UL, 64UL, 128UL, 256UL, 512UL};
 
-  const uint32_t APBPrescTable[8UL]  = {0UL, 0UL, 0UL, 0UL, 1UL, 2UL, 3UL, 4UL};
+const uint32_t APBPrescTable[8UL]  = {0UL, 0UL, 0UL, 0UL, 1UL, 2UL, 3UL, 4UL};
 
-  const uint32_t MSIRangeTable[16UL] = {100000UL, 200000UL, 400000UL, 800000UL, 1000000UL, 2000000UL, \
-                                      4000000UL, 8000000UL, 16000000UL, 24000000UL, 32000000UL, 48000000UL, 0UL, 0UL, 0UL, 0UL}; /* 0UL values are incorrect cases */
+const uint32_t MSIRangeTable[16UL] = {100000UL, 200000UL, 400000UL, 800000UL, 1000000UL, 2000000UL, \
+                                      4000000UL, 8000000UL, 16000000UL, 24000000UL, 32000000UL, 48000000UL, 0UL, 0UL, 0UL, 0UL
+                                     }; /* 0UL values are incorrect cases */
 
-#if defined(STM32WB55xx) || defined(STM32WB5Mxx) || defined(STM32WB35xx)
-  const uint32_t SmpsPrescalerTable[4UL][6UL]={{1UL,3UL,2UL,2UL,1UL,2UL}, \
-                                        {2UL,6UL,4UL,3UL,2UL,4UL}, \
-                                        {4UL,12UL,8UL,6UL,4UL,8UL}, \
-                                        {4UL,12UL,8UL,6UL,4UL,8UL}};
-#endif
+#if defined(STM32WB55xx) || defined(STM32WB5Mxx) || defined(STM32WB35xx) || defined (STM32WB15xx) || defined (STM32WB1Mxx)
+const uint32_t SmpsPrescalerTable[4UL][6UL] = {{1UL, 3UL, 2UL, 2UL, 1UL, 2UL}, \
+  {2UL, 6UL, 4UL, 3UL, 2UL, 4UL}, \
+  {4UL, 12UL, 8UL, 6UL, 4UL, 8UL}, \
+  {4UL, 12UL, 8UL, 6UL, 4UL, 8UL}
+};
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx || STM32WB15xx || STM32WB1Mxx */
 
 /**
   * @}
@@ -191,18 +217,15 @@
   */
 void SystemInit(void)
 {
+#if defined(USER_VECT_TAB_ADDRESS)
   /* Configure the Vector Table location add offset address ------------------*/
-#if defined(VECT_TAB_SRAM) && defined(VECT_TAB_BASE_ADDRESS)
-  /* program in SRAMx */
-  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;  /* Vector Table Relocation in Internal SRAMx for CPU1 */
-#else    /* program in FLASH */
-  SCB->VTOR = VECT_TAB_OFFSET;              /* Vector Table Relocation in Internal FLASH */
-#endif
+  SCB->VTOR = VECT_TAB_BASE_ADDRESS | VECT_TAB_OFFSET;
+#endif /* USER_VECT_TAB_ADDRESS */
 
   /* FPU settings ------------------------------------------------------------*/
-  #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-    SCB->CPACR |= ((3UL << (10UL*2UL))|(3UL << (11UL*2UL)));  /* set CP10 and CP11 Full Access */
-  #endif
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+  SCB->CPACR |= ((3UL << (10UL * 2UL)) | (3UL << (11UL * 2UL))); /* set CP10 and CP11 Full Access */
+#endif /* FPU */
 
   /* Reset the RCC clock configuration to the default reset state ------------*/
   /* Set MSION bit */
@@ -226,7 +249,7 @@ void SystemInit(void)
 #if defined(STM32WB55xx) || defined(STM32WB5Mxx)
   /* Reset PLLSAI1CFGR register */
   RCC->PLLSAI1CFGR = 0x22041000U;
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 
   /* Reset HSEBYP bit */
   RCC->CR &= 0xFFFBFFFFU;
@@ -279,7 +302,7 @@ void SystemInit(void)
   */
 void SystemCoreClockUpdate(void)
 {
-  uint32_t tmp, msirange, pllvco, pllr, pllsource , pllm;
+  uint32_t tmp, msirange, pllvco, pllr, pllsource, pllm;
 
   /* Get MSI Range frequency--------------------------------------------------*/
 
@@ -289,13 +312,13 @@ void SystemCoreClockUpdate(void)
   /* Get SYSCLK source -------------------------------------------------------*/
   switch (RCC->CFGR & RCC_CFGR_SWS)
   {
-    case 0x00:   /* MSI used as system clock source */
+    case 0x00: /* MSI used as system clock source */
       SystemCoreClock = msirange;
       break;
 
-    case 0x04:  /* HSI used as system clock source */
+    case 0x04: /* HSI used as system clock source */
       /* HSI used as system clock source */
-        SystemCoreClock = HSI_VALUE;
+      SystemCoreClock = HSI_VALUE;
       break;
 
     case 0x08:  /* HSE used as system clock source */
@@ -309,11 +332,11 @@ void SystemCoreClockUpdate(void)
       pllsource = (RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC);
       pllm = ((RCC->PLLCFGR & RCC_PLLCFGR_PLLM) >> RCC_PLLCFGR_PLLM_Pos) + 1UL ;
 
-      if(pllsource == 0x02UL) /* HSI used as PLL clock source */
+      if (pllsource == 0x02UL) /* HSI used as PLL clock source */
       {
         pllvco = (HSI_VALUE / pllm);
       }
-      else if(pllsource == 0x03UL) /* HSE used as PLL clock source */
+      else if (pllsource == 0x03UL) /* HSE used as PLL clock source */
       {
         pllvco = (HSE_VALUE / pllm);
       }
@@ -325,7 +348,7 @@ void SystemCoreClockUpdate(void)
       pllvco = pllvco * ((RCC->PLLCFGR & RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos);
       pllr = (((RCC->PLLCFGR & RCC_PLLCFGR_PLLR) >> RCC_PLLCFGR_PLLR_Pos) + 1UL);
 
-      SystemCoreClock = pllvco/pllr;
+      SystemCoreClock = pllvco / pllr;
       break;
 
     default:
@@ -336,9 +359,9 @@ void SystemCoreClockUpdate(void)
   /* Compute HCLK clock frequency --------------------------------------------*/
   /* Get HCLK1 prescaler */
   tmp = AHBPrescTable[((RCC->CFGR & RCC_CFGR_HPRE) >> RCC_CFGR_HPRE_Pos)];
+
   /* HCLK clock frequency */
   SystemCoreClock = SystemCoreClock / tmp;
-
 }
 
 
@@ -353,5 +376,3 @@ void SystemCoreClockUpdate(void)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/Legacy/stm32_hal_legacy.h
+++ b/STM32WBxx_HAL_Driver/Inc/Legacy/stm32_hal_legacy.h
@@ -7,13 +7,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2021 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 #define STM32_HAL_LEGACY
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -38,6 +37,12 @@
 #define AES_CLEARFLAG_CCF               CRYP_CLEARFLAG_CCF
 #define AES_CLEARFLAG_RDERR             CRYP_CLEARFLAG_RDERR
 #define AES_CLEARFLAG_WRERR             CRYP_CLEARFLAG_WRERR
+#if defined(STM32H7) || defined(STM32MP1)
+#define CRYP_DATATYPE_32B               CRYP_NO_SWAP
+#define CRYP_DATATYPE_16B               CRYP_HALFWORD_SWAP
+#define CRYP_DATATYPE_8B                CRYP_BYTE_SWAP
+#define CRYP_DATATYPE_1B                CRYP_BIT_SWAP
+#endif /* STM32H7 || STM32MP1 */
 /**
   * @}
   */
@@ -97,6 +102,16 @@
 #if defined(STM32H7)
 #define ADC_CHANNEL_VBAT_DIV4           ADC_CHANNEL_VBAT
 #endif /* STM32H7 */
+
+#if defined(STM32U5)
+#define ADC_SAMPLETIME_5CYCLE           ADC_SAMPLETIME_5CYCLES
+#define ADC_SAMPLETIME_391CYCLES_5      ADC_SAMPLETIME_391CYCLES
+#define ADC4_SAMPLETIME_160CYCLES_5     ADC4_SAMPLETIME_814CYCLES_5
+#endif /* STM32U5 */
+
+#if defined(STM32H5)
+#define ADC_CHANNEL_VCORE               ADC_CHANNEL_VDDCORE
+#endif /* STM32H5 */
 /**
   * @}
   */
@@ -124,7 +139,8 @@
 #define COMP_EXTI_LINE_COMP6_EVENT     COMP_EXTI_LINE_COMP6
 #define COMP_EXTI_LINE_COMP7_EVENT     COMP_EXTI_LINE_COMP7
 #if defined(STM32L0)
-#define COMP_LPTIMCONNECTION_ENABLED   ((uint32_t)0x00000003U)    /*!< COMPX output generic naming: connected to LPTIM input 1 for COMP1, LPTIM input 2 for COMP2 */
+#define COMP_LPTIMCONNECTION_ENABLED   ((uint32_t)0x00000003U)    /*!< COMPX output generic naming: connected to LPTIM
+                                                                       input 1 for COMP1, LPTIM input 2 for COMP2 */
 #endif
 #define COMP_OUTPUT_COMP6TIM2OCREFCLR  COMP_OUTPUT_COMP6_TIM2OCREFCLR
 #if defined(STM32F373xC) || defined(STM32F378xx)
@@ -198,6 +214,11 @@
 #endif
 
 #endif
+
+#if defined(STM32U5)
+#define __HAL_COMP_COMP1_EXTI_CLEAR_RASING_FLAG __HAL_COMP_COMP1_EXTI_CLEAR_RISING_FLAG
+#endif
+
 /**
   * @}
   */
@@ -206,6 +227,25 @@
   * @{
   */
 #define __HAL_CORTEX_SYSTICKCLK_CONFIG HAL_SYSTICK_CLKSourceConfig
+#if defined(STM32U5)
+#define  MPU_DEVICE_nGnRnE          MPU_DEVICE_NGNRNE
+#define  MPU_DEVICE_nGnRE           MPU_DEVICE_NGNRE
+#define  MPU_DEVICE_nGRE            MPU_DEVICE_NGRE
+#endif /* STM32U5 */
+/**
+  * @}
+  */
+
+/** @defgroup CRC_Aliases CRC API aliases
+  * @{
+  */
+#if defined(STM32H5) || defined(STM32C0)
+#else
+#define HAL_CRC_Input_Data_Reverse   HAL_CRCEx_Input_Data_Reverse    /*!< Aliased to HAL_CRCEx_Input_Data_Reverse for
+                                                                          inter STM32 series compatibility  */
+#define HAL_CRC_Output_Data_Reverse  HAL_CRCEx_Output_Data_Reverse   /*!< Aliased to HAL_CRCEx_Output_Data_Reverse for
+                                                                          inter STM32 series compatibility */
+#endif
 /**
   * @}
   */
@@ -235,12 +275,25 @@
 #define DAC_WAVEGENERATION_NOISE                        DAC_WAVE_NOISE
 #define DAC_WAVEGENERATION_TRIANGLE                     DAC_WAVE_TRIANGLE
 
-#if defined(STM32G4) || defined(STM32H7)
+#if defined(STM32G4) || defined(STM32H7) || defined (STM32U5)
 #define DAC_CHIPCONNECT_DISABLE       DAC_CHIPCONNECT_EXTERNAL
 #define DAC_CHIPCONNECT_ENABLE        DAC_CHIPCONNECT_INTERNAL
 #endif
 
-#if defined(STM32L1) || defined(STM32L4) || defined(STM32G0) || defined(STM32L5) || defined(STM32H7) || defined(STM32F4) || defined(STM32G4)
+#if defined(STM32U5)
+#define DAC_TRIGGER_STOP_LPTIM1_OUT  DAC_TRIGGER_STOP_LPTIM1_CH1
+#define DAC_TRIGGER_STOP_LPTIM3_OUT  DAC_TRIGGER_STOP_LPTIM3_CH1
+#define DAC_TRIGGER_LPTIM1_OUT       DAC_TRIGGER_LPTIM1_CH1
+#define DAC_TRIGGER_LPTIM3_OUT       DAC_TRIGGER_LPTIM3_CH1
+#endif
+
+#if defined(STM32H5)
+#define DAC_TRIGGER_LPTIM1_OUT       DAC_TRIGGER_LPTIM1_CH1
+#define DAC_TRIGGER_LPTIM2_OUT       DAC_TRIGGER_LPTIM2_CH1
+#endif
+
+#if defined(STM32L1) || defined(STM32L4) || defined(STM32G0) || defined(STM32L5) || defined(STM32H7) || \
+    defined(STM32F4) || defined(STM32G4)
 #define HAL_DAC_MSP_INIT_CB_ID       HAL_DAC_MSPINIT_CB_ID
 #define HAL_DAC_MSP_DEINIT_CB_ID     HAL_DAC_MSPDEINIT_CB_ID
 #endif
@@ -305,7 +358,8 @@
 #define HAL_DMAMUX_REQUEST_GEN_FALLING           HAL_DMAMUX_REQ_GEN_FALLING
 #define HAL_DMAMUX_REQUEST_GEN_RISING_FALLING    HAL_DMAMUX_REQ_GEN_RISING_FALLING
 
-#if defined(STM32L4R5xx) || defined(STM32L4R9xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
+#if defined(STM32L4R5xx) || defined(STM32L4R9xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || \
+    defined(STM32L4S7xx) || defined(STM32L4S9xx)
 #define DMA_REQUEST_DCMI_PSSI                    DMA_REQUEST_DCMI
 #endif
 
@@ -383,6 +437,9 @@
 
 #endif /* STM32H7 */
 
+#if defined(STM32U5)
+#define GPDMA1_REQUEST_DCMI                        GPDMA1_REQUEST_DCMI_PSSI
+#endif /* STM32U5 */
 /**
   * @}
   */
@@ -415,7 +472,9 @@
 #define TYPEPROGRAMDATA_FASTBYTE      FLASH_TYPEPROGRAMDATA_FASTBYTE
 #define TYPEPROGRAMDATA_FASTHALFWORD  FLASH_TYPEPROGRAMDATA_FASTHALFWORD
 #define TYPEPROGRAMDATA_FASTWORD      FLASH_TYPEPROGRAMDATA_FASTWORD
+#if !defined(STM32F2) && !defined(STM32F4) && !defined(STM32F7) && !defined(STM32H7) && !defined(STM32H5)
 #define PAGESIZE                      FLASH_PAGE_SIZE
+#endif /* STM32F2 && STM32F4 && STM32F7 &&  STM32H7 && STM32H5 */
 #define TYPEPROGRAM_FASTBYTE          FLASH_TYPEPROGRAM_BYTE
 #define TYPEPROGRAM_FASTHALFWORD      FLASH_TYPEPROGRAM_HALFWORD
 #define TYPEPROGRAM_FASTWORD          FLASH_TYPEPROGRAM_WORD
@@ -462,7 +521,7 @@
 #define OB_RDP_LEVEL0                 OB_RDP_LEVEL_0
 #define OB_RDP_LEVEL1                 OB_RDP_LEVEL_1
 #define OB_RDP_LEVEL2                 OB_RDP_LEVEL_2
-#if defined(STM32G0)
+#if defined(STM32G0) || defined(STM32C0)
 #define OB_BOOT_LOCK_DISABLE          OB_BOOT_ENTRY_FORCED_NONE
 #define OB_BOOT_LOCK_ENABLE           OB_BOOT_ENTRY_FORCED_FLASH
 #else
@@ -470,15 +529,44 @@
 #define OB_BOOT_ENTRY_FORCED_FLASH    OB_BOOT_LOCK_ENABLE
 #endif
 #if defined(STM32H7)
-#define FLASH_FLAG_SNECCE_BANK1RR FLASH_FLAG_SNECCERR_BANK1
-#define FLASH_FLAG_DBECCE_BANK1RR FLASH_FLAG_DBECCERR_BANK1
-#define FLASH_FLAG_STRBER_BANK1R  FLASH_FLAG_STRBERR_BANK1
-#define FLASH_FLAG_SNECCE_BANK2RR FLASH_FLAG_SNECCERR_BANK2
-#define FLASH_FLAG_DBECCE_BANK2RR FLASH_FLAG_DBECCERR_BANK2
-#define FLASH_FLAG_STRBER_BANK2R  FLASH_FLAG_STRBERR_BANK2
-#define FLASH_FLAG_WDW            FLASH_FLAG_WBNE
-#define OB_WRP_SECTOR_All         OB_WRP_SECTOR_ALL
+#define FLASH_FLAG_SNECCE_BANK1RR     FLASH_FLAG_SNECCERR_BANK1
+#define FLASH_FLAG_DBECCE_BANK1RR     FLASH_FLAG_DBECCERR_BANK1
+#define FLASH_FLAG_STRBER_BANK1R      FLASH_FLAG_STRBERR_BANK1
+#define FLASH_FLAG_SNECCE_BANK2RR     FLASH_FLAG_SNECCERR_BANK2
+#define FLASH_FLAG_DBECCE_BANK2RR     FLASH_FLAG_DBECCERR_BANK2
+#define FLASH_FLAG_STRBER_BANK2R      FLASH_FLAG_STRBERR_BANK2
+#define FLASH_FLAG_WDW                FLASH_FLAG_WBNE
+#define OB_WRP_SECTOR_All             OB_WRP_SECTOR_ALL
 #endif /* STM32H7 */
+#if defined(STM32H7RS)
+#define FLASH_OPTKEY1                 FLASH_OPT_KEY1
+#define FLASH_OPTKEY2                 FLASH_OPT_KEY2
+#endif /* STM32H7RS */
+#if defined(STM32U5)
+#define OB_USER_nRST_STOP             OB_USER_NRST_STOP
+#define OB_USER_nRST_STDBY            OB_USER_NRST_STDBY
+#define OB_USER_nRST_SHDW             OB_USER_NRST_SHDW
+#define OB_USER_nSWBOOT0              OB_USER_NSWBOOT0
+#define OB_USER_nBOOT0                OB_USER_NBOOT0
+#define OB_nBOOT0_RESET               OB_NBOOT0_RESET
+#define OB_nBOOT0_SET                 OB_NBOOT0_SET
+#define OB_USER_SRAM134_RST           OB_USER_SRAM_RST
+#define OB_SRAM134_RST_ERASE          OB_SRAM_RST_ERASE
+#define OB_SRAM134_RST_NOT_ERASE      OB_SRAM_RST_NOT_ERASE
+#endif /* STM32U5 */
+#if defined(STM32U0)
+#define OB_USER_nRST_STOP             OB_USER_NRST_STOP
+#define OB_USER_nRST_STDBY            OB_USER_NRST_STDBY
+#define OB_USER_nRST_SHDW             OB_USER_NRST_SHDW
+#define OB_USER_nBOOT_SEL             OB_USER_NBOOT_SEL
+#define OB_USER_nBOOT0                OB_USER_NBOOT0
+#define OB_USER_nBOOT1                OB_USER_NBOOT1
+#define OB_nBOOT0_RESET               OB_NBOOT0_RESET
+#define OB_nBOOT0_SET                 OB_NBOOT0_SET
+#endif /* STM32U0 */
+#if defined(STM32H5)
+#define FLASH_ECC_AREA_EDATA          FLASH_ECC_AREA_EDATA_BANK1
+#endif /* STM32H5 */
 
 /**
   * @}
@@ -521,6 +609,116 @@
 #define HAL_SYSCFG_EnableIOAnalogSwitchVDD        HAL_SYSCFG_EnableIOSwitchVDD
 #define HAL_SYSCFG_DisableIOAnalogSwitchVDD       HAL_SYSCFG_DisableIOSwitchVDD
 #endif /* STM32G4 */
+
+#if defined(STM32U5)
+
+#define HAL_SYSCFG_EnableIOAnalogSwitchBooster                 HAL_SYSCFG_EnableIOAnalogBooster
+#define HAL_SYSCFG_DisableIOAnalogSwitchBooster                HAL_SYSCFG_DisableIOAnalogBooster
+#define HAL_SYSCFG_EnableIOAnalogSwitchVoltageSelection        HAL_SYSCFG_EnableIOAnalogVoltageSelection
+#define HAL_SYSCFG_DisableIOAnalogSwitchVoltageSelection       HAL_SYSCFG_DisableIOAnalogVoltageSelection
+
+#endif /* STM32U5 */
+
+#if defined(STM32H5)
+#define SYSCFG_IT_FPU_IOC         SBS_IT_FPU_IOC
+#define SYSCFG_IT_FPU_DZC         SBS_IT_FPU_DZC
+#define SYSCFG_IT_FPU_UFC         SBS_IT_FPU_UFC
+#define SYSCFG_IT_FPU_OFC         SBS_IT_FPU_OFC
+#define SYSCFG_IT_FPU_IDC         SBS_IT_FPU_IDC
+#define SYSCFG_IT_FPU_IXC         SBS_IT_FPU_IXC
+
+#define SYSCFG_BREAK_FLASH_ECC    SBS_BREAK_FLASH_ECC
+#define SYSCFG_BREAK_PVD          SBS_BREAK_PVD
+#define SYSCFG_BREAK_SRAM_ECC     SBS_BREAK_SRAM_ECC
+#define SYSCFG_BREAK_LOCKUP       SBS_BREAK_LOCKUP
+
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE0   VREFBUF_VOLTAGE_SCALE0
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE1   VREFBUF_VOLTAGE_SCALE1
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE2   VREFBUF_VOLTAGE_SCALE2
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE3   VREFBUF_VOLTAGE_SCALE3
+
+#define SYSCFG_VREFBUF_HIGH_IMPEDANCE_DISABLE   VREFBUF_HIGH_IMPEDANCE_DISABLE
+#define SYSCFG_VREFBUF_HIGH_IMPEDANCE_ENABLE    VREFBUF_HIGH_IMPEDANCE_ENABLE
+
+#define SYSCFG_FASTMODEPLUS_PB6   SBS_FASTMODEPLUS_PB6
+#define SYSCFG_FASTMODEPLUS_PB7   SBS_FASTMODEPLUS_PB7
+#define SYSCFG_FASTMODEPLUS_PB8   SBS_FASTMODEPLUS_PB8
+#define SYSCFG_FASTMODEPLUS_PB9   SBS_FASTMODEPLUS_PB9
+
+#define SYSCFG_ETH_MII   SBS_ETH_MII
+#define SYSCFG_ETH_RMII  SBS_ETH_RMII
+#define IS_SYSCFG_ETHERNET_CONFIG  IS_SBS_ETHERNET_CONFIG
+
+#define SYSCFG_MEMORIES_ERASE_FLAG_IPMEE   SBS_MEMORIES_ERASE_FLAG_IPMEE
+#define SYSCFG_MEMORIES_ERASE_FLAG_MCLR    SBS_MEMORIES_ERASE_FLAG_MCLR
+#define IS_SYSCFG_MEMORIES_ERASE_FLAG      IS_SBS_MEMORIES_ERASE_FLAG
+
+#define IS_SYSCFG_CODE_CONFIG IS_SBS_CODE_CONFIG
+
+#define SYSCFG_MPU_NSEC   SBS_MPU_NSEC
+#define SYSCFG_VTOR_NSEC  SBS_VTOR_NSEC
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define SYSCFG_SAU              SBS_SAU
+#define SYSCFG_MPU_SEC          SBS_MPU_SEC
+#define SYSCFG_VTOR_AIRCR_SEC   SBS_VTOR_AIRCR_SEC
+#define SYSCFG_LOCK_ALL         SBS_LOCK_ALL
+#else
+#define SYSCFG_LOCK_ALL         SBS_LOCK_ALL
+#endif /* __ARM_FEATURE_CMSE */
+
+#define SYSCFG_CLK      SBS_CLK
+#define SYSCFG_CLASSB   SBS_CLASSB
+#define SYSCFG_FPU      SBS_FPU
+#define SYSCFG_ALL      SBS_ALL
+
+#define SYSCFG_SEC      SBS_SEC
+#define SYSCFG_NSEC     SBS_NSEC
+
+#define __HAL_SYSCFG_FPU_INTERRUPT_ENABLE   __HAL_SBS_FPU_INTERRUPT_ENABLE
+#define __HAL_SYSCFG_FPU_INTERRUPT_DISABLE  __HAL_SBS_FPU_INTERRUPT_DISABLE
+
+#define __HAL_SYSCFG_BREAK_ECC_LOCK        __HAL_SBS_BREAK_ECC_LOCK
+#define __HAL_SYSCFG_BREAK_LOCKUP_LOCK     __HAL_SBS_BREAK_LOCKUP_LOCK
+#define __HAL_SYSCFG_BREAK_PVD_LOCK        __HAL_SBS_BREAK_PVD_LOCK
+#define __HAL_SYSCFG_BREAK_SRAM_ECC_LOCK   __HAL_SBS_BREAK_SRAM_ECC_LOCK
+
+#define __HAL_SYSCFG_FASTMODEPLUS_ENABLE   __HAL_SBS_FASTMODEPLUS_ENABLE
+#define __HAL_SYSCFG_FASTMODEPLUS_DISABLE  __HAL_SBS_FASTMODEPLUS_DISABLE
+
+#define __HAL_SYSCFG_GET_MEMORIES_ERASE_STATUS    __HAL_SBS_GET_MEMORIES_ERASE_STATUS
+#define __HAL_SYSCFG_CLEAR_MEMORIES_ERASE_STATUS  __HAL_SBS_CLEAR_MEMORIES_ERASE_STATUS
+
+#define IS_SYSCFG_FPU_INTERRUPT    IS_SBS_FPU_INTERRUPT
+#define IS_SYSCFG_BREAK_CONFIG     IS_SBS_BREAK_CONFIG
+#define IS_SYSCFG_VREFBUF_VOLTAGE_SCALE     IS_VREFBUF_VOLTAGE_SCALE
+#define IS_SYSCFG_VREFBUF_HIGH_IMPEDANCE    IS_VREFBUF_HIGH_IMPEDANCE
+#define IS_SYSCFG_VREFBUF_TRIMMING  IS_VREFBUF_TRIMMING
+#define IS_SYSCFG_FASTMODEPLUS      IS_SBS_FASTMODEPLUS
+#define IS_SYSCFG_ITEMS_ATTRIBUTES  IS_SBS_ITEMS_ATTRIBUTES
+#define IS_SYSCFG_ATTRIBUTES        IS_SBS_ATTRIBUTES
+#define IS_SYSCFG_LOCK_ITEMS        IS_SBS_LOCK_ITEMS
+
+#define HAL_SYSCFG_VREFBUF_VoltageScalingConfig   HAL_VREFBUF_VoltageScalingConfig
+#define HAL_SYSCFG_VREFBUF_HighImpedanceConfig    HAL_VREFBUF_HighImpedanceConfig
+#define HAL_SYSCFG_VREFBUF_TrimmingConfig         HAL_VREFBUF_TrimmingConfig
+#define HAL_SYSCFG_EnableVREFBUF                  HAL_EnableVREFBUF
+#define HAL_SYSCFG_DisableVREFBUF                 HAL_DisableVREFBUF
+
+#define HAL_SYSCFG_EnableIOAnalogSwitchBooster    HAL_SBS_EnableIOAnalogSwitchBooster
+#define HAL_SYSCFG_DisableIOAnalogSwitchBooster   HAL_SBS_DisableIOAnalogSwitchBooster
+#define HAL_SYSCFG_ETHInterfaceSelect             HAL_SBS_ETHInterfaceSelect
+
+#define HAL_SYSCFG_Lock     HAL_SBS_Lock
+#define HAL_SYSCFG_GetLock  HAL_SBS_GetLock
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define HAL_SYSCFG_ConfigAttributes     HAL_SBS_ConfigAttributes
+#define HAL_SYSCFG_GetConfigAttributes  HAL_SBS_GetConfigAttributes
+#endif /* __ARM_FEATURE_CMSE */
+
+#endif /* STM32H5 */
+
+
 /**
   * @}
   */
@@ -588,34 +786,87 @@
 #define GPIO_AF10_OTG2_HS  GPIO_AF10_OTG2_FS
 #define GPIO_AF10_OTG1_FS  GPIO_AF10_OTG1_HS
 #define GPIO_AF12_OTG2_FS  GPIO_AF12_OTG1_FS
-#endif /*STM32H743xx || STM32H753xx || STM32H750xx || STM32H742xx || STM32H745xx || STM32H755xx || STM32H747xx || STM32H757xx */
+#endif /*STM32H743xx || STM32H753xx || STM32H750xx || STM32H742xx || STM32H745xx || STM32H755xx || STM32H747xx || \
+         STM32H757xx */
 #endif /* STM32H7 */
 
 #define GPIO_AF0_LPTIM                            GPIO_AF0_LPTIM1
 #define GPIO_AF1_LPTIM                            GPIO_AF1_LPTIM1
 #define GPIO_AF2_LPTIM                            GPIO_AF2_LPTIM1
 
-#if defined(STM32L0) || defined(STM32L4) || defined(STM32F4) || defined(STM32F2) || defined(STM32F7) || defined(STM32G4) || defined(STM32H7)
+#if defined(STM32L0) || defined(STM32L4) || defined(STM32F4) || defined(STM32F2) || defined(STM32F7) || \
+    defined(STM32G4) || defined(STM32H7) || defined(STM32WB) || defined(STM32U5)
 #define  GPIO_SPEED_LOW                           GPIO_SPEED_FREQ_LOW
 #define  GPIO_SPEED_MEDIUM                        GPIO_SPEED_FREQ_MEDIUM
 #define  GPIO_SPEED_FAST                          GPIO_SPEED_FREQ_HIGH
 #define  GPIO_SPEED_HIGH                          GPIO_SPEED_FREQ_VERY_HIGH
-#endif /* STM32L0 || STM32L4 || STM32F4 || STM32F2 || STM32F7 || STM32G4 || STM32H7*/
+#endif /* STM32L0 || STM32L4 || STM32F4 || STM32F2 || STM32F7 || STM32G4 || STM32H7 || STM32WB || STM32U5*/
 
 #if defined(STM32L1)
- #define  GPIO_SPEED_VERY_LOW    GPIO_SPEED_FREQ_LOW
- #define  GPIO_SPEED_LOW         GPIO_SPEED_FREQ_MEDIUM
- #define  GPIO_SPEED_MEDIUM      GPIO_SPEED_FREQ_HIGH
- #define  GPIO_SPEED_HIGH        GPIO_SPEED_FREQ_VERY_HIGH
+#define  GPIO_SPEED_VERY_LOW    GPIO_SPEED_FREQ_LOW
+#define  GPIO_SPEED_LOW         GPIO_SPEED_FREQ_MEDIUM
+#define  GPIO_SPEED_MEDIUM      GPIO_SPEED_FREQ_HIGH
+#define  GPIO_SPEED_HIGH        GPIO_SPEED_FREQ_VERY_HIGH
 #endif /* STM32L1 */
 
 #if defined(STM32F0) || defined(STM32F3) || defined(STM32F1)
- #define  GPIO_SPEED_LOW    GPIO_SPEED_FREQ_LOW
- #define  GPIO_SPEED_MEDIUM GPIO_SPEED_FREQ_MEDIUM
- #define  GPIO_SPEED_HIGH   GPIO_SPEED_FREQ_HIGH
+#define  GPIO_SPEED_LOW    GPIO_SPEED_FREQ_LOW
+#define  GPIO_SPEED_MEDIUM GPIO_SPEED_FREQ_MEDIUM
+#define  GPIO_SPEED_HIGH   GPIO_SPEED_FREQ_HIGH
 #endif /* STM32F0 || STM32F3 || STM32F1 */
 
 #define GPIO_AF6_DFSDM                            GPIO_AF6_DFSDM1
+
+#if defined(STM32U5) || defined(STM32H5)
+#define GPIO_AF0_RTC_50Hz                         GPIO_AF0_RTC_50HZ
+#endif /* STM32U5 || STM32H5 */
+#if defined(STM32U5)
+#define GPIO_AF0_S2DSTOP                          GPIO_AF0_SRDSTOP
+#define GPIO_AF11_LPGPIO                          GPIO_AF11_LPGPIO1
+#endif /* STM32U5 */
+
+#if defined(STM32WBA)
+#define GPIO_AF11_RF_ANTSW0    GPIO_AF11_RF
+#define GPIO_AF11_RF_ANTSW1    GPIO_AF11_RF
+#define GPIO_AF11_RF_ANTSW2    GPIO_AF11_RF
+#define GPIO_AF11_RF_IO1       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO2       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO3       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO4       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO5       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO6       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO7       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO8       GPIO_AF11_RF
+#define GPIO_AF11_RF_IO9       GPIO_AF11_RF
+#endif /* STM32WBA */
+/**
+  * @}
+  */
+
+/** @defgroup HAL_GTZC_Aliased_Defines HAL GTZC Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#if defined(STM32U5)
+#define GTZC_PERIPH_DCMI                      GTZC_PERIPH_DCMI_PSSI
+#define GTZC_PERIPH_LTDC                      GTZC_PERIPH_LTDCUSB
+#endif /* STM32U5 */
+#if defined(STM32H5)
+#define GTZC_PERIPH_DAC12                     GTZC_PERIPH_DAC1
+#define GTZC_PERIPH_ADC12                     GTZC_PERIPH_ADC
+#define GTZC_PERIPH_USBFS                     GTZC_PERIPH_USB
+#endif /* STM32H5 */
+#if defined(STM32H5) || defined(STM32U5)
+#define GTZC_MCPBB_NB_VCTR_REG_MAX            GTZC_MPCBB_NB_VCTR_REG_MAX
+#define GTZC_MCPBB_NB_LCK_VCTR_REG_MAX        GTZC_MPCBB_NB_LCK_VCTR_REG_MAX
+#define GTZC_MCPBB_SUPERBLOCK_UNLOCKED        GTZC_MPCBB_SUPERBLOCK_UNLOCKED
+#define GTZC_MCPBB_SUPERBLOCK_LOCKED          GTZC_MPCBB_SUPERBLOCK_LOCKED
+#define GTZC_MCPBB_BLOCK_NSEC                 GTZC_MPCBB_BLOCK_NSEC
+#define GTZC_MCPBB_BLOCK_SEC                  GTZC_MPCBB_BLOCK_SEC
+#define GTZC_MCPBB_BLOCK_NPRIV                GTZC_MPCBB_BLOCK_NPRIV
+#define GTZC_MCPBB_BLOCK_PRIV                 GTZC_MPCBB_BLOCK_PRIV
+#define GTZC_MCPBB_LOCK_OFF                   GTZC_MPCBB_LOCK_OFF
+#define GTZC_MCPBB_LOCK_ON                    GTZC_MPCBB_LOCK_ON
+#endif /* STM32H5 || STM32U5 */
 /**
   * @}
   */
@@ -641,6 +892,10 @@
 #define __HAL_HRTIM_GetClockPrescaler __HAL_HRTIM_GETCLOCKPRESCALER
 #define __HAL_HRTIM_SetCompare        __HAL_HRTIM_SETCOMPARE
 #define __HAL_HRTIM_GetCompare        __HAL_HRTIM_GETCOMPARE
+
+#if defined(STM32F3) || defined(STM32G4) || defined(STM32H7)
+#define HRTIMInterruptResquests  HRTIMInterruptRequests
+#endif /* STM32F3 || STM32G4 || STM32H7 */
 
 #if defined(STM32G4)
 #define HAL_HRTIM_ExternalEventCounterConfig    HAL_HRTIM_ExtEventCounterConfig
@@ -773,57 +1028,14 @@
 #define HRTIM_EVENTSRC_3              (HRTIM_EECR1_EE1SRC_1)
 #define HRTIM_EVENTSRC_4              (HRTIM_EECR1_EE1SRC_1 | HRTIM_EECR1_EE1SRC_0)
 
-/** @brief Constants defining the events that can be selected to configure the
-  *        set/reset crossbar of a timer output
-  */
-#define HRTIM_OUTPUTSET_TIMEV_1       (HRTIM_SET1R_TIMEVNT1)
-#define HRTIM_OUTPUTSET_TIMEV_2       (HRTIM_SET1R_TIMEVNT2)
-#define HRTIM_OUTPUTSET_TIMEV_3       (HRTIM_SET1R_TIMEVNT3)
-#define HRTIM_OUTPUTSET_TIMEV_4       (HRTIM_SET1R_TIMEVNT4)
-#define HRTIM_OUTPUTSET_TIMEV_5       (HRTIM_SET1R_TIMEVNT5)
-#define HRTIM_OUTPUTSET_TIMEV_6       (HRTIM_SET1R_TIMEVNT6)
-#define HRTIM_OUTPUTSET_TIMEV_7       (HRTIM_SET1R_TIMEVNT7)
-#define HRTIM_OUTPUTSET_TIMEV_8       (HRTIM_SET1R_TIMEVNT8)
-#define HRTIM_OUTPUTSET_TIMEV_9       (HRTIM_SET1R_TIMEVNT9)
-
-#define HRTIM_OUTPUTRESET_TIMEV_1     (HRTIM_RST1R_TIMEVNT1)
-#define HRTIM_OUTPUTRESET_TIMEV_2     (HRTIM_RST1R_TIMEVNT2)
-#define HRTIM_OUTPUTRESET_TIMEV_3     (HRTIM_RST1R_TIMEVNT3)
-#define HRTIM_OUTPUTRESET_TIMEV_4     (HRTIM_RST1R_TIMEVNT4)
-#define HRTIM_OUTPUTRESET_TIMEV_5     (HRTIM_RST1R_TIMEVNT5)
-#define HRTIM_OUTPUTRESET_TIMEV_6     (HRTIM_RST1R_TIMEVNT6)
-#define HRTIM_OUTPUTRESET_TIMEV_7     (HRTIM_RST1R_TIMEVNT7)
-#define HRTIM_OUTPUTRESET_TIMEV_8     (HRTIM_RST1R_TIMEVNT8)
-#define HRTIM_OUTPUTRESET_TIMEV_9     (HRTIM_RST1R_TIMEVNT9)
-
-/** @brief Constants defining the event filtering applied to external events
-  *        by a timer
-  */
-#define HRTIM_TIMEVENTFILTER_NONE             (0x00000000U)
-#define HRTIM_TIMEVENTFILTER_BLANKINGCMP1     (HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_BLANKINGCMP2     (HRTIM_EEFR1_EE1FLTR_1)
-#define HRTIM_TIMEVENTFILTER_BLANKINGCMP3     (HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_BLANKINGCMP4     (HRTIM_EEFR1_EE1FLTR_2)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR1    (HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR2    (HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR3    (HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR4    (HRTIM_EEFR1_EE1FLTR_3)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR5    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR6    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_1)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR7    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_BLANKINGFLTR8    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2)
-#define HRTIM_TIMEVENTFILTER_WINDOWINGCMP2    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_0)
-#define HRTIM_TIMEVENTFILTER_WINDOWINGCMP3    (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1)
-#define HRTIM_TIMEVENTFILTER_WINDOWINGTIM     (HRTIM_EEFR1_EE1FLTR_3 | HRTIM_EEFR1_EE1FLTR_2 | HRTIM_EEFR1_EE1FLTR_1 | HRTIM_EEFR1_EE1FLTR_0)
-
 /** @brief Constants defining the DLL calibration periods (in micro seconds)
   */
 #define HRTIM_CALIBRATIONRATE_7300             0x00000000U
 #define HRTIM_CALIBRATIONRATE_910              (HRTIM_DLLCR_CALRTE_0)
 #define HRTIM_CALIBRATIONRATE_114              (HRTIM_DLLCR_CALRTE_1)
 #define HRTIM_CALIBRATIONRATE_14               (HRTIM_DLLCR_CALRTE_1 | HRTIM_DLLCR_CALRTE_0)
-
 #endif /* STM32F3 */
+
 /**
   * @}
   */
@@ -839,7 +1051,8 @@
 #define I2C_NOSTRETCH_ENABLED                   I2C_NOSTRETCH_ENABLE
 #define I2C_ANALOGFILTER_ENABLED                I2C_ANALOGFILTER_ENABLE
 #define I2C_ANALOGFILTER_DISABLED               I2C_ANALOGFILTER_DISABLE
-#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32G0) || defined(STM32L4) || defined(STM32L1) || defined(STM32F7)
+#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32G0) || defined(STM32L4) || \
+    defined(STM32L1) || defined(STM32F7)
 #define HAL_I2C_STATE_MEM_BUSY_TX               HAL_I2C_STATE_BUSY_TX
 #define HAL_I2C_STATE_MEM_BUSY_RX               HAL_I2C_STATE_BUSY_RX
 #define HAL_I2C_STATE_MASTER_BUSY_TX            HAL_I2C_STATE_BUSY_TX
@@ -896,6 +1109,20 @@
 #define LPTIM_TRIGSAMPLETIME_4TRANSITION        LPTIM_TRIGSAMPLETIME_4TRANSITIONS
 #define LPTIM_TRIGSAMPLETIME_8TRANSITION        LPTIM_TRIGSAMPLETIME_8TRANSITIONS
 
+
+/** @defgroup HAL_LPTIM_Aliased_Defines HAL LPTIM Aliased Defines maintained for legacy purpose
+  * @{
+  */
+#define HAL_LPTIM_ReadCompare      HAL_LPTIM_ReadCapturedValue
+/**
+  * @}
+  */
+
+#if defined(STM32U5)
+#define LPTIM_ISR_CC1        LPTIM_ISR_CC1IF
+#define LPTIM_ISR_CC2        LPTIM_ISR_CC2IF
+#define LPTIM_CHANNEL_ALL    0x00000000U
+#endif /* STM32U5 */
 /**
   * @}
   */
@@ -963,11 +1190,16 @@
 #define OPAMP_PGACONNECT_VM0                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0
 #define OPAMP_PGACONNECT_VM1                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO1
 
-#if defined(STM32L1) || defined(STM32L4) || defined(STM32L5) || defined(STM32H7) || defined(STM32G4)
+#if defined(STM32L1) || defined(STM32L4) || defined(STM32L5) || defined(STM32H7) || defined(STM32G4) || defined(STM32U5)
 #define HAL_OPAMP_MSP_INIT_CB_ID       HAL_OPAMP_MSPINIT_CB_ID
 #define HAL_OPAMP_MSP_DEINIT_CB_ID     HAL_OPAMP_MSPDEINIT_CB_ID
 #endif
 
+#if defined(STM32L4) || defined(STM32L5)
+#define OPAMP_POWERMODE_NORMAL                OPAMP_POWERMODE_NORMALPOWER
+#elif defined(STM32G4)
+#define OPAMP_POWERMODE_NORMAL                OPAMP_POWERMODE_NORMALSPEED
+#endif
 
 /**
   * @}
@@ -979,15 +1211,15 @@
 #define I2S_STANDARD_PHILLIPS      I2S_STANDARD_PHILIPS
 
 #if defined(STM32H7)
-  #define I2S_IT_TXE               I2S_IT_TXP
-  #define I2S_IT_RXNE              I2S_IT_RXP
+#define I2S_IT_TXE               I2S_IT_TXP
+#define I2S_IT_RXNE              I2S_IT_RXP
 
-  #define I2S_FLAG_TXE             I2S_FLAG_TXP
-  #define I2S_FLAG_RXNE            I2S_FLAG_RXP
+#define I2S_FLAG_TXE             I2S_FLAG_TXP
+#define I2S_FLAG_RXNE            I2S_FLAG_RXP
 #endif
 
 #if defined(STM32F7)
-  #define I2S_CLOCK_SYSCLK           I2S_CLOCK_PLL
+#define I2S_CLOCK_SYSCLK           I2S_CLOCK_PLL
 #endif
 /**
   * @}
@@ -1042,8 +1274,8 @@
 #define RTC_TAMPER1_2_3_INTERRUPT       RTC_ALL_TAMPER_INTERRUPT
 
 #define RTC_TIMESTAMPPIN_PC13  RTC_TIMESTAMPPIN_DEFAULT
-#define RTC_TIMESTAMPPIN_PA0 RTC_TIMESTAMPPIN_POS1
-#define RTC_TIMESTAMPPIN_PI8 RTC_TIMESTAMPPIN_POS1
+#define RTC_TIMESTAMPPIN_PA0   RTC_TIMESTAMPPIN_POS1
+#define RTC_TIMESTAMPPIN_PI8   RTC_TIMESTAMPPIN_POS1
 #define RTC_TIMESTAMPPIN_PC1   RTC_TIMESTAMPPIN_POS2
 
 #define RTC_OUTPUT_REMAP_PC13  RTC_OUTPUT_REMAP_NONE
@@ -1054,15 +1286,42 @@
 #define RTC_TAMPERPIN_PA0  RTC_TAMPERPIN_POS1
 #define RTC_TAMPERPIN_PI8  RTC_TAMPERPIN_POS1
 
+#if defined(STM32H5) || defined(STM32H7RS) || defined(STM32N6)
+#define TAMP_SECRETDEVICE_ERASE_NONE        TAMP_DEVICESECRETS_ERASE_NONE
+#define TAMP_SECRETDEVICE_ERASE_BKP_SRAM    TAMP_DEVICESECRETS_ERASE_BKPSRAM
+#endif /* STM32H5 || STM32H7RS || STM32N6 */
+
+#if defined(STM32WBA)
+#define TAMP_SECRETDEVICE_ERASE_NONE            TAMP_DEVICESECRETS_ERASE_NONE
+#define TAMP_SECRETDEVICE_ERASE_SRAM2           TAMP_DEVICESECRETS_ERASE_SRAM2
+#define TAMP_SECRETDEVICE_ERASE_RHUK            TAMP_DEVICESECRETS_ERASE_RHUK
+#define TAMP_SECRETDEVICE_ERASE_ICACHE          TAMP_DEVICESECRETS_ERASE_ICACHE
+#define TAMP_SECRETDEVICE_ERASE_SAES_AES_HASH   TAMP_DEVICESECRETS_ERASE_SAES_AES_HASH
+#define TAMP_SECRETDEVICE_ERASE_PKA_SRAM        TAMP_DEVICESECRETS_ERASE_PKA_SRAM
+#define TAMP_SECRETDEVICE_ERASE_ALL             TAMP_DEVICESECRETS_ERASE_ALL
+#endif /* STM32WBA */
+
+#if defined(STM32H5) || defined(STM32WBA) || defined(STM32H7RS) || defined(STM32N6)
+#define TAMP_SECRETDEVICE_ERASE_DISABLE     TAMP_DEVICESECRETS_ERASE_NONE
+#define TAMP_SECRETDEVICE_ERASE_ENABLE      TAMP_SECRETDEVICE_ERASE_ALL
+#endif /* STM32H5 || STM32WBA || STM32H7RS ||  STM32N6 */
+
+#if defined(STM32F7) || defined(STM32WB)
+#define RTC_TAMPCR_TAMPXE          RTC_TAMPER_ENABLE_BITS_MASK
+#define RTC_TAMPCR_TAMPXIE         RTC_TAMPER_IT_ENABLE_BITS_MASK
+#endif /* STM32F7 || STM32WB */
+
 #if defined(STM32H7)
 #define RTC_TAMPCR_TAMPXE          RTC_TAMPER_X
 #define RTC_TAMPCR_TAMPXIE         RTC_TAMPER_X_INTERRUPT
+#endif /* STM32H7 */
 
+#if defined(STM32F7) || defined(STM32H7) || defined(STM32L0) || defined(STM32WB)
 #define RTC_TAMPER1_INTERRUPT      RTC_IT_TAMP1
 #define RTC_TAMPER2_INTERRUPT      RTC_IT_TAMP2
 #define RTC_TAMPER3_INTERRUPT      RTC_IT_TAMP3
-#define RTC_ALL_TAMPER_INTERRUPT   RTC_IT_TAMPALL
-#endif /* STM32H7 */
+#define RTC_ALL_TAMPER_INTERRUPT   RTC_IT_TAMP
+#endif /* STM32F7 || STM32H7 || STM32L0 || STM32WB */
 
 /**
   * @}
@@ -1122,16 +1381,16 @@
 
 #if defined(STM32H7)
 
- #define SPI_FLAG_TXE                    SPI_FLAG_TXP
- #define SPI_FLAG_RXNE                   SPI_FLAG_RXP
+#define SPI_FLAG_TXE                    SPI_FLAG_TXP
+#define SPI_FLAG_RXNE                   SPI_FLAG_RXP
 
- #define SPI_IT_TXE                      SPI_IT_TXP
- #define SPI_IT_RXNE                     SPI_IT_RXP
+#define SPI_IT_TXE                      SPI_IT_TXP
+#define SPI_IT_RXNE                     SPI_IT_RXP
 
- #define SPI_FRLVL_EMPTY                 SPI_RX_FIFO_0PACKET
- #define SPI_FRLVL_QUARTER_FULL          SPI_RX_FIFO_1PACKET
- #define SPI_FRLVL_HALF_FULL             SPI_RX_FIFO_2PACKET
- #define SPI_FRLVL_FULL                  SPI_RX_FIFO_3PACKET
+#define SPI_FRLVL_EMPTY                 SPI_RX_FIFO_0PACKET
+#define SPI_FRLVL_QUARTER_FULL          SPI_RX_FIFO_1PACKET
+#define SPI_FRLVL_HALF_FULL             SPI_RX_FIFO_2PACKET
+#define SPI_FRLVL_FULL                  SPI_RX_FIFO_3PACKET
 
 #endif /* STM32H7 */
 
@@ -1229,6 +1488,10 @@
 #define TIM_TIM3_TI1_COMP1COMP2_OUT   TIM_TIM3_TI1_COMP1_COMP2
 #endif
 
+#if defined(STM32U5) || defined(STM32MP2)
+#define OCREF_CLEAR_SELECT_Pos       OCREF_CLEAR_SELECT_POS
+#define OCREF_CLEAR_SELECT_Msk       OCREF_CLEAR_SELECT_MSK
+#endif
 /**
   * @}
   */
@@ -1338,36 +1601,48 @@
 #define ETH_MMCRFAECR          0x00000198U
 #define ETH_MMCRGUFCR          0x000001C4U
 
-#define ETH_MAC_TXFIFO_FULL                             0x02000000U  /* Tx FIFO full */
-#define ETH_MAC_TXFIFONOT_EMPTY                         0x01000000U  /* Tx FIFO not empty */
-#define ETH_MAC_TXFIFO_WRITE_ACTIVE                     0x00400000U  /* Tx FIFO write active */
-#define ETH_MAC_TXFIFO_IDLE                             0x00000000U  /* Tx FIFO read status: Idle */
-#define ETH_MAC_TXFIFO_READ                             0x00100000U  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
-#define ETH_MAC_TXFIFO_WAITING                          0x00200000U  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
-#define ETH_MAC_TXFIFO_WRITING                          0x00300000U  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
-#define ETH_MAC_TRANSMISSION_PAUSE                      0x00080000U  /* MAC transmitter in pause */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            0x00000000U  /* MAC transmit frame controller: Idle */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         0x00020000U  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   0x00040000U  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    0x00060000U  /* MAC transmit frame controller: Transferring input frame for transmission */
+#define ETH_MAC_TXFIFO_FULL                           0x02000000U  /* Tx FIFO full */
+#define ETH_MAC_TXFIFONOT_EMPTY                       0x01000000U  /* Tx FIFO not empty */
+#define ETH_MAC_TXFIFO_WRITE_ACTIVE                   0x00400000U  /* Tx FIFO write active */
+#define ETH_MAC_TXFIFO_IDLE                           0x00000000U  /* Tx FIFO read status: Idle */
+#define ETH_MAC_TXFIFO_READ                           0x00100000U  /* Tx FIFO read status: Read (transferring data to
+                                                                      the MAC transmitter) */
+#define ETH_MAC_TXFIFO_WAITING                        0x00200000U  /* Tx FIFO read status: Waiting for TxStatus from
+                                                                      MAC transmitter */
+#define ETH_MAC_TXFIFO_WRITING                        0x00300000U  /* Tx FIFO read status: Writing the received TxStatus
+                                                                      or flushing the TxFIFO */
+#define ETH_MAC_TRANSMISSION_PAUSE                    0x00080000U  /* MAC transmitter in pause */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE          0x00000000U  /* MAC transmit frame controller: Idle */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING       0x00020000U  /* MAC transmit frame controller: Waiting for Status
+                                                                   of previous frame or IFG/backoff period to be over */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF 0x00040000U  /* MAC transmit frame controller: Generating and
+                                                             transmitting a Pause control frame (in full duplex mode) */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING  0x00060000U  /* MAC transmit frame controller: Transferring input
+                                                                      frame for transmission */
 #define ETH_MAC_MII_TRANSMIT_ACTIVE           0x00010000U  /* MAC MII transmit engine active */
 #define ETH_MAC_RXFIFO_EMPTY                  0x00000000U  /* Rx FIFO fill level: empty */
-#define ETH_MAC_RXFIFO_BELOW_THRESHOLD        0x00000100U  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
-#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD        0x00000200U  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+#define ETH_MAC_RXFIFO_BELOW_THRESHOLD        0x00000100U  /* Rx FIFO fill level: fill-level below flow-control
+                                                              de-activate threshold */
+#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD        0x00000200U  /* Rx FIFO fill level: fill-level above flow-control
+                                                              activate threshold */
 #define ETH_MAC_RXFIFO_FULL                   0x00000300U  /* Rx FIFO fill level: full */
 #if defined(STM32F1)
 #else
 #define ETH_MAC_READCONTROLLER_IDLE           0x00000000U  /* Rx FIFO read controller IDLE state */
 #define ETH_MAC_READCONTROLLER_READING_DATA   0x00000020U  /* Rx FIFO read controller Reading frame data */
-#define ETH_MAC_READCONTROLLER_READING_STATUS 0x00000040U  /* Rx FIFO read controller Reading frame status (or time-stamp) */
+#define ETH_MAC_READCONTROLLER_READING_STATUS 0x00000040U  /* Rx FIFO read controller Reading frame status
+                                                             (or time-stamp) */
 #endif
-#define ETH_MAC_READCONTROLLER_FLUSHING       0x00000060U  /* Rx FIFO read controller Flushing the frame data and status */
+#define ETH_MAC_READCONTROLLER_FLUSHING       0x00000060U  /* Rx FIFO read controller Flushing the frame data and
+                                                              status */
 #define ETH_MAC_RXFIFO_WRITE_ACTIVE           0x00000010U  /* Rx FIFO write controller active */
 #define ETH_MAC_SMALL_FIFO_NOTACTIVE          0x00000000U  /* MAC small FIFO read / write controllers not active */
 #define ETH_MAC_SMALL_FIFO_READ_ACTIVE        0x00000002U  /* MAC small FIFO read controller active */
 #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE       0x00000004U  /* MAC small FIFO write controller active */
 #define ETH_MAC_SMALL_FIFO_RW_ACTIVE          0x00000006U  /* MAC small FIFO read / write controllers active */
 #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   0x00000001U  /* MAC MII receive protocol engine active */
+
+#define ETH_TxPacketConfig        ETH_TxPacketConfigTypeDef   /* Transmit Packet Configuration structure definition */
 
 /**
   * @}
@@ -1417,6 +1692,20 @@
   */
 #endif  /* STM32L4 ||  STM32F7 ||  STM32F4 ||  STM32H7 */
 
+#if defined(STM32L4) || defined(STM32F7) || defined(STM32F427xx) || defined(STM32F437xx) \
+  || defined(STM32F429xx) || defined(STM32F439xx) || defined(STM32F469xx) || defined(STM32F479xx) \
+  || defined(STM32H7) || defined(STM32U5)
+/** @defgroup DMA2D_Aliases DMA2D API Aliases
+  * @{
+  */
+#define HAL_DMA2D_DisableCLUT       HAL_DMA2D_CLUTLoading_Abort    /*!< Aliased to HAL_DMA2D_CLUTLoading_Abort
+                                                                        for compatibility with legacy code */
+/**
+  * @}
+  */
+
+#endif  /* STM32L4 ||  STM32F7 ||  STM32F4 ||  STM32H7 || STM32U5 */
+
 /** @defgroup HAL_PPP_Aliased_Defines HAL PPP Aliased Defines maintained for legacy purpose
   * @{
   */
@@ -1435,6 +1724,29 @@
   * @}
   */
 
+/** @defgroup HAL_DCACHE_Aliased_Functions HAL DCACHE Aliased Functions maintained for legacy purpose
+  * @{
+  */
+
+#if defined(STM32U5)
+#define HAL_DCACHE_CleanInvalidateByAddr     HAL_DCACHE_CleanInvalidByAddr
+#define HAL_DCACHE_CleanInvalidateByAddr_IT  HAL_DCACHE_CleanInvalidByAddr_IT
+#endif /* STM32U5 */
+
+/**
+  * @}
+  */
+
+#if !defined(STM32F2)
+/** @defgroup HASH_alias HASH API alias
+  * @{
+  */
+#define HAL_HASHEx_IRQHandler   HAL_HASH_IRQHandler  /*!< Redirection for compatibility with legacy code */
+/**
+  *
+  * @}
+  */
+#endif /* STM32F2 */
 /** @defgroup HAL_HASH_Aliased_Functions HAL HASH Aliased Functions maintained for legacy purpose
   * @{
   */
@@ -1494,7 +1806,9 @@
 #define HAL_DisableDBGStopMode HAL_DBGMCU_DisableDBGStopMode
 #define HAL_EnableDBGStandbyMode HAL_DBGMCU_EnableDBGStandbyMode
 #define HAL_DisableDBGStandbyMode HAL_DBGMCU_DisableDBGStandbyMode
-#define HAL_DBG_LowPowerConfig(Periph, cmd) (((cmd)==ENABLE)? HAL_DBGMCU_DBG_EnableLowPowerConfig(Periph) : HAL_DBGMCU_DBG_DisableLowPowerConfig(Periph))
+#define HAL_DBG_LowPowerConfig(Periph, cmd) (((cmd\
+                                              )==ENABLE)? HAL_DBGMCU_DBG_EnableLowPowerConfig(Periph) : \
+                                             HAL_DBGMCU_DBG_DisableLowPowerConfig(Periph))
 #define HAL_VREFINT_OutputSelect  HAL_SYSCFG_VREFINT_OutputSelect
 #define HAL_Lock_Cmd(cmd) (((cmd)==ENABLE) ? HAL_SYSCFG_Enable_Lock_VREFINT() : HAL_SYSCFG_Disable_Lock_VREFINT())
 #if defined(STM32L0)
@@ -1502,8 +1816,11 @@
 #define HAL_VREFINT_Cmd(cmd) (((cmd)==ENABLE)? HAL_SYSCFG_EnableVREFINT() : HAL_SYSCFG_DisableVREFINT())
 #endif
 #define HAL_ADC_EnableBuffer_Cmd(cmd)  (((cmd)==ENABLE) ? HAL_ADCEx_EnableVREFINT() : HAL_ADCEx_DisableVREFINT())
-#define HAL_ADC_EnableBufferSensor_Cmd(cmd) (((cmd)==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : HAL_ADCEx_DisableVREFINTTempSensor())
-#if defined(STM32H7A3xx) || defined(STM32H7B3xx) || defined(STM32H7B0xx) || defined(STM32H7A3xxQ) || defined(STM32H7B3xxQ) || defined(STM32H7B0xxQ)
+#define HAL_ADC_EnableBufferSensor_Cmd(cmd) (((cmd\
+                                              )==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : \
+                                             HAL_ADCEx_DisableVREFINTTempSensor())
+#if defined(STM32H7A3xx) || defined(STM32H7B3xx) || defined(STM32H7B0xx) || defined(STM32H7A3xxQ) || \
+    defined(STM32H7B3xxQ) || defined(STM32H7B0xxQ)
 #define HAL_EnableSRDomainDBGStopMode      HAL_EnableDomain3DBGStopMode
 #define HAL_DisableSRDomainDBGStopMode     HAL_DisableDomain3DBGStopMode
 #define HAL_EnableSRDomainDBGStandbyMode   HAL_EnableDomain3DBGStandbyMode
@@ -1525,9 +1842,9 @@
 #define HAL_DATA_EEPROMEx_Erase    HAL_FLASHEx_DATAEEPROM_Erase
 #define HAL_DATA_EEPROMEx_Program  HAL_FLASHEx_DATAEEPROM_Program
 
- /**
+/**
   * @}
-  */
+ */
 
 /** @defgroup HAL_I2C_Aliased_Functions HAL I2C Aliased Functions maintained for legacy purpose
   * @{
@@ -1537,15 +1854,21 @@
 #define HAL_FMPI2CEx_AnalogFilter_Config      HAL_FMPI2CEx_ConfigAnalogFilter
 #define HAL_FMPI2CEx_DigitalFilter_Config     HAL_FMPI2CEx_ConfigDigitalFilter
 
-#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd)==ENABLE)? HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
+#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd) == ENABLE)? \
+                                                                HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): \
+                                                                HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
 
-#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4) || defined(STM32L1)
+#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || \
+    defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || \
+    defined(STM32L4) || defined(STM32L5) || defined(STM32G4) || defined(STM32L1)
 #define HAL_I2C_Master_Sequential_Transmit_IT  HAL_I2C_Master_Seq_Transmit_IT
 #define HAL_I2C_Master_Sequential_Receive_IT   HAL_I2C_Master_Seq_Receive_IT
 #define HAL_I2C_Slave_Sequential_Transmit_IT   HAL_I2C_Slave_Seq_Transmit_IT
 #define HAL_I2C_Slave_Sequential_Receive_IT    HAL_I2C_Slave_Seq_Receive_IT
-#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F0 || STM32F1 || STM32F2 || STM32F3 || STM32F4 || STM32F7 || STM32L0 || STM32L4 || STM32L5 || STM32G4 || STM32L1 */
-#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4)|| defined(STM32L1)
+#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F0 || STM32F1 || STM32F2 || STM32F3 || STM32F4 || STM32F7 || STM32L0 ||
+          STM32L4 || STM32L5 || STM32G4 || STM32L1 */
+#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F4) || defined(STM32F7) || \
+    defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4)|| defined(STM32L1)
 #define HAL_I2C_Master_Sequential_Transmit_DMA HAL_I2C_Master_Seq_Transmit_DMA
 #define HAL_I2C_Master_Sequential_Receive_DMA  HAL_I2C_Master_Seq_Receive_DMA
 #define HAL_I2C_Slave_Sequential_Transmit_DMA  HAL_I2C_Slave_Seq_Transmit_DMA
@@ -1562,9 +1885,9 @@
 #define HAL_FMPI2C_Slave_Sequential_Transmit_DMA  HAL_FMPI2C_Slave_Seq_Transmit_DMA
 #define HAL_FMPI2C_Slave_Sequential_Receive_DMA   HAL_FMPI2C_Slave_Seq_Receive_DMA
 #endif /* STM32F4 */
- /**
+/**
   * @}
-  */
+ */
 
 /** @defgroup HAL_PWR_Aliased HAL PWR Aliased maintained for legacy purpose
   * @{
@@ -1619,7 +1942,108 @@
 
 #define PWR_MODE_EVT                                  PWR_PVD_MODE_NORMAL
 
- /**
+#if defined (STM32U5)
+#define PWR_SRAM1_PAGE1_STOP_RETENTION                PWR_SRAM1_PAGE1_STOP
+#define PWR_SRAM1_PAGE2_STOP_RETENTION                PWR_SRAM1_PAGE2_STOP
+#define PWR_SRAM1_PAGE3_STOP_RETENTION                PWR_SRAM1_PAGE3_STOP
+#define PWR_SRAM1_PAGE4_STOP_RETENTION                PWR_SRAM1_PAGE4_STOP
+#define PWR_SRAM1_PAGE5_STOP_RETENTION                PWR_SRAM1_PAGE5_STOP
+#define PWR_SRAM1_PAGE6_STOP_RETENTION                PWR_SRAM1_PAGE6_STOP
+#define PWR_SRAM1_PAGE7_STOP_RETENTION                PWR_SRAM1_PAGE7_STOP
+#define PWR_SRAM1_PAGE8_STOP_RETENTION                PWR_SRAM1_PAGE8_STOP
+#define PWR_SRAM1_PAGE9_STOP_RETENTION                PWR_SRAM1_PAGE9_STOP
+#define PWR_SRAM1_PAGE10_STOP_RETENTION               PWR_SRAM1_PAGE10_STOP
+#define PWR_SRAM1_PAGE11_STOP_RETENTION               PWR_SRAM1_PAGE11_STOP
+#define PWR_SRAM1_PAGE12_STOP_RETENTION               PWR_SRAM1_PAGE12_STOP
+#define PWR_SRAM1_FULL_STOP_RETENTION                 PWR_SRAM1_FULL_STOP
+
+#define PWR_SRAM2_PAGE1_STOP_RETENTION                PWR_SRAM2_PAGE1_STOP
+#define PWR_SRAM2_PAGE2_STOP_RETENTION                PWR_SRAM2_PAGE2_STOP
+#define PWR_SRAM2_FULL_STOP_RETENTION                 PWR_SRAM2_FULL_STOP
+
+#define PWR_SRAM3_PAGE1_STOP_RETENTION                PWR_SRAM3_PAGE1_STOP
+#define PWR_SRAM3_PAGE2_STOP_RETENTION                PWR_SRAM3_PAGE2_STOP
+#define PWR_SRAM3_PAGE3_STOP_RETENTION                PWR_SRAM3_PAGE3_STOP
+#define PWR_SRAM3_PAGE4_STOP_RETENTION                PWR_SRAM3_PAGE4_STOP
+#define PWR_SRAM3_PAGE5_STOP_RETENTION                PWR_SRAM3_PAGE5_STOP
+#define PWR_SRAM3_PAGE6_STOP_RETENTION                PWR_SRAM3_PAGE6_STOP
+#define PWR_SRAM3_PAGE7_STOP_RETENTION                PWR_SRAM3_PAGE7_STOP
+#define PWR_SRAM3_PAGE8_STOP_RETENTION                PWR_SRAM3_PAGE8_STOP
+#define PWR_SRAM3_PAGE9_STOP_RETENTION                PWR_SRAM3_PAGE9_STOP
+#define PWR_SRAM3_PAGE10_STOP_RETENTION               PWR_SRAM3_PAGE10_STOP
+#define PWR_SRAM3_PAGE11_STOP_RETENTION               PWR_SRAM3_PAGE11_STOP
+#define PWR_SRAM3_PAGE12_STOP_RETENTION               PWR_SRAM3_PAGE12_STOP
+#define PWR_SRAM3_PAGE13_STOP_RETENTION               PWR_SRAM3_PAGE13_STOP
+#define PWR_SRAM3_FULL_STOP_RETENTION                 PWR_SRAM3_FULL_STOP
+
+#define PWR_SRAM4_FULL_STOP_RETENTION                 PWR_SRAM4_FULL_STOP
+
+#define PWR_SRAM5_PAGE1_STOP_RETENTION                PWR_SRAM5_PAGE1_STOP
+#define PWR_SRAM5_PAGE2_STOP_RETENTION                PWR_SRAM5_PAGE2_STOP
+#define PWR_SRAM5_PAGE3_STOP_RETENTION                PWR_SRAM5_PAGE3_STOP
+#define PWR_SRAM5_PAGE4_STOP_RETENTION                PWR_SRAM5_PAGE4_STOP
+#define PWR_SRAM5_PAGE5_STOP_RETENTION                PWR_SRAM5_PAGE5_STOP
+#define PWR_SRAM5_PAGE6_STOP_RETENTION                PWR_SRAM5_PAGE6_STOP
+#define PWR_SRAM5_PAGE7_STOP_RETENTION                PWR_SRAM5_PAGE7_STOP
+#define PWR_SRAM5_PAGE8_STOP_RETENTION                PWR_SRAM5_PAGE8_STOP
+#define PWR_SRAM5_PAGE9_STOP_RETENTION                PWR_SRAM5_PAGE9_STOP
+#define PWR_SRAM5_PAGE10_STOP_RETENTION               PWR_SRAM5_PAGE10_STOP
+#define PWR_SRAM5_PAGE11_STOP_RETENTION               PWR_SRAM5_PAGE11_STOP
+#define PWR_SRAM5_PAGE12_STOP_RETENTION               PWR_SRAM5_PAGE12_STOP
+#define PWR_SRAM5_PAGE13_STOP_RETENTION               PWR_SRAM5_PAGE13_STOP
+#define PWR_SRAM5_FULL_STOP_RETENTION                 PWR_SRAM5_FULL_STOP
+
+#define PWR_SRAM6_PAGE1_STOP_RETENTION                PWR_SRAM6_PAGE1_STOP
+#define PWR_SRAM6_PAGE2_STOP_RETENTION                PWR_SRAM6_PAGE2_STOP
+#define PWR_SRAM6_PAGE3_STOP_RETENTION                PWR_SRAM6_PAGE3_STOP
+#define PWR_SRAM6_PAGE4_STOP_RETENTION                PWR_SRAM6_PAGE4_STOP
+#define PWR_SRAM6_PAGE5_STOP_RETENTION                PWR_SRAM6_PAGE5_STOP
+#define PWR_SRAM6_PAGE6_STOP_RETENTION                PWR_SRAM6_PAGE6_STOP
+#define PWR_SRAM6_PAGE7_STOP_RETENTION                PWR_SRAM6_PAGE7_STOP
+#define PWR_SRAM6_PAGE8_STOP_RETENTION                PWR_SRAM6_PAGE8_STOP
+#define PWR_SRAM6_FULL_STOP_RETENTION                 PWR_SRAM6_FULL_STOP
+
+
+#define PWR_ICACHE_FULL_STOP_RETENTION                PWR_ICACHE_FULL_STOP
+#define PWR_DCACHE1_FULL_STOP_RETENTION               PWR_DCACHE1_FULL_STOP
+#define PWR_DCACHE2_FULL_STOP_RETENTION               PWR_DCACHE2_FULL_STOP
+#define PWR_DMA2DRAM_FULL_STOP_RETENTION              PWR_DMA2DRAM_FULL_STOP
+#define PWR_PERIPHRAM_FULL_STOP_RETENTION             PWR_PERIPHRAM_FULL_STOP
+#define PWR_PKA32RAM_FULL_STOP_RETENTION              PWR_PKA32RAM_FULL_STOP
+#define PWR_GRAPHICPRAM_FULL_STOP_RETENTION           PWR_GRAPHICPRAM_FULL_STOP
+#define PWR_DSIRAM_FULL_STOP_RETENTION                PWR_DSIRAM_FULL_STOP
+#define PWR_JPEGRAM_FULL_STOP_RETENTION               PWR_JPEGRAM_FULL_STOP
+
+
+#define PWR_SRAM2_PAGE1_STANDBY_RETENTION             PWR_SRAM2_PAGE1_STANDBY
+#define PWR_SRAM2_PAGE2_STANDBY_RETENTION             PWR_SRAM2_PAGE2_STANDBY
+#define PWR_SRAM2_FULL_STANDBY_RETENTION              PWR_SRAM2_FULL_STANDBY
+
+#define PWR_SRAM1_FULL_RUN_RETENTION                  PWR_SRAM1_FULL_RUN
+#define PWR_SRAM2_FULL_RUN_RETENTION                  PWR_SRAM2_FULL_RUN
+#define PWR_SRAM3_FULL_RUN_RETENTION                  PWR_SRAM3_FULL_RUN
+#define PWR_SRAM4_FULL_RUN_RETENTION                  PWR_SRAM4_FULL_RUN
+#define PWR_SRAM5_FULL_RUN_RETENTION                  PWR_SRAM5_FULL_RUN
+#define PWR_SRAM6_FULL_RUN_RETENTION                  PWR_SRAM6_FULL_RUN
+
+#define PWR_ALL_RAM_RUN_RETENTION_MASK                PWR_ALL_RAM_RUN_MASK
+#endif
+
+/**
+  * @}
+ */
+
+/** @defgroup HAL_RTC_Aliased_Functions HAL RTC Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#if defined(STM32H5) || defined(STM32WBA) || defined(STM32H7RS) || defined(STM32N6)
+#define HAL_RTCEx_SetBoothardwareKey            HAL_RTCEx_LockBootHardwareKey
+#define HAL_RTCEx_BKUPBlock_Enable              HAL_RTCEx_BKUPBlock
+#define HAL_RTCEx_BKUPBlock_Disable             HAL_RTCEx_BKUPUnblock
+#define HAL_RTCEx_Erase_SecretDev_Conf          HAL_RTCEx_ConfigEraseDeviceSecrets
+#endif /* STM32H5 || STM32WBA || STM32H7RS || STM32N6 */
+
+/**
   * @}
   */
 
@@ -1648,7 +2072,8 @@
 #define HAL_TIM_DMAError                                TIM_DMAError
 #define HAL_TIM_DMACaptureCplt                          TIM_DMACaptureCplt
 #define HAL_TIMEx_DMACommutationCplt                    TIMEx_DMACommutationCplt
-#if defined(STM32H7) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4)
+#if defined(STM32H7) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || \
+    defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4)
 #define HAL_TIM_SlaveConfigSynchronization              HAL_TIM_SlaveConfigSynchro
 #define HAL_TIM_SlaveConfigSynchronization_IT           HAL_TIM_SlaveConfigSynchro_IT
 #define HAL_TIMEx_CommutationCallback                   HAL_TIMEx_CommutCallback
@@ -1870,15 +2295,15 @@
 #define __HAL_FREEZE_RTC_DBGMCU __HAL_DBGMCU_FREEZE_RTC
 #define __HAL_UNFREEZE_RTC_DBGMCU __HAL_DBGMCU_UNFREEZE_RTC
 #if defined(STM32H7)
-  #define __HAL_FREEZE_WWDG_DBGMCU __HAL_DBGMCU_FREEZE_WWDG1
-  #define __HAL_UNFREEZE_WWDG_DBGMCU __HAL_DBGMCU_UnFreeze_WWDG1
-  #define __HAL_FREEZE_IWDG_DBGMCU __HAL_DBGMCU_FREEZE_IWDG1
-  #define __HAL_UNFREEZE_IWDG_DBGMCU __HAL_DBGMCU_UnFreeze_IWDG1
+#define __HAL_FREEZE_WWDG_DBGMCU __HAL_DBGMCU_FREEZE_WWDG1
+#define __HAL_UNFREEZE_WWDG_DBGMCU __HAL_DBGMCU_UnFreeze_WWDG1
+#define __HAL_FREEZE_IWDG_DBGMCU __HAL_DBGMCU_FREEZE_IWDG1
+#define __HAL_UNFREEZE_IWDG_DBGMCU __HAL_DBGMCU_UnFreeze_IWDG1
 #else
-  #define __HAL_FREEZE_WWDG_DBGMCU __HAL_DBGMCU_FREEZE_WWDG
-  #define __HAL_UNFREEZE_WWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_WWDG
-  #define __HAL_FREEZE_IWDG_DBGMCU __HAL_DBGMCU_FREEZE_IWDG
-  #define __HAL_UNFREEZE_IWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_IWDG
+#define __HAL_FREEZE_WWDG_DBGMCU __HAL_DBGMCU_FREEZE_WWDG
+#define __HAL_UNFREEZE_WWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_WWDG
+#define __HAL_FREEZE_IWDG_DBGMCU __HAL_DBGMCU_FREEZE_IWDG
+#define __HAL_UNFREEZE_IWDG_DBGMCU __HAL_DBGMCU_UNFREEZE_IWDG
 #endif /* STM32H7 */
 #define __HAL_FREEZE_I2C1_TIMEOUT_DBGMCU __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT
 #define __HAL_UNFREEZE_I2C1_TIMEOUT_DBGMCU __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT
@@ -1905,7 +2330,8 @@
 #define COMP_STOP                                        __HAL_COMP_DISABLE
 #define COMP_LOCK                                        __HAL_COMP_LOCK
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || defined(STM32F303x8) || \
+    defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP6_EXTI_ENABLE_RISING_EDGE())
@@ -1930,8 +2356,8 @@
 #define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F302xE) || defined(STM32F302xC)
+#endif
+#if defined(STM32F302xE) || defined(STM32F302xC)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
@@ -1964,8 +2390,8 @@
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
+#endif
+#if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_ENABLE_RISING_EDGE() : \
@@ -2022,8 +2448,8 @@
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP7_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F373xC) ||defined(STM32F378xx)
+#endif
+#if defined(STM32F373xC) ||defined(STM32F378xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
 #define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
@@ -2040,7 +2466,7 @@
                                                           __HAL_COMP_COMP2_EXTI_GET_FLAG())
 #define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP2_EXTI_CLEAR_FLAG())
-# endif
+#endif
 #else
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
@@ -2077,8 +2503,10 @@
 /** @defgroup HAL_COMP_Aliased_Functions HAL COMP Aliased Functions maintained for legacy purpose
   * @{
   */
-#define HAL_COMP_Start_IT       HAL_COMP_Start /* Function considered as legacy as EXTI event or IT configuration is done into HAL_COMP_Init() */
-#define HAL_COMP_Stop_IT        HAL_COMP_Stop  /* Function considered as legacy as EXTI event or IT configuration is done into HAL_COMP_Init() */
+#define HAL_COMP_Start_IT       HAL_COMP_Start /* Function considered as legacy as EXTI event or IT configuration is
+                                                  done into HAL_COMP_Init() */
+#define HAL_COMP_Stop_IT        HAL_COMP_Stop  /* Function considered as legacy as EXTI event or IT configuration is
+                                                  done into HAL_COMP_Init() */
 /**
   * @}
   */
@@ -2089,8 +2517,8 @@
   */
 
 #define IS_DAC_WAVE(WAVE) (((WAVE) == DAC_WAVE_NONE) || \
-                          ((WAVE) == DAC_WAVE_NOISE)|| \
-                          ((WAVE) == DAC_WAVE_TRIANGLE))
+                           ((WAVE) == DAC_WAVE_NOISE)|| \
+                           ((WAVE) == DAC_WAVE_TRIANGLE))
 
 /**
   * @}
@@ -2146,7 +2574,7 @@
 #define IS_I2S_INSTANCE_EXT             IS_I2S_ALL_INSTANCE_EXT
 
 #if defined(STM32H7)
-  #define __HAL_I2S_CLEAR_FREFLAG       __HAL_I2S_CLEAR_TIFREFLAG
+#define __HAL_I2S_CLEAR_FREFLAG       __HAL_I2S_CLEAR_TIFREFLAG
 #endif
 
 /**
@@ -2237,7 +2665,9 @@
 #define __HAL_PWR_INTERNALWAKEUP_ENABLE                          HAL_PWREx_EnableInternalWakeUpLine
 #define __HAL_PWR_PULL_UP_DOWN_CONFIG_DISABLE                    HAL_PWREx_DisablePullUpPullDownConfig
 #define __HAL_PWR_PULL_UP_DOWN_CONFIG_ENABLE                     HAL_PWREx_EnablePullUpPullDownConfig
-#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()                  do { __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();__HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE(); } while(0)
+#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()                  do { __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE(); \
+                                                                      __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                    } while(0)
 #define __HAL_PWR_PVD_EXTI_EVENT_DISABLE                         __HAL_PWR_PVD_EXTI_DISABLE_EVENT
 #define __HAL_PWR_PVD_EXTI_EVENT_ENABLE                          __HAL_PWR_PVD_EXTI_ENABLE_EVENT
 #define __HAL_PWR_PVD_EXTI_FALLINGTRIGGER_DISABLE                __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE
@@ -2246,8 +2676,12 @@
 #define __HAL_PWR_PVD_EXTI_RISINGTRIGGER_ENABLE                  __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
 #define __HAL_PWR_PVD_EXTI_SET_FALLING_EGDE_TRIGGER              __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
 #define __HAL_PWR_PVD_EXTI_SET_RISING_EDGE_TRIGGER               __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
-#define __HAL_PWR_PVM_DISABLE()                                  do { HAL_PWREx_DisablePVM1();HAL_PWREx_DisablePVM2();HAL_PWREx_DisablePVM3();HAL_PWREx_DisablePVM4(); } while(0)
-#define __HAL_PWR_PVM_ENABLE()                                   do { HAL_PWREx_EnablePVM1();HAL_PWREx_EnablePVM2();HAL_PWREx_EnablePVM3();HAL_PWREx_EnablePVM4(); } while(0)
+#define __HAL_PWR_PVM_DISABLE()                                  do { HAL_PWREx_DisablePVM1();HAL_PWREx_DisablePVM2(); \
+                                                                      HAL_PWREx_DisablePVM3();HAL_PWREx_DisablePVM4(); \
+                                                                    } while(0)
+#define __HAL_PWR_PVM_ENABLE()                                   do { HAL_PWREx_EnablePVM1();HAL_PWREx_EnablePVM2(); \
+                                                                      HAL_PWREx_EnablePVM3();HAL_PWREx_EnablePVM4(); \
+                                                                    } while(0)
 #define __HAL_PWR_SRAM2CONTENT_PRESERVE_DISABLE                  HAL_PWREx_DisableSRAM2ContentRetention
 #define __HAL_PWR_SRAM2CONTENT_PRESERVE_ENABLE                   HAL_PWREx_EnableSRAM2ContentRetention
 #define __HAL_PWR_VDDIO2_DISABLE                                 HAL_PWREx_DisableVddIO2
@@ -2283,7 +2717,8 @@
 #define RCC_StopWakeUpClock_HSI     RCC_STOP_WAKEUPCLOCK_HSI
 
 #define HAL_RCC_CCSCallback HAL_RCC_CSSCallback
-#define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd)==ENABLE) ? HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
+#define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd)==ENABLE) ? \
+                                        HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
 
 #define __ADC_CLK_DISABLE          __HAL_RCC_ADC_CLK_DISABLE
 #define __ADC_CLK_ENABLE           __HAL_RCC_ADC_CLK_ENABLE
@@ -2333,6 +2768,12 @@
 #define __APB1_RELEASE_RESET __HAL_RCC_APB1_RELEASE_RESET
 #define __APB2_FORCE_RESET __HAL_RCC_APB2_FORCE_RESET
 #define __APB2_RELEASE_RESET __HAL_RCC_APB2_RELEASE_RESET
+#if defined(STM32C0)
+#define __HAL_RCC_APB1_FORCE_RESET    __HAL_RCC_APB1_GRP1_FORCE_RESET
+#define __HAL_RCC_APB1_RELEASE_RESET  __HAL_RCC_APB1_GRP1_RELEASE_RESET
+#define __HAL_RCC_APB2_FORCE_RESET    __HAL_RCC_APB1_GRP2_FORCE_RESET
+#define __HAL_RCC_APB2_RELEASE_RESET  __HAL_RCC_APB1_GRP2_RELEASE_RESET
+#endif /* STM32C0 */
 #define __BKP_CLK_DISABLE __HAL_RCC_BKP_CLK_DISABLE
 #define __BKP_CLK_ENABLE __HAL_RCC_BKP_CLK_ENABLE
 #define __BKP_FORCE_RESET __HAL_RCC_BKP_FORCE_RESET
@@ -2787,6 +3228,11 @@
 
 #define  __HAL_RCC_WWDG_IS_CLK_ENABLED    __HAL_RCC_WWDG1_IS_CLK_ENABLED
 #define  __HAL_RCC_WWDG_IS_CLK_DISABLED  __HAL_RCC_WWDG1_IS_CLK_DISABLED
+#define  RCC_SPI4CLKSOURCE_D2PCLK1       RCC_SPI4CLKSOURCE_D2PCLK2
+#define  RCC_SPI5CLKSOURCE_D2PCLK1       RCC_SPI5CLKSOURCE_D2PCLK2
+#define  RCC_SPI45CLKSOURCE_D2PCLK1      RCC_SPI45CLKSOURCE_D2PCLK2
+#define  RCC_SPI45CLKSOURCE_CDPCLK1      RCC_SPI45CLKSOURCE_CDPCLK2
+#define  RCC_SPI45CLKSOURCE_PCLK1        RCC_SPI45CLKSOURCE_PCLK2
 #endif
 
 #define __WWDG_CLK_DISABLE __HAL_RCC_WWDG_CLK_DISABLE
@@ -3251,7 +3697,12 @@
 #define RCC_MCOSOURCE_PLLCLK_NODIV  RCC_MCO1SOURCE_PLLCLK
 #define RCC_MCOSOURCE_PLLCLK_DIV2   RCC_MCO1SOURCE_PLLCLK_DIV2
 
-#if defined(STM32L4) || defined(STM32WB) || defined(STM32G0) || defined(STM32G4) || defined(STM32L5) || defined(STM32WL)
+#if defined(STM32U0)
+#define RCC_SYSCLKSOURCE_STATUS_PLLR   RCC_SYSCLKSOURCE_STATUS_PLLCLK
+#endif
+
+#if defined(STM32L4) || defined(STM32WB) || defined(STM32G0) || defined(STM32G4) || defined(STM32L5) || \
+    defined(STM32WL) || defined(STM32C0) || defined(STM32N6) || defined(STM32H7RS) || defined(STM32U0)
 #define RCC_RTCCLKSOURCE_NO_CLK     RCC_RTCCLKSOURCE_NONE
 #else
 #define RCC_RTCCLKSOURCE_NONE       RCC_RTCCLKSOURCE_NO_CLK
@@ -3353,8 +3804,10 @@
 #define __HAL_RCC_GET_DFSDM_SOURCE  __HAL_RCC_GET_DFSDM1_SOURCE
 #define RCC_DFSDM1CLKSOURCE_PCLK    RCC_DFSDM1CLKSOURCE_PCLK2
 #define RCC_SWPMI1CLKSOURCE_PCLK    RCC_SWPMI1CLKSOURCE_PCLK1
+#if !defined(STM32U0)
 #define RCC_LPTIM1CLKSOURCE_PCLK    RCC_LPTIM1CLKSOURCE_PCLK1
 #define RCC_LPTIM2CLKSOURCE_PCLK    RCC_LPTIM2CLKSOURCE_PCLK1
+#endif
 
 #define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB1    RCC_DFSDM1AUDIOCLKSOURCE_I2S1
 #define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB2    RCC_DFSDM1AUDIOCLKSOURCE_I2S2
@@ -3363,6 +3816,124 @@
 #define RCC_DFSDM1CLKSOURCE_APB2            RCC_DFSDM1CLKSOURCE_PCLK2
 #define RCC_DFSDM2CLKSOURCE_APB2            RCC_DFSDM2CLKSOURCE_PCLK2
 #define RCC_FMPI2C1CLKSOURCE_APB            RCC_FMPI2C1CLKSOURCE_PCLK1
+#if defined(STM32U5)
+#define MSIKPLLModeSEL                        RCC_MSIKPLL_MODE_SEL
+#define MSISPLLModeSEL                        RCC_MSISPLL_MODE_SEL
+#define __HAL_RCC_AHB21_CLK_DISABLE           __HAL_RCC_AHB2_1_CLK_DISABLE
+#define __HAL_RCC_AHB22_CLK_DISABLE           __HAL_RCC_AHB2_2_CLK_DISABLE
+#define __HAL_RCC_AHB1_CLK_Disable_Clear      __HAL_RCC_AHB1_CLK_ENABLE
+#define __HAL_RCC_AHB21_CLK_Disable_Clear     __HAL_RCC_AHB2_1_CLK_ENABLE
+#define __HAL_RCC_AHB22_CLK_Disable_Clear     __HAL_RCC_AHB2_2_CLK_ENABLE
+#define __HAL_RCC_AHB3_CLK_Disable_Clear      __HAL_RCC_AHB3_CLK_ENABLE
+#define __HAL_RCC_APB1_CLK_Disable_Clear      __HAL_RCC_APB1_CLK_ENABLE
+#define __HAL_RCC_APB2_CLK_Disable_Clear      __HAL_RCC_APB2_CLK_ENABLE
+#define __HAL_RCC_APB3_CLK_Disable_Clear      __HAL_RCC_APB3_CLK_ENABLE
+#define IS_RCC_MSIPLLModeSelection            IS_RCC_MSIPLLMODE_SELECT
+#define RCC_PERIPHCLK_CLK48                   RCC_PERIPHCLK_ICLK
+#define RCC_CLK48CLKSOURCE_HSI48              RCC_ICLK_CLKSOURCE_HSI48
+#define RCC_CLK48CLKSOURCE_PLL2               RCC_ICLK_CLKSOURCE_PLL2
+#define RCC_CLK48CLKSOURCE_PLL1               RCC_ICLK_CLKSOURCE_PLL1
+#define RCC_CLK48CLKSOURCE_MSIK               RCC_ICLK_CLKSOURCE_MSIK
+#define __HAL_RCC_ADC1_CLK_ENABLE             __HAL_RCC_ADC12_CLK_ENABLE
+#define __HAL_RCC_ADC1_CLK_DISABLE            __HAL_RCC_ADC12_CLK_DISABLE
+#define __HAL_RCC_ADC1_IS_CLK_ENABLED         __HAL_RCC_ADC12_IS_CLK_ENABLED
+#define __HAL_RCC_ADC1_IS_CLK_DISABLED        __HAL_RCC_ADC12_IS_CLK_DISABLED
+#define __HAL_RCC_ADC1_FORCE_RESET            __HAL_RCC_ADC12_FORCE_RESET
+#define __HAL_RCC_ADC1_RELEASE_RESET          __HAL_RCC_ADC12_RELEASE_RESET
+#define __HAL_RCC_ADC1_CLK_SLEEP_ENABLE       __HAL_RCC_ADC12_CLK_SLEEP_ENABLE
+#define __HAL_RCC_ADC1_CLK_SLEEP_DISABLE      __HAL_RCC_ADC12_CLK_SLEEP_DISABLE
+#define __HAL_RCC_GET_CLK48_SOURCE            __HAL_RCC_GET_ICLK_SOURCE
+#define __HAL_RCC_PLLFRACN_ENABLE             __HAL_RCC_PLL_FRACN_ENABLE
+#define __HAL_RCC_PLLFRACN_DISABLE            __HAL_RCC_PLL_FRACN_DISABLE
+#define __HAL_RCC_PLLFRACN_CONFIG             __HAL_RCC_PLL_FRACN_CONFIG
+#define IS_RCC_PLLFRACN_VALUE                 IS_RCC_PLL_FRACN_VALUE
+#endif /* STM32U5 */
+
+#if defined(STM32H5)
+#define __HAL_RCC_PLLFRACN_ENABLE       __HAL_RCC_PLL_FRACN_ENABLE
+#define __HAL_RCC_PLLFRACN_DISABLE      __HAL_RCC_PLL_FRACN_DISABLE
+#define __HAL_RCC_PLLFRACN_CONFIG       __HAL_RCC_PLL_FRACN_CONFIG
+#define IS_RCC_PLLFRACN_VALUE           IS_RCC_PLL_FRACN_VALUE
+
+#define RCC_PLLSOURCE_NONE              RCC_PLL1_SOURCE_NONE
+#define RCC_PLLSOURCE_HSI               RCC_PLL1_SOURCE_HSI
+#define RCC_PLLSOURCE_CSI               RCC_PLL1_SOURCE_CSI
+#define RCC_PLLSOURCE_HSE               RCC_PLL1_SOURCE_HSE
+#define RCC_PLLVCIRANGE_0               RCC_PLL1_VCIRANGE_0
+#define RCC_PLLVCIRANGE_1               RCC_PLL1_VCIRANGE_1
+#define RCC_PLLVCIRANGE_2               RCC_PLL1_VCIRANGE_2
+#define RCC_PLLVCIRANGE_3               RCC_PLL1_VCIRANGE_3
+#define RCC_PLL1VCOWIDE                 RCC_PLL1_VCORANGE_WIDE
+#define RCC_PLL1VCOMEDIUM               RCC_PLL1_VCORANGE_MEDIUM
+
+#define IS_RCC_PLLSOURCE                IS_RCC_PLL1_SOURCE
+#define IS_RCC_PLLRGE_VALUE             IS_RCC_PLL1_VCIRGE_VALUE
+#define IS_RCC_PLLVCORGE_VALUE          IS_RCC_PLL1_VCORGE_VALUE
+#define IS_RCC_PLLCLOCKOUT_VALUE        IS_RCC_PLL1_CLOCKOUT_VALUE
+#define IS_RCC_PLL_FRACN_VALUE          IS_RCC_PLL1_FRACN_VALUE
+#define IS_RCC_PLLM_VALUE               IS_RCC_PLL1_DIVM_VALUE
+#define IS_RCC_PLLN_VALUE               IS_RCC_PLL1_MULN_VALUE
+#define IS_RCC_PLLP_VALUE               IS_RCC_PLL1_DIVP_VALUE
+#define IS_RCC_PLLQ_VALUE               IS_RCC_PLL1_DIVQ_VALUE
+#define IS_RCC_PLLR_VALUE               IS_RCC_PLL1_DIVR_VALUE
+
+#define __HAL_RCC_PLL_ENABLE            __HAL_RCC_PLL1_ENABLE
+#define __HAL_RCC_PLL_DISABLE           __HAL_RCC_PLL1_DISABLE
+#define __HAL_RCC_PLL_FRACN_ENABLE      __HAL_RCC_PLL1_FRACN_ENABLE
+#define __HAL_RCC_PLL_FRACN_DISABLE     __HAL_RCC_PLL1_FRACN_DISABLE
+#define __HAL_RCC_PLL_CONFIG            __HAL_RCC_PLL1_CONFIG
+#define __HAL_RCC_PLL_PLLSOURCE_CONFIG  __HAL_RCC_PLL1_PLLSOURCE_CONFIG
+#define __HAL_RCC_PLL_DIVM_CONFIG       __HAL_RCC_PLL1_DIVM_CONFIG
+#define __HAL_RCC_PLL_FRACN_CONFIG      __HAL_RCC_PLL1_FRACN_CONFIG
+#define __HAL_RCC_PLL_VCIRANGE          __HAL_RCC_PLL1_VCIRANGE
+#define __HAL_RCC_PLL_VCORANGE          __HAL_RCC_PLL1_VCORANGE
+#define __HAL_RCC_GET_PLL_OSCSOURCE     __HAL_RCC_GET_PLL1_OSCSOURCE
+#define __HAL_RCC_PLLCLKOUT_ENABLE      __HAL_RCC_PLL1_CLKOUT_ENABLE
+#define __HAL_RCC_PLLCLKOUT_DISABLE     __HAL_RCC_PLL1_CLKOUT_DISABLE
+#define __HAL_RCC_GET_PLLCLKOUT_CONFIG  __HAL_RCC_GET_PLL1_CLKOUT_CONFIG
+
+#define __HAL_RCC_PLL2FRACN_ENABLE      __HAL_RCC_PLL2_FRACN_ENABLE
+#define __HAL_RCC_PLL2FRACN_DISABLE     __HAL_RCC_PLL2_FRACN_DISABLE
+#define __HAL_RCC_PLL2CLKOUT_ENABLE     __HAL_RCC_PLL2_CLKOUT_ENABLE
+#define __HAL_RCC_PLL2CLKOUT_DISABLE    __HAL_RCC_PLL2_CLKOUT_DISABLE
+#define __HAL_RCC_PLL2FRACN_CONFIG      __HAL_RCC_PLL2_FRACN_CONFIG
+#define __HAL_RCC_GET_PLL2CLKOUT_CONFIG __HAL_RCC_GET_PLL2_CLKOUT_CONFIG
+
+#define __HAL_RCC_PLL3FRACN_ENABLE      __HAL_RCC_PLL3_FRACN_ENABLE
+#define __HAL_RCC_PLL3FRACN_DISABLE     __HAL_RCC_PLL3_FRACN_DISABLE
+#define __HAL_RCC_PLL3CLKOUT_ENABLE     __HAL_RCC_PLL3_CLKOUT_ENABLE
+#define __HAL_RCC_PLL3CLKOUT_DISABLE    __HAL_RCC_PLL3_CLKOUT_DISABLE
+#define __HAL_RCC_PLL3FRACN_CONFIG      __HAL_RCC_PLL3_FRACN_CONFIG
+#define __HAL_RCC_GET_PLL3CLKOUT_CONFIG __HAL_RCC_GET_PLL3_CLKOUT_CONFIG
+
+#define RCC_PLL2VCIRANGE_0              RCC_PLL2_VCIRANGE_0
+#define RCC_PLL2VCIRANGE_1              RCC_PLL2_VCIRANGE_1
+#define RCC_PLL2VCIRANGE_2              RCC_PLL2_VCIRANGE_2
+#define RCC_PLL2VCIRANGE_3              RCC_PLL2_VCIRANGE_3
+
+#define RCC_PLL2VCOWIDE                 RCC_PLL2_VCORANGE_WIDE
+#define RCC_PLL2VCOMEDIUM               RCC_PLL2_VCORANGE_MEDIUM
+
+#define RCC_PLL2SOURCE_NONE             RCC_PLL2_SOURCE_NONE
+#define RCC_PLL2SOURCE_HSI              RCC_PLL2_SOURCE_HSI
+#define RCC_PLL2SOURCE_CSI              RCC_PLL2_SOURCE_CSI
+#define RCC_PLL2SOURCE_HSE              RCC_PLL2_SOURCE_HSE
+
+#define RCC_PLL3VCIRANGE_0              RCC_PLL3_VCIRANGE_0
+#define RCC_PLL3VCIRANGE_1              RCC_PLL3_VCIRANGE_1
+#define RCC_PLL3VCIRANGE_2              RCC_PLL3_VCIRANGE_2
+#define RCC_PLL3VCIRANGE_3              RCC_PLL3_VCIRANGE_3
+
+#define RCC_PLL3VCOWIDE                 RCC_PLL3_VCORANGE_WIDE
+#define RCC_PLL3VCOMEDIUM               RCC_PLL3_VCORANGE_MEDIUM
+
+#define RCC_PLL3SOURCE_NONE             RCC_PLL3_SOURCE_NONE
+#define RCC_PLL3SOURCE_HSI              RCC_PLL3_SOURCE_HSI
+#define RCC_PLL3SOURCE_CSI              RCC_PLL3_SOURCE_CSI
+#define RCC_PLL3SOURCE_HSE              RCC_PLL3_SOURCE_HSE
+
+
+#endif /* STM32H5 */
 
 /**
   * @}
@@ -3380,7 +3951,10 @@
 /** @defgroup HAL_RTC_Aliased_Macros HAL RTC Aliased Macros maintained for legacy purpose
   * @{
   */
-#if defined (STM32G0) || defined (STM32L5) || defined (STM32L412xx) || defined (STM32L422xx) || defined (STM32L4P5xx) || defined (STM32L4Q5xx) || defined (STM32G4) || defined (STM32WL)
+#if defined (STM32G0) || defined (STM32L5) || defined (STM32L412xx) || defined (STM32L422xx) || \
+    defined (STM32L4P5xx)|| defined (STM32L4Q5xx) || defined (STM32G4) || defined (STM32WL) || defined (STM32U5) || \
+    defined (STM32WBA) || defined (STM32H5) || defined (STM32C0) || defined (STM32N6) || defined (STM32H7RS) || \
+    defined (STM32U0) || defined (STM32U3)
 #else
 #define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
 #endif
@@ -3400,20 +3974,27 @@
 #else
 #define __HAL_RTC_EXTI_CLEAR_FLAG(__EXTI_LINE__)  (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_CLEAR_FLAG() : \
                                                    (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG() : \
-                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()))
+                                                    __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()))
 #define __HAL_RTC_EXTI_ENABLE_IT(__EXTI_LINE__)   (((__EXTI_LINE__)  == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_ENABLE_IT() : \
-                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT() : \
-                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()))
+                                                   (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT() : \
+                                                    __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()))
 #define __HAL_RTC_EXTI_DISABLE_IT(__EXTI_LINE__)  (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_DISABLE_IT() : \
-                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT() : \
-                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()))
+                                                   (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT() : \
+                                                    __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()))
 #define __HAL_RTC_EXTI_GET_FLAG(__EXTI_LINE__)    (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_GET_FLAG() : \
-                                                  (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG() : \
-                                                      __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()))
+                                                   (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG() : \
+                                                    __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()))
 #define __HAL_RTC_EXTI_GENERATE_SWIT(__EXTI_LINE__)   (((__EXTI_LINE__) == RTC_EXTI_LINE_ALARM_EVENT) ? __HAL_RTC_ALARM_EXTI_GENERATE_SWIT() : \
-                                                      (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT() :  \
-                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()))
+                                                       (((__EXTI_LINE__) == RTC_EXTI_LINE_WAKEUPTIMER_EVENT) ? __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT() :  \
+                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()))
 #endif   /* STM32F1 */
+
+#if defined (STM32F0) || defined (STM32F2) || defined (STM32F3) || defined (STM32F4) || defined (STM32F7) || \
+    defined (STM32H7) || \
+    defined (STM32L0) || defined (STM32L1) || \
+    defined (STM32WB)
+#define __HAL_RTC_TAMPER_GET_IT                   __HAL_RTC_TAMPER_GET_FLAG
+#endif
 
 #define IS_ALARM                                  IS_RTC_ALARM
 #define IS_ALARM_MASK                             IS_RTC_ALARM_MASK
@@ -3433,16 +4014,30 @@
 #define __RTC_WRITEPROTECTION_ENABLE  __HAL_RTC_WRITEPROTECTION_ENABLE
 #define __RTC_WRITEPROTECTION_DISABLE  __HAL_RTC_WRITEPROTECTION_DISABLE
 
+#if defined (STM32H5)
+#define __HAL_RCC_RTCAPB_CLK_ENABLE   __HAL_RCC_RTC_CLK_ENABLE
+#define __HAL_RCC_RTCAPB_CLK_DISABLE  __HAL_RCC_RTC_CLK_DISABLE
+#endif   /* STM32H5 */
+
 /**
   * @}
   */
 
-/** @defgroup HAL_SD_Aliased_Macros HAL SD Aliased Macros maintained for legacy purpose
+/** @defgroup HAL_SD_Aliased_Macros HAL SD/MMC Aliased Macros maintained for legacy purpose
   * @{
   */
 
 #define SD_OCR_CID_CSD_OVERWRIETE   SD_OCR_CID_CSD_OVERWRITE
 #define SD_CMD_SD_APP_STAUS         SD_CMD_SD_APP_STATUS
+
+#if !defined(STM32F1) && !defined(STM32F2) && !defined(STM32F4) && !defined(STM32L1)
+#define eMMC_HIGH_VOLTAGE_RANGE     EMMC_HIGH_VOLTAGE_RANGE
+#define eMMC_DUAL_VOLTAGE_RANGE     EMMC_DUAL_VOLTAGE_RANGE
+#define eMMC_LOW_VOLTAGE_RANGE      EMMC_LOW_VOLTAGE_RANGE
+
+#define SDMMC_NSpeed_CLK_DIV        SDMMC_NSPEED_CLK_DIV
+#define SDMMC_HSpeed_CLK_DIV        SDMMC_HSPEED_CLK_DIV
+#endif
 
 #if defined(STM32F4) || defined(STM32F2)
 #define  SD_SDMMC_DISABLED          SD_SDIO_DISABLED
@@ -3596,6 +4191,13 @@
 #define __HAL_USART_GETCLOCKSOURCE      USART_GETCLOCKSOURCE
 #define __USART_GETCLOCKSOURCE          USART_GETCLOCKSOURCE
 
+#if defined(STM32F0) || defined(STM32F3) || defined(STM32F7)
+#define USART_OVERSAMPLING_16               0x00000000U
+#define USART_OVERSAMPLING_8                USART_CR1_OVER8
+
+#define IS_USART_OVERSAMPLING(__SAMPLING__) (((__SAMPLING__) == USART_OVERSAMPLING_16) || \
+                                             ((__SAMPLING__) == USART_OVERSAMPLING_8))
+#endif /* STM32F0 || STM32F3 || STM32F7 */
 /**
   * @}
   */
@@ -3646,6 +4248,33 @@
 
 #define HAL_PCD_SetTxFiFo                                  HAL_PCDEx_SetTxFiFo
 #define HAL_PCD_SetRxFiFo                                  HAL_PCDEx_SetRxFiFo
+#if defined(STM32U5)
+#define USB_OTG_GOTGCTL_BSESVLD                            USB_OTG_GOTGCTL_BSVLD
+#define USB_OTG_GAHBCFG_GINT                               USB_OTG_GAHBCFG_GINTMSK
+#define USB_OTG_GUSBCFG_PHYLPCS                            USB_OTG_GUSBCFG_PHYLPC
+#define USB_OTG_GRSTCTL_HSRST                              USB_OTG_GRSTCTL_PSRST
+#define USB_OTG_GINTSTS_BOUTNAKEFF                         USB_OTG_GINTSTS_GONAKEFF
+#define USB_OTG_GINTSTS_WKUINT                             USB_OTG_GINTSTS_WKUPINT
+#define USB_OTG_GINTMSK_PXFRM_IISOOXFRM                    USB_OTG_GINTMSK_IPXFRM_IISOOXFRM
+#define USB_OTG_GRXSTSP_EPNUM                              USB_OTG_GRXSTSP_EPNUM_CHNUM
+#define USB_OTG_GLPMCFG_L1ResumeOK                         USB_OTG_GLPMCFG_L1RSMOK
+#define USB_OTG_HPTXFSIZ_PTXFD                             USB_OTG_HPTXFSIZ_PTXFSIZ
+#define USB_OTG_HCCHAR_MC                                  USB_OTG_HCCHAR_MCNT
+#define USB_OTG_HCCHAR_MC_0                                USB_OTG_HCCHAR_MCNT_0
+#define USB_OTG_HCCHAR_MC_1                                USB_OTG_HCCHAR_MCNT_1
+#define USB_OTG_HCINTMSK_AHBERR                            USB_OTG_HCINTMSK_AHBERRM
+#define USB_OTG_HCTSIZ_DOPING                              USB_OTG_HCTSIZ_DOPNG
+#define USB_OTG_DOEPMSK_OPEM                               USB_OTG_DOEPMSK_OUTPKTERRM
+#define USB_OTG_DIEPCTL_SODDFRM                            USB_OTG_DIEPCTL_SD1PID_SODDFRM
+#define USB_OTG_DIEPTSIZ_MULCNT                            USB_OTG_DIEPTSIZ_MCNT
+#define USB_OTG_DOEPCTL_SODDFRM                            USB_OTG_DOEPCTL_SD1PID_SODDFRM
+#define USB_OTG_DOEPCTL_DPID                               USB_OTG_DOEPCTL_DPID_EONUM
+#define USB_OTG_DOEPTSIZ_STUPCNT                           USB_OTG_DOEPTSIZ_RXDPID
+#define USB_OTG_DOEPTSIZ_STUPCNT_0                         USB_OTG_DOEPTSIZ_RXDPID_0
+#define USB_OTG_DOEPTSIZ_STUPCNT_1                         USB_OTG_DOEPTSIZ_RXDPID_1
+#define USB_OTG_PCGCCTL_STOPCLK                            USB_OTG_PCGCCTL_STPPCLK
+#define USB_OTG_PCGCCTL_GATECLK                            USB_OTG_PCGCCTL_GATEHCLK
+#endif
 /**
   * @}
   */
@@ -3675,6 +4304,9 @@
 #define __HAL_TIM_GetCompare            __HAL_TIM_GET_COMPARE
 
 #define TIM_BREAKINPUTSOURCE_DFSDM  TIM_BREAKINPUTSOURCE_DFSDM1
+
+#define TIM_OCMODE_ASSYMETRIC_PWM1      TIM_OCMODE_ASYMMETRIC_PWM1
+#define TIM_OCMODE_ASSYMETRIC_PWM2      TIM_OCMODE_ASYMMETRIC_PWM2
 /**
   * @}
   */
@@ -3765,6 +4397,16 @@
   * @}
   */
 
+/** @defgroup HAL_Generic_Aliased_Macros HAL Generic Aliased Macros maintained for legacy purpose
+  * @{
+  */
+#if defined (STM32F7)
+#define ART_ACCLERATOR_ENABLE ART_ACCELERATOR_ENABLE
+#endif /* STM32F7 */
+/**
+  * @}
+  */
+
 /** @defgroup HAL_PPP_Aliased_Macros HAL PPP Aliased Macros maintained for legacy purpose
   * @{
   */
@@ -3779,5 +4421,4 @@
 
 #endif /* STM32_HAL_LEGACY */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/STM32WBxx_HAL_Driver/Inc/stm32_assert_template.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32_assert_template.h
@@ -8,13 +8,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -24,7 +23,7 @@
 #define STM32_ASSERT_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Exported types ------------------------------------------------------------*/
@@ -40,11 +39,11 @@
   *         If expr is true, it returns no value.
   * @retval None
   */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+#define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
 /* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+void assert_failed(uint8_t *file, uint32_t line);
 #else
-  #define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */
 
 #ifdef __cplusplus
@@ -52,6 +51,3 @@
 #endif
 
 #endif /* STM32_ASSERT_H */
-
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal.h
@@ -7,13 +7,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 #define STM32WBxx_HAL_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -70,7 +69,7 @@ typedef enum
 #define SYSCFG_BOOT_SRAM                LL_SYSCFG_REMAP_SRAM            /*!< SRAM1 mapped at 0x00000000               */
 #if defined(LL_SYSCFG_REMAP_QUADSPI)
 #define SYSCFG_BOOT_QUADSPI             LL_SYSCFG_REMAP_QUADSPI         /*!< QUADSPI memory mapped at 0x00000000      */
-#endif
+#endif /* LL_SYSCFG_REMAP_QUADSPI */
 /**
   * @}
   */
@@ -216,15 +215,15 @@ typedef enum
 #define SYSCFG_FASTMODEPLUS_PB9         SYSCFG_CFGR1_I2C_PB9_FMP        /*!< Enable Fast-mode Plus on PB9 */
 
 /**
- * @}
- */
+  * @}
+  */
 
 /** @defgroup Secure_IP_Write_Access Secure IP Write Access
   * @{
   */
 #if defined(LL_SYSCFG_SECURE_ACCESS_AES1)
 #define HAL_SYSCFG_SECURE_ACCESS_AES1   LL_SYSCFG_SECURE_ACCESS_AES1    /*!< Enabling the security access of Advanced Encryption Standard 1 KEY[7:0] */
-#endif
+#endif /* LL_SYSCFG_SECURE_ACCESS_AES1 */
 #define HAL_SYSCFG_SECURE_ACCESS_AES2   LL_SYSCFG_SECURE_ACCESS_AES2    /*!< Enabling the security access of Advanced Encryption Standard 2          */
 #define HAL_SYSCFG_SECURE_ACCESS_PKA    LL_SYSCFG_SECURE_ACCESS_PKA     /*!< Enabling the security access of Public Key Accelerator                  */
 #define HAL_SYSCFG_SECURE_ACCESS_RNG    LL_SYSCFG_SECURE_ACCESS_RNG     /*!< Enabling the security access of Random Number Generator                 */
@@ -258,57 +257,57 @@ typedef enum
 #if defined(LL_DBGMCU_APB1_GRP1_TIM2_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM2()              LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_TIM2_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM2()            LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_TIM2_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_TIM2_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP1_RTC_STOP)
 #define __HAL_DBGMCU_FREEZE_RTC()               LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_RTC_STOP)
 #define __HAL_DBGMCU_UNFREEZE_RTC()             LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_RTC_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_RTC_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP1_WWDG_STOP)
 #define __HAL_DBGMCU_FREEZE_WWDG()              LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG_STOP)
 #define __HAL_DBGMCU_UNFREEZE_WWDG()            LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_WWDG_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_WWDG_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP1_IWDG_STOP)
 #define __HAL_DBGMCU_FREEZE_IWDG()              LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_IWDG_STOP)
 #define __HAL_DBGMCU_UNFREEZE_IWDG()            LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_IWDG_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_IWDG_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP1_I2C1_STOP)
 #define __HAL_DBGMCU_FREEZE_I2C1_TIMEOUT()      LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_I2C1_STOP)
 #define __HAL_DBGMCU_UNFREEZE_I2C1_TIMEOUT()    LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_I2C1_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_I2C1_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP1_I2C3_STOP)
 #define __HAL_DBGMCU_FREEZE_I2C3_TIMEOUT()      LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_I2C3_STOP)
 #define __HAL_DBGMCU_UNFREEZE_I2C3_TIMEOUT()    LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_I2C3_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_I2C3_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP1_LPTIM1_STOP)
 #define __HAL_DBGMCU_FREEZE_LPTIM1()            LL_DBGMCU_APB1_GRP1_FreezePeriph(LL_DBGMCU_APB1_GRP1_LPTIM1_STOP)
 #define __HAL_DBGMCU_UNFREEZE_LPTIM1()          LL_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_DBGMCU_APB1_GRP1_LPTIM1_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP1_LPTIM1_STOP */
 
 #if defined(LL_DBGMCU_APB1_GRP2_LPTIM2_STOP)
 #define __HAL_DBGMCU_FREEZE_LPTIM2()            LL_DBGMCU_APB1_GRP2_FreezePeriph(LL_DBGMCU_APB1_GRP2_LPTIM2_STOP)
 #define __HAL_DBGMCU_UNFREEZE_LPTIM2()          LL_DBGMCU_APB1_GRP2_UnFreezePeriph(LL_DBGMCU_APB1_GRP2_LPTIM2_STOP)
-#endif
+#endif /* LL_DBGMCU_APB1_GRP2_LPTIM2_STOP */
 
 #if defined(LL_DBGMCU_APB2_GRP1_TIM1_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM1()              LL_DBGMCU_APB2_GRP1_FreezePeriph(LL_DBGMCU_APB2_GRP1_TIM1_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM1()            LL_DBGMCU_APB2_GRP1_UnFreezePeriph(LL_DBGMCU_APB2_GRP1_TIM1_STOP)
-#endif
+#endif /* LL_DBGMCU_APB2_GRP1_TIM1_STOP */
 
 #if defined(LL_DBGMCU_APB2_GRP1_TIM16_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM16()             LL_DBGMCU_APB2_GRP1_FreezePeriph(LL_DBGMCU_APB2_GRP1_TIM16_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM16()           LL_DBGMCU_APB2_GRP1_UnFreezePeriph(LL_DBGMCU_APB2_GRP1_TIM16_STOP)
-#endif
+#endif /* LL_DBGMCU_APB2_GRP1_TIM16_STOP */
 
 #if defined(LL_DBGMCU_APB2_GRP1_TIM17_STOP)
 #define __HAL_DBGMCU_FREEZE_TIM17()             LL_DBGMCU_APB2_GRP1_FreezePeriph(LL_DBGMCU_APB2_GRP1_TIM17_STOP)
 #define __HAL_DBGMCU_UNFREEZE_TIM17()           LL_DBGMCU_APB2_GRP1_UnFreezePeriph(LL_DBGMCU_APB2_GRP1_TIM17_STOP)
-#endif
+#endif /* LL_DBGMCU_APB2_GRP1_TIM17_STOP */
 
 /**
   * @}
@@ -320,52 +319,52 @@ typedef enum
 #if defined(LL_C2_DBGMCU_APB1_GRP1_TIM2_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_TIM2()           LL_C2_DBGMCU_APB1_GRP1_FreezePeriph(LL_C2_DBGMCU_APB1_GRP1_TIM2_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_TIM2()         LL_C2_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP1_TIM2_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP1_TIM2_STOP */
 
 #if defined(LL_C2_DBGMCU_APB1_GRP1_RTC_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_RTC()            LL_C2_DBGMCU_APB1_GRP1_FreezePeriph(LL_C2_DBGMCU_APB1_GRP1_RTC_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_RTC()          LL_C2_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP1_RTC_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP1_RTC_STOP */
 
 #if defined(LL_C2_DBGMCU_APB1_GRP1_IWDG_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_IWDG()           LL_C2_DBGMCU_APB1_GRP1_FreezePeriph(LL_C2_DBGMCU_APB1_GRP1_IWDG_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_IWDG()         LL_C2_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP1_IWDG_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP1_IWDG_STOP */
 
 #if defined(LL_C2_DBGMCU_APB1_GRP1_I2C1_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_I2C1_TIMEOUT()   LL_C2_DBGMCU_APB1_GRP1_FreezePeriph(LL_C2_DBGMCU_APB1_GRP1_I2C1_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_I2C1_TIMEOUT() LL_C2_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP1_I2C1_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP1_I2C1_STOP */
 
 #if defined(LL_C2_DBGMCU_APB1_GRP1_I2C3_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_I2C3_TIMEOUT()   LL_C2_DBGMCU_APB1_GRP1_FreezePeriph(LL_C2_DBGMCU_APB1_GRP1_I2C3_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_I2C3_TIMEOUT() LL_C2_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP1_I2C3_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP1_I2C3_STOP */
 
 #if defined(LL_C2_DBGMCU_APB1_GRP1_LPTIM1_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_LPTIM1()         LL_C2_DBGMCU_APB1_GRP1_FreezePeriph(LL_C2_DBGMCU_APB1_GRP1_LPTIM1_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_LPTIM1()       LL_C2_DBGMCU_APB1_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP1_LPTIM1_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP1_LPTIM1_STOP */
 
 #if defined(LL_C2_DBGMCU_APB1_GRP2_LPTIM2_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_LPTIM2()         LL_C2_DBGMCU_APB1_GRP2_FreezePeriph(LL_C2_DBGMCU_APB1_GRP2_LPTIM2_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_LPTIM2()       LL_C2_DBGMCU_APB1_GRP2_UnFreezePeriph(LL_C2_DBGMCU_APB1_GRP2_LPTIM2_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB1_GRP2_LPTIM2_STOP */
 
 #if defined(LL_C2_DBGMCU_APB2_GRP1_TIM1_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_TIM1()           LL_C2_DBGMCU_APB2_GRP1_FreezePeriph(LL_C2_DBGMCU_APB2_GRP1_TIM1_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_TIM1()         LL_C2_DBGMCU_APB2_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB2_GRP1_TIM1_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB2_GRP1_TIM1_STOP */
 
 #if defined(LL_C2_DBGMCU_APB2_GRP1_TIM16_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_TIM16()          LL_C2_DBGMCU_APB2_GRP1_FreezePeriph(LL_C2_DBGMCU_APB2_GRP1_TIM16_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_TIM16()        LL_C2_DBGMCU_APB2_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB2_GRP1_TIM16_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB2_GRP1_TIM16_STOP */
 
 #if defined(LL_C2_DBGMCU_APB2_GRP1_TIM17_STOP)
 #define __HAL_C2_DBGMCU_FREEZE_TIM17()          LL_C2_DBGMCU_APB2_GRP1_FreezePeriph(LL_C2_DBGMCU_APB2_GRP1_TIM17_STOP)
 #define __HAL_C2_DBGMCU_UNFREEZE_TIM17()        LL_C2_DBGMCU_APB2_GRP1_UnFreezePeriph(LL_C2_DBGMCU_APB2_GRP1_TIM17_STOP)
-#endif
+#endif /* LL_C2_DBGMCU_APB2_GRP1_TIM17_STOP */
 
 /**
   * @}
@@ -395,7 +394,7 @@ typedef enum
 /** @brief  QUADSPI mapped at 0x00000000.
   */
 #define __HAL_SYSCFG_REMAPMEMORY_QUADSPI()      LL_SYSCFG_SetRemapMemory(LL_SYSCFG_REMAP_QUADSPI)
-#endif
+#endif /* LL_SYSCFG_REMAP_QUADSPI */
 
 /**
   * @brief  Return the boot mode as configured by user.
@@ -416,17 +415,21 @@ typedef enum
   */
 /* Legacy define */
 #define __HAL_SYSCFG_SRAM2_WRP_1_31_ENABLE      __HAL_SYSCFG_SRAM2_WRP_0_31_ENABLE
-#define __HAL_SYSCFG_SRAM2_WRP_0_31_ENABLE(__SRAM2WRP__)    do {assert_param(IS_SYSCFG_SRAM2WRP_PAGE((__SRAM2WRP__)));\
-                                                                LL_SYSCFG_EnableSRAM2PageWRP_0_31(__SRAM2WRP__);\
-                                                            }while(0)
+#define __HAL_SYSCFG_SRAM2_WRP_0_31_ENABLE(__SRAM2WRP__)   \
+  do {                                                     \
+    assert_param(IS_SYSCFG_SRAM2WRP_PAGE((__SRAM2WRP__))); \
+    LL_SYSCFG_EnableSRAM2PageWRP_0_31(__SRAM2WRP__);       \
+  } while(0)
 
 /** @brief  SRAM2 page 32 to 63 write protection enable macro
   * @param  __SRAM2WRP__  This parameter can be a combination of values of @ref SYSCFG_SRAM2WRP_32_63
   * @note   Write protection can only be disabled by a system reset
   */
-#define __HAL_SYSCFG_SRAM2_WRP_32_63_ENABLE(__SRAM2WRP__)   do {assert_param(IS_SYSCFG_SRAM2WRP2_PAGE((__SRAM2WRP__)));\
-                                                                LL_SYSCFG_EnableSRAM2PageWRP_32_63(__SRAM2WRP__);\
-                                                            }while(0)
+#define __HAL_SYSCFG_SRAM2_WRP_32_63_ENABLE(__SRAM2WRP__)   \
+  do {                                                      \
+    assert_param(IS_SYSCFG_SRAM2WRP2_PAGE((__SRAM2WRP__))); \
+    LL_SYSCFG_EnableSRAM2PageWRP_32_63(__SRAM2WRP__);       \
+  } while(0)
 
 /** @brief  SRAM2 page write protection unlock prior to erase
   * @note   Writing a wrong key reactivates the write protection
@@ -441,13 +444,17 @@ typedef enum
 /** @brief  Floating Point Unit interrupt enable/disable macros
   * @param __INTERRUPT__  This parameter can be a value of @ref SYSCFG_FPU_Interrupts
   */
-#define __HAL_SYSCFG_FPU_INTERRUPT_ENABLE(__INTERRUPT__)    do {assert_param(IS_SYSCFG_FPU_INTERRUPT((__INTERRUPT__)));\
-                                                                SET_BIT(SYSCFG->CFGR1, (__INTERRUPT__));\
-                                                            }while(0)
+#define __HAL_SYSCFG_FPU_INTERRUPT_ENABLE(__INTERRUPT__)    \
+  do {                                                      \
+    assert_param(IS_SYSCFG_FPU_INTERRUPT((__INTERRUPT__))); \
+    SET_BIT(SYSCFG->CFGR1, (__INTERRUPT__));                \
+  } while(0)
 
-#define __HAL_SYSCFG_FPU_INTERRUPT_DISABLE(__INTERRUPT__)   do {assert_param(IS_SYSCFG_FPU_INTERRUPT((__INTERRUPT__)));\
-                                                                CLEAR_BIT(SYSCFG->CFGR1, (__INTERRUPT__));\
-                                                            }while(0)
+#define __HAL_SYSCFG_FPU_INTERRUPT_DISABLE(__INTERRUPT__)   \
+  do {                                                      \
+    assert_param(IS_SYSCFG_FPU_INTERRUPT((__INTERRUPT__))); \
+    CLEAR_BIT(SYSCFG->CFGR1, (__INTERRUPT__));              \
+  } while(0)
 
 /** @brief  SYSCFG Break ECC lock.
   *         Enable and lock the connection of Flash ECC error connection to TIM1/16/17 Break input.
@@ -462,7 +469,8 @@ typedef enum
 #define __HAL_SYSCFG_BREAK_LOCKUP_LOCK()        LL_SYSCFG_SetTIMBreakInputs(LL_SYSCFG_TIMBREAK_LOCKUP)
 
 /** @brief  SYSCFG Break PVD lock.
-  *         Enable and lock the PVD connection to Timer1/16/17 Break input, as well as the PVDE and PLS[2:0] in the PWR_CR2 register.
+  *         Enable and lock the PVD connection to Timer1/16/17 Break input, as well as the PVDE and PLS[2:0]
+  *         in the PWR_CR2 register.
   * @note   The selected configuration is locked and can be unlocked only by system reset.
   */
 #define __HAL_SYSCFG_BREAK_PVD_LOCK()           LL_SYSCFG_SetTIMBreakInputs(LL_SYSCFG_TIMBREAK_PVD)
@@ -480,7 +488,8 @@ typedef enum
   *            @arg @ref SYSCFG_FLAG_SRAM2_BUSY SRAM2 Erase Ongoing
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
-#define __HAL_SYSCFG_GET_FLAG(__FLAG__)         ((((((__FLAG__) == SYSCFG_SCSR_SRAM2BSY)? SYSCFG->SCSR : SYSCFG->CFGR2) & (__FLAG__))!= 0U) ? 1U : 0U)
+#define __HAL_SYSCFG_GET_FLAG(__FLAG__)      ((((((__FLAG__) == SYSCFG_SCSR_SRAM2BSY)? SYSCFG->SCSR : SYSCFG->CFGR2) & \
+                                                (__FLAG__))!= 0U) ? 1U : 0U)
 
 /** @brief  Set the SPF bit to clear the SRAM Parity Error Flag.
   */
@@ -489,13 +498,17 @@ typedef enum
 /** @brief  Fast mode Plus driving capability enable/disable macros
   * @param __FASTMODEPLUS__ This parameter can be a value of @ref SYSCFG_FastModePlus_GPIO
   */
-#define __HAL_SYSCFG_FASTMODEPLUS_ENABLE(__FASTMODEPLUS__)  do {assert_param(IS_SYSCFG_FASTMODEPLUS((__FASTMODEPLUS__))); \
-                                                                LL_SYSCFG_EnableFastModePlus(__FASTMODEPLUS__);           \
-                                                               }while(0)
+#define __HAL_SYSCFG_FASTMODEPLUS_ENABLE(__FASTMODEPLUS__)    \
+  do {                                                        \
+    assert_param(IS_SYSCFG_FASTMODEPLUS((__FASTMODEPLUS__))); \
+    LL_SYSCFG_EnableFastModePlus(__FASTMODEPLUS__);           \
+  } while(0)
 
-#define __HAL_SYSCFG_FASTMODEPLUS_DISABLE(__FASTMODEPLUS__) do {assert_param(IS_SYSCFG_FASTMODEPLUS((__FASTMODEPLUS__))); \
-                                                                LL_SYSCFG_DisableFastModePlus(__FASTMODEPLUS__);          \
-                                                               }while(0)
+#define __HAL_SYSCFG_FASTMODEPLUS_DISABLE(__FASTMODEPLUS__)   \
+  do {                                                        \
+    assert_param(IS_SYSCFG_FASTMODEPLUS((__FASTMODEPLUS__))); \
+    LL_SYSCFG_DisableFastModePlus(__FASTMODEPLUS__);          \
+  } while(0)
 
 /**
   * @}
@@ -514,15 +527,20 @@ typedef enum
   * @{
   */
 
-#define IS_SYSCFG_FPU_INTERRUPT(__INTERRUPT__)          ((((__INTERRUPT__) & SYSCFG_IT_FPU_IOC) == SYSCFG_IT_FPU_IOC) || \
-                                                         (((__INTERRUPT__) & SYSCFG_IT_FPU_DZC) == SYSCFG_IT_FPU_DZC) || \
-                                                         (((__INTERRUPT__) & SYSCFG_IT_FPU_UFC) == SYSCFG_IT_FPU_UFC) || \
-                                                         (((__INTERRUPT__) & SYSCFG_IT_FPU_OFC) == SYSCFG_IT_FPU_OFC) || \
-                                                         (((__INTERRUPT__) & SYSCFG_IT_FPU_IDC) == SYSCFG_IT_FPU_IDC) || \
-                                                         (((__INTERRUPT__) & SYSCFG_IT_FPU_IXC) == SYSCFG_IT_FPU_IXC))
+#define IS_SYSCFG_FPU_INTERRUPT(__INTERRUPT__)        ((((__INTERRUPT__) & SYSCFG_IT_FPU_IOC) == SYSCFG_IT_FPU_IOC) || \
+                                                       (((__INTERRUPT__) & SYSCFG_IT_FPU_DZC) == SYSCFG_IT_FPU_DZC) || \
+                                                       (((__INTERRUPT__) & SYSCFG_IT_FPU_UFC) == SYSCFG_IT_FPU_UFC) || \
+                                                       (((__INTERRUPT__) & SYSCFG_IT_FPU_OFC) == SYSCFG_IT_FPU_OFC) || \
+                                                       (((__INTERRUPT__) & SYSCFG_IT_FPU_IDC) == SYSCFG_IT_FPU_IDC) || \
+                                                       (((__INTERRUPT__) & SYSCFG_IT_FPU_IXC) == SYSCFG_IT_FPU_IXC))
 
+#if defined(STM32WB15xx) || defined(STM32WB10xx)
+#define IS_SYSCFG_SRAM2WRP_PAGE(__PAGE__)               (((__PAGE__) > 0U) && ((__PAGE__) <= 0xFFFFFFFFU))
+#define IS_SYSCFG_SRAM2WRP2_PAGE(__PAGE__)              (((__PAGE__) > 0U) && ((__PAGE__) <= 0x0000000FU))
+#else
 #define IS_SYSCFG_SRAM2WRP_PAGE(__PAGE__)               (((__PAGE__) > 0U) && ((__PAGE__) <= 0xFFFFFFFFU))
 #define IS_SYSCFG_SRAM2WRP2_PAGE(__PAGE__)              IS_SYSCFG_SRAM2WRP_PAGE(__PAGE__)
+#endif /* STM32WB15xx || STM32WB10xx */
 
 #if defined(VREFBUF)
 #define IS_SYSCFG_VREFBUF_VOLTAGE_SCALE(__SCALE__)      (((__SCALE__) == SYSCFG_VREFBUF_VOLTAGE_SCALE0) || \
@@ -532,23 +550,23 @@ typedef enum
                                                          ((__VALUE__) == SYSCFG_VREFBUF_HIGH_IMPEDANCE_ENABLE))
 
 #define IS_SYSCFG_VREFBUF_TRIMMING(__VALUE__)           (((__VALUE__) > 0U) && ((__VALUE__) <= VREFBUF_CCR_TRIM))
-#endif
+#endif /* VREFBUF */
 
-#define IS_SYSCFG_FASTMODEPLUS(__PIN__)                 ((((__PIN__) & SYSCFG_FASTMODEPLUS_PB6)  == SYSCFG_FASTMODEPLUS_PB6)  || \
-                                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB7)  == SYSCFG_FASTMODEPLUS_PB7)  || \
-                                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB8)  == SYSCFG_FASTMODEPLUS_PB8)  || \
-                                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB9)  == SYSCFG_FASTMODEPLUS_PB9))
+#define IS_SYSCFG_FASTMODEPLUS(__PIN__)                 ((((__PIN__) & SYSCFG_FASTMODEPLUS_PB6) == SYSCFG_FASTMODEPLUS_PB6)  || \
+                                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB7) == SYSCFG_FASTMODEPLUS_PB7)  || \
+                                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB8) == SYSCFG_FASTMODEPLUS_PB8)  || \
+                                                         (((__PIN__) & SYSCFG_FASTMODEPLUS_PB9) == SYSCFG_FASTMODEPLUS_PB9))
 
 #if defined(LL_SYSCFG_SECURE_ACCESS_AES1)
-#define IS_SYSCFG_SECURITY_ACCESS(__VALUE__)            ((((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_AES1)  == HAL_SYSCFG_SECURE_ACCESS_AES1)  || \
-                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_AES2)  == HAL_SYSCFG_SECURE_ACCESS_AES2)  || \
-                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_PKA)   == HAL_SYSCFG_SECURE_ACCESS_PKA)   || \
-                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_RNG)   == HAL_SYSCFG_SECURE_ACCESS_RNG))
+#define IS_SYSCFG_SECURITY_ACCESS(__VALUE__)            ((((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_AES1) == HAL_SYSCFG_SECURE_ACCESS_AES1) || \
+                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_AES2) == HAL_SYSCFG_SECURE_ACCESS_AES2) || \
+                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_PKA)  == HAL_SYSCFG_SECURE_ACCESS_PKA)  || \
+                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_RNG)  == HAL_SYSCFG_SECURE_ACCESS_RNG))
 #else
-#define IS_SYSCFG_SECURITY_ACCESS(__VALUE__)            ((((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_AES2)  == HAL_SYSCFG_SECURE_ACCESS_AES2)  || \
-                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_PKA)   == HAL_SYSCFG_SECURE_ACCESS_PKA)   || \
-                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_RNG)   == HAL_SYSCFG_SECURE_ACCESS_RNG))
-#endif
+#define IS_SYSCFG_SECURITY_ACCESS(__VALUE__)            ((((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_AES2) == HAL_SYSCFG_SECURE_ACCESS_AES2) || \
+                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_PKA)  == HAL_SYSCFG_SECURE_ACCESS_PKA)  || \
+                                                         (((__VALUE__) & HAL_SYSCFG_SECURE_ACCESS_RNG)  == HAL_SYSCFG_SECURE_ACCESS_RNG))
+#endif /* LL_SYSCFG_SECURE_ACCESS_AES1 */
 
 /**
   * @}
@@ -585,7 +603,7 @@ HAL_StatusTypeDef HAL_DeInit(void);
 void HAL_MspInit(void);
 void HAL_MspDeInit(void);
 
-HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority);
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority);
 
 /**
   * @}
@@ -656,14 +674,14 @@ void HAL_SYSCFG_VREFBUF_HighImpedanceConfig(uint32_t Mode);
 void HAL_SYSCFG_VREFBUF_TrimmingConfig(uint32_t TrimmingValue);
 HAL_StatusTypeDef HAL_SYSCFG_EnableVREFBUF(void);
 void HAL_SYSCFG_DisableVREFBUF(void);
-#endif
+#endif /* VREFBUF */
 
 void HAL_SYSCFG_EnableIOBooster(void);
 void HAL_SYSCFG_DisableIOBooster(void);
 #if defined(SYSCFG_CFGR1_ANASWVDD)
 void HAL_SYSCFG_EnableIOVdd(void);
 void HAL_SYSCFG_DisableIOVdd(void);
-#endif
+#endif /* SYSCFG_CFGR1_ANASWVDD */
 
 void HAL_SYSCFG_EnableSecurityAccess(uint32_t SecurityAccess);
 void HAL_SYSCFG_DisableSecurityAccess(uint32_t SecurityAccess);
@@ -690,5 +708,3 @@ uint32_t HAL_SYSCFG_IsEnabledSecurityAccess(uint32_t SecurityAccess);
 #endif
 
 #endif /* STM32WBxx_HAL_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_adc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_adc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -44,7 +43,7 @@ extern "C" {
   * @{
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC oversampling" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -70,7 +69,7 @@ typedef struct
                                                This parameter can be a value of @ref ADC_HAL_EC_OVS_SCOPE_REG */
 
 } ADC_OversamplingTypeDef;
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief  Structure definition of ADC instance and ADC group regular.
@@ -135,13 +134,13 @@ typedef struct
                                              use HAL_ADC_PollForConversion() to ensure that conversion is completed and HAL_ADC_GetValue() to retrieve conversion result and trig another conversion start.
                                              (in case of usage of ADC group injected, use the equivalent functions HAL_ADCExInjected_Start(), HAL_ADCEx_InjectedGetValue(), ...). */
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
   FunctionalState LowPowerAutoPowerOff; /*!< Select the auto-off mode: the ADC automatically powers-off after a conversion and automatically wakes-up when a new conversion is triggered (with startup time between trigger and start of sampling).
                                        This feature can be combined with automatic wait mode (parameter 'LowPowerAutoWait').
                                        This parameter can be set to ENABLE or DISABLE.
                                        Note: If enabled, this feature also turns off the ADC dedicated 14 MHz RC oscillator (HSI14) */
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   FunctionalState ContinuousConvMode; /*!< Specify whether the conversion is performed in single mode (one conversion) or continuous mode for ADC group regular,
                                        after the first ADC conversion start trigger occurred (software start or external trigger).
                                        This parameter can be set to ENABLE or DISABLE. */
@@ -158,13 +157,13 @@ typedef struct
                                        Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
                                        This parameter can be set to ENABLE or DISABLE. */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group regular number of discontinuous conversions" not available on ADC peripheral of this STM32WB device */
 #else
   uint32_t NbrOfDiscConversion;   /*!< Specifies the number of discontinuous conversions in which the main sequence of ADC group regular (parameter NbrOfConversion) will be subdivided.
                                        If parameter 'DiscontinuousConvMode' is disabled, this parameter is discarded.
                                        This parameter must be a number between Min_Data = 1 and Max_Data = 8. */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
   uint32_t ExternalTrigConv;      /*!< Select the external event source used to trigger ADC group regular conversion start.
                                        If set to ADC_SOFTWARE_START, external triggers are disabled and software trigger is used instead.
@@ -191,7 +190,7 @@ typedef struct
                                                overwritten, user can willingly not read all the converted data, this is not considered as an erroneous case.
                                              - Usage with ADC conversion by DMA: Error is reported whatever overrun setting (DMA is expected to process all data from data register). */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t SamplingTimeCommon1;   /*!< Set sampling time common to a group of channels.
                                        Unit: ADC clock cycles
                                        Conversion time is the addition of sampling time and processing time (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
@@ -209,18 +208,18 @@ typedef struct
                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
                                              sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
                                              Refer to device datasheet for timings values, parameters TS_vrefint, TS_vbat, TS_temp (values rough order: few tens of microseconds). */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
   FunctionalState OversamplingMode;       /*!< Specify whether the oversampling feature is enabled or disabled.
                                                This parameter can be set to ENABLE or DISABLE.
                                                Note: This parameter can be modified only if there is no conversion is ongoing on ADC group regular. */
 
   ADC_OversamplingTypeDef Oversampling;   /*!< Specify the Oversampling parameters.
                                                Caution: this setting overwrites the previous oversampling configuration if oversampling is already enabled. */
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t TriggerFrequencyMode;  /*!< Set ADC trigger frequency mode.
                                        This parameter can be a value of @ref ADC_HAL_EC_REG_TRIGGER_FREQ.
                                        Note: ADC trigger frequency mode must be set to low frequency when
@@ -231,7 +230,7 @@ typedef struct
                                        Note: When ADC trigger frequency mode is set to low frequency,
                                              some rearm cycles are inserted before performing ADC conversion
                                              start, inducing a delay of 2 ADC clock cycles. */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 } ADC_InitTypeDef;
 
@@ -268,6 +267,7 @@ typedef struct
                                               sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
                                               Refer to device datasheet for timings values. */
 
+#if  !defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t SingleDiff;             /*!< Select single-ended or differential input.
                                         In differential mode: Differential measurement is carried out between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
                                                               Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
@@ -291,6 +291,7 @@ typedef struct
                                         Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled
                                               without continuous mode or external trigger that could launch a conversion). */
 
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 } ADC_ChannelConfTypeDef;
 
 /**
@@ -303,7 +304,7 @@ typedef struct
 {
   uint32_t WatchdogNumber;    /*!< Select which ADC analog watchdog is monitoring the selected channel.
                                    For Analog Watchdog 1: Only 1 channel can be monitored (or overall group of channels by setting parameter 'WatchdogMode')
-                                   For Analog Watchdog 2 and 3: Several channels can be monitored (by successive calls of 'HAL_ADC_AnalogWDGConfig()' for each channel). Note: Analog Watchdog 2 and 3 are not available on devices: STM32WB10xx, STM32WB15xx.
+                                   For Analog Watchdog 2 and 3: Several channels can be monitored (by successive calls of 'HAL_ADC_AnalogWDGConfig()' for each channel). Note: Analog Watchdog 2 and 3 are not available on devices: STM32WB10xx, STM32WB15xx, , STM32WB1Mxx.
                                    This parameter can be a value of @ref ADC_HAL_EC_AWD_NUMBER. */
 
   uint32_t WatchdogMode;      /*!< Configure the ADC analog watchdog mode: single/all/none channels.
@@ -381,7 +382,7 @@ typedef struct
                                                               external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available)) */
 #define HAL_ADC_STATE_REG_EOC           (0x00000200UL)   /*!< Conversion data available on group regular */
 #define HAL_ADC_STATE_REG_OVR           (0x00000400UL)   /*!< Overrun occurrence */
-#define HAL_ADC_STATE_REG_EOSMP         (0x00000800UL)   /*!< Not available on this STM32 serie: End Of Sampling flag raised  */
+#define HAL_ADC_STATE_REG_EOSMP         (0x00000800UL)   /*!< Not available on this STM32 series: End Of Sampling flag raised  */
 
 /* States of ADC group injected */
 #define HAL_ADC_STATE_INJ_BUSY          (0x00001000UL)   /*!< A conversion on ADC group injected is ongoing or can occur (either by auto-injection mode,
@@ -395,7 +396,7 @@ typedef struct
 #define HAL_ADC_STATE_AWD3              (0x00040000UL)   /*!< Out-of-window occurrence of ADC analog watchdog 3 */
 
 /* States of ADC multi-mode */
-#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000UL)   /*!< Not available on this STM32 serie: ADC in multimode slave state, controlled by another ADC master (when feature available) */
+#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000UL)   /*!< Not available on this STM32 series: ADC in multimode slave state, controlled by another ADC master (when feature available) */
 
 
 /**
@@ -417,11 +418,11 @@ typedef struct
   HAL_LockTypeDef               Lock;                   /*!< ADC locking object */
   __IO uint32_t                 State;                  /*!< ADC communication state (bitmap of ADC states) */
   __IO uint32_t                 ErrorCode;              /*!< ADC Error code */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t                      ADCGroupRegularSequencerRanks; /*!< ADC group regular sequencer memorization of ranks setting, used in mode "fully configurable" (refer to parameter 'ScanConvMode') */
 #else
   ADC_InjectionConfigTypeDef    InjectionConfig ;       /*!< ADC injected channel configuration build-up structure */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
   void (* ConvCpltCallback)(struct __ADC_HandleTypeDef *hadc);              /*!< ADC conversion complete callback */
   void (* ConvHalfCpltCallback)(struct __ADC_HandleTypeDef *hadc);          /*!< ADC conversion DMA half-transfer callback */
@@ -536,10 +537,10 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /** @defgroup ADC_Scan_mode ADC sequencer scan mode
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
-/* Note: On STM32WB10xx, STM32WB15xx devices, ADC group regular sequencer     */
-/*       both modes "fully configurable" or "not fully configurable" are      */
-/*       available.                                                           */
+#if defined(ADC_SUPPORT_2_5_MSPS)
+/* Note: On STM32WB10xx, STM32WB15xx, STM32WB1Mxx devices, ADC group regular  */
+/*       sequencer both modes "fully configurable" or "not fully configurable"*/
+/*       are available.                                                       */
 /*       Scan mode values must be compatible with other STM32 devices having  */
 /*       a configurable sequencer.                                            */
 /*       Scan direction setting values are defined by taking in account       */
@@ -588,7 +589,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_EXTERNALTRIG_T2_TRGO      (LL_ADC_REG_TRIG_EXT_TIM2_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM2 TRGO. Trigger edge set to rising edge (default setting). */
 #define ADC_EXTERNALTRIG_T2_CC2       (LL_ADC_REG_TRIG_EXT_TIM2_CH2)             /*!< ADC group regular conversion trigger from external peripheral: TIM2 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define ADC_EXTERNALTRIG_EXT_IT11     (LL_ADC_REG_TRIG_EXT_EXTI_LINE11)          /*!< ADC group regular conversion trigger from external peripheral: external interrupt line 11. Trigger edge set to rising edge (default setting). */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -625,7 +626,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /** @defgroup ADC_HAL_EC_REG_SEQ_RANKS  ADC group regular - Sequencer ranks
   * @{
   */
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_RANK_CHANNEL_NUMBER            (0x00000001U)  /*!< Setting relevant if parameter "ScanConvMode" is set to sequencer not fully configurable: Enable the rank of the selected channels. Number of ranks in the sequence is defined by number of channels enabled, rank of each channel is defined by channel number (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...) */
 #define ADC_RANK_NONE                      (0x00000002U)  /*!< Setting relevant if parameter "ScanConvMode" is set to sequencer not fully configurable: Disable the selected rank (selected channel) from sequencer */
 
@@ -654,12 +655,12 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_REGULAR_RANK_14                (LL_ADC_REG_RANK_14) /*!< ADC group regular sequencer rank 14 */
 #define ADC_REGULAR_RANK_15                (LL_ADC_REG_RANK_15) /*!< ADC group regular sequencer rank 15 */
 #define ADC_REGULAR_RANK_16                (LL_ADC_REG_RANK_16) /*!< ADC group regular sequencer rank 16 */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /** @defgroup ADC_HAL_EC_CHANNEL_SAMPLINGTIME  ADC instance - Sampling time common to a group of channels
   * @{
   */
@@ -698,7 +699,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /**
   * @}
   */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /** @defgroup ADC_HAL_EC_CHANNEL  ADC instance - Channel number
   * @{
@@ -735,12 +736,12 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @{
   */
 #define ADC_ANALOGWATCHDOG_1               (LL_ADC_AWD1) /*!< ADC analog watchdog number 1 */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC analog watchdog 2 and 3" not available on ADC peripheral of this STM32WB device */
 #else
 #define ADC_ANALOGWATCHDOG_2               (LL_ADC_AWD2) /*!< ADC analog watchdog number 2 */
 #define ADC_ANALOGWATCHDOG_3               (LL_ADC_AWD3) /*!< ADC analog watchdog number 3 */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -759,7 +760,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC oversampling" not available on ADC peripheral of this STM32WB device */
 #else
 /** @defgroup ADC_HAL_EC_OVS_RATIO  Oversampling - Ratio
@@ -792,7 +793,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /**
   * @}
   */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /** @defgroup ADC_HAL_EC_OVS_DISCONT_MODE  Oversampling - Discontinuous mode
   * @{
@@ -812,7 +813,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /** @defgroup ADC_HAL_EC_REG_TRIGGER_FREQ  ADC group regular - Trigger frequency mode
   * @{
   */
@@ -821,7 +822,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /**
   * @}
   */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 
 /** @defgroup ADC_Event_type ADC Event type
@@ -832,9 +833,9 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_AWD2_EVENT           (ADC_FLAG_AWD2)  /*!< ADC Analog watchdog 2 event (additional analog watchdog, not present on all STM32 series) */
 #define ADC_AWD3_EVENT           (ADC_FLAG_AWD3)  /*!< ADC Analog watchdog 3 event (additional analog watchdog, not present on all STM32 series) */
 #define ADC_OVR_EVENT            (ADC_FLAG_OVR)   /*!< ADC overrun event */
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_JQOVF_EVENT          (ADC_FLAG_JQOVF) /*!< ADC Injected Context Queue Overflow event */
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -848,14 +849,14 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_IT_EOC           ADC_IER_EOCIE      /*!< ADC End of regular conversion interrupt source */
 #define ADC_IT_EOS           ADC_IER_EOSIE      /*!< ADC End of regular sequence of conversions interrupt source */
 #define ADC_IT_OVR           ADC_IER_OVRIE      /*!< ADC overrun interrupt source */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_IT_EOCAL         ADC_IER_EOCALIE    /*!< ADC end of calibration interrupt source */
 #define ADC_IT_CCRDY         ADC_IER_CCRDYIE    /*!< ADC channel configuration ready interrupt source */
 #else
 #define ADC_IT_JEOC          ADC_IER_JEOCIE     /*!< ADC End of injected conversion interrupt source */
 #define ADC_IT_JEOS          ADC_IER_JEOSIE     /*!< ADC End of injected sequence of conversions interrupt source */
 #define ADC_IT_JQOVF         ADC_IER_JQOVFIE    /*!< ADC Injected Context Queue Overflow interrupt source */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define ADC_IT_AWD1          ADC_IER_AWD1IE     /*!< ADC Analog watchdog 1 interrupt source (main analog watchdog) */
 #define ADC_IT_AWD2          ADC_IER_AWD2IE     /*!< ADC Analog watchdog 2 interrupt source (additional analog watchdog) */
 #define ADC_IT_AWD3          ADC_IER_AWD3IE     /*!< ADC Analog watchdog 3 interrupt source (additional analog watchdog) */
@@ -874,14 +875,14 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define ADC_FLAG_EOC           ADC_ISR_EOC      /*!< ADC End of Regular Conversion flag */
 #define ADC_FLAG_EOS           ADC_ISR_EOS      /*!< ADC End of Regular sequence of Conversions flag */
 #define ADC_FLAG_OVR           ADC_ISR_OVR      /*!< ADC overrun flag */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_FLAG_EOCAL         ADC_ISR_EOCAL    /*!< ADC end of calibration flag */
 #define ADC_FLAG_CCRDY         ADC_ISR_CCRDY    /*!< ADC channel configuration ready flag */
 #else
 #define ADC_FLAG_JEOC          ADC_ISR_JEOC     /*!< ADC End of Injected Conversion flag */
 #define ADC_FLAG_JEOS          ADC_ISR_JEOS     /*!< ADC End of Injected sequence of Conversions flag */
 #define ADC_FLAG_JQOVF         ADC_ISR_JQOVF    /*!< ADC Injected Context Queue Overflow flag */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define ADC_FLAG_AWD1          ADC_ISR_AWD1     /*!< ADC Analog watchdog 1 flag (main analog watchdog) */
 #define ADC_FLAG_AWD2          ADC_ISR_AWD2     /*!< ADC Analog watchdog 2 flag (additional analog watchdog) */
 #define ADC_FLAG_AWD3          ADC_ISR_AWD3     /*!< ADC Analog watchdog 3 flag (additional analog watchdog) */
@@ -939,11 +940,11 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @param __LENGTH__ number of programmed conversions.
   * @retval SET (__LENGTH__ is within the maximum number of possible programmable regular conversions) or RESET (__LENGTH__ is null or too large)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_REGULAR_NB_CONV(__LENGTH__) (((__LENGTH__) >= (1UL)) && ((__LENGTH__) <= (8UL)))
 #else
 #define IS_ADC_REGULAR_NB_CONV(__LENGTH__) (((__LENGTH__) >= (1UL)) && ((__LENGTH__) <= (16UL)))
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 
 /**
@@ -1025,7 +1026,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @param __REGTRIG__ programmed ADC regular conversions external trigger.
   * @retval SET (__REGTRIG__ is a valid value) or RESET (__REGTRIG__ is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_EXTTRIG(__HANDLE__, __REGTRIG__) (((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO2) || \
                                                  ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC4)   || \
                                                  ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_TRGO)  || \
@@ -1043,7 +1044,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
                                                  ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO2) || \
                                                  ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_TRGO)  || \
                                                  ((__REGTRIG__) == ADC_SOFTWARE_START)           )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC regular conversions check for converted data availability.
@@ -1061,17 +1062,17 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 #define IS_ADC_OVERRUN(__OVR__) (((__OVR__) == ADC_OVR_DATA_PRESERVED)  || \
                                  ((__OVR__) == ADC_OVR_DATA_OVERWRITTEN)  )
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_SAMPLING_TIME_COMMON(SAMPLING_TIME_COMMON) (((SAMPLING_TIME_COMMON) == ADC_SAMPLINGTIME_COMMON_1) || \
                                                            ((SAMPLING_TIME_COMMON) == ADC_SAMPLINGTIME_COMMON_2)   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC conversions sampling time.
   * @param __TIME__ ADC conversions sampling time.
   * @retval SET (__TIME__ is a valid value) or RESET (__TIME__ is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_SAMPLE_TIME(__TIME__) (((__TIME__) == ADC_SAMPLETIME_1CYCLE_5)    || \
                                       ((__TIME__) == ADC_SAMPLETIME_3CYCLES_5)   || \
                                       ((__TIME__) == ADC_SAMPLETIME_7CYCLES_5)   || \
@@ -1089,19 +1090,19 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
                                       ((__TIME__) == ADC_SAMPLETIME_92CYCLES_5)  || \
                                       ((__TIME__) == ADC_SAMPLETIME_247CYCLES_5) || \
                                       ((__TIME__) == ADC_SAMPLETIME_640CYCLES_5)   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_REGULAR_RANK_SEQ_FIXED(RANK) (((RANK) == ADC_RANK_CHANNEL_NUMBER) || \
                                              ((RANK) == ADC_RANK_NONE)             )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC regular channel setting.
   * @param  RANK programmed ADC regular channel.
   * @retval SET (RANK is valid) or RESET (RANK is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_REGULAR_RANK(RANK) (((RANK) == ADC_REGULAR_RANK_1 ) || \
                                    ((RANK) == ADC_REGULAR_RANK_2 ) || \
                                    ((RANK) == ADC_REGULAR_RANK_3 ) || \
@@ -1154,9 +1155,9 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
 /* Unit: us                                                                 */
 #define ADC_TEMPSENSOR_DELAY_US         (LL_ADC_DELAY_TEMPSENSOR_STAB_US)
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_SCAN_SEQ_FIXED_INT  0x80000000U  /* Internal definition to differentiate sequencer setting fixed or configurable */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @}
@@ -1207,7 +1208,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *            @arg @ref ADC_IT_AWD2   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
   *            @arg @ref ADC_IT_AWD3   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 #define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                         \
@@ -1230,7 +1231,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *            @arg @ref ADC_IT_AWD2   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
   *            @arg @ref ADC_IT_AWD3   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 #define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                        \
@@ -1252,7 +1253,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *            @arg @ref ADC_IT_AWD2   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
   *            @arg @ref ADC_IT_AWD3   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval State of interruption (SET or RESET)
   */
 #define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)                     \
@@ -1275,7 +1276,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *            @arg @ref ADC_FLAG_AWD2    ADC Analog watchdog 2 flag (additional analog watchdog)
   *            @arg @ref ADC_FLAG_AWD3    ADC Analog watchdog 3 flag (additional analog watchdog)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval State of flag (TRUE or FALSE).
   */
 #define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__)                               \
@@ -1298,7 +1299,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *            @arg @ref ADC_FLAG_AWD2    ADC Analog watchdog 2 flag (additional analog watchdog)
   *            @arg @ref ADC_FLAG_AWD3    ADC Analog watchdog 3 flag (additional analog watchdog)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 /* Note: bit cleared bit by writing 1 (writing 0 has no effect on any bit of register ISR) */
@@ -1636,7 +1637,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   *         connected to pin Vref+.
   *         On devices with small package, the pin Vref+ is not present
   *         and internally bonded to pin Vdda.
-  * @note   On this STM32 serie, calibration data of internal voltage reference
+  * @note   On this STM32 series, calibration data of internal voltage reference
   *         VrefInt corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         internal voltage reference VrefInt.
@@ -1683,7 +1684,7 @@ typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to 
   * @note   Analog reference voltage (Vref+) must be either known from
   *         user board environment or can be calculated using ADC measurement
   *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
-  * @note   On this STM32 serie, calibration data of temperature sensor
+  * @note   On this STM32 series, calibration data of temperature sensor
   *         corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         temperature sensor.
@@ -1822,7 +1823,7 @@ HAL_StatusTypeDef       HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pDa
 HAL_StatusTypeDef       HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc);
 
 /* ADC retrieve conversion value intended to be used with polling or interruption */
-uint32_t                HAL_ADC_GetValue(ADC_HandleTypeDef *hadc);
+uint32_t                HAL_ADC_GetValue(const ADC_HandleTypeDef *hadc);
 
 /* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption and DMA) */
 void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc);
@@ -1839,8 +1840,8 @@ void                    HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
   * @{
   */
 /* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConfTypeDef *sConfig);
-HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDGConfTypeDef *AnalogWDGConfig);
+HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, const ADC_ChannelConfTypeDef *sConfig);
+HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, const ADC_AnalogWDGConfTypeDef *AnalogWDGConfig);
 
 /**
   * @}
@@ -1850,8 +1851,8 @@ HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_Ana
 /** @addtogroup ADC_Exported_Functions_Group4
   * @{
   */
-uint32_t                HAL_ADC_GetState(ADC_HandleTypeDef *hadc);
-uint32_t                HAL_ADC_GetError(ADC_HandleTypeDef *hadc);
+uint32_t                HAL_ADC_GetState(const ADC_HandleTypeDef *hadc);
+uint32_t                HAL_ADC_GetError(const ADC_HandleTypeDef *hadc);
 
 /**
   * @}
@@ -1888,7 +1889,4 @@ void ADC_DMAError(DMA_HandleTypeDef *hdma);
 }
 #endif
 
-
 #endif /* STM32WBxx_HAL_ADC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_adc_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_adc_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -41,7 +40,7 @@ extern "C" {
   * @{
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -185,10 +184,10 @@ typedef struct
   * @{
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
-/** @defgroup ADC_injected_external_trigger_source ADC group injected trigger source
+/** @defgroup ADCEx_injected_external_trigger_source ADC group injected trigger source
   * @{
   */
 /* ADC group regular trigger sources for all ADC instances */
@@ -203,7 +202,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_injected_external_trigger_edge ADC group injected trigger edge (when external trigger is selected)
+/** @defgroup ADCEx_injected_external_trigger_edge ADC group injected trigger edge (when external trigger is selected)
   * @{
   */
 #define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           (0x00000000UL)        /*!< Injected conversions hardware trigger detection disabled                             */
@@ -215,18 +214,18 @@ typedef struct
   */
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-/** @defgroup ADC_HAL_EC_CHANNEL_SINGLE_DIFF_ENDING  Channel - Single or differential ending
+/** @defgroup ADCEx_HAL_EC_CHANNEL_SINGLE_DIFF_ENDING  Channel - Single or differential ending
   * @{
   */
 #define ADC_SINGLE_ENDED                (LL_ADC_SINGLE_ENDED)         /*!< ADC channel ending set to single ended (literal also used to set calibration mode) */
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_DIFFERENTIAL_ENDED          (LL_ADC_DIFFERENTIAL_ENDED)   /*!< ADC channel ending set to differential (literal also used to set calibration mode) */
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
 
-/** @defgroup ADC_HAL_EC_OFFSET_NB  ADC instance - Offset number
+/** @defgroup ADCEx_HAL_EC_OFFSET_NB  ADC instance - Offset number
   * @{
   */
 #define ADC_OFFSET_NONE              (ADC_OFFSET_4 + 1U) /*!< ADC offset disabled: no offset correction for the selected ADC channel */
@@ -238,10 +237,10 @@ typedef struct
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
-/** @defgroup ADC_INJ_SEQ_RANKS  ADC group injected - Sequencer ranks
+/** @defgroup ADCEx_INJ_SEQ_RANKS  ADC group injected - Sequencer ranks
   * @{
   */
 #define ADC_INJECTED_RANK_1                (LL_ADC_INJ_RANK_1) /*!< ADC group injected sequencer rank 1 */
@@ -253,11 +252,11 @@ typedef struct
   */
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-/** @defgroup ADC_HAL_EC_GROUPS  ADC instance - Groups
+/** @defgroup ADCEx_HAL_EC_GROUPS  ADC instance - Groups
   * @{
   */
 #define ADC_REGULAR_GROUP                  (LL_ADC_GROUP_REGULAR)           /*!< ADC group regular (available on all STM32 devices) */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 #define ADC_INJECTED_GROUP                 (LL_ADC_GROUP_INJECTED)          /*!< ADC group injected (not available on all STM32 devices)*/
@@ -267,7 +266,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_CFGR_fields ADCx CFGR fields
+/** @defgroup ADCEx_CFGR_fields ADCx CFGR fields
   * @{
   */
 #define ADC_CFGR_FIELDS    (ADC_CFGR_AWD1CH  | ADC_CFGR_JAUTO   | ADC_CFGR_JAWD1EN |\
@@ -280,7 +279,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_SMPR1_fields ADCx SMPR1 fields
+/** @defgroup ADCEx_SMPR1_fields ADCx SMPR1 fields
   * @{
   */
 #define ADC_SMPR1_FIELDS    (ADC_SMPR1_SMP9 | ADC_SMPR1_SMP8 | ADC_SMPR1_SMP7 |\
@@ -291,7 +290,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup ADC_CFGR_fields_2 ADCx CFGR sub fields
+/** @defgroup ADCEx_CFGR_fields_2 ADCx CFGR sub fields
   * @{
   */
 /* ADC_CFGR fields of parameters that can be updated when no conversion
@@ -333,7 +332,7 @@ typedef struct
   */
 #define ADC_IS_INDEPENDENT(__HANDLE__)   (SET)
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -387,11 +386,11 @@ typedef struct
   */
 #define ADC_CFGR_CONTINUOUS(__CONTINUOUS_MODE__) ((__CONTINUOUS_MODE__) << ADC_CFGR_CONT_Pos)
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief Enable ADC overrun mode.
   * @param _OVERRUN_MODE_ Overrun mode.
-  * @retval Overun bit setting to be programmed into CFGR register
+  * @retval Overrun bit setting to be programmed into CFGR register
   */
 /* Note: Bit ADC_CFGR1_OVRMOD not used directly in constant                   */
 /* "ADC_OVR_DATA_OVERWRITTEN" to have this case defined to 0x00, to set it    */
@@ -427,7 +426,7 @@ typedef struct
      (ADC_CFGR1_CHSELRMOD)                                                     \
   )
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief Configure the ADC DMA continuous request.
   * @param __DMACONTREQ_MODE__ DMA continuous request mode.
@@ -463,13 +462,13 @@ typedef struct
   * @param __THRESHOLD__ Value to be shifted
   * @retval None
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__) \
   ((__THRESHOLD__) << ((((__HANDLE__)->Instance->CFGR1 & ADC_CFGR1_RES) >> 3UL) * 2UL))
 #else
 #define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__) \
   ((__THRESHOLD__) << ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3UL) * 2UL))
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Shift the AWD2 and AWD3 threshold with respect to the selected ADC resolution.
@@ -482,7 +481,7 @@ typedef struct
   * @param __THRESHOLD__ Value to be shifted
   * @retval None
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__)                                       \
   ((((__HANDLE__)->Instance->CFGR1 & ADC_CFGR1_RES) != (ADC_CFGR1_RES_1 | ADC_CFGR1_RES_0))                    ? \
    ((__THRESHOLD__) >> ((4UL - ((((__HANDLE__)->Instance->CFGR1 & ADC_CFGR1_RES) >> 3UL) * 2UL)) & 0x1FUL)) : \
@@ -494,14 +493,14 @@ typedef struct
    ((__THRESHOLD__) >> ((4UL - ((((__HANDLE__)->Instance->CFGR & ADC_CFGR_RES) >> 3UL) * 2UL)) & 0x1FUL)) : \
    ((__THRESHOLD__) << 2UL)                                                                                 \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Clear Common Control Register.
   * @param __HANDLE__ ADC handle.
   * @retval None
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_CLEAR_COMMON_CONTROL_REGISTER(__HANDLE__) CLEAR_BIT(__LL_ADC_COMMON_INSTANCE((__HANDLE__)->Instance)->CCR, \
                                                                                                       ADC_CCR_PRESC  | \
                                                                                                       ADC_CCR_VBATEN | \
@@ -513,7 +512,7 @@ typedef struct
                                                                                                       ADC_CCR_VBATEN | \
                                                                                                       ADC_CCR_TSEN   | \
                                                                                                       ADC_CCR_VREFEN )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 
 /**
@@ -537,7 +536,7 @@ typedef struct
   */
 #define ADC_VREFINT_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC1)
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -613,12 +612,12 @@ typedef struct
   * @param __SING_DIFF__ programmed channel setting.
   * @retval SET (__SING_DIFF__ is valid) or RESET (__SING_DIFF__ is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_SINGLE_DIFFERENTIAL(__SING_DIFF__) ((__SING_DIFF__) == ADC_SINGLE_ENDED)
 #else
 #define IS_ADC_SINGLE_DIFFERENTIAL(__SING_DIFF__) (((__SING_DIFF__) == ADC_SINGLE_ENDED)      || \
                                                    ((__SING_DIFF__) == ADC_DIFFERENTIAL_ENDED)  )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC offset management setting.
@@ -631,7 +630,7 @@ typedef struct
                                                  ((__OFFSET_NUMBER__) == ADC_OFFSET_3)    || \
                                                  ((__OFFSET_NUMBER__) == ADC_OFFSET_4)      )
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -674,20 +673,20 @@ typedef struct
   * @param __WATCHDOG__ programmed ADC analog watchdog setting.
   * @retval SET (__WATCHDOG__ is valid) or RESET (__WATCHDOG__ is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_ANALOG_WATCHDOG_NUMBER(__WATCHDOG__) ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_1)
 #else
 #define IS_ADC_ANALOG_WATCHDOG_NUMBER(__WATCHDOG__) (((__WATCHDOG__) == ADC_ANALOGWATCHDOG_1) || \
                                                      ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_2) || \
                                                      ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_3)   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC analog watchdog mode setting.
   * @param __WATCHDOG_MODE__ programmed ADC analog watchdog mode setting.
   * @retval SET (__WATCHDOG_MODE__ is valid) or RESET (__WATCHDOG_MODE__ is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_ANALOG_WATCHDOG_MODE(__WATCHDOG_MODE__) (((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_NONE)             || \
                                                         ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_REG)       || \
                                                         ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_REG)            )
@@ -701,10 +700,10 @@ typedef struct
                                                         ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_REGINJEC)       )
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_TRIGGER_FREQ(TRIGGER_FREQ) (((TRIGGER_FREQ) == LL_ADC_TRIGGER_FREQ_HIGH) || \
                                            ((TRIGGER_FREQ) == LL_ADC_TRIGGER_FREQ_LOW)    )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC conversion (regular or injected or both).
@@ -720,7 +719,7 @@ typedef struct
   * @param __EVENT__ ADC event.
   * @retval SET (__EVENT__ is valid) or RESET (__EVENT__ is invalid)
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_ADC_EVENT_TYPE(__EVENT__) (((__EVENT__) == ADC_EOSMP_EVENT) || \
                                       ((__EVENT__) == ADC_AWD1_EVENT)  || \
                                       ((__EVENT__) == ADC_AWD2_EVENT)  || \
@@ -735,7 +734,7 @@ typedef struct
                                       ((__EVENT__) == ADC_JQOVF_EVENT)  )
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC oversampling" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -751,7 +750,7 @@ typedef struct
                                                    ((__RATIO__) == ADC_OVERSAMPLING_RATIO_64  ) || \
                                                    ((__RATIO__) == ADC_OVERSAMPLING_RATIO_128 ) || \
                                                    ((__RATIO__) == ADC_OVERSAMPLING_RATIO_256 ))
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the ADC oversampling shift.
@@ -776,7 +775,7 @@ typedef struct
 #define IS_ADC_TRIGGERED_OVERSAMPLING_MODE(__MODE__) (((__MODE__) == ADC_TRIGGEREDMODE_SINGLE_TRIGGER) || \
                                                       ((__MODE__) == ADC_TRIGGEREDMODE_MULTI_TRIGGER) )
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #else
 /**
   * @brief Verify the ADC oversampling regular conversion resumed or continued mode.
@@ -785,7 +784,7 @@ typedef struct
   */
 #define IS_ADC_REGOVERSAMPLING_MODE(__MODE__) (((__MODE__) == ADC_REGOVERSAMPLING_CONTINUED_MODE) || \
                                                ((__MODE__) == ADC_REGOVERSAMPLING_RESUMED_MODE) )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief Verify the DFSDM mode configuration.
@@ -824,11 +823,11 @@ typedef struct
 
 /* ADC calibration */
 HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
-uint32_t                HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
+uint32_t                HAL_ADCEx_Calibration_GetValue(const ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
 HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff,
                                                        uint32_t CalibrationFactor);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /* Blocking mode: Polling */
@@ -841,15 +840,15 @@ HAL_StatusTypeDef       HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef *hadc);
 HAL_StatusTypeDef       HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef *hadc);
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /* ADC retrieve conversion value intended to be used with polling or interruption */
-uint32_t                HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef *hadc, uint32_t InjectedRank);
+uint32_t                HAL_ADCEx_InjectedGetValue(const ADC_HandleTypeDef *hadc, uint32_t InjectedRank);
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
 /* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption) */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 void                    HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *hadc);
@@ -859,7 +858,7 @@ void                    HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef *h
 void                    HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef *hadc);
 void                    HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef *hadc);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /* ADC group regular conversions stop */
@@ -875,23 +874,23 @@ HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef *hadc);
   * @{
   */
 /* Peripheral Control functions ***********************************************/
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
-HAL_StatusTypeDef       HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc,ADC_InjectionConfTypeDef* sConfigInjected);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc, const ADC_InjectionConfTypeDef* sConfigInjected);
 #endif /* ADC_SUPPORT_2_5_MSPS */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 HAL_StatusTypeDef       HAL_ADCEx_EnableInjectedQueue(ADC_HandleTypeDef *hadc);
 HAL_StatusTypeDef       HAL_ADCEx_DisableInjectedQueue(ADC_HandleTypeDef *hadc);
 #endif /* ADC_SUPPORT_2_5_MSPS */
 HAL_StatusTypeDef       HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef *hadc);
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature " ADC deep power-down" not available on ADC peripheral of this STM32WB device */
 #else
 HAL_StatusTypeDef       HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef *hadc);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @}
@@ -914,6 +913,3 @@ HAL_StatusTypeDef       HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef *h
 #endif
 
 #endif /* STM32WBxx_HAL_ADC_EX_H */
-
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_comp.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_comp.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -52,7 +51,8 @@ typedef struct
 #if defined(COMP2)
   uint32_t WindowMode;         /*!< Set window mode of a pair of comparators instances
                                     (2 consecutive instances odd and even COMP<x> and COMP<x+1>).
-                                    Note: HAL COMP driver allows to set window mode from any COMP instance of the pair of COMP instances composing window mode.
+                                    Note: HAL COMP driver allows to set window mode from any COMP
+                                    instance of the pair of COMP instances composing window mode.
                                     This parameter can be a value of @ref COMP_WindowMode */
 #endif /* COMP2 */
 
@@ -102,7 +102,7 @@ typedef enum
 typedef struct __COMP_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_COMP_REGISTER_CALLBACKS */
 {
   COMP_TypeDef       *Instance;       /*!< Register base address    */
   COMP_InitTypeDef   Init;            /*!< COMP required parameters */
@@ -154,16 +154,26 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   * @}
   */
 
+
 #if defined(COMP2)
 /** @defgroup COMP_WindowMode COMP Window Mode
   * @{
   */
-#define COMP_WINDOWMODE_DISABLE                 (0x00000000UL)         /*!< Window mode disable: Comparators instances pair COMP1 and COMP2 are independent */
-#define COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON (COMP_CSR_WINMODE)     /*!< Window mode enable: Comparators instances pair COMP1 and COMP2 have their input plus connected together. The common input is COMP1 input plus (COMP2 input plus is no more accessible). */
+#define COMP_WINDOWMODE_DISABLE                 (0x00000000UL)            /*!< Window mode disable: Comparators
+                                                                               instances pair COMP1 and COMP2 are
+                                                                               independent */
+#define COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON (COMP_CSR_WINMODE)        /*!< Window mode enable: Comparators instances
+                                                                               pair COMP1 and COMP2 have their input
+                                                                               plus connected together.
+                                                                               The common input is COMP1 input plus
+                                                                               (COMP2 input plus is no more accessible).
+                                                                               */
 /**
   * @}
   */
-#endif
+#endif /* COMP2 */
+
+
 
 /** @defgroup COMP_PowerMode COMP power mode
   * @{
@@ -181,7 +191,11 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 /** @defgroup COMP_InputPlus COMP input plus (non-inverting input)
   * @{
   */
-#define COMP_INPUT_PLUS_IO1            (0x00000000UL)         /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1 (except device STM32WB35xx), pin PB4 for COMP2). Note: On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx. */
+#if defined(STM32WB15xx) || defined(STM32WB10xx) || defined(STM32WB1Mxx)
+/* COMP_INPUT_PLUS_IO1 not available on this device */
+#else
+#define COMP_INPUT_PLUS_IO1            (0x00000000UL)         /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1 (except device STM32WB35xx), pin PB4 for COMP2). Note: On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx. */
+#endif
 #define COMP_INPUT_PLUS_IO2            (COMP_CSR_INPSEL_0)    /*!< Comparator input plus connected to IO2 (pin PB2 for COMP1, pin PB6 for COMP2) */
 #define COMP_INPUT_PLUS_IO3            (COMP_CSR_INPSEL_1)    /*!< Comparator input plus connected to IO3 (pin PA1 for COMP1, pin PA3 for COMP2) */
 /**
@@ -196,7 +210,11 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 #define COMP_INPUT_MINUS_3_4VREFINT    (                    COMP_CSR_INMSEL_1                     | COMP_CSR_SCALEN | COMP_CSR_BRGEN)        /*!< Comparator input minus connected to 3/4 VrefInt */
 #define COMP_INPUT_MINUS_VREFINT       (                    COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0 | COMP_CSR_SCALEN                 )        /*!< Comparator input minus connected to VrefInt */
 #define COMP_INPUT_MINUS_IO1           (COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1                    )                                           /*!< Comparator input minus connected to IO1 (pin PB1 for COMP1, pin PB3 for COMP2) */
-#define COMP_INPUT_MINUS_IO2           (COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0)                                           /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1 (except device STM32WB35xx), pin PB7 for COMP2). Note: On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx. */
+#if defined(STM32WB15xx) || defined(STM32WB10xx) || defined(STM32WB1Mxx)
+/* COMP_INPUT_MINUS_IO2 not available on this device */
+#else
+#define COMP_INPUT_MINUS_IO2           (COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0)                                           /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1 (except device STM32WB35xx), pin PB7 for COMP2). Note: On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx. */
+#endif /* STM32WB51xx || STM32WB10xx */
 #define COMP_INPUT_MINUS_IO3           (                     COMP_CSR_INMESEL_0 | COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO3 (pin PA0 for COMP1, pin PA2 for COMP2) */
 #define COMP_INPUT_MINUS_IO4           (COMP_CSR_INMESEL_1                      | COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO4 (pin PA4 for COMP1, pin PA4 for COMP2) */
 #define COMP_INPUT_MINUS_IO5           (COMP_CSR_INMESEL_1 | COMP_CSR_INMESEL_0 | COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO5 (pin PA5 for COMP1, pin PA5 for COMP2) */
@@ -291,7 +309,7 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
                                                     } while(0)
 #else
 #define __HAL_COMP_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_COMP_STATE_RESET)
-#endif
+#endif /* USE_HAL_COMP_REGISTER_CALLBACKS */
 
 /**
   * @brief Clear COMP error code (set it to no error code "HAL_COMP_ERROR_NONE").
@@ -305,14 +323,14 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   * @param  __HANDLE__  COMP handle
   * @retval None
   */
-#define __HAL_COMP_ENABLE(__HANDLE__)              SET_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_EN)
+#define __HAL_COMP_ENABLE(__HANDLE__)       SET_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_EN)
 
 /**
   * @brief  Disable the specified comparator.
   * @param  __HANDLE__  COMP handle
   * @retval None
   */
-#define __HAL_COMP_DISABLE(__HANDLE__)             CLEAR_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_EN)
+#define __HAL_COMP_DISABLE(__HANDLE__)      CLEAR_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_EN)
 
 /**
   * @brief  Lock the specified comparator configuration.
@@ -323,14 +341,14 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   * @param  __HANDLE__  COMP handle
   * @retval None
   */
-#define __HAL_COMP_LOCK(__HANDLE__)                SET_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_LOCK)
+#define __HAL_COMP_LOCK(__HANDLE__)         SET_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_LOCK)
 
 /**
   * @brief  Check whether the specified comparator is locked.
   * @param  __HANDLE__  COMP handle
   * @retval Value 0 if COMP instance is not locked, value 1 if COMP instance is locked
   */
-#define __HAL_COMP_IS_LOCKED(__HANDLE__)           (READ_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_LOCK) == COMP_CSR_LOCK)
+#define __HAL_COMP_IS_LOCKED(__HANDLE__)    (READ_BIT((__HANDLE__)->Instance->CSR, COMP_CSR_LOCK) == COMP_CSR_LOCK)
 
 /**
   * @}
@@ -339,7 +357,6 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 /** @defgroup COMP_Exti_Management  COMP external interrupt line management
   * @{
   */
-
 /**
   * @brief  Enable the COMP1 EXTI line rising edge trigger.
   * @retval None
@@ -368,19 +385,19 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   * @brief  Enable the COMP1 EXTI line rising & falling edge trigger.
   * @retval None
   */
-#define __HAL_COMP_COMP1_EXTI_ENABLE_RISING_FALLING_EDGE()   do { \
-                                                               LL_EXTI_EnableRisingTrig_0_31(COMP_EXTI_LINE_COMP1); \
-                                                               LL_EXTI_EnableFallingTrig_0_31(COMP_EXTI_LINE_COMP1); \
-                                                             } while(0)
+#define __HAL_COMP_COMP1_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                                        \
+                                                                LL_EXTI_EnableRisingTrig_0_31(COMP_EXTI_LINE_COMP1);   \
+                                                                LL_EXTI_EnableFallingTrig_0_31(COMP_EXTI_LINE_COMP1);  \
+                                                              } while(0)
 
 /**
   * @brief  Disable the COMP1 EXTI line rising & falling edge trigger.
   * @retval None
   */
-#define __HAL_COMP_COMP1_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
-                                                               LL_EXTI_DisableRisingTrig_0_31(COMP_EXTI_LINE_COMP1); \
-                                                               LL_EXTI_DisableFallingTrig_0_31(COMP_EXTI_LINE_COMP1); \
-                                                             } while(0)
+#define __HAL_COMP_COMP1_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                                       \
+                                                                 LL_EXTI_DisableRisingTrig_0_31(COMP_EXTI_LINE_COMP1); \
+                                                                 LL_EXTI_DisableFallingTrig_0_31(COMP_EXTI_LINE_COMP1);\
+                                                               } while(0)
 
 /**
   * @brief  Enable the COMP1 EXTI line in interrupt mode.
@@ -453,19 +470,19 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
   * @brief  Enable the COMP2 EXTI line rising & falling edge trigger.
   * @retval None
   */
-#define __HAL_COMP_COMP2_EXTI_ENABLE_RISING_FALLING_EDGE()   do { \
-                                                               LL_EXTI_EnableRisingTrig_0_31(COMP_EXTI_LINE_COMP2); \
-                                                               LL_EXTI_EnableFallingTrig_0_31(COMP_EXTI_LINE_COMP2); \
-                                                             } while(0)
+#define __HAL_COMP_COMP2_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                                        \
+                                                                LL_EXTI_EnableRisingTrig_0_31(COMP_EXTI_LINE_COMP2);   \
+                                                                LL_EXTI_EnableFallingTrig_0_31(COMP_EXTI_LINE_COMP2);  \
+                                                              } while(0)
 
 /**
   * @brief  Disable the COMP2 EXTI line rising & falling edge trigger.
   * @retval None
   */
-#define __HAL_COMP_COMP2_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
-                                                               LL_EXTI_DisableRisingTrig_0_31(COMP_EXTI_LINE_COMP2); \
-                                                               LL_EXTI_DisableFallingTrig_0_31(COMP_EXTI_LINE_COMP2); \
-                                                             } while(0)
+#define __HAL_COMP_COMP2_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                                       \
+                                                                 LL_EXTI_DisableRisingTrig_0_31(COMP_EXTI_LINE_COMP2); \
+                                                                 LL_EXTI_DisableFallingTrig_0_31(COMP_EXTI_LINE_COMP2);\
+                                                               } while(0)
 
 /**
   * @brief  Enable the COMP2 EXTI line in interrupt mode.
@@ -580,7 +597,7 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 #if defined(COMP2)
 #define IS_COMP_WINDOWMODE(__WINDOWMODE__)  (((__WINDOWMODE__) == COMP_WINDOWMODE_DISABLE)                || \
                                              ((__WINDOWMODE__) == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)  )
-#endif
+#endif /* COMP2 */
 
 #define IS_COMP_POWERMODE(__POWERMODE__)    (((__POWERMODE__) == COMP_POWERMODE_HIGHSPEED)    || \
                                              ((__POWERMODE__) == COMP_POWERMODE_MEDIUMSPEED)  || \
@@ -593,12 +610,12 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 #else
 #define IS_COMP_INPUT_PLUS(__COMP_INSTANCE__, __INPUT_PLUS__) (((__INPUT_PLUS__) == COMP_INPUT_PLUS_IO2) || \
                                                                ((__INPUT_PLUS__) == COMP_INPUT_PLUS_IO3))
-#endif
+#endif /* COMP_INPUT_PLUS_IO1 */
 
 /* Note: On this STM32 series, comparator input minus parameters are          */
 /*       the same on all COMP instances.                                      */
 /*       However, comparator instance kept as macro parameter for             */
-/*       compatibility with other STM32 families.                             */
+/*       compatibility with other STM32 series.                               */
 #if defined(COMP_INPUT_MINUS_IO2)
 #define IS_COMP_INPUT_MINUS(__COMP_INSTANCE__, __INPUT_MINUS__) (((__INPUT_MINUS__) == COMP_INPUT_MINUS_1_4VREFINT)  || \
                                                                  ((__INPUT_MINUS__) == COMP_INPUT_MINUS_1_2VREFINT)  || \
@@ -629,7 +646,7 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
                                              ((__POL__) == COMP_OUTPUTPOL_INVERTED))
 
 #define IS_COMP_BLANKINGSRCE(__OUTPUT_BLANKING_SOURCE__)                    \
-  (   ((__OUTPUT_BLANKING_SOURCE__) == COMP_BLANKINGSRC_NONE)               \
+  (((__OUTPUT_BLANKING_SOURCE__) == COMP_BLANKINGSRC_NONE)                  \
    || ((__OUTPUT_BLANKING_SOURCE__) == COMP_BLANKINGSRC_TIM1_OC5)           \
    || ((__OUTPUT_BLANKING_SOURCE__) == COMP_BLANKINGSRC_TIM2_OC3)           \
   )
@@ -637,7 +654,7 @@ typedef  void (*pCOMP_CallbackTypeDef)(COMP_HandleTypeDef *hcomp); /*!< pointer 
 /* Note: Output blanking source common to all COMP instances */
 /*       Macro kept for compatibility with other STM32 series */
 #define IS_COMP_BLANKINGSRC_INSTANCE(__INSTANCE__, __OUTPUT_BLANKING_SOURCE__)  \
-   (IS_COMP_BLANKINGSRCE(__OUTPUT_BLANKING_SOURCE__))
+  (IS_COMP_BLANKINGSRCE(__OUTPUT_BLANKING_SOURCE__))
 
 
 #define IS_COMP_TRIGGERMODE(__MODE__)       (((__MODE__) == COMP_TRIGGERMODE_NONE)                 || \
@@ -701,7 +718,7 @@ void              HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp);
   * @{
   */
 HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp);
-uint32_t          HAL_COMP_GetOutputLevel(COMP_HandleTypeDef *hcomp);
+uint32_t          HAL_COMP_GetOutputLevel(const COMP_HandleTypeDef *hcomp);
 /* Callback in interrupt mode */
 void              HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp);
 /**
@@ -712,8 +729,8 @@ void              HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp);
 /** @addtogroup COMP_Exported_Functions_Group4
   * @{
   */
-HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp);
-uint32_t              HAL_COMP_GetError(COMP_HandleTypeDef *hcomp);
+HAL_COMP_StateTypeDef HAL_COMP_GetState(const COMP_HandleTypeDef *hcomp);
+uint32_t              HAL_COMP_GetError(const COMP_HandleTypeDef *hcomp);
 /**
   * @}
   */
@@ -735,5 +752,3 @@ uint32_t              HAL_COMP_GetError(COMP_HandleTypeDef *hcomp);
 #endif
 
 #endif /* STM32WBxx_HAL_COMP_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_conf_template.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_conf_template.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,7 +21,7 @@
 #define STM32WBxx_HAL_CONF_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Exported types ------------------------------------------------------------*/
@@ -87,6 +86,8 @@
 #define USE_HAL_USART_REGISTER_CALLBACKS     0u
 #define USE_HAL_WWDG_REGISTER_CALLBACKS      0u
 
+#define USE_HAL_CRYP_SUSPEND_RESUME 0u
+
 /* ########################## Oscillator Values adaptation ####################*/
 /**
   * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
@@ -95,11 +96,11 @@
   */
 
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    (32000000UL) /*!< Value of the External oscillator in Hz */
+#define HSE_VALUE    (32000000UL) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT    (100UL)   /*!< Time out for HSE start up, in ms */
+#define HSE_STARTUP_TIMEOUT    (100UL)   /*!< Time out for HSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**
@@ -107,7 +108,7 @@
   *        This value is the default MSI range value after Reset.
   */
 #if !defined  (MSI_VALUE)
-  #define MSI_VALUE    (4000000UL) /*!< Value of the Internal oscillator in Hz*/
+#define MSI_VALUE    (4000000UL) /*!< Value of the Internal oscillator in Hz*/
 #endif /* MSI_VALUE */
 
 /**
@@ -116,14 +117,14 @@
   *        (when HSI is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSI_VALUE)
-  #define HSI_VALUE    (16000000UL) /*!< Value of the Internal oscillator in Hz*/
+#define HSI_VALUE    (16000000UL) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
 /**
   * @brief Internal Low Speed oscillator (LSI1) value.
   */
 #if !defined  (LSI1_VALUE)
- #define LSI1_VALUE  (32000UL)       /*!< LSI1 Typical Value in Hz*/
+#define LSI1_VALUE  (32000UL)       /*!< LSI1 Typical Value in Hz*/
 #endif /* LSI1_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
                                              The real value may vary depending on the variations
                                              in voltage and temperature.*/
@@ -131,7 +132,7 @@
   * @brief Internal Low Speed oscillator (LSI2) value.
   */
 #if !defined  (LSI2_VALUE)
- #define LSI2_VALUE  (32000UL)       /*!< LSI2 Typical Value in Hz*/
+#define LSI2_VALUE  (32000UL)       /*!< LSI2 Typical Value in Hz*/
 #endif /* LSI2_VALUE */                      /*!< Value of the Internal Low Speed oscillator in Hz
                                              The real value may vary depending on the variations
                                              in voltage and temperature.*/
@@ -141,7 +142,11 @@
   *        This value is used by the UART, RTC HAL module to compute the system frequency
   */
 #if !defined  (LSE_VALUE)
-  #define LSE_VALUE    (32768UL) /*!< Value of the External oscillator in Hz*/
+#if defined(STM32WB5Mxx)
+#define LSE_VALUE    (32774UL)     /*!< Value of the LSE oscillator in Hz */
+#else
+#define LSE_VALUE    (32768UL)     /*!< Value of the LSE oscillator in Hz */
+#endif /* STM32WB5Mxx */
 #endif /* LSE_VALUE */
 
 /**
@@ -149,11 +154,11 @@
   *        This value is the default HSI48 range value after Reset.
   */
 #if !defined (HSI48_VALUE)
-  #define HSI48_VALUE    (48000000UL) /*!< Value of the Internal oscillator in Hz*/
+#define HSI48_VALUE    (48000000UL) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI48_VALUE */
 
 #if !defined (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    (5000UL)   /*!< Time out for LSE start up, in ms */
+#define LSE_STARTUP_TIMEOUT    (5000UL)   /*!< Time out for LSE start up, in ms */
 #endif /* LSE_STARTUP_TIMEOUT */
 
 /**
@@ -162,7 +167,7 @@
   *        frequency.
   */
 #if !defined (EXTERNAL_SAI1_CLOCK_VALUE)
-  #define EXTERNAL_SAI1_CLOCK_VALUE    (48000UL) /*!< Value of the SAI1 External clock source in Hz*/
+#define EXTERNAL_SAI1_CLOCK_VALUE    (48000UL) /*!< Value of the SAI1 External clock source in Hz*/
 #endif /* EXTERNAL_SAI1_CLOCK_VALUE */
 
 /* Tip: To avoid modifying this file each time you need to use different HSE,
@@ -200,131 +205,131 @@
   * @brief Include module's header file
   */
 #ifdef HAL_DMA_MODULE_ENABLED
-  #include "stm32wbxx_hal_dma.h"
+#include "stm32wbxx_hal_dma.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-  #include "stm32wbxx_hal_adc.h"
+#include "stm32wbxx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-  #include "stm32wbxx_hal_comp.h"
+#include "stm32wbxx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CORTEX_MODULE_ENABLED
-  #include "stm32wbxx_hal_cortex.h"
+#include "stm32wbxx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-  #include "stm32wbxx_hal_crc.h"
+#include "stm32wbxx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_CRYP_MODULE_ENABLED
-  #include "stm32wbxx_hal_cryp.h"
+#include "stm32wbxx_hal_cryp.h"
 #endif /* HAL_CRYP_MODULE_ENABLED */
 
 #ifdef HAL_EXTI_MODULE_ENABLED
-  #include "stm32wbxx_hal_exti.h"
+#include "stm32wbxx_hal_exti.h"
 #endif /* HAL_EXTI_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-  #include "stm32wbxx_hal_flash.h"
+#include "stm32wbxx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_GPIO_MODULE_ENABLED
-  #include "stm32wbxx_hal_gpio.h"
+#include "stm32wbxx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_HSEM_MODULE_ENABLED
-  #include "stm32wbxx_hal_hsem.h"
+#include "stm32wbxx_hal_hsem.h"
 #endif /* HAL_HSEM_MODULE_ENABLED */
 
 #ifdef HAL_I2C_MODULE_ENABLED
- #include "stm32wbxx_hal_i2c.h"
+#include "stm32wbxx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_IPCC_MODULE_ENABLED
- #include "stm32wbxx_hal_ipcc.h"
+#include "stm32wbxx_hal_ipcc.h"
 #endif /* HAL_IPCC_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
- #include "stm32wbxx_hal_irda.h"
+#include "stm32wbxx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
- #include "stm32wbxx_hal_iwdg.h"
+#include "stm32wbxx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_LCD_MODULE_ENABLED
- #include "stm32wbxx_hal_lcd.h"
+#include "stm32wbxx_hal_lcd.h"
 #endif /* HAL_LCD_MODULE_ENABLED */
 
 #ifdef HAL_LPTIM_MODULE_ENABLED
-  #include "stm32wbxx_hal_lptim.h"
+#include "stm32wbxx_hal_lptim.h"
 #endif /* HAL_LPTIM_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-  #include "stm32wbxx_hal_pcd.h"
+#include "stm32wbxx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
 
 #ifdef HAL_PKA_MODULE_ENABLED
-  #include "stm32wbxx_hal_pka.h"
+#include "stm32wbxx_hal_pka.h"
 #endif /* HAL_PKA_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
- #include "stm32wbxx_hal_pwr.h"
+#include "stm32wbxx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_QSPI_MODULE_ENABLED
- #include "stm32wbxx_hal_qspi.h"
+#include "stm32wbxx_hal_qspi.h"
 #endif /* HAL_QSPI_MODULE_ENABLED */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-  #include "stm32wbxx_hal_rcc.h"
+#include "stm32wbxx_hal_rcc.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
 
 #ifdef HAL_RNG_MODULE_ENABLED
-  #include "stm32wbxx_hal_rng.h"
+#include "stm32wbxx_hal_rng.h"
 #endif /* HAL_RNG_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
- #include "stm32wbxx_hal_rtc.h"
+#include "stm32wbxx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SAI_MODULE_ENABLED
- #include "stm32wbxx_hal_sai.h"
+#include "stm32wbxx_hal_sai.h"
 #endif /* HAL_SAI_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
- #include "stm32wbxx_hal_smartcard.h"
+#include "stm32wbxx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_SMBUS_MODULE_ENABLED
- #include "stm32wbxx_hal_smbus.h"
+#include "stm32wbxx_hal_smbus.h"
 #endif /* HAL_SMBUS_MODULE_ENABLED */
 
 #ifdef HAL_SPI_MODULE_ENABLED
- #include "stm32wbxx_hal_spi.h"
+#include "stm32wbxx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
- #include "stm32wbxx_hal_tim.h"
+#include "stm32wbxx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_TSC_MODULE_ENABLED
-  #include "stm32wbxx_hal_tsc.h"
+#include "stm32wbxx_hal_tsc.h"
 #endif /* HAL_TSC_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
- #include "stm32wbxx_hal_uart.h"
+#include "stm32wbxx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
- #include "stm32wbxx_hal_usart.h"
+#include "stm32wbxx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
- #include "stm32wbxx_hal_wwdg.h"
+#include "stm32wbxx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 /* Exported macro ------------------------------------------------------------*/
@@ -337,11 +342,11 @@
   *         If expr is true, it returns no value.
   * @retval None
   */
-  #define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+#define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
 /* Exported functions ------------------------------------------------------- */
-  void assert_failed(uint8_t* file, uint32_t line);
+void assert_failed(uint8_t *file, uint32_t line);
 #else
-  #define assert_param(expr) ((void)0U)
+#define assert_param(expr) ((void)0U)
 #endif /* USE_FULL_ASSERT */
 
 #ifdef __cplusplus
@@ -349,5 +354,3 @@
 #endif
 
 #endif /* STM32WBxx_HAL_CONF_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_cortex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_cortex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,7 +21,7 @@
 #define STM32WBxx_HAL_CORTEX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -71,7 +70,7 @@ typedef struct
                                       This parameter can be a value of @ref CORTEX_MPU_Access_Cacheable             */
   uint8_t IsBufferable;          /*!< Specifies the bufferable status of the protected region.
                                       This parameter can be a value of @ref CORTEX_MPU_Access_Bufferable            */
-}MPU_Region_InitTypeDef;
+} MPU_Region_InitTypeDef;
 /**
   * @}
   */
@@ -263,12 +262,12 @@ typedef struct
   */
 
 /** @defgroup CORTEX_Exported_Functions_Group1 Initialization and Configuration functions
- *  @brief    Initialization and Configuration functions
- * @{
- */
+  * @brief    Initialization and Configuration functions
+  * @{
+  */
 /* Initialization and Configuration functions *****************************/
 void HAL_NVIC_SetPriorityGrouping(uint32_t PriorityGroup);
-void HAL_NVIC_SetPriority(IRQn_Type IRQn,uint32_t PreemptPriority, uint32_t SubPriority);
+void HAL_NVIC_SetPriority(IRQn_Type IRQn, uint32_t PreemptPriority, uint32_t SubPriority);
 void HAL_NVIC_EnableIRQ(IRQn_Type IRQn);
 void HAL_NVIC_DisableIRQ(IRQn_Type IRQn);
 void HAL_NVIC_SystemReset(void);
@@ -278,11 +277,11 @@ uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
   */
 
 /** @defgroup CORTEX_Exported_Functions_Group2 Peripheral Control functions
- *  @brief   Cortex control functions
- * @{
- */
+  * @brief   Cortex control functions
+  * @{
+  */
 /* Peripheral Control functions *************************************************/
-void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t* pPreemptPriority, uint32_t* pSubPriority);
+void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t *pPreemptPriority, uint32_t *pSubPriority);
 uint32_t HAL_NVIC_GetPriorityGrouping(void);
 uint32_t HAL_NVIC_GetPendingIRQ(IRQn_Type IRQn);
 void HAL_NVIC_SetPendingIRQ(IRQn_Type IRQn);
@@ -294,6 +293,8 @@ void HAL_SYSTICK_Callback(void);
 #if (__MPU_PRESENT == 1U)
 void HAL_MPU_Enable(uint32_t MPU_Control);
 void HAL_MPU_Disable(void);
+void HAL_MPU_EnableRegion(uint32_t RegionNumber);
+void HAL_MPU_DisableRegion(uint32_t RegionNumber);
 void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
 #endif /* __MPU_PRESENT */
 /**
@@ -362,34 +363,34 @@ void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
                                                    ((NUMBER) == MPU_REGION_NUMBER6) || \
                                                    ((NUMBER) == MPU_REGION_NUMBER7))
 
-#define IS_MPU_REGION_SIZE(SIZE)                  (((SIZE) == MPU_REGION_SIZE_32B)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_64B)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_128B)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_256B)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_512B)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_1KB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_2KB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_4KB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_8KB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_16KB)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_32KB)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_64KB)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_128KB) || \
-                                                   ((SIZE) == MPU_REGION_SIZE_256KB) || \
-                                                   ((SIZE) == MPU_REGION_SIZE_512KB) || \
-                                                   ((SIZE) == MPU_REGION_SIZE_1MB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_2MB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_4MB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_8MB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_16MB)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_32MB)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_64MB)  || \
-                                                   ((SIZE) == MPU_REGION_SIZE_128MB) || \
-                                                   ((SIZE) == MPU_REGION_SIZE_256MB) || \
-                                                   ((SIZE) == MPU_REGION_SIZE_512MB) || \
-                                                   ((SIZE) == MPU_REGION_SIZE_1GB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_2GB)   || \
-                                                   ((SIZE) == MPU_REGION_SIZE_4GB))
+#define IS_MPU_REGION_SIZE(SIZE)    (((SIZE) == MPU_REGION_SIZE_32B)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_64B)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_128B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_256B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_512B)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_1KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_8KB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_16KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_32KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_64KB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_128KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_256KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_512KB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_1MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_8MB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_16MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_32MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_64MB)  || \
+                                     ((SIZE) == MPU_REGION_SIZE_128MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_256MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_512MB) || \
+                                     ((SIZE) == MPU_REGION_SIZE_1GB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_2GB)   || \
+                                     ((SIZE) == MPU_REGION_SIZE_4GB))
 
 #define IS_MPU_SUB_REGION_DISABLE(SUBREGION)      ((SUBREGION) < (uint16_t)0x00FFU)
 #endif /* __MPU_PRESENT */
@@ -413,7 +414,3 @@ void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
 #endif
 
 #endif /* STM32WBxx_HAL_CORTEX_H */
-
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_crc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_crc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -60,19 +59,22 @@ typedef struct
 {
   uint8_t DefaultPolynomialUse;       /*!< This parameter is a value of @ref CRC_Default_Polynomial and indicates if default polynomial is used.
                                             If set to DEFAULT_POLYNOMIAL_ENABLE, resort to default
-                                            X^32 + X^26 + X^23 + X^22 + X^16 + X^12 + X^11 + X^10 +X^8 + X^7 + X^5 + X^4 + X^2+ X +1.
+                                            X^32 + X^26 + X^23 + X^22 + X^16 + X^12 + X^11 + X^10 +X^8 + X^7 + X^5 +
+                                            X^4 + X^2+ X +1.
                                             In that case, there is no need to set GeneratingPolynomial field.
-                                            If otherwise set to DEFAULT_POLYNOMIAL_DISABLE, GeneratingPolynomial and CRCLength fields must be set. */
+                                            If otherwise set to DEFAULT_POLYNOMIAL_DISABLE, GeneratingPolynomial and
+                                            CRCLength fields must be set. */
 
   uint8_t DefaultInitValueUse;        /*!< This parameter is a value of @ref CRC_Default_InitValue_Use and indicates if default init value is used.
                                            If set to DEFAULT_INIT_VALUE_ENABLE, resort to default
-                                           0xFFFFFFFF value. In that case, there is no need to set InitValue field.
-                                           If otherwise set to DEFAULT_INIT_VALUE_DISABLE,  InitValue field must be set. */
+                                           0xFFFFFFFF value. In that case, there is no need to set InitValue field. If
+                                           otherwise set to DEFAULT_INIT_VALUE_DISABLE, InitValue field must be set. */
 
   uint32_t GeneratingPolynomial;      /*!< Set CRC generating polynomial as a 7, 8, 16 or 32-bit long value for a polynomial degree
-                                           respectively equal to 7, 8, 16 or 32. This field is written in normal representation,
-                                           e.g., for a polynomial of degree 7, X^7 + X^6 + X^5 + X^2 + 1 is written 0x65.
-                                           No need to specify it if DefaultPolynomialUse is set to DEFAULT_POLYNOMIAL_ENABLE.   */
+                                           respectively equal to 7, 8, 16 or 32. This field is written in normal,
+                                           representation e.g., for a polynomial of degree 7, X^7 + X^6 + X^5 + X^2 + 1
+                                           is written 0x65. No need to specify it if DefaultPolynomialUse is set to
+                                            DEFAULT_POLYNOMIAL_ENABLE.   */
 
   uint32_t CRCLength;                 /*!< This parameter is a value of @ref CRC_Polynomial_Sizes and indicates CRC length.
                                            Value can be either one of
@@ -87,14 +89,18 @@ typedef struct
   uint32_t InputDataInversionMode;    /*!< This parameter is a value of @ref CRCEx_Input_Data_Inversion and specifies input data inversion mode.
                                            Can be either one of the following values
                                            @arg @ref CRC_INPUTDATA_INVERSION_NONE       no input data inversion
-                                           @arg @ref CRC_INPUTDATA_INVERSION_BYTE       byte-wise inversion, 0x1A2B3C4D becomes 0x58D43CB2
-                                           @arg @ref CRC_INPUTDATA_INVERSION_HALFWORD   halfword-wise inversion, 0x1A2B3C4D becomes 0xD458B23C
-                                           @arg @ref CRC_INPUTDATA_INVERSION_WORD       word-wise inversion, 0x1A2B3C4D becomes 0xB23CD458 */
+                                           @arg @ref CRC_INPUTDATA_INVERSION_BYTE       byte-wise inversion, 0x1A2B3C4D
+                                           becomes 0x58D43CB2
+                                           @arg @ref CRC_INPUTDATA_INVERSION_HALFWORD   halfword-wise inversion,
+                                           0x1A2B3C4D becomes 0xD458B23C
+                                           @arg @ref CRC_INPUTDATA_INVERSION_WORD       word-wise inversion, 0x1A2B3C4D
+                                           becomes 0xB23CD458 */
 
   uint32_t OutputDataInversionMode;   /*!< This parameter is a value of @ref CRCEx_Output_Data_Inversion and specifies output data (i.e. CRC) inversion mode.
                                             Can be either
                                             @arg @ref CRC_OUTPUTDATA_INVERSION_DISABLE   no CRC inversion,
-                                            @arg @ref CRC_OUTPUTDATA_INVERSION_ENABLE    CRC 0x11223344 is converted into 0x22CC4488 */
+                                            @arg @ref CRC_OUTPUTDATA_INVERSION_ENABLE    CRC 0x11223344 is converted
+                                             into 0x22CC4488 */
 } CRC_InitTypeDef;
 
 /**
@@ -112,12 +118,16 @@ typedef struct
 
   uint32_t InputDataFormat;                /*!< This parameter is a value of @ref CRC_Input_Buffer_Format and specifies input data format.
                                             Can be either
-                                            @arg @ref CRC_INPUTDATA_FORMAT_BYTES       input data is a stream of bytes (8-bit data)
-                                            @arg @ref CRC_INPUTDATA_FORMAT_HALFWORDS   input data is a stream of half-words (16-bit data)
-                                            @arg @ref CRC_INPUTDATA_FORMAT_WORDS       input data is a stream of words (32-bit data)
+                                            @arg @ref CRC_INPUTDATA_FORMAT_BYTES       input data is a stream of bytes
+                                            (8-bit data)
+                                            @arg @ref CRC_INPUTDATA_FORMAT_HALFWORDS   input data is a stream of
+                                            half-words (16-bit data)
+                                            @arg @ref CRC_INPUTDATA_FORMAT_WORDS       input data is a stream of words
+                                            (32-bit data)
 
-                                           Note that constant CRC_INPUT_FORMAT_UNDEFINED is defined but an initialization error
-                                           must occur if InputBufferFormat is not one of the three values listed above  */
+                                          Note that constant CRC_INPUT_FORMAT_UNDEFINED is defined but an initialization
+                                          error must occur if InputBufferFormat is not one of the three values listed
+                                          above  */
 } CRC_HandleTypeDef;
 /**
   * @}
@@ -199,15 +209,6 @@ typedef struct
   * @}
   */
 
-/** @defgroup CRC_Aliases CRC API aliases
-  * @{
-  */
-#define HAL_CRC_Input_Data_Reverse   HAL_CRCEx_Input_Data_Reverse    /*!< Aliased to HAL_CRCEx_Input_Data_Reverse for inter STM32 series compatibility  */
-#define HAL_CRC_Output_Data_Reverse  HAL_CRCEx_Output_Data_Reverse   /*!< Aliased to HAL_CRCEx_Output_Data_Reverse for inter STM32 series compatibility */
-/**
-  * @}
-  */
-
 /**
   * @}
   */
@@ -267,7 +268,6 @@ typedef struct
 #define IS_DEFAULT_POLYNOMIAL(DEFAULT) (((DEFAULT) == DEFAULT_POLYNOMIAL_ENABLE) || \
                                         ((DEFAULT) == DEFAULT_POLYNOMIAL_DISABLE))
 
-
 #define IS_DEFAULT_INIT_VALUE(VALUE)  (((VALUE) == DEFAULT_INIT_VALUE_ENABLE) || \
                                        ((VALUE) == DEFAULT_INIT_VALUE_DISABLE))
 
@@ -318,7 +318,7 @@ uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t
 /** @defgroup CRC_Exported_Functions_Group3 Peripheral State functions
   * @{
   */
-HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc);
+HAL_CRC_StateTypeDef HAL_CRC_GetState(const CRC_HandleTypeDef *hcrc);
 /**
   * @}
   */
@@ -340,5 +340,3 @@ HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc);
 #endif
 
 #endif /* STM32WBxx_HAL_CRC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_crc_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_crc_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -149,5 +148,3 @@ HAL_StatusTypeDef HAL_CRCEx_Output_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_
 #endif
 
 #endif /* STM32WBxx_HAL_CRC_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_cryp.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_cryp.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -54,7 +53,8 @@ typedef struct
   uint32_t DataType;                   /*!< 32-bit data, 16-bit data, 8-bit data or 1-bit string.
                                         This parameter can be a value of @ref CRYP_Data_Type */
   uint32_t KeySize;                    /*!< Used only in AES mode : 128, 192 or 256 bit key length in CRYP1.
-                                        128 or 256 bit key length in TinyAES This parameter can be a value of @ref CRYP_Key_Size */
+                                        128 or 256 bit key length in TinyAES
+                                        This parameter can be a value of @ref CRYP_Key_Size */
   uint32_t *pKey;                      /*!< The key used for encryption/decryption */
   uint32_t *pInitVect;                 /*!< The initialization vector used also as initialization
                                          counter in CTR mode */
@@ -97,7 +97,7 @@ typedef enum
 {
   HAL_CRYP_SUSPEND_NONE            = 0x00U,    /*!< CRYP processing suspension not requested */
   HAL_CRYP_SUSPEND                 = 0x01U     /*!< CRYP processing suspension requested     */
-}HAL_SuspendTypeDef;
+} HAL_SuspendTypeDef;
 #endif /* USE_HAL_CRYP_SUSPEND_RESUME */
 
 /**
@@ -107,7 +107,7 @@ typedef enum
 typedef struct __CRYP_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
 {
   AES_TypeDef                       *Instance;        /*!< AES Register base address */
 
@@ -408,7 +408,7 @@ typedef  void (*pCRYP_CallbackTypeDef)(CRYP_HandleTypeDef *hcryp);    /*!< point
   *            @arg CRYP_FLAG_OFNE: Output FIFO is not empty
   *            @arg CRYP_FLAG_OFFU: Output FIFO is full
   *            @arg CRYP_FLAG_OUTRIS: Input FIFO service raw interrupt is pending
- * @retval The state of __FLAG__ (TRUE or FALSE).
+  * @retval The state of __FLAG__ (TRUE or FALSE).
   */
 
 #define CRYP_FLAG_MASK  0x0000001FU
@@ -435,7 +435,8 @@ typedef  void (*pCRYP_CallbackTypeDef)(CRYP_HandleTypeDef *hcryp);    /*!< point
   * @retval State of interruption (TRUE or FALSE).
   */
 
-#define __HAL_CRYP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR & (__INTERRUPT__)) == (__INTERRUPT__))
+#define __HAL_CRYP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) (((__HANDLE__)->Instance->CR &\
+                                                              (__INTERRUPT__)) == (__INTERRUPT__))
 
 /** @brief  Check whether the specified CRYP interrupt is set or not.
   * @param  __HANDLE__ specifies the CRYP handle.
@@ -504,7 +505,8 @@ void HAL_CRYP_MspDeInit(CRYP_HandleTypeDef *hcryp);
 HAL_StatusTypeDef HAL_CRYP_SetConfig(CRYP_HandleTypeDef *hcryp, CRYP_ConfigTypeDef *pConf);
 HAL_StatusTypeDef HAL_CRYP_GetConfig(CRYP_HandleTypeDef *hcryp, CRYP_ConfigTypeDef *pConf);
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-HAL_StatusTypeDef HAL_CRYP_RegisterCallback(CRYP_HandleTypeDef *hcryp, HAL_CRYP_CallbackIDTypeDef CallbackID, pCRYP_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_CRYP_RegisterCallback(CRYP_HandleTypeDef *hcryp, HAL_CRYP_CallbackIDTypeDef CallbackID,
+                                            pCRYP_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_CRYP_UnRegisterCallback(CRYP_HandleTypeDef *hcryp, HAL_CRYP_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
@@ -521,8 +523,10 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp);
   */
 
 /* encryption/decryption ***********************************/
-HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output, uint32_t Timeout);
-HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output, uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output,
+                                   uint32_t Timeout);
+HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output,
+                                   uint32_t Timeout);
 HAL_StatusTypeDef HAL_CRYP_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output);
 HAL_StatusTypeDef HAL_CRYP_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output);
 HAL_StatusTypeDef HAL_CRYP_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output);
@@ -580,11 +584,11 @@ uint32_t HAL_CRYP_GetError(CRYP_HandleTypeDef *hcryp);
                              ((CONFIG) == CRYP_KEYIVCONFIG_ONCE))
 
 #define IS_CRYP_BUFFERSIZE(ALGO, DATAWIDTH, SIZE)                                             \
-       (((((ALGO) == CRYP_AES_CTR)) &&                                             \
-            ((((DATAWIDTH) == CRYP_DATAWIDTHUNIT_WORD) && (((SIZE) % 4U) == 0U))           || \
-             (((DATAWIDTH) == CRYP_DATAWIDTHUNIT_BYTE) && (((SIZE) % 16U) == 0U))))        || \
-         (((ALGO) == CRYP_AES_ECB) || ((ALGO) == CRYP_AES_CBC)                  || \
-          ((ALGO)== CRYP_AES_GCM_GMAC) || ((ALGO) == CRYP_AES_CCM)))
+  (((((ALGO) == CRYP_AES_CTR)) &&                                             \
+    ((((DATAWIDTH) == CRYP_DATAWIDTHUNIT_WORD) && (((SIZE) % 4U) == 0U))           || \
+     (((DATAWIDTH) == CRYP_DATAWIDTHUNIT_BYTE) && (((SIZE) % 16U) == 0U))))        || \
+   (((ALGO) == CRYP_AES_ECB) || ((ALGO) == CRYP_AES_CBC)                  || \
+    ((ALGO)== CRYP_AES_GCM_GMAC) || ((ALGO) == CRYP_AES_CCM)))
 
 /**
   * @}
@@ -644,5 +648,3 @@ uint32_t HAL_CRYP_GetError(CRYP_HandleTypeDef *hcryp);
 #endif
 
 #endif /* STM32WBxx_HAL_CRYP_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_cryp_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_cryp_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -74,8 +73,8 @@ extern "C" {
   */
 
 /**
- * @}
- */
+  * @}
+  */
 
 /* Private functions ---------------------------------------------------------*/
 /** @defgroup CRYPEx_Private_Functions CRYPEx Private Functions
@@ -129,5 +128,3 @@ void  HAL_CRYPEx_DisableAutoKeyDerivation(CRYP_HandleTypeDef *hcryp);
 #endif
 
 #endif /* STM32WBxx_HAL_CRYP_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_def.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_def.h
@@ -7,13 +7,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 #define __STM32WBxx_HAL_DEF
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -54,8 +53,9 @@ typedef enum
 } HAL_LockTypeDef;
 
 /* Exported macros -----------------------------------------------------------*/
-
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+#define UNUSED(X) (void)(X)      /* To avoid gcc/g++ warnings */
+#endif /* UNUSED */
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 
@@ -63,10 +63,10 @@ typedef enum
 #define HAL_IS_BIT_CLR(REG, BIT)         (((REG) & (BIT)) == 0U)
 
 #define __HAL_LINKDMA(__HANDLE__, __PPP_DMA_FIELD__, __DMA_HANDLE__)               \
-                        do{                                                      \
-                              (__HANDLE__)->__PPP_DMA_FIELD__ = &(__DMA_HANDLE__); \
-                              (__DMA_HANDLE__).Parent = (__HANDLE__);             \
-                          } while(0)
+  do{                                                      \
+    (__HANDLE__)->__PPP_DMA_FIELD__ = &(__DMA_HANDLE__); \
+    (__DMA_HANDLE__).Parent = (__HANDLE__);             \
+  } while(0)
 
 /** @brief Reset the Handle's State field.
   * @param __HANDLE__ specifies the Peripheral Handle.
@@ -86,67 +86,79 @@ typedef enum
 #define __HAL_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = 0)
 
 #if (USE_RTOS == 1)
-  /* Reserved for future use */
-  #error " USE_RTOS should be 0 in the current HAL release "
+/* Reserved for future use */
+#error " USE_RTOS should be 0 in the current HAL release "
 #else
-  #define __HAL_LOCK(__HANDLE__)                                           \
-                                do{                                        \
-                                    if((__HANDLE__)->Lock == HAL_LOCKED)   \
-                                    {                                      \
-                                       return HAL_BUSY;                    \
-                                    }                                      \
-                                    else                                   \
-                                    {                                      \
-                                       (__HANDLE__)->Lock = HAL_LOCKED;    \
-                                    }                                      \
-                                  }while (0)
+#define __HAL_LOCK(__HANDLE__)            \
+  do {                                    \
+    if((__HANDLE__)->Lock == HAL_LOCKED)  \
+    {                                     \
+      return HAL_BUSY;                    \
+    }                                     \
+    else                                  \
+    {                                     \
+      (__HANDLE__)->Lock = HAL_LOCKED;    \
+    }                                     \
+  } while (0)
 
-  #define __HAL_UNLOCK(__HANDLE__)                                          \
-                                  do{                                       \
-                                      (__HANDLE__)->Lock = HAL_UNLOCKED;    \
-                                    }while (0)
+#define __HAL_UNLOCK(__HANDLE__)          \
+  do {                                    \
+    (__HANDLE__)->Lock = HAL_UNLOCKED;    \
+  } while (0)
 #endif /* USE_RTOS */
 
-#if  defined ( __GNUC__ )
-  #ifndef __weak
-    #define __weak   __attribute__((weak))
-  #endif /* __weak */
-  #ifndef __packed
-    #define __packed __attribute__((__packed__))
-  #endif /* __packed */
+
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) /* ARM Compiler V6 */
+#ifndef __weak
+#define __weak  __attribute__((weak))
+#endif /* __weak */
+#ifndef __packed
+#define __packed  __attribute__((packed))
+#endif /* __packed */
+#elif defined ( __GNUC__ ) && !defined (__CC_ARM) /* GNU Compiler */
+#ifndef __weak
+#define __weak   __attribute__((weak))
+#endif /* __weak */
+#ifndef __packed
+#define __packed __attribute__((__packed__))
+#endif /* __packed */
 #endif /* __GNUC__ */
 
 
 /* Macro to get variable aligned on 4-bytes, for __ICCARM__ the directive "#pragma data_alignment=4" must be used instead */
-/* GNU Compiler */
-#if defined   (__GNUC__)
-  #ifndef __ALIGN_END
-    #define __ALIGN_END    __attribute__ ((aligned (4)))
-  #endif /* __ALIGN_END */
-  #ifndef __ALIGN_BEGIN
-    #define __ALIGN_BEGIN
-  #endif /* __ALIGN_BEGIN */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) /* ARM Compiler V6 */
+#ifndef __ALIGN_BEGIN
+#define __ALIGN_BEGIN
+#endif /* __ALIGN_BEGIN */
+#ifndef __ALIGN_END
+#define __ALIGN_END      __attribute__ ((aligned (4)))
+#endif /* __ALIGN_END */
+#elif defined ( __GNUC__ ) && !defined (__CC_ARM) /* GNU Compiler */
+#ifndef __ALIGN_END
+#define __ALIGN_END    __attribute__ ((aligned (4)))
+#endif /* __ALIGN_END */
+#ifndef __ALIGN_BEGIN
+#define __ALIGN_BEGIN
+#endif /* __ALIGN_BEGIN */
 #else
-  #ifndef __ALIGN_END
-    #define __ALIGN_END
-  #endif /* __ALIGN_END */
-  #ifndef __ALIGN_BEGIN
-    /* ARM Compiler */
-    #if defined   (__CC_ARM)
-      #define __ALIGN_BEGIN    __align(4)
-    /* IAR Compiler */
-    #elif defined (__ICCARM__)
-      #define __ALIGN_BEGIN
-    #endif /* __CC_ARM */
-  #endif /* __ALIGN_BEGIN */
+#ifndef __ALIGN_END
+#define __ALIGN_END
+#endif /* __ALIGN_END */
+#ifndef __ALIGN_BEGIN
+#if defined   (__CC_ARM)      /* ARM Compiler V5 */
+#define __ALIGN_BEGIN    __align(4)
+#elif defined (__ICCARM__)    /* IAR Compiler */
+#define __ALIGN_BEGIN
+#endif /* __CC_ARM */
+#endif /* __ALIGN_BEGIN */
 #endif /* __GNUC__ */
 
 /**
   * @brief  __RAM_FUNC definition
   */
-#if defined ( __CC_ARM   )
-/* ARM Compiler
-   ------------
+#if defined ( __CC_ARM   ) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+/* ARM Compiler V4/V5 and V6
+   --------------------------
    RAM functions are defined using the toolchain options.
    Functions that are executed in RAM should reside in a separate source module.
    Using the 'Options for File' dialog you can simply change the 'Code / Const'
@@ -171,14 +183,14 @@ typedef enum
 */
 #define __RAM_FUNC __attribute__((section(".RamFunc")))
 
-#endif
+#endif /* __CC_ARM || ... */
 
 /**
   * @brief  __NOINLINE definition
   */
-#if defined ( __CC_ARM   ) || defined   (  __GNUC__  )
-/* ARM & GNUCompiler
-   ----------------
+#if defined ( __CC_ARM   ) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)) || defined   (  __GNUC__  )
+/* ARM V4/V5 and V6 & GNU Compiler
+   -------------------------------
 */
 #define __NOINLINE __attribute__ ( (noinline) )
 
@@ -188,7 +200,7 @@ typedef enum
 */
 #define __NOINLINE _Pragma("optimize = no_inline")
 
-#endif
+#endif /* __CC_ARM || ... */
 
 
 #ifdef __cplusplus
@@ -196,5 +208,3 @@ typedef enum
 #endif
 
 #endif /* ___STM32WBxx_HAL_DEF */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_dma.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_dma.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -404,29 +403,29 @@ typedef struct __DMA_HandleTypeDef
 
 #if defined(DMA2)
 #define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TC1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TC2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TC3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TC4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TC5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_TC6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TC1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TC2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TC3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TC4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TC5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_TC6 :\
    DMA_FLAG_TC7)
 #else
 #define __HAL_DMA_GET_TC_FLAG_INDEX(__HANDLE__) \
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TC1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TC2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TC3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TC4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TC5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TC6 :\
    DMA_FLAG_TC7)
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Return the current DMA Channel half transfer complete flag.
@@ -435,29 +434,29 @@ typedef struct __DMA_HandleTypeDef
   */
 #if defined(DMA2)
 #define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_HT1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_HT2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_HT3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_HT4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_HT5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_HT6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_HT1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_HT2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_HT3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_HT4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_HT5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_HT6 :\
    DMA_FLAG_HT7)
 #else
 #define __HAL_DMA_GET_HT_FLAG_INDEX(__HANDLE__)\
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_HT1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_HT2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_HT3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_HT4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_HT5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_HT6 :\
    DMA_FLAG_HT7)
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Return the current DMA Channel transfer error flag.
@@ -466,29 +465,29 @@ typedef struct __DMA_HandleTypeDef
   */
 #if defined(DMA2)
 #define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TE1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TE2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TE3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TE4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TE5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_TE6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_FLAG_TE1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_FLAG_TE2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_FLAG_TE3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_FLAG_TE4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_FLAG_TE5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_FLAG_TE6 :\
    DMA_FLAG_TE7)
 #else
 #define __HAL_DMA_GET_TE_FLAG_INDEX(__HANDLE__)\
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_FLAG_TE1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_FLAG_TE2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_FLAG_TE3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_FLAG_TE4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_FLAG_TE5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_FLAG_TE6 :\
    DMA_FLAG_TE7)
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Return the current DMA Channel Global interrupt flag.
@@ -497,29 +496,29 @@ typedef struct __DMA_HandleTypeDef
   */
 #if defined(DMA2)
 #define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__)\
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_ISR_GIF1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_ISR_GIF1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_ISR_GIF2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_ISR_GIF2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_ISR_GIF3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_ISR_GIF3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_ISR_GIF4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_ISR_GIF4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_ISR_GIF5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_ISR_GIF5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_ISR_GIF6 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_ISR_GIF6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_ISR_GIF1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel1))? DMA_ISR_GIF1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_ISR_GIF2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel2))? DMA_ISR_GIF2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_ISR_GIF3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel3))? DMA_ISR_GIF3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_ISR_GIF4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel4))? DMA_ISR_GIF4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_ISR_GIF5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel5))? DMA_ISR_GIF5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_ISR_GIF6 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA2_Channel6))? DMA_ISR_GIF6 :\
    DMA_ISR_GIF7)
 #else
 #define __HAL_DMA_GET_GI_FLAG_INDEX(__HANDLE__)\
-(((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_ISR_GIF1 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_ISR_GIF2 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_ISR_GIF3 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_ISR_GIF4 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_ISR_GIF5 :\
- ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_ISR_GIF6 :\
+  (((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel1))? DMA_ISR_GIF1 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel2))? DMA_ISR_GIF2 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel3))? DMA_ISR_GIF3 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel4))? DMA_ISR_GIF4 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel5))? DMA_ISR_GIF5 :\
+   ((uint32_t)((__HANDLE__)->Instance) == ((uint32_t)DMA1_Channel6))? DMA_ISR_GIF6 :\
    DMA_ISR_GIF7)
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Get the DMA Channel pending flags.
@@ -535,10 +534,10 @@ typedef struct __DMA_HandleTypeDef
   */
 #if defined(DMA2)
 #define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__) (((uint32_t)((__HANDLE__)->Instance) > ((uint32_t)DMA1_Channel7))? \
- (DMA2->ISR & (__FLAG__)) : (DMA1->ISR & (__FLAG__)))
+                                                  (DMA2->ISR & (__FLAG__)) : (DMA1->ISR & (__FLAG__)))
 #else
 #define __HAL_DMA_GET_FLAG(__HANDLE__, __FLAG__) (DMA1->ISR & (__FLAG__))
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Clear the DMA Channel pending flags.
@@ -554,10 +553,10 @@ typedef struct __DMA_HandleTypeDef
   */
 #if defined(DMA2)
 #define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (((uint32_t)((__HANDLE__)->Instance) > ((uint32_t)DMA1_Channel7))? \
- (DMA2->IFCR = (__FLAG__)) : (DMA1->IFCR = (__FLAG__)))
+                                                    (DMA2->IFCR = (__FLAG__)) : (DMA1->IFCR = (__FLAG__)))
 #else
 #define __HAL_DMA_CLEAR_FLAG(__HANDLE__, __FLAG__) (DMA1->IFCR = (__FLAG__))
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Enable the specified DMA Channel interrupts.
@@ -630,10 +629,12 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma);
   */
 /* IO operation functions *****************************************************/
 HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
-HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength);
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress,
+                                   uint32_t DataLength);
 HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma);
 HAL_StatusTypeDef HAL_DMA_Abort_IT(DMA_HandleTypeDef *hdma);
-HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_LevelCompleteTypeDef CompleteLevel, uint32_t Timeout);
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_LevelCompleteTypeDef CompleteLevel,
+                                          uint32_t Timeout);
 void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma);
 HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_CallbackIDTypeDef CallbackID, void (* pCallback)(DMA_HandleTypeDef *_hdma));
 HAL_StatusTypeDef HAL_DMA_UnRegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_CallbackIDTypeDef CallbackID);
@@ -711,5 +712,3 @@ uint32_t             HAL_DMA_GetError(DMA_HandleTypeDef *hdma);
 #endif
 
 #endif /* STM32WBxx_HAL_DMA_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_dma_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_dma_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -261,5 +260,3 @@ void HAL_DMAEx_MUX_IRQHandler(DMA_HandleTypeDef *hdma);
 #endif
 
 #endif /* STM32WBxx_HAL_DMA_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_exti.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_exti.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -105,42 +104,42 @@ typedef struct
 #define EXTI_LINE_17                        (EXTI_CONFIG   | EXTI_EVENT | EXTI_REG1 | 0x11u)
 #define EXTI_LINE_18                        (EXTI_CONFIG   | EXTI_EVENT | EXTI_REG1 | 0x12u)
 #define EXTI_LINE_19                        (EXTI_CONFIG   | EXTI_EVENT | EXTI_REG1 | 0x13u)
-#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined STM32WB35xx
+#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx) || defined (STM32WB15xx) || defined(STM32WB1Mxx)
 #define EXTI_LINE_20                        (EXTI_CONFIG   | EXTI_EVENT | EXTI_REG1 | 0x14u)
 #else
 #define EXTI_LINE_20                        (EXTI_RESERVED |              EXTI_REG1 | 0x14u)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define EXTI_LINE_21                        (EXTI_CONFIG   | EXTI_EVENT | EXTI_REG1 | 0x15u)
 #else
 #define EXTI_LINE_21                        (EXTI_RESERVED |              EXTI_REG1 | 0x15u)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define EXTI_LINE_22                        (EXTI_DIRECT   |              EXTI_REG1 | 0x16u)
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define EXTI_LINE_23                        (EXTI_DIRECT   |              EXTI_REG1 | 0x17u)
 #else
 #define EXTI_LINE_23                        (EXTI_RESERVED |              EXTI_REG1 | 0x17u)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define EXTI_LINE_24                        (EXTI_DIRECT   |              EXTI_REG1 | 0x18u)
-#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined STM32WB35xx
+#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx) || defined (STM32WB15xx) || defined(STM32WB1Mxx)
 #define EXTI_LINE_25                        (EXTI_DIRECT   |              EXTI_REG1 | 0x19u)
 #else
 #define EXTI_LINE_25                        (EXTI_RESERVED |              EXTI_REG1 | 0x19u)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #define EXTI_LINE_26                        (EXTI_RESERVED |              EXTI_REG1 | 0x1Au)
 #define EXTI_LINE_27                        (EXTI_RESERVED |              EXTI_REG1 | 0x1Bu)
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define EXTI_LINE_28                        (EXTI_DIRECT   |              EXTI_REG1 | 0x1Cu)
 #else
 #define EXTI_LINE_28                        (EXTI_RESERVED |              EXTI_REG1 | 0x1Cu)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define EXTI_LINE_29                        (EXTI_DIRECT   |              EXTI_REG1 | 0x1Du)
 #define EXTI_LINE_30                        (EXTI_DIRECT   |              EXTI_REG1 | 0x1Eu)
-#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined STM32WB35xx
+#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx) || defined (STM32WB15xx) || defined(STM32WB1Mxx)
 #define EXTI_LINE_31                        (EXTI_CONFIG   |              EXTI_REG1 | 0x1Fu)
 #else
 #define EXTI_LINE_31                        (EXTI_RESERVED |              EXTI_REG1 | 0x1Fu)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #define EXTI_LINE_32                        (EXTI_RESERVED |              EXTI_REG2 | 0x00u)
 #define EXTI_LINE_33                        (EXTI_CONFIG   |              EXTI_REG2 | 0x01u)
 #define EXTI_LINE_34                        (EXTI_RESERVED |              EXTI_REG2 | 0x02u)
@@ -156,14 +155,14 @@ typedef struct
 #define EXTI_LINE_43                        (EXTI_DIRECT   |              EXTI_REG2 | 0x0Bu)
 #else
 #define EXTI_LINE_43                        (EXTI_RESERVED |              EXTI_REG2 | 0x0Bu)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 #define EXTI_LINE_44                        (EXTI_DIRECT   |              EXTI_REG2 | 0x0Cu)
 #define EXTI_LINE_45                        (EXTI_DIRECT   |              EXTI_REG2 | 0x0Du)
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB50xx) || defined (STM32WB35xx) || defined (STM32WB30xx)
 #define EXTI_LINE_46                        (EXTI_DIRECT   |              EXTI_REG2 | 0x0Eu)
 #else
 #define EXTI_LINE_46                        (EXTI_RESERVED |              EXTI_REG2 | 0x0Eu)
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #define EXTI_LINE_47                        (EXTI_RESERVED |              EXTI_REG2 | 0x0Fu)
 #define EXTI_LINE_48                        (EXTI_DIRECT   |              EXTI_REG2 | 0x10u)
 /**
@@ -200,7 +199,7 @@ typedef struct
 #define EXTI_GPIOC                          0x00000002u
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx)
 #define EXTI_GPIOD                          0x00000003u
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 #define EXTI_GPIOE                          0x00000004u
 #define EXTI_GPIOH                          0x00000007u
 /**
@@ -274,14 +273,14 @@ typedef struct
   * @{
   */
 #define IS_EXTI_LINE(__EXTI_LINE__)          ((((__EXTI_LINE__) & ~(EXTI_PROPERTY_MASK | EXTI_EVENT_PRESENCE_MASK | EXTI_REG_MASK | EXTI_PIN_MASK)) == 0x00u) && \
-                                        ((((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_DIRECT)   || \
-                                         (((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_CONFIG)   || \
-                                         (((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_GPIO))    && \
-                                         (((__EXTI_LINE__) & (EXTI_REG_MASK | EXTI_PIN_MASK))      < \
-                                         (((EXTI_LINE_NB / 32u) << EXTI_REG_SHIFT) | (EXTI_LINE_NB % 32u))))
+                                              ((((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_DIRECT)   || \
+                                               (((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_CONFIG)   || \
+                                               (((__EXTI_LINE__) & EXTI_PROPERTY_MASK) == EXTI_GPIO))    && \
+                                              (((__EXTI_LINE__) & (EXTI_REG_MASK | EXTI_PIN_MASK))      < \
+                                               (((EXTI_LINE_NB / 32u) << EXTI_REG_SHIFT) | (EXTI_LINE_NB % 32u))))
 
 #define IS_EXTI_MODE(__EXTI_LINE__)          ((((__EXTI_LINE__) & EXTI_MODE_MASK) != 0x00u) && \
-                                         (((__EXTI_LINE__) & ~EXTI_MODE_MASK) == 0x00u))
+                                              (((__EXTI_LINE__) & ~EXTI_MODE_MASK) == 0x00u))
 
 #define IS_EXTI_TRIGGER(__EXTI_LINE__)       (((__EXTI_LINE__) & ~EXTI_TRIGGER_MASK) == 0x00u)
 
@@ -302,7 +301,7 @@ typedef struct
                                          ((__PORT__) == EXTI_GPIOC) || \
                                          ((__PORT__) == EXTI_GPIOE) || \
                                          ((__PORT__) == EXTI_GPIOH))
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 
 #define IS_EXTI_GPIO_PIN(__PIN__)       ((__PIN__) < 16u)
 
@@ -362,5 +361,3 @@ void              HAL_EXTI_GenerateSWI(EXTI_HandleTypeDef *hexti);
 #endif
 
 #endif /* STM32WBxx_HAL_EXTI_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -100,10 +99,10 @@ typedef struct
                                         This parameter can be a value of @ref FLASH_SRAM2A_ADDRESS_RANGE */
   uint32_t SecureRAM2bStartAddr;   /*!< Secure non-Backup RAM2b start address (used for OPTIONBYTE_SECURE_MODE)
                                         This parameter can be a value of @ref FLASH_SRAM2B_ADDRESS_RANGE */
-  uint32_t SecureMode;             /*!< Secure mode activated or desactivated.
+  uint32_t SecureMode;             /*!< Secure mode activated or deactivated.
                                         This parameter can be a value of @ref FLASH_OB_SECURITY_MODE */
   uint32_t C2BootRegion;           /*!< CPU2 Secure Boot memory region(used for OPTIONBYTE_C2_BOOT_VECT).
-                                        This parameter can be a value of @ref C2_FLASH_OB_BOOT_REGION */
+                                        This parameter can be a value of @ref FLASH_C2_OB_BOOT_REGION */
   uint32_t C2SecureBootVectAddr;   /*!< CPU2 Secure Boot reset vector (used for OPTIONBYTE_C2_BOOT_VECT).
                                         This parameter contains the CPU2 boot reset start address within
                                         the selected memory region. Make sure this parameter is word aligned. */
@@ -113,8 +112,8 @@ typedef struct
 } FLASH_OBProgramInitTypeDef;
 
 /**
-* @brief  FLASH handle Structure definition
-*/
+  * @brief  FLASH handle Structure definition
+  */
 typedef struct
 {
   HAL_LockTypeDef   Lock;              /* FLASH locking object */
@@ -283,7 +282,7 @@ typedef struct
 #define OB_USER_nRST_SHDW               FLASH_OPTR_nRST_SHDW  /*!< Reset generated when entering the shutdown mode */
 #if defined(FLASH_OPTR_IRHEN)
 #define OB_USER_INPUT_RESET_HOLDER      FLASH_OPTR_IRHEN      /*!< Internal reset holder enable */
-#endif
+#endif /* FLASH_OPTR_IRHEN */
 #define OB_USER_IWDG_SW                 FLASH_OPTR_IWDG_SW    /*!< Independent watchdog selection */
 #define OB_USER_IWDG_STOP               FLASH_OPTR_IWDG_STOP  /*!< Independent watchdog counter freeze in stop mode */
 #define OB_USER_IWDG_STDBY              FLASH_OPTR_IWDG_STDBY /*!< Independent watchdog counter freeze in standby mode */
@@ -295,7 +294,7 @@ typedef struct
 #define OB_USER_nBOOT0                  FLASH_OPTR_nBOOT0     /*!< nBOOT0 option bit */
 #if defined(FLASH_OPTR_nRST_MODE)
 #define OB_USER_NRST_MODE               FLASH_OPTR_nRST_MODE  /*!< Reset pin configuration */
-#endif
+#endif /* FLASH_OPTR_nRST_MODE */
 #define OB_USER_AGC_TRIM                FLASH_OPTR_AGC_TRIM   /*!< Automatic Gain Control Trimming */
 #if defined(FLASH_OPTR_IRHEN) && defined(FLASH_OPTR_nRST_MODE)
 #define OB_USER_ALL                     (OB_USER_BOR_LEV    | OB_USER_nRST_STOP | OB_USER_nRST_STDBY | \
@@ -310,7 +309,7 @@ typedef struct
                                          OB_USER_IWDG_STDBY | OB_USER_WWDG_SW   | OB_USER_nBOOT1     | \
                                          OB_USER_SRAM2PE    | OB_USER_SRAM2RST  | OB_USER_nSWBOOT0   | \
                                          OB_USER_nBOOT0     | OB_USER_AGC_TRIM)   /*!< all option bits */
-#endif
+#endif /* FLASH_OPTR_IRHEN */
 
 /**
   * @}
@@ -461,7 +460,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* FLASH_OPTR_nRST_MODE */
 
 #if defined(FLASH_OPTR_IRHEN)
 /** @defgroup FLASH_OB_USER_INPUT_RESET_HOLDER FLASH Option Bytes User input reset holder bit
@@ -472,7 +471,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* FLASH_OPTR_IRHEN */
 
 /** @defgroup FLASH_OB_PCROP_ZONE FLASH PCROP ZONE
   * @{
@@ -503,7 +502,7 @@ typedef struct
   * @}
   */
 
-/** @defgroup C2_FLASH_OB_BOOT_REGION CPU2 Option Bytes Reset Boot Vector
+/** @defgroup FLASH_C2_OB_BOOT_REGION CPU2 Option Bytes Reset Boot Vector
   * @{
   */
 #define OB_C2_BOOT_FROM_SRAM            0x00000000U        /*!< CPU2 boot from Sram  */
@@ -565,6 +564,7 @@ typedef struct
 #define SRAM2B_START_SECURE_ADDR_1       (SRAM2B_BASE + 0x0400U)  /*  When in secure mode (SRAM2B_BASE + 0x0400) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_2       (SRAM2B_BASE + 0x0800U)  /*  When in secure mode (SRAM2B_BASE + 0x0800) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_3       (SRAM2B_BASE + 0x0C00U)  /*  When in secure mode (SRAM2B_BASE + 0x0C00) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
+#if !defined(STM32WB10xx) && !defined(STM32WB15xx) && !defined(STM32WB1Mxx)
 #define SRAM2B_START_SECURE_ADDR_4       (SRAM2B_BASE + 0x1000U)  /*  When in secure mode (SRAM2B_BASE + 0x1000) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_5       (SRAM2B_BASE + 0x1400U)  /*  When in secure mode (SRAM2B_BASE + 0x1400) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_6       (SRAM2B_BASE + 0x1800U)  /*  When in secure mode (SRAM2B_BASE + 0x1800) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
@@ -594,6 +594,9 @@ typedef struct
 #define SRAM2B_START_SECURE_ADDR_30      (SRAM2B_BASE + 0x7800U)  /*  When in secure mode (SRAM2B_BASE + 0x7800) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_START_SECURE_ADDR_31      (SRAM2B_BASE + 0x7C00U)  /*  When in secure mode (SRAM2B_BASE + 0x7C00) -> SRAM2B_END_ADDR is accessible only by M0 Plus  */
 #define SRAM2B_FULL_UNSECURE             (SRAM2B_BASE + 0x8000U)  /*  The RAM2B is accessible to M0 Plus and M4                                  */
+#else
+#define SRAM2B_FULL_UNSECURE             (SRAM2B_BASE + 0x1000U)  /*  The RAM2B is accessible to M0 Plus and M4                                  */
+#endif /* !(STM32WB10xx) && !(STM32WB15xx) && !(STM32WB1Mxx) */
 
 /**
   * @}
@@ -691,9 +694,9 @@ typedef struct
   */
 
 /** @defgroup FLASH_Interrupt FLASH Interrupts Macros
- *  @brief macros to handle FLASH interrupts
- * @{
- */
+  *  @brief macros to handle FLASH interrupts
+  * @{
+  */
 
 /**
   * @brief  Enable the specified FLASH interrupt.
@@ -749,6 +752,7 @@ typedef struct
 #define __HAL_FLASH_GET_FLAG(__FLAG__)          ((((__FLAG__) & (FLASH_FLAG_ECCR_ERRORS)) != 0U) ? \
                                                  (READ_BIT(FLASH->ECCR, (__FLAG__)) == (__FLAG__))  : \
                                                  (READ_BIT(FLASH->SR,   (__FLAG__)) == (__FLAG__)))
+
 /**
   * @brief  Clear the FLASH's pending flags.
   * @param __FLAG__ specifies the FLASH flags to clear.
@@ -774,6 +778,7 @@ typedef struct
 #define __HAL_FLASH_CLEAR_FLAG(__FLAG__)        do { if(((__FLAG__) & (FLASH_FLAG_ECCR_ERRORS)) != 0U) { SET_BIT(FLASH->ECCR, ((__FLAG__) & (FLASH_FLAG_ECCR_ERRORS))); }\
                                                      if(((__FLAG__) & ~(FLASH_FLAG_ECCR_ERRORS)) != 0U) { WRITE_REG(FLASH->SR, ((__FLAG__) & ~(FLASH_FLAG_ECCR_ERRORS))); }\
                                                    } while(0)
+
 /**
   * @}
   */
@@ -852,14 +857,23 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #define FLASH_END_ADDR                          (FLASH_BASE + FLASH_SIZE - 1U)
 
 #define FLASH_BANK_SIZE                         FLASH_SIZE   /*!< FLASH Bank Size */
+#if defined(STM32WB10xx) || defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#define FLASH_PAGE_SIZE                         0x00000800U  /*!< FLASH Page Size, 2 KBytes */
+#else
 #define FLASH_PAGE_SIZE                         0x00001000U  /*!< FLASH Page Size, 4 KBytes */
+#endif /* STM32WB10xx || STM32WB15xx || STM32WB1Mxx */
 #define FLASH_PAGE_NB                           (FLASH_SIZE / FLASH_PAGE_SIZE)
 #define FLASH_TIMEOUT_VALUE                     1000U        /*!< FLASH Execution Timeout, 1 s */
 
+#if defined(STM32WB10xx) || defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#define FLASH_PCROP_GRANULARITY_OFFSET          10U                                      /*!< FLASH Code Readout Protection granularity offset */
+#define FLASH_PCROP_GRANULARITY                 (1UL << FLASH_PCROP_GRANULARITY_OFFSET)  /*!< FLASH Code Readout Protection granularity, 1 KBytes */
+#else
 #define FLASH_PCROP_GRANULARITY_OFFSET          11U                                      /*!< FLASH Code Readout Protection granularity offset */
 #define FLASH_PCROP_GRANULARITY                 (1UL << FLASH_PCROP_GRANULARITY_OFFSET)  /*!< FLASH Code Readout Protection granularity, 2 KBytes */
+#endif /* STM32WB10xx || STM32WB15xx || STM32WB1Mxx */
 
-#define FLASH_TYPENONE                          0x00000000U                                /*!< No Programmation Procedure On Going */
+#define FLASH_TYPENONE                          0x00000000U                              /*!< No Programmation Procedure On Going */
 /**
   * @}
   */
@@ -867,25 +881,30 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 /** @defgroup SRAM_MEMORY_SIZE  SRAM memory size
   * @{
   */
-#define SRAM_SECURE_PAGE_GRANULARITY_OFFSET     10U                                      /*!< Secure SRAM2A and SRAM2B Protection granularity offset */
-#define SRAM_SECURE_PAGE_GRANULARITY            (1UL << FLASH_PCROP_GRANULARITY_OFFSET)  /*!< Secure SRAM2A and SRAM2B Protection granularity, 1KBytes */
+#define SRAM_SECURE_PAGE_GRANULARITY_OFFSET     10U                                           /*!< Secure SRAM2A and SRAM2B Protection granularity offset */
+#define SRAM_SECURE_PAGE_GRANULARITY            (1UL << SRAM_SECURE_PAGE_GRANULARITY_OFFSET)  /*!< Secure SRAM2A and SRAM2B Protection granularity, 1KBytes */
 /**
   * @}
   */
 
 /* Private macros ------------------------------------------------------------*/
 /** @defgroup FLASH_Private_Macros FLASH Private Macros
- *  @{
- */
-#define IS_FLASH_MAIN_MEM_ADDRESS(__VALUE__)        (((__VALUE__) >= FLASH_BASE) && ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 1UL)))
+  *  @{
+  */
+#define IS_FLASH_MAIN_MEM_ADDRESS(__VALUE__)        (((__VALUE__) >= FLASH_BASE) &&\
+                                                     ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 1UL)))
 
-#define IS_FLASH_FAST_PROGRAM_ADDRESS(__VALUE__)    (((__VALUE__) >= FLASH_BASE) && ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 256UL)) && (((__VALUE__) % 256UL) == 0UL))
+#define IS_FLASH_FAST_PROGRAM_ADDRESS(__VALUE__)    (((__VALUE__) >= FLASH_BASE) &&\
+                                                     ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 256UL)) && (((__VALUE__) % 256UL) == 0UL))
 
-#define IS_FLASH_PROGRAM_MAIN_MEM_ADDRESS(__VALUE__)   (((__VALUE__) >= FLASH_BASE) && ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 8UL)) && (((__VALUE__) % 8UL) == 0UL))
+#define IS_FLASH_PROGRAM_MAIN_MEM_ADDRESS(__VALUE__)   (((__VALUE__) >= FLASH_BASE) &&\
+                                                        ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 8UL)) && (((__VALUE__) % 8UL) == 0UL))
 
-#define IS_FLASH_PROGRAM_OTP_ADDRESS(__VALUE__)     (((__VALUE__) >= OTP_AREA_BASE) && ((__VALUE__) <= (OTP_AREA_END_ADDR + 1UL - 8UL)) && (((__VALUE__) % 8UL) == 0UL))
+#define IS_FLASH_PROGRAM_OTP_ADDRESS(__VALUE__)     (((__VALUE__) >= OTP_AREA_BASE) &&\
+                                                     ((__VALUE__) <= (OTP_AREA_END_ADDR + 1UL - 8UL)) && (((__VALUE__) % 8UL) == 0UL))
 
-#define IS_FLASH_PROGRAM_ADDRESS(__VALUE__)         (IS_FLASH_PROGRAM_MAIN_MEM_ADDRESS(__VALUE__) || IS_FLASH_PROGRAM_OTP_ADDRESS(__VALUE__))
+#define IS_FLASH_PROGRAM_ADDRESS(__VALUE__)         (IS_FLASH_PROGRAM_MAIN_MEM_ADDRESS(__VALUE__) ||\
+                                                     IS_FLASH_PROGRAM_OTP_ADDRESS(__VALUE__))
 
 #define IS_FLASH_PAGE(__VALUE__)                    ((__VALUE__) < FLASH_PAGE_NB)
 
@@ -896,15 +915,20 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #define IS_FLASH_TYPEPROGRAM(__VALUE__)             (((__VALUE__) == FLASH_TYPEPROGRAM_DOUBLEWORD) || \
                                                      ((__VALUE__) == FLASH_TYPEPROGRAM_FAST))
 
-#define IS_OB_SFSA_START_ADDR(__VALUE__)            (((__VALUE__) >= FLASH_BASE) && ((__VALUE__) <= FLASH_END_ADDR) && (((__VALUE__) & ~(uint32_t)(FLASH_PAGE_SIZE - 1U)) == (__VALUE__)))
-#define IS_OB_SBRSA_START_ADDR(__VALUE__)           (((__VALUE__) >= SRAM2A_BASE) && ((__VALUE__) <= (SRAM2A_BASE + SRAM2A_SIZE - 1U)) && (((__VALUE__) & ~0x3FFU) == (__VALUE__)))
-#define IS_OB_SNBRSA_START_ADDR(__VALUE__)          (((__VALUE__) >= SRAM2B_BASE) && ((__VALUE__) <= (SRAM2B_BASE + SRAM2B_SIZE - 1U)) && (((__VALUE__) & ~0x3FFU) == (__VALUE__)))
-#define IS_OB_SECURE_MODE(__VALUE__)                (((__VALUE__) == SYSTEM_IN_SECURE_MODE) || ((__VALUE__) == SYSTEM_NOT_IN_SECURE_MODE))
+#define IS_OB_SFSA_START_ADDR(__VALUE__)            (((__VALUE__) >= FLASH_BASE) &&\
+                                                     ((__VALUE__) <= FLASH_END_ADDR) && (((__VALUE__) & ~(uint32_t)(FLASH_PAGE_SIZE - 1U)) == (__VALUE__)))
+#define IS_OB_SBRSA_START_ADDR(__VALUE__)           (((__VALUE__) >= SRAM2A_BASE) &&\
+                                                     ((__VALUE__) <= (SRAM2A_BASE + SRAM2A_SIZE - 1U)) && (((__VALUE__) & ~0x3FFU) == (__VALUE__)))
+#define IS_OB_SNBRSA_START_ADDR(__VALUE__)          (((__VALUE__) >= SRAM2B_BASE) &&\
+                                                     ((__VALUE__) <= (SRAM2B_BASE + SRAM2B_SIZE - 1U)) && (((__VALUE__) & ~0x3FFU) == (__VALUE__)))
+#define IS_OB_SECURE_MODE(__VALUE__)                (((__VALUE__) == SYSTEM_IN_SECURE_MODE) ||\
+                                                     ((__VALUE__) == SYSTEM_NOT_IN_SECURE_MODE))
 
 #define IS_OPTIONBYTE(__VALUE__)                    (((__VALUE__) <= (OPTIONBYTE_WRP | OPTIONBYTE_RDP | OPTIONBYTE_USER | OPTIONBYTE_PCROP | \
-                                                              OPTIONBYTE_IPCC_BUF_ADDR | OPTIONBYTE_C2_BOOT_VECT | OPTIONBYTE_SECURE_MODE)))
+                                                                      OPTIONBYTE_IPCC_BUF_ADDR | OPTIONBYTE_C2_BOOT_VECT | OPTIONBYTE_SECURE_MODE)))
 
-#define IS_OB_WRPAREA(__VALUE__)                    (((__VALUE__) == OB_WRPAREA_BANK1_AREAA) || ((__VALUE__) == OB_WRPAREA_BANK1_AREAB))
+#define IS_OB_WRPAREA(__VALUE__)                    (((__VALUE__) == OB_WRPAREA_BANK1_AREAA) ||\
+                                                     ((__VALUE__) == OB_WRPAREA_BANK1_AREAB))
 
 #define IS_OB_RDP_LEVEL(__VALUE__)                  (((__VALUE__) == OB_RDP_LEVEL_0)   ||\
                                                      ((__VALUE__) == OB_RDP_LEVEL_1)   ||\
@@ -914,21 +938,21 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
                                                      (((__VALUE__) & ~OB_USER_ALL) == 0U))
 
 #define IS_OB_USER_CONFIG(__TYPE__, __VALUE__)      ((((__TYPE__) & OB_USER_BOR_LEV) == OB_USER_BOR_LEV) \
-                                                      ? ((((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_0) || \
-                                                         (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_1) || \
-                                                         (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_2) || \
-                                                         (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_3) || \
-                                                         (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_4)) \
-                                                      : ((((__TYPE__) & OB_USER_AGC_TRIM) == OB_USER_AGC_TRIM) \
-                                                       ? ((((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_0) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_1) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_2) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_3) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_4) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_5) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_6) || \
-                                                          (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_7)) \
-                                                       : ((~(__TYPE__) & (__VALUE__)) == 0U)))
+                                                     ? ((((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_0) || \
+                                                        (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_1) || \
+                                                        (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_2) || \
+                                                        (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_3) || \
+                                                        (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_BOR_LEV)) == OB_BOR_LEVEL_4)) \
+                                                     : ((((__TYPE__) & OB_USER_AGC_TRIM) == OB_USER_AGC_TRIM) \
+                                                        ? ((((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_0) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_1) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_2) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_3) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_4) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_5) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_6) || \
+                                                           (((__VALUE__) & ~(OB_USER_ALL & ~OB_USER_AGC_TRIM)) == OB_AGC_TRIM_7)) \
+                                                        : ((~(__TYPE__) & (__VALUE__)) == 0U)))
 
 #define IS_OB_USER_AGC_TRIMMING(__VALUE__)          (((__VALUE__) == OB_AGC_TRIM_0) || ((__VALUE__) == OB_AGC_TRIM_1) || \
                                                      ((__VALUE__) == OB_AGC_TRIM_2) || ((__VALUE__) == OB_AGC_TRIM_3) || \
@@ -939,18 +963,22 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
                                                      ((__VALUE__) == OB_BOR_LEVEL_2) || ((__VALUE__) == OB_BOR_LEVEL_3) || \
                                                      ((__VALUE__) == OB_BOR_LEVEL_4))
 
-#define IS_OB_PCROP_CONFIG(__VALUE__)               (((__VALUE__) & ~(OB_PCROP_ZONE_A | OB_PCROP_ZONE_B | OB_PCROP_RDP_ERASE)) == 0U)
+#define IS_OB_PCROP_CONFIG(__VALUE__)               (((__VALUE__) &\
+                                                      ~(OB_PCROP_ZONE_A | OB_PCROP_ZONE_B | OB_PCROP_RDP_ERASE)) == 0U)
 
-#define IS_OB_IPCC_BUF_ADDR(__VALUE__)              (IS_OB_SBRSA_START_ADDR(__VALUE__) || IS_OB_SNBRSA_START_ADDR(__VALUE__))
+#define IS_OB_IPCC_BUF_ADDR(__VALUE__)              (IS_OB_SBRSA_START_ADDR(__VALUE__) ||\
+                                                     IS_OB_SNBRSA_START_ADDR(__VALUE__))
 
 #define IS_OB_BOOT_VECTOR_ADDR(__VALUE__)           ((((__VALUE__) >= FLASH_BASE) && ((__VALUE__) <= (FLASH_BASE + FLASH_SIZE - 1U)))    || \
                                                      (((__VALUE__) >= SRAM1_BASE) && ((__VALUE__) <= (SRAM1_BASE + SRAM1_SIZE - 1U)))    || \
                                                      (((__VALUE__) >= SRAM2A_BASE) && ((__VALUE__) <= (SRAM2A_BASE + SRAM2A_SIZE - 1U))) || \
                                                      (((__VALUE__) >= SRAM2B_BASE) && ((__VALUE__) <= (SRAM2B_BASE + SRAM2B_SIZE - 1U))))
 
-#define IS_OB_BOOT_REGION(__VALUE__)                (((__VALUE__) == OB_C2_BOOT_FROM_FLASH) || ((__VALUE__) == OB_C2_BOOT_FROM_SRAM))
+#define IS_OB_BOOT_REGION(__VALUE__)                (((__VALUE__) == OB_C2_BOOT_FROM_FLASH) ||\
+                                                     ((__VALUE__) == OB_C2_BOOT_FROM_SRAM))
 
-#define IS_OB_SECURE_CONFIG(__VALUE__)              (((__VALUE__) & ~(OB_SECURE_CONFIG_MEMORY | OB_SECURE_CONFIG_BOOT_RESET)) == 0U)
+#define IS_OB_SECURE_CONFIG(__VALUE__)              (((__VALUE__) &\
+                                                      ~(OB_SECURE_CONFIG_MEMORY | OB_SECURE_CONFIG_BOOT_RESET)) == 0U)
 
 #define IS_FLASH_LATENCY(__VALUE__)                 (((__VALUE__) == FLASH_LATENCY_0) || \
                                                      ((__VALUE__) == FLASH_LATENCY_1) || \
@@ -973,5 +1001,3 @@ HAL_StatusTypeDef  FLASH_WaitForLastOperation(uint32_t Timeout);
 #endif
 
 #endif /* STM32WBxx_HAL_FLASH_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_flash_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -49,11 +48,36 @@ extern "C" {
 /**
   * @}
   */
+
+/** @defgroup FLASHEx_ECC_CPUID FLASHEx ECC CPU Identification
+  * @{
+  */
+#define FLASH_ECC_CPUID_1    0x00000000U            /*!< Bus-ID of the CPU1 access causing the ECC failure. */
+#define FLASH_ECC_CPUID_2    FLASH_ECCR_CPUID_0     /*!< Bus-ID of the CPU2 access causing the ECC failure. */
+
+/**
+  * @}
+  */
 /**
   * @}
   */
 
 /* Exported macro ------------------------------------------------------------*/
+/** @defgroup FLASHEx_ECC FLASH ECC Macros
+  *  @brief macros to get Error Code Correction information
+  * @{
+  */
+
+/**
+  * @brief Get the Bus-ID of the CPU access causing the ECC failure
+  * @retval CPUID
+  */
+#define __HAL_FLASH_ECC_CPUID()   READ_BIT(FLASH->ECCR, FLASH_ECCR_CPUID)
+
+/**
+  * @}
+  */
+
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup FLASHEx_Exported_Functions
   * @{
@@ -111,5 +135,3 @@ void              FLASH_PageErase(uint32_t Page);
 #endif
 
 #endif /* STM32WBxx_HAL_FLASH_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_gpio.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_gpio.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,7 +21,7 @@
 #define STM32WBxx_HAL_GPIO_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -61,7 +60,7 @@ typedef struct
 
   uint32_t Alternate;  /*!< Peripheral to be connected to the selected pins
                             This parameter can be a value of @ref GPIOEx_Alternate_function_selection */
-}GPIO_InitTypeDef;
+} GPIO_InitTypeDef;
 
 /**
   * @brief  GPIO Bit SET and Bit RESET enumeration
@@ -70,7 +69,7 @@ typedef enum
 {
   GPIO_PIN_RESET = 0U,
   GPIO_PIN_SET
-}GPIO_PinState;
+} GPIO_PinState;
 /**
   * @}
   */
@@ -107,26 +106,26 @@ typedef enum
 
 /** @defgroup GPIO_mode GPIO mode
   * @brief GPIO Configuration Mode
-  *        Elements values convention: 0xX0yz00YZ
-  *           - X  : GPIO mode or EXTI Mode
-  *           - y  : External IT or Event trigger detection
-  *           - z  : IO configuration on External IT or Event
-  *           - Y  : Output type (Push Pull or Open Drain)
-  *           - Z  : IO Direction mode (Input, Output, Alternate or Analog)
+  *        Elements values convention: 0x00WX00YZ
+  *           - W  : EXTI trigger detection on 3 bits
+  *           - X  : EXTI mode (IT or Event) on 2 bits
+  *           - Y  : Output type (Push Pull or Open Drain) on 1 bit
+  *           - Z  : GPIO mode (Input, Output, Alternate or Analog) on 2 bits
   * @{
   */
-#define  GPIO_MODE_INPUT                        (0x00000000u)   /*!< Input Floating Mode                   */
-#define  GPIO_MODE_OUTPUT_PP                    (0x00000001u)   /*!< Output Push Pull Mode                 */
-#define  GPIO_MODE_OUTPUT_OD                    (0x00000011u)   /*!< Output Open Drain Mode                */
-#define  GPIO_MODE_AF_PP                        (0x00000002u)   /*!< Alternate Function Push Pull Mode     */
-#define  GPIO_MODE_AF_OD                        (0x00000012u)   /*!< Alternate Function Open Drain Mode    */
-#define  GPIO_MODE_ANALOG                       (0x00000003u)   /*!< Analog Mode  */
-#define  GPIO_MODE_IT_RISING                    (0x10110000u)   /*!< External Interrupt Mode with Rising edge trigger detection          */
-#define  GPIO_MODE_IT_FALLING                   (0x10210000u)   /*!< External Interrupt Mode with Falling edge trigger detection         */
-#define  GPIO_MODE_IT_RISING_FALLING            (0x10310000u)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
-#define  GPIO_MODE_EVT_RISING                   (0x10120000u)   /*!< External Event Mode with Rising edge trigger detection               */
-#define  GPIO_MODE_EVT_FALLING                  (0x10220000u)   /*!< External Event Mode with Falling edge trigger detection              */
-#define  GPIO_MODE_EVT_RISING_FALLING           (0x10320000u)   /*!< External Event Mode with Rising/Falling edge trigger detection       */
+#define GPIO_MODE_INPUT                 MODE_INPUT                                                  /*!< Input Floating Mode                                                */
+#define GPIO_MODE_OUTPUT_PP             (MODE_OUTPUT | OUTPUT_PP)                                   /*!< Output Push Pull Mode                                              */
+#define GPIO_MODE_OUTPUT_OD             (MODE_OUTPUT | OUTPUT_OD)                                   /*!< Output Open Drain Mode                                             */
+#define GPIO_MODE_AF_PP                 (MODE_AF | OUTPUT_PP)                                       /*!< Alternate Function Push Pull Mode                                  */
+#define GPIO_MODE_AF_OD                 (MODE_AF | OUTPUT_OD)                                       /*!< Alternate Function Open Drain Mode                                 */
+#define GPIO_MODE_ANALOG                MODE_ANALOG                                                 /*!< Analog Mode                                                        */
+#define GPIO_MODE_IT_RISING             (MODE_INPUT | EXTI_IT | TRIGGER_RISING)                     /*!< External Interrupt Mode with Rising edge trigger detection         */
+#define GPIO_MODE_IT_FALLING            (MODE_INPUT | EXTI_IT | TRIGGER_FALLING)                    /*!< External Interrupt Mode with Falling edge trigger detection        */
+#define GPIO_MODE_IT_RISING_FALLING     (MODE_INPUT | EXTI_IT | TRIGGER_RISING | TRIGGER_FALLING)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define GPIO_MODE_EVT_RISING            (MODE_INPUT | EXTI_EVT | TRIGGER_RISING)                    /*!< External Event Mode with Rising edge trigger detection             */
+#define GPIO_MODE_EVT_FALLING           (MODE_INPUT | EXTI_EVT | TRIGGER_FALLING)                   /*!< External Event Mode with Falling edge trigger detection            */
+#define GPIO_MODE_EVT_RISING_FALLING    (MODE_INPUT | EXTI_EVT | TRIGGER_RISING | TRIGGER_FALLING)  /*!< External Event Mode with Rising/Falling edge trigger detection     */
+
 /**
   * @}
   */
@@ -135,21 +134,21 @@ typedef enum
   * @brief GPIO Output Maximum frequency
   * @{
   */
-#define  GPIO_SPEED_FREQ_LOW        (0x00000000u)  /*!< Low speed       */
-#define  GPIO_SPEED_FREQ_MEDIUM     (0x00000001u)  /*!< Medium speed    */
-#define  GPIO_SPEED_FREQ_HIGH       (0x00000002u)  /*!< High speed      */
-#define  GPIO_SPEED_FREQ_VERY_HIGH  (0x00000003u)  /*!< Very high speed */
+#define GPIO_SPEED_FREQ_LOW             0x00000000u  /*!< Low speed       */
+#define GPIO_SPEED_FREQ_MEDIUM          0x00000001u  /*!< Medium speed    */
+#define GPIO_SPEED_FREQ_HIGH            0x00000002u  /*!< High speed      */
+#define GPIO_SPEED_FREQ_VERY_HIGH       0x00000003u  /*!< Very high speed */
 /**
   * @}
   */
 
- /** @defgroup GPIO_pull GPIO pull
-   * @brief GPIO Pull-Up or Pull-Down Activation
-   * @{
-   */
-#define  GPIO_NOPULL        (0x00000000u)   /*!< No Pull-up or Pull-down activation  */
-#define  GPIO_PULLUP        (0x00000001u)   /*!< Pull-up activation                  */
-#define  GPIO_PULLDOWN      (0x00000002u)   /*!< Pull-down activation                */
+/** @defgroup GPIO_pull GPIO pull
+  * @brief GPIO Pull-Up or Pull-Down Activation
+  * @{
+  */
+#define GPIO_NOPULL                     0x00000000u   /*!< No Pull-up or Pull-down activation  */
+#define GPIO_PULLUP                     0x00000001u   /*!< Pull-up activation                  */
+#define GPIO_PULLDOWN                   0x00000002u   /*!< Pull-down activation                */
 /**
   * @}
   */
@@ -208,6 +207,32 @@ typedef enum
   */
 
 /* Private macros ------------------------------------------------------------*/
+/** @defgroup GPIO_Private_Constants GPIO Private Constants
+  * @{
+  */
+#define GPIO_MODE_Pos                           0u
+#define GPIO_MODE                               (0x3uL << GPIO_MODE_Pos)
+#define MODE_INPUT                              (0x0uL << GPIO_MODE_Pos)
+#define MODE_OUTPUT                             (0x1uL << GPIO_MODE_Pos)
+#define MODE_AF                                 (0x2uL << GPIO_MODE_Pos)
+#define MODE_ANALOG                             (0x3uL << GPIO_MODE_Pos)
+#define OUTPUT_TYPE_Pos                         4u
+#define OUTPUT_TYPE                             (0x1uL << OUTPUT_TYPE_Pos)
+#define OUTPUT_PP                               (0x0uL << OUTPUT_TYPE_Pos)
+#define OUTPUT_OD                               (0x1uL << OUTPUT_TYPE_Pos)
+#define EXTI_MODE_Pos                           16u
+#define EXTI_MODE                               (0x3uL << EXTI_MODE_Pos)
+#define EXTI_IT                                 (0x1uL << EXTI_MODE_Pos)
+#define EXTI_EVT                                (0x2uL << EXTI_MODE_Pos)
+#define TRIGGER_MODE_Pos                         20u
+#define TRIGGER_MODE                            (0x7uL << TRIGGER_MODE_Pos)
+#define TRIGGER_RISING                          (0x1uL << TRIGGER_MODE_Pos)
+#define TRIGGER_FALLING                         (0x2uL << TRIGGER_MODE_Pos)
+
+/**
+  * @}
+  */
+
 /** @defgroup GPIO_Private_Macros GPIO Private Macros
   * @{
   */
@@ -215,6 +240,10 @@ typedef enum
 
 #define IS_GPIO_PIN(__PIN__)        ((((uint32_t)(__PIN__) & GPIO_PIN_MASK) != 0x00u) &&\
                                      (((uint32_t)(__PIN__) & ~GPIO_PIN_MASK) == 0x00u))
+
+#define IS_GPIO_COMMON_PIN(__RESETMASK__, __SETMASK__)  \
+  (((uint32_t)(__RESETMASK__) & (uint32_t)(__SETMASK__)) == 0x00u)
+
 
 #define IS_GPIO_MODE(__MODE__)      (((__MODE__) == GPIO_MODE_INPUT)              ||\
                                      ((__MODE__) == GPIO_MODE_OUTPUT_PP)          ||\
@@ -246,14 +275,14 @@ typedef enum
 
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup GPIO_Exported_Functions GPIO Exported Functions
- *  @brief    GPIO Exported Functions
+  *  @brief    GPIO Exported Functions
   * @{
   */
 
 /** @defgroup GPIO_Exported_Functions_Group1 Initialization/de-initialization functions
- *  @brief    Initialization and Configuration functions
- * @{
- */
+  *  @brief    Initialization and Configuration functions
+  * @{
+  */
 
 /* Initialization and de-initialization functions *****************************/
 void              HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init);
@@ -264,15 +293,16 @@ void              HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin);
   */
 
 /** @defgroup GPIO_Exported_Functions_Group2 IO operation functions
- *  @brief    IO operation functions
- * @{
- */
+  *  @brief    IO operation functions
+  * @{
+  */
 
 /* IO operation functions *****************************************************/
-GPIO_PinState     HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
-void              HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
-void              HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
-HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+GPIO_PinState     HAL_GPIO_ReadPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+void              HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
+void              HAL_GPIO_WriteMultipleStatePin(GPIO_TypeDef *GPIOx, uint16_t PinReset, uint16_t PinSet);
+void              HAL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
 void              HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin);
 void              HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
 
@@ -297,5 +327,3 @@ void              HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
 #endif
 
 #endif /* STM32WBxx_HAL_GPIO_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_gpio_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_gpio_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,7 +21,7 @@
 #define STM32WBxx_HAL_GPIO_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -48,10 +47,10 @@
   */
 
 
- /* The table below gives an overview of the different alternate functions per port.
-  * For more details refer yourself to the product data sheet.
-  *
-  */
+/* The table below gives an overview of the different alternate functions per port.
+ * For more details refer yourself to the product data sheet.
+ *
+ */
 
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx)
 /**
@@ -74,23 +73,23 @@
 #define GPIO_AF0_TRACECK       ((uint8_t)0x00)  /*!< TRACECK Alternate Function mapping             */
 #define GPIO_AF0_SYS           ((uint8_t)0x00)  /*!< System Function mapping                        */
 
- /**
+/**
   * @brief   AF 1 selection
   */
-#define GPIO_AF1_TIM1           ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping           */
-#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /*!< TIM2 Alternate Function mapping            */
-#define GPIO_AF1_LPTIM1         ((uint8_t)0x01)  /*!< LPTIM1 Alternate Function mapping          */
+#define GPIO_AF1_TIM1           ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping          */
+#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /*!< TIM2 Alternate Function mapping          */
+#define GPIO_AF1_LPTIM1         ((uint8_t)0x01)  /*!< LPTIM1 Alternate Function mapping        */
 
 /**
   * @brief   AF 2 selection
   */
-#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /*!< TIM2 Alternate Function mapping           */
-#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping         */
+#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /*!< TIM2 Alternate Function mapping          */
+#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping          */
 
 /**
   * @brief   AF 3 selection
   */
-#define GPIO_AF3_SAI1           ((uint8_t)0x03)  /*!< SAI1_CK1 Alternate Function mapping           */
+#define GPIO_AF3_SAI1           ((uint8_t)0x03)  /*!< SAI1_CK1 Alternate Function mapping      */
 #define GPIO_AF3_SPI2           ((uint8_t)0x03)  /*!< SPI2 Alternate Function mapping          */
 #define GPIO_AF3_TIM1           ((uint8_t)0x03)  /*!< TIM1 Alternate Function mapping          */
 
@@ -98,7 +97,7 @@
   * @brief   AF 4 selection
   */
 #define GPIO_AF4_I2C1           ((uint8_t)0x04)  /*!< I2C1 Alternate Function mapping         */
-#define GPIO_AF4_I2C3           ((uint8_t)0x04)  /*!< I2C3 Alternate Function mapping          */
+#define GPIO_AF4_I2C3           ((uint8_t)0x04)  /*!< I2C3 Alternate Function mapping         */
 
 /**
   * @brief   AF 5 selection
@@ -136,18 +135,18 @@
 /**
   * @brief   AF 7 selection
   */
-#define GPIO_AF7_USART1         ((uint8_t)0x07)  /*!< USART1 Alternate Function mapping     */
+#define GPIO_AF7_USART1         ((uint8_t)0x07)  /*!< USART1 Alternate Function mapping    */
 
 /**
   * @brief   AF 8 selection
   */
-#define GPIO_AF8_LPUART1        ((uint8_t)0x08)  /*!< LPUART1 Alternate Function mapping      */
-#define GPIO_AF8_IR             ((uint8_t)0x08)  /*!< IR Alternate Function mapping          */
+#define GPIO_AF8_LPUART1        ((uint8_t)0x08)  /*!< LPUART1 Alternate Function mapping   */
+#define GPIO_AF8_IR             ((uint8_t)0x08)  /*!< IR Alternate Function mapping        */
 
 /**
   * @brief   AF 9 selection
   */
- #define GPIO_AF9_TSC           ((uint8_t)0x09)  /*!< TSC Alternate Function mapping      */
+#define GPIO_AF9_TSC           ((uint8_t)0x09)  /*!< TSC Alternate Function mapping      */
 
 /**
   * @brief   AF 10 selection
@@ -161,20 +160,20 @@
 #define GPIO_AF11_LCD           ((uint8_t)0x0b)  /*!< LCD Alternate Function mapping      */
 
 /**
- * @brief   AF 12 selection
- */
+  * @brief   AF 12 selection
+  */
 #define GPIO_AF12_COMP1         ((uint8_t)0x0c)  /*!< COMP1 Alternate Function mapping      */
 #define GPIO_AF12_COMP2         ((uint8_t)0x0c)  /*!< COMP2 Alternate Function mapping      */
 #define GPIO_AF12_TIM1          ((uint8_t)0x0c)  /*!< TIM1 Alternate Function mapping      */
 
 /**
- * @brief   AF 13 selection
- */
+  * @brief   AF 13 selection
+  */
 #define GPIO_AF13_SAI1          ((uint8_t)0x0d)  /*!< SAI1 Alternate Function mapping      */
 
 /**
- * @brief   AF 14 selection
- */
+  * @brief   AF 14 selection
+  */
 #define GPIO_AF14_TIM2          ((uint8_t)0x0e)  /*!< TIM2 Alternate Function mapping       */
 #define GPIO_AF14_TIM16         ((uint8_t)0x0e)  /*!< TIM16 Alternate Function mapping      */
 #define GPIO_AF14_TIM17         ((uint8_t)0x0e)  /*!< TIM17 Alternate Function mapping      */
@@ -182,13 +181,13 @@
 
 
 /**
-* @brief   AF 15 selection
-*/
+  * @brief   AF 15 selection
+  */
 #define GPIO_AF15_EVENTOUT          ((uint8_t)0x0f)  /*!< EVENTOUT Alternate Function mapping      */
 
 #define IS_GPIO_AF(AF)              ((AF) <= (uint8_t)0x0f)
 
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 
 
 #if defined (STM32WB50xx)
@@ -204,7 +203,7 @@
 #define GPIO_AF0_JTD_TRACE     ((uint8_t)0x00)  /*!< JTDO-TRACESWO Alternate Function mapping       */
 #define GPIO_AF0_NJTRST        ((uint8_t)0x00)  /*!< NJTRST Alternate Function mapping              */
 
- /**
+/**
   * @brief   AF 1 selection
   */
 #define GPIO_AF1_TIM1           ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping           */
@@ -271,26 +270,27 @@
 #define GPIO_AF8_IR             ((uint8_t)0x08)  /*!< IR Alternate Function mapping          */
 
 /**
- * @brief   AF 12 selection
- */
+  * @brief   AF 12 selection
+  */
 #define GPIO_AF12_TIM1          ((uint8_t)0x0c)  /*!< TIM1 Alternate Function mapping      */
 
 /**
- * @brief   AF 14 selection
- */
+  * @brief   AF 14 selection
+  */
 #define GPIO_AF14_TIM2          ((uint8_t)0x0e)  /*!< TIM2 Alternate Function mapping       */
 #define GPIO_AF14_TIM16         ((uint8_t)0x0e)  /*!< TIM16 Alternate Function mapping      */
 #define GPIO_AF14_TIM17         ((uint8_t)0x0e)  /*!< TIM17 Alternate Function mapping      */
 #define GPIO_AF14_LPTIM2        ((uint8_t)0x0e)  /*!< LPTIM2 Alternate Function mapping     */
 
 /**
-* @brief   AF 15 selection
-*/
-#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0f)  /*!< EVENTOUT Alternate Function mapping      */
+  * @brief   AF 15 selection
+  */
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0f)  /*!< EVENTOUT Alternate Function mapping   */
 
-#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0F) && ((AF) != (uint8_t)0x09) && ((AF) != (uint8_t)0x0A) && ((AF) != (uint8_t)0x0B) && ((AF) != (uint8_t)0x0D))
+#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0F)\
+                                 && ((AF) != (uint8_t)0x09) && ((AF) != (uint8_t)0x0A) && ((AF) != (uint8_t)0x0B) && ((AF) != (uint8_t)0x0D))
 
-#endif
+#endif /* STM32WB50xx */
 
 
 #if defined (STM32WB35xx)
@@ -394,8 +394,8 @@
 #define GPIO_AF12_TIM1          ((uint8_t)0x0C)  /*!< TIM1 Alternate Function mapping       */
 
 /**
- * @brief   AF 13 selection
- */
+  * @brief   AF 13 selection
+  */
 #define GPIO_AF13_SAI1          ((uint8_t)0x0d)  /*!< SAI1 Alternate Function mapping      */
 
 /**
@@ -413,7 +413,7 @@
 
 #define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0F) && ((AF) != (uint8_t)0x0B) && ((AF) != (uint8_t)0x0D))
 
-#endif
+#endif /* STM32WB35xx */
 
 #if defined (STM32WB30xx)
 /**
@@ -432,7 +432,7 @@
 #define GPIO_AF0_TRACED2       ((uint8_t)0x00)  /*!< TRACED2 Alternate Function mapping             */
 #define GPIO_AF0_TRACED3       ((uint8_t)0x00)  /*!< TRACED3 Alternate Function mapping             */
 
- /**
+/**
   * @brief   AF 1 selection
   */
 #define GPIO_AF1_TIM1           ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping       */
@@ -517,10 +517,115 @@
   */
 #define GPIO_AF15_EVENTOUT      ((uint8_t)0x0F)  /*!< EVENTOUT Alternate Function mapping   */
 
-#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0F) && ((AF) != (uint8_t)0x0A) && ((AF) != (uint8_t)0x0B) && ((AF) != (uint8_t)0x0D))
+#define IS_GPIO_AF(AF)          (((AF) <= (uint8_t)0x0F)\
+                                 && ((AF) != (uint8_t)0x0A) && ((AF) != (uint8_t)0x0B) && ((AF) != (uint8_t)0x0D))
 
-#endif
+#endif /* STM32WB30xx */
 
+#if defined (STM32WB15xx) || defined (STM32WB10xx) || defined (STM32WB1Mxx)
+/**
+  * @brief   AF 0 selection
+  */
+#define GPIO_AF0_MCO           ((uint8_t)0x00)  /*!< MCO Alternate Function mapping                 */
+#define GPIO_AF0_LSCO          ((uint8_t)0x00)  /*!< LSCO Alternate Function mapping                */
+#define GPIO_AF0_JTMS_SWDIO    ((uint8_t)0x00)  /*!< JTMS-SWDIO Alternate Function mapping          */
+#define GPIO_AF0_JTCK_SWCLK    ((uint8_t)0x00)  /*!< JTCK-SWCLK Alternate Function mapping          */
+#define GPIO_AF0_JTDI          ((uint8_t)0x00)  /*!< JTDI Alternate Function mapping                */
+#define GPIO_AF0_RTC_OUT       ((uint8_t)0x00)  /*!< RCT_OUT Alternate Function mapping             */
+#define GPIO_AF0_JTD_TRACE     ((uint8_t)0x00)  /*!< JTDO-TRACESWO Alternate Function mapping       */
+#define GPIO_AF0_NJTRST        ((uint8_t)0x00)  /*!< NJTRST Alternate Function mapping              */
+
+/**
+  * @brief   AF 1 selection
+  */
+#define GPIO_AF1_TIM1           ((uint8_t)0x01)  /*!< TIM1 Alternate Function mapping           */
+#define GPIO_AF1_TIM2           ((uint8_t)0x01)  /*!< TIM2 Alternate Function mapping            */
+#define GPIO_AF1_LPTIM1         ((uint8_t)0x01)  /*!< LPTIM1 Alternate Function mapping          */
+
+/**
+  * @brief   AF 2 selection
+  */
+#define GPIO_AF2_TIM2           ((uint8_t)0x02)  /*!< TIM2 Alternate Function mapping           */
+#define GPIO_AF2_TIM1           ((uint8_t)0x02)  /*!< TIM1 Alternate Function mapping         */
+
+/**
+  * @brief   AF 3 selection
+  */
+#define GPIO_AF3_TIM1           ((uint8_t)0x03)  /*!< TIM1 Alternate Function mapping          */
+
+/**
+  * @brief   AF 4 selection
+  */
+#define GPIO_AF4_I2C1           ((uint8_t)0x04)  /*!< I2C1 Alternate Function mapping         */
+#define GPIO_AF4_SPI1           ((uint8_t)0x04)  /*!< SPI1 Alternate Function mapping        */
+
+/**
+  * @brief   AF 5 selection
+  */
+#define GPIO_AF5_SPI1           ((uint8_t)0x05)  /*!< SPI1 Alternate Function mapping        */
+
+/**
+  * @brief   AF 6 selection
+  */
+#define GPIO_AF6_MCO            ((uint8_t)0x06)  /*!< MCO Alternate Function mapping       */
+#define GPIO_AF6_RF_DTB0        ((uint8_t)0x06)  /*!< RF_DTB0 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB1        ((uint8_t)0x06)  /*!< RF_DTB1 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB2        ((uint8_t)0x06)  /*!< RF_DTB2 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB3        ((uint8_t)0x06)  /*!< RF_DTB3 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB4        ((uint8_t)0x06)  /*!< RF_DTB4 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB5        ((uint8_t)0x06)  /*!< RF_DTB5 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB6        ((uint8_t)0x06)  /*!< RF_DTB6 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB7        ((uint8_t)0x06)  /*!< RF_DTB7 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB8        ((uint8_t)0x06)  /*!< RF_DTB8 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB9        ((uint8_t)0x06)  /*!< RF_DTB9 Alternate Function mapping   */
+#define GPIO_AF6_RF_DTB10       ((uint8_t)0x06)  /*!< RF_DTB10 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB11       ((uint8_t)0x06)  /*!< RF_DTB11 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB12       ((uint8_t)0x06)  /*!< RF_DTB12 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB13       ((uint8_t)0x06)  /*!< RF_DTB13 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB14       ((uint8_t)0x06)  /*!< RF_DTB14 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB15       ((uint8_t)0x06)  /*!< RF_DTB15 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB16       ((uint8_t)0x06)  /*!< RF_DTB16 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB17       ((uint8_t)0x06)  /*!< RF_DTB17 Alternate Function mapping  */
+#define GPIO_AF6_RF_DTB18       ((uint8_t)0x06)  /*!< RF_DTB18 Alternate Function mapping  */
+#define GPIO_AF6_RF_MISO        ((uint8_t)0x06)  /*!< RF_MISO Alternate Function mapping   */
+#define GPIO_AF6_RF_MOSI        ((uint8_t)0x06)  /*!< RF_MOSI Alternate Function mapping   */
+#define GPIO_AF6_RF_SCK         ((uint8_t)0x06)  /*!< RF_SCK Alternate Function mapping    */
+#define GPIO_AF6_RF_NSS         ((uint8_t)0x06)  /*!< RF_NSS Alternate Function mapping    */
+/**
+  * @brief   AF 7 selection
+  */
+#define GPIO_AF7_USART1         ((uint8_t)0x07)  /*!< USART1 Alternate Function mapping     */
+
+/**
+  * @brief   AF 8 selection
+  */
+#define GPIO_AF8_LPUART1        ((uint8_t)0x08)  /*!< LPUART1 Alternate Function mapping      */
+
+/**
+  * @brief   AF 9 selection
+  */
+#define GPIO_AF9_TSC           ((uint8_t)0x09)  /*!< TSC Alternate Function mapping      */
+
+/**
+  * @brief   AF 12 selection
+  */
+#define GPIO_AF12_COMP1         ((uint8_t)0x0c)  /*!< COMP1 Alternate Function mapping      */
+#define GPIO_AF12_TIM1          ((uint8_t)0x0c)  /*!< TIM1 Alternate Function mapping      */
+
+/**
+  * @brief   AF 14 selection
+  */
+#define GPIO_AF14_TIM2          ((uint8_t)0x0e)  /*!< TIM2 Alternate Function mapping       */
+#define GPIO_AF14_LPTIM2        ((uint8_t)0x0e)  /*!< LPTIM2 Alternate Function mapping     */
+
+
+/**
+  * @brief   AF 15 selection
+  */
+#define GPIO_AF15_EVENTOUT          ((uint8_t)0x0f)  /*!< EVENTOUT Alternate Function mapping      */
+
+#define IS_GPIO_AF(AF)              ((AF) <= (uint8_t)0x0f)
+#endif /* STM32WB15xx || STM32WB10xx || STM32WB1Mxx */
 
 /**
   * @}
@@ -536,7 +641,7 @@
   */
 
 /** @defgroup GPIOEx_Get_Port_Index GPIOEx Get Port Index
-* @{
+  * @{
   */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx)
 #define GPIO_GET_INDEX(__GPIOx__)    (((__GPIOx__) == (GPIOA))? 0uL :\
@@ -549,8 +654,8 @@
                                       ((__GPIOx__) == (GPIOB))? 1uL :\
                                       ((__GPIOx__) == (GPIOC))? 2uL :\
                                       ((__GPIOx__) == (GPIOE))? 4uL : 7uL)
-#endif
- /**
+#endif /* STM32WB55xx || STM32WB5Mxx */
+/**
   * @}
   */
 
@@ -572,5 +677,3 @@
 #endif
 
 #endif /* STM32WBxx_HAL_GPIO_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_hsem.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_hsem.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -53,64 +52,44 @@ extern "C" {
   * @param  __SEM_MASK__: semaphores Mask
   * @retval None.
   */
-#if defined(DUAL_CORE)
 #define __HAL_HSEM_ENABLE_IT(__SEM_MASK__) ((((SCB->CPUID & 0x000000F0) >> 4 )== 0x7) ? \
                                             (HSEM->C1IER |= (__SEM_MASK__)) : \
                                             (HSEM->C2IER |= (__SEM_MASK__)))
-#else
-#define __HAL_HSEM_ENABLE_IT(__SEM_MASK__) (HSEM->IER |= (__SEM_MASK__))
-#endif /* DUAL_CORE */
 /**
   * @brief  Disables the specified HSEM interrupts.
   * @param  __SEM_MASK__: semaphores Mask
   * @retval None.
   */
-#if defined(DUAL_CORE)
 #define __HAL_HSEM_DISABLE_IT(__SEM_MASK__) ((((SCB->CPUID & 0x000000F0) >> 4 )== 0x7) ? \
                                              (HSEM->C1IER &= ~(__SEM_MASK__)) :       \
                                              (HSEM->C2IER &= ~(__SEM_MASK__)))
-#else
-#define __HAL_HSEM_DISABLE_IT(__SEM_MASK__) (HSEM->IER &= ~(__SEM_MASK__))
-#endif /* DUAL_CORE */
 
 /**
   * @brief  Checks whether interrupt has occurred or not for semaphores specified by a mask.
   * @param  __SEM_MASK__: semaphores Mask
   * @retval semaphores Mask : Semaphores where an interrupt occurred.
   */
-#if defined(DUAL_CORE)
 #define __HAL_HSEM_GET_IT(__SEM_MASK__) ((((SCB->CPUID & 0x000000F0) >> 4 )== 0x7) ? \
                                          ((__SEM_MASK__) & HSEM->C1MISR) :        \
-                                         ((__SEM_MASK__) & HSEM->C2MISR1))
-#else
-#define __HAL_HSEM_GET_IT(__SEM_MASK__) ((__SEM_MASK__) & HSEM->MISR)
-#endif /* DUAL_CORE */
+                                         ((__SEM_MASK__) & HSEM->C2MISR))
 
 /**
   * @brief  Get the semaphores release status flags.
   * @param  __SEM_MASK__: semaphores Mask
   * @retval semaphores Mask : Semaphores where Release flags rise.
   */
-#if defined(DUAL_CORE)
 #define __HAL_HSEM_GET_FLAG(__SEM_MASK__) ((((SCB->CPUID & 0x000000F0) >> 4 )== 0x7) ? \
                                            (__SEM_MASK__) & HSEM->C1ISR :           \
                                            (__SEM_MASK__) & HSEM->C2ISR)
-#else
-#define __HAL_HSEM_GET_FLAG(__SEM_MASK__) ((__SEM_MASK__) & HSEM->ISR)
-#endif /* DUAL_CORE */
 
 /**
   * @brief  Clears the HSEM Interrupt flags.
   * @param  __SEM_MASK__: semaphores Mask
   * @retval None.
   */
-#if defined(DUAL_CORE)
 #define __HAL_HSEM_CLEAR_FLAG(__SEM_MASK__) ((((SCB->CPUID & 0x000000F0) >> 4 )== 0x7) ? \
                                              (HSEM->C1ICR |= (__SEM_MASK__)) :        \
                                              (HSEM->C2ICR |= (__SEM_MASK__)))
-#else
-#define __HAL_HSEM_CLEAR_FLAG(__SEM_MASK__) (HSEM->ICR |= (__SEM_MASK__))
-#endif /* DUAL_CORE */
 
 /**
   * @}
@@ -130,12 +109,12 @@ extern "C" {
 HAL_StatusTypeDef  HAL_HSEM_Take(uint32_t SemID, uint32_t ProcessID);
 /* HSEM semaphore fast take (lock) using 1-Step  method ***********************/
 HAL_StatusTypeDef  HAL_HSEM_FastTake(uint32_t SemID);
-/* HSEM Check semaphore state Taken or not   **********************************/
-uint32_t HAL_HSEM_IsSemTaken(uint32_t SemID);
 /* HSEM Release  **************************************************************/
 void  HAL_HSEM_Release(uint32_t SemID, uint32_t ProcessID);
 /* HSEM Release All************************************************************/
 void HAL_HSEM_ReleaseAll(uint32_t Key, uint32_t CoreID);
+/* HSEM Check semaphore state Taken or not   **********************************/
+uint32_t HAL_HSEM_IsSemTaken(uint32_t SemID);
 
 /**
   * @}
@@ -206,5 +185,3 @@ void HAL_HSEM_IRQHandler(void);
 #endif
 
 #endif /* STM32WBxx_HAL_HSEM_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_i2c.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_i2c.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -48,29 +47,30 @@ extern "C" {
 typedef struct
 {
   uint32_t Timing;              /*!< Specifies the I2C_TIMINGR_register value.
-                                  This parameter calculated by referring to I2C initialization
-                                         section in Reference manual */
+                                     This parameter calculated by referring to I2C initialization section
+                                     in Reference manual */
 
   uint32_t OwnAddress1;         /*!< Specifies the first device own address.
-                                  This parameter can be a 7-bit or 10-bit address. */
+                                     This parameter can be a 7-bit or 10-bit address. */
 
   uint32_t AddressingMode;      /*!< Specifies if 7-bit or 10-bit addressing mode is selected.
-                                  This parameter can be a value of @ref I2C_ADDRESSING_MODE */
+                                     This parameter can be a value of @ref I2C_ADDRESSING_MODE */
 
   uint32_t DualAddressMode;     /*!< Specifies if dual addressing mode is selected.
-                                  This parameter can be a value of @ref I2C_DUAL_ADDRESSING_MODE */
+                                     This parameter can be a value of @ref I2C_DUAL_ADDRESSING_MODE */
 
   uint32_t OwnAddress2;         /*!< Specifies the second device own address if dual addressing mode is selected
-                                  This parameter can be a 7-bit address. */
+                                     This parameter can be a 7-bit address. */
 
-  uint32_t OwnAddress2Masks;    /*!< Specifies the acknowledge mask address second device own address if dual addressing mode is selected
-                                  This parameter can be a value of @ref I2C_OWN_ADDRESS2_MASKS */
+  uint32_t OwnAddress2Masks;    /*!< Specifies the acknowledge mask address second device own address if dual addressing
+                                     mode is selected.
+                                     This parameter can be a value of @ref I2C_OWN_ADDRESS2_MASKS */
 
   uint32_t GeneralCallMode;     /*!< Specifies if general call mode is selected.
-                                  This parameter can be a value of @ref I2C_GENERAL_CALL_ADDRESSING_MODE */
+                                     This parameter can be a value of @ref I2C_GENERAL_CALL_ADDRESSING_MODE */
 
   uint32_t NoStretchMode;       /*!< Specifies if nostretch mode is selected.
-                                  This parameter can be a value of @ref I2C_NOSTRETCH_MODE */
+                                     This parameter can be a value of @ref I2C_NOSTRETCH_MODE */
 
 } I2C_InitTypeDef;
 
@@ -118,8 +118,6 @@ typedef enum
   HAL_I2C_STATE_BUSY_RX_LISTEN    = 0x2AU,   /*!< Address Listen Mode and Data Reception
                                                  process is ongoing                         */
   HAL_I2C_STATE_ABORT             = 0x60U,   /*!< Abort user request ongoing                */
-  HAL_I2C_STATE_TIMEOUT           = 0xA0U,   /*!< Timeout state                             */
-  HAL_I2C_STATE_ERROR             = 0xE0U    /*!< Error                                     */
 
 } HAL_I2C_StateTypeDef;
 
@@ -200,11 +198,15 @@ typedef struct __I2C_HandleTypeDef
 
   __IO uint32_t              PreviousState;  /*!< I2C communication Previous state          */
 
-  HAL_StatusTypeDef(*XferISR)(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources);  /*!< I2C transfer IRQ handler function pointer */
+  HAL_StatusTypeDef(*XferISR)(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources);
+  /*!< I2C transfer IRQ handler function pointer */
 
+#if defined(HAL_DMA_MODULE_ENABLED)
   DMA_HandleTypeDef          *hdmatx;        /*!< I2C Tx DMA handle parameters              */
 
   DMA_HandleTypeDef          *hdmarx;        /*!< I2C Rx DMA handle parameters              */
+
+#endif /*HAL_DMA_MODULE_ENABLED*/
 
   HAL_LockTypeDef            Lock;           /*!< I2C locking object                        */
 
@@ -216,21 +218,37 @@ typedef struct __I2C_HandleTypeDef
 
   __IO uint32_t              AddrEventCount; /*!< I2C Address Event counter                 */
 
+  __IO uint32_t              Devaddress;     /*!< I2C Target device address                 */
+
+  __IO uint32_t              Memaddress;     /*!< I2C Target memory address                 */
+
 #if (USE_HAL_I2C_REGISTER_CALLBACKS == 1)
-  void (* MasterTxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);           /*!< I2C Master Tx Transfer completed callback */
-  void (* MasterRxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);           /*!< I2C Master Rx Transfer completed callback */
-  void (* SlaveTxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);            /*!< I2C Slave Tx Transfer completed callback  */
-  void (* SlaveRxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);            /*!< I2C Slave Rx Transfer completed callback  */
-  void (* ListenCpltCallback)(struct __I2C_HandleTypeDef *hi2c);             /*!< I2C Listen Complete callback              */
-  void (* MemTxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);              /*!< I2C Memory Tx Transfer completed callback */
-  void (* MemRxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);              /*!< I2C Memory Rx Transfer completed callback */
-  void (* ErrorCallback)(struct __I2C_HandleTypeDef *hi2c);                  /*!< I2C Error callback                        */
-  void (* AbortCpltCallback)(struct __I2C_HandleTypeDef *hi2c);              /*!< I2C Abort callback                        */
+  void (* MasterTxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Master Tx Transfer completed callback */
+  void (* MasterRxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Master Rx Transfer completed callback */
+  void (* SlaveTxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Slave Tx Transfer completed callback  */
+  void (* SlaveRxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Slave Rx Transfer completed callback  */
+  void (* ListenCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Listen Complete callback              */
+  void (* MemTxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Memory Tx Transfer completed callback */
+  void (* MemRxCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Memory Rx Transfer completed callback */
+  void (* ErrorCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Error callback                        */
+  void (* AbortCpltCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Abort callback                        */
 
-  void (* AddrCallback)(struct __I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode);  /*!< I2C Slave Address Match callback */
+  void (* AddrCallback)(struct __I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode);
+  /*!< I2C Slave Address Match callback */
 
-  void (* MspInitCallback)(struct __I2C_HandleTypeDef *hi2c);                /*!< I2C Msp Init callback                     */
-  void (* MspDeInitCallback)(struct __I2C_HandleTypeDef *hi2c);              /*!< I2C Msp DeInit callback                   */
+  void (* MspInitCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Msp Init callback                     */
+  void (* MspDeInitCallback)(struct __I2C_HandleTypeDef *hi2c);
+  /*!< I2C Msp DeInit callback                   */
 
 #endif  /* USE_HAL_I2C_REGISTER_CALLBACKS */
 } I2C_HandleTypeDef;
@@ -259,8 +277,11 @@ typedef enum
 /**
   * @brief  HAL I2C Callback pointer definition
   */
-typedef  void (*pI2C_CallbackTypeDef)(I2C_HandleTypeDef *hi2c); /*!< pointer to an I2C callback function */
-typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection, uint16_t AddrMatchCode); /*!< pointer to an I2C Address Match callback function */
+typedef  void (*pI2C_CallbackTypeDef)(I2C_HandleTypeDef *hi2c);
+/*!< pointer to an I2C callback function */
+typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t TransferDirection,
+                                          uint16_t AddrMatchCode);
+/*!< pointer to an I2C Address Match callback function */
 
 #endif /* USE_HAL_I2C_REGISTER_CALLBACKS */
 /**
@@ -440,14 +461,14 @@ typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t Trans
   * @retval None
   */
 #if (USE_HAL_I2C_REGISTER_CALLBACKS == 1)
-#define __HAL_I2C_RESET_HANDLE_STATE(__HANDLE__)                do{                                                   \
-                                                                    (__HANDLE__)->State = HAL_I2C_STATE_RESET;       \
-                                                                    (__HANDLE__)->MspInitCallback = NULL;            \
-                                                                    (__HANDLE__)->MspDeInitCallback = NULL;          \
+#define __HAL_I2C_RESET_HANDLE_STATE(__HANDLE__)                do{                                             \
+                                                                    (__HANDLE__)->State = HAL_I2C_STATE_RESET;  \
+                                                                    (__HANDLE__)->MspInitCallback = NULL;       \
+                                                                    (__HANDLE__)->MspDeInitCallback = NULL;     \
                                                                   } while(0)
 #else
 #define __HAL_I2C_RESET_HANDLE_STATE(__HANDLE__)                ((__HANDLE__)->State = HAL_I2C_STATE_RESET)
-#endif
+#endif /* USE_HAL_I2C_REGISTER_CALLBACKS */
 
 /** @brief  Enable the specified I2C interrupt.
   * @param  __HANDLE__ specifies the I2C Handle.
@@ -495,7 +516,8 @@ typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t Trans
   *
   * @retval The new state of __INTERRUPT__ (SET or RESET).
   */
-#define __HAL_I2C_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_I2C_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      ((((__HANDLE__)->Instance->CR1 & \
+                                                                   (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Check whether the specified I2C flag is set or not.
   * @param  __HANDLE__ specifies the I2C Handle.
@@ -521,7 +543,8 @@ typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t Trans
   * @retval The new state of __FLAG__ (SET or RESET).
   */
 #define I2C_FLAG_MASK  (0x0001FFFFU)
-#define __HAL_I2C_GET_FLAG(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) == (__FLAG__)) ? SET : RESET)
+#define __HAL_I2C_GET_FLAG(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->ISR) & \
+                                                    (__FLAG__)) == (__FLAG__)) ? SET : RESET)
 
 /** @brief  Clear the I2C pending flags which are cleared by writing 1 in a specific bit.
   * @param  __HANDLE__ specifies the I2C Handle.
@@ -540,26 +563,27 @@ typedef  void (*pI2C_AddrCallbackTypeDef)(I2C_HandleTypeDef *hi2c, uint8_t Trans
   *
   * @retval None
   */
-#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__FLAG__) == I2C_FLAG_TXE) ? ((__HANDLE__)->Instance->ISR |= (__FLAG__)) \
-                                                                                 : ((__HANDLE__)->Instance->ICR = (__FLAG__)))
+#define __HAL_I2C_CLEAR_FLAG(__HANDLE__, __FLAG__) (((__FLAG__) == I2C_FLAG_TXE) ? \
+                                                    ((__HANDLE__)->Instance->ISR |= (__FLAG__)) : \
+                                                    ((__HANDLE__)->Instance->ICR = (__FLAG__)))
 
 /** @brief  Enable the specified I2C peripheral.
   * @param  __HANDLE__ specifies the I2C Handle.
   * @retval None
   */
-#define __HAL_I2C_ENABLE(__HANDLE__)                            (SET_BIT((__HANDLE__)->Instance->CR1,  I2C_CR1_PE))
+#define __HAL_I2C_ENABLE(__HANDLE__)                         (SET_BIT((__HANDLE__)->Instance->CR1, I2C_CR1_PE))
 
 /** @brief  Disable the specified I2C peripheral.
   * @param  __HANDLE__ specifies the I2C Handle.
   * @retval None
   */
-#define __HAL_I2C_DISABLE(__HANDLE__)                           (CLEAR_BIT((__HANDLE__)->Instance->CR1, I2C_CR1_PE))
+#define __HAL_I2C_DISABLE(__HANDLE__)                        (CLEAR_BIT((__HANDLE__)->Instance->CR1, I2C_CR1_PE))
 
 /** @brief  Generate a Non-Acknowledge I2C peripheral in Slave mode.
   * @param  __HANDLE__ specifies the I2C Handle.
   * @retval None
   */
-#define __HAL_I2C_GENERATE_NACK(__HANDLE__)                     (SET_BIT((__HANDLE__)->Instance->CR2, I2C_CR2_NACK))
+#define __HAL_I2C_GENERATE_NACK(__HANDLE__)                  (SET_BIT((__HANDLE__)->Instance->CR2, I2C_CR2_NACK))
 /**
   * @}
   */
@@ -583,7 +607,8 @@ void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_I2C_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_CallbackIDTypeDef CallbackID, pI2C_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_CallbackIDTypeDef CallbackID,
+                                           pI2C_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_I2C_UnRegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_CallbackIDTypeDef CallbackID);
 
 HAL_StatusTypeDef HAL_I2C_RegisterAddrCallback(I2C_HandleTypeDef *hi2c, pI2C_AddrCallbackTypeDef pCallback);
@@ -598,49 +623,74 @@ HAL_StatusTypeDef HAL_I2C_UnRegisterAddrCallback(I2C_HandleTypeDef *hi2c);
   */
 /* IO operation functions  ****************************************************/
 /******* Blocking mode: Polling */
-HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                          uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                         uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                         uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                        uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                    uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                   uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials,
+                                        uint32_t Timeout);
 
 /******* Non-Blocking mode: Interrupt */
-HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                             uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                            uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                       uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                      uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
 
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                 uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                                uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                               uint32_t XferOptions);
 HAL_StatusTypeDef HAL_I2C_EnableListen_IT(I2C_HandleTypeDef *hi2c);
 HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c);
 HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress);
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /******* Non-Blocking mode: DMA */
-HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                              uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                             uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                        uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                       uint16_t MemAddSize, uint8_t *pData, uint16_t Size);
 
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                  uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                 uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                                 uint32_t XferOptions);
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                                uint32_t XferOptions);
+#endif /*HAL_DMA_MODULE_ENABLED*/
 /**
   * @}
   */
 
 /** @addtogroup I2C_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
- * @{
- */
+  * @{
+  */
 /******* I2C IRQHandler and Callbacks used in non blocking modes (Interrupt and DMA) */
 void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c);
 void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c);
@@ -662,9 +712,9 @@ void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c);
   * @{
   */
 /* Peripheral State, Mode and Error functions  *********************************/
-HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c);
-HAL_I2C_ModeTypeDef  HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c);
-uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
+HAL_I2C_StateTypeDef HAL_I2C_GetState(const I2C_HandleTypeDef *hi2c);
+HAL_I2C_ModeTypeDef  HAL_I2C_GetMode(const I2C_HandleTypeDef *hi2c);
+uint32_t             HAL_I2C_GetError(const I2C_HandleTypeDef *hi2c);
 
 /**
   * @}
@@ -732,10 +782,15 @@ uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
 #define IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST) (((REQUEST) == I2C_OTHER_FRAME)     || \
                                                         ((REQUEST) == I2C_OTHER_AND_LAST_FRAME))
 
-#define I2C_RESET_CR2(__HANDLE__)                 ((__HANDLE__)->Instance->CR2 &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_RD_WRN)))
+#define I2C_RESET_CR2(__HANDLE__)                 ((__HANDLE__)->Instance->CR2 &= \
+                                                   (uint32_t)~((uint32_t)(I2C_CR2_SADD   | I2C_CR2_HEAD10R | \
+                                                                          I2C_CR2_NBYTES | I2C_CR2_RELOAD  | \
+                                                                          I2C_CR2_RD_WRN)))
 
-#define I2C_GET_ADDR_MATCH(__HANDLE__)            ((uint16_t)(((__HANDLE__)->Instance->ISR & I2C_ISR_ADDCODE) >> 16U))
-#define I2C_GET_DIR(__HANDLE__)                   ((uint8_t)(((__HANDLE__)->Instance->ISR & I2C_ISR_DIR) >> 16U))
+#define I2C_GET_ADDR_MATCH(__HANDLE__)            ((uint16_t)(((__HANDLE__)->Instance->ISR & I2C_ISR_ADDCODE) \
+                                                              >> 16U))
+#define I2C_GET_DIR(__HANDLE__)                   ((uint8_t)(((__HANDLE__)->Instance->ISR & I2C_ISR_DIR) \
+                                                             >> 16U))
 #define I2C_GET_STOP_MODE(__HANDLE__)             ((__HANDLE__)->Instance->CR2 & I2C_CR2_AUTOEND)
 #define I2C_GET_OWN_ADDRESS1(__HANDLE__)          ((uint16_t)((__HANDLE__)->Instance->OAR1 & I2C_OAR1_OA1))
 #define I2C_GET_OWN_ADDRESS2(__HANDLE__)          ((uint16_t)((__HANDLE__)->Instance->OAR2 & I2C_OAR2_OA2))
@@ -743,13 +798,20 @@ uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
 #define IS_I2C_OWN_ADDRESS1(ADDRESS1)             ((ADDRESS1) <= 0x000003FFU)
 #define IS_I2C_OWN_ADDRESS2(ADDRESS2)             ((ADDRESS2) <= (uint16_t)0x00FFU)
 
-#define I2C_MEM_ADD_MSB(__ADDRESS__)              ((uint8_t)((uint16_t)(((uint16_t)((__ADDRESS__) & (uint16_t)(0xFF00U))) >> 8U)))
+#define I2C_MEM_ADD_MSB(__ADDRESS__)              ((uint8_t)((uint16_t)(((uint16_t)((__ADDRESS__) & \
+                                                                         (uint16_t)(0xFF00U))) >> 8U)))
 #define I2C_MEM_ADD_LSB(__ADDRESS__)              ((uint8_t)((uint16_t)((__ADDRESS__) & (uint16_t)(0x00FFU))))
 
-#define I2C_GENERATE_START(__ADDMODE__,__ADDRESS__) (((__ADDMODE__) == I2C_ADDRESSINGMODE_7BIT) ? (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)) : \
-                                                          (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
+#define I2C_GENERATE_START(__ADDMODE__,__ADDRESS__) (((__ADDMODE__) == I2C_ADDRESSINGMODE_7BIT) ? \
+                                                     (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | \
+                                                                 (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & \
+                                                                (~I2C_CR2_RD_WRN)) : \
+                                                     (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | \
+                                                                 (I2C_CR2_ADD10) | (I2C_CR2_START) | \
+                                                                 (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)))
 
-#define I2C_CHECK_FLAG(__ISR__, __FLAG__)         ((((__ISR__) & ((__FLAG__) & I2C_FLAG_MASK)) == ((__FLAG__) & I2C_FLAG_MASK)) ? SET : RESET)
+#define I2C_CHECK_FLAG(__ISR__, __FLAG__)         ((((__ISR__) & ((__FLAG__) & I2C_FLAG_MASK)) == \
+                                                    ((__FLAG__) & I2C_FLAG_MASK)) ? SET : RESET)
 #define I2C_CHECK_IT_SOURCE(__CR1__, __IT__)      ((((__CR1__) & (__IT__)) == (__IT__)) ? SET : RESET)
 /**
   * @}
@@ -778,5 +840,3 @@ uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
 
 
 #endif /* STM32WBxx_HAL_I2C_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_i2c_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_i2c_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -64,7 +63,7 @@ extern "C" {
 #define I2C_FASTMODEPLUS_I2C3           SYSCFG_CFGR1_I2C3_FMP                           /*!< Enable Fast Mode Plus on I2C3 pins */
 #else
 #define I2C_FASTMODEPLUS_I2C3           (uint32_t)(0x00000400U | I2C_FMP_NOT_SUPPORTED) /*!< Fast Mode Plus I2C3 not supported  */
-#endif
+#endif /* SYSCFG_CFGR1_I2C3_FMP */
 /**
   * @}
   */
@@ -87,7 +86,7 @@ extern "C" {
   * @{
   */
 
-/** @addtogroup I2CEx_Exported_Functions_Group1 I2C Extended Filter Mode Functions
+/** @addtogroup I2CEx_Exported_Functions_Group1 Filter Mode Functions
   * @{
   */
 /* Peripheral Control functions  ************************************************/
@@ -97,7 +96,7 @@ HAL_StatusTypeDef HAL_I2CEx_ConfigDigitalFilter(I2C_HandleTypeDef *hi2c, uint32_
   * @}
   */
 
-/** @addtogroup I2CEx_Exported_Functions_Group2 I2C Extended WakeUp Mode Functions
+/** @addtogroup I2CEx_Exported_Functions_Group2 WakeUp Mode Functions
   * @{
   */
 HAL_StatusTypeDef HAL_I2CEx_EnableWakeUp(I2C_HandleTypeDef *hi2c);
@@ -106,7 +105,7 @@ HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp(I2C_HandleTypeDef *hi2c);
   * @}
   */
 
-/** @addtogroup I2CEx_Exported_Functions_Group3 I2C Extended FastModePlus Functions
+/** @addtogroup I2CEx_Exported_Functions_Group3 Fast Mode Plus Functions
   * @{
   */
 void HAL_I2CEx_EnableFastModePlus(uint32_t ConfigFastModePlus);
@@ -114,7 +113,6 @@ void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus);
 /**
   * @}
   */
-
 
 /**
   * @}
@@ -134,7 +132,7 @@ void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus);
   * @{
   */
 #define IS_I2C_ANALOG_FILTER(FILTER)    (((FILTER) == I2C_ANALOGFILTER_ENABLE) || \
-                                          ((FILTER) == I2C_ANALOGFILTER_DISABLE))
+                                         ((FILTER) == I2C_ANALOGFILTER_DISABLE))
 
 #define IS_I2C_DIGITAL_FILTER(FILTER)   ((FILTER) <= 0x0000000FU)
 
@@ -170,5 +168,3 @@ void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus);
 #endif
 
 #endif /* STM32WBxx_HAL_I2C_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_ipcc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_ipcc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* __cplusplus */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_hal_def.h"
@@ -200,8 +199,8 @@ typedef void ChannelCb(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex, IPCC_CH
 
 /* Initialization and de-initialization functions *******************************/
 /** @defgroup IPCC_Exported_Functions_Group1 Initialization and deinitialization functions
- *  @{
- */
+  *  @{
+  */
 HAL_StatusTypeDef HAL_IPCC_Init(IPCC_HandleTypeDef *hipcc);
 HAL_StatusTypeDef HAL_IPCC_DeInit(IPCC_HandleTypeDef *hipcc);
 void HAL_IPCC_MspInit(IPCC_HandleTypeDef *hipcc);
@@ -211,20 +210,24 @@ void HAL_IPCC_MspDeInit(IPCC_HandleTypeDef *hipcc);
   */
 
 /** @defgroup IPCC_Exported_Functions_Group2 Communication functions
- *  @{
- */
+  *  @{
+  */
 /* IO operation functions  *****************************************************/
-HAL_StatusTypeDef HAL_IPCC_ActivateNotification(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir, ChannelCb cb);
-HAL_StatusTypeDef HAL_IPCC_DeActivateNotification(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir);
-IPCC_CHANNELStatusTypeDef HAL_IPCC_GetChannelStatus(IPCC_HandleTypeDef const *const hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir);
-HAL_StatusTypeDef HAL_IPCC_NotifyCPU(IPCC_HandleTypeDef const *const hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir);
+HAL_StatusTypeDef HAL_IPCC_ActivateNotification(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex,
+                                                IPCC_CHANNELDirTypeDef ChannelDir, ChannelCb cb);
+HAL_StatusTypeDef HAL_IPCC_DeActivateNotification(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex,
+                                                  IPCC_CHANNELDirTypeDef ChannelDir);
+IPCC_CHANNELStatusTypeDef HAL_IPCC_GetChannelStatus(IPCC_HandleTypeDef const *const hipcc,
+                                                    uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir);
+HAL_StatusTypeDef HAL_IPCC_NotifyCPU(IPCC_HandleTypeDef const *const hipcc, uint32_t ChannelIndex,
+                                     IPCC_CHANNELDirTypeDef ChannelDir);
 /**
   * @}
   */
 
 /** @defgroup IPCC_Exported_Functions_Group3 Peripheral State and Error functions
- *  @{
- */
+  *  @{
+  */
 /* Peripheral State and Error functions ****************************************/
 HAL_IPCC_StateTypeDef HAL_IPCC_GetState(IPCC_HandleTypeDef const *const hipcc);
 /**
@@ -232,8 +235,8 @@ HAL_IPCC_StateTypeDef HAL_IPCC_GetState(IPCC_HandleTypeDef const *const hipcc);
   */
 
 /** @defgroup IPCC_IRQ_Handler_and_Callbacks Peripheral IRQ Handler and Callbacks
- *  @{
- */
+  *  @{
+  */
 /* IRQHandler and Callbacks used in non blocking modes  ************************/
 void HAL_IPCC_TX_IRQHandler(IPCC_HandleTypeDef   *const hipcc);
 void HAL_IPCC_RX_IRQHandler(IPCC_HandleTypeDef *const hipcc);
@@ -258,8 +261,7 @@ void HAL_IPCC_RxCallback(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex, IPCC_
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* __cplusplus */
 
 #endif /* STM32WBxx_HAL_IPCC_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_irda.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_irda.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -52,7 +51,7 @@ typedef struct
                                            where usart_ker_ckpres is the IRDA input clock divided by a prescaler */
 
   uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
-                                           This parameter can be a value of @ref IRDA_Word_Length */
+                                           This parameter can be a value of @ref IRDAEx_Word_Length */
 
   uint32_t Parity;                    /*!< Specifies the parity mode.
                                            This parameter can be a value of @ref IRDA_Parity
@@ -78,7 +77,8 @@ typedef struct
 
 /**
   * @brief HAL IRDA State definition
-  * @note  HAL IRDA State value is a combination of 2 different substates: gState and RxState (see @ref IRDA_State_Definition).
+  * @note  HAL IRDA State value is a combination of 2 different substates:
+  *        gState and RxState (see @ref IRDA_State_Definition).
   *        - gState contains IRDA state information related to global Handle management
   *          and also information related to Tx operations.
   *          gState value coding follow below described bitmap :
@@ -87,14 +87,14 @@ typedef struct
   *             01 : (Not Used)
   *             10 : Timeout
   *             11 : Error
-  *          b5     IP initilisation status
-  *             0  : Reset (IP not initialized)
-  *             1  : Init done (IP not initialized. HAL IRDA Init function already called)
+  *          b5     Peripheral initialization status
+  *             0  : Reset (Peripheral not initialized)
+  *             1  : Init done (Peripheral initialized. HAL IRDA Init function already called)
   *          b4-b3  (not used)
   *             xx : Should be set to 00
   *          b2     Intrinsic process state
   *             0  : Ready
-  *             1  : Busy (IP busy with some configuration or internal operations)
+  *             1  : Busy (Peripheral busy with some configuration or internal operations)
   *          b1     (not used)
   *             x  : Should be set to 0
   *          b0     Tx state
@@ -104,9 +104,9 @@ typedef struct
   *          RxState value coding follow below described bitmap :
   *          b7-b6  (not used)
   *             xx : Should be set to 00
-  *          b5     IP initilisation status
-  *             0  : Reset (IP not initialized)
-  *             1  : Init done (IP not initialized)
+  *          b5     Peripheral initialization status
+  *             0  : Reset (Peripheral not initialized)
+  *             1  : Init done (Peripheral initialized)
   *          b4-b2  (not used)
   *            xxx : Should be set to 000
   *          b1     Rx state
@@ -142,7 +142,7 @@ typedef struct
 
   IRDA_InitTypeDef         Init;             /*!< IRDA communication parameters      */
 
-  uint8_t                  *pTxBuffPtr;      /*!< Pointer to IRDA Tx transfer Buffer */
+  const uint8_t            *pTxBuffPtr;      /*!< Pointer to IRDA Tx transfer Buffer */
 
   uint16_t                 TxXferSize;       /*!< IRDA Tx Transfer size              */
 
@@ -169,7 +169,7 @@ typedef struct
   __IO HAL_IRDA_StateTypeDef    RxState;     /*!< IRDA state information related to Rx operations.
                                                   This parameter can be a value of @ref HAL_IRDA_StateTypeDef */
 
-  uint32_t                 ErrorCode;        /*!< IRDA Error code                    */
+  __IO uint32_t            ErrorCode;        /*!< IRDA Error code                    */
 
 #if (USE_HAL_IRDA_REGISTER_CALLBACKS == 1)
   void (* TxHalfCpltCallback)(struct __IRDA_HandleTypeDef *hirda);        /*!< IRDA Tx Half Complete Callback        */
@@ -247,7 +247,8 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
                                                                Value is allowed for RxState only */
 #define HAL_IRDA_STATE_BUSY_TX_RX           0x00000023U   /*!< Data Transmission and Reception process is ongoing
                                                                Not to be used for neither gState nor RxState.
-                                                               Value is result of combination (Or) between gState and RxState values */
+                                                               Value is result of combination (Or) between
+                                                               gState and RxState values */
 #define HAL_IRDA_STATE_TIMEOUT              0x000000A0U   /*!< Timeout state
                                                                Value is allowed for gState only */
 #define HAL_IRDA_STATE_ERROR                0x000000E0U   /*!< Error
@@ -259,26 +260,16 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
 /** @defgroup IRDA_Error_Definition IRDA Error Code Definition
   * @{
   */
-#define HAL_IRDA_ERROR_NONE                 ((uint32_t)0x00000000U)          /*!< No error                */
-#define HAL_IRDA_ERROR_PE                   ((uint32_t)0x00000001U)          /*!< Parity error            */
-#define HAL_IRDA_ERROR_NE                   ((uint32_t)0x00000002U)          /*!< Noise error             */
-#define HAL_IRDA_ERROR_FE                   ((uint32_t)0x00000004U)          /*!< frame error             */
-#define HAL_IRDA_ERROR_ORE                  ((uint32_t)0x00000008U)          /*!< Overrun error           */
-#define HAL_IRDA_ERROR_DMA                  ((uint32_t)0x00000010U)          /*!< DMA transfer error      */
-#define HAL_IRDA_ERROR_BUSY                 ((uint32_t)0x00000020U)          /*!< Busy Error              */
+#define HAL_IRDA_ERROR_NONE                 (0x00000000U)          /*!< No error                */
+#define HAL_IRDA_ERROR_PE                   (0x00000001U)          /*!< Parity error            */
+#define HAL_IRDA_ERROR_NE                   (0x00000002U)          /*!< Noise error             */
+#define HAL_IRDA_ERROR_FE                   (0x00000004U)          /*!< frame error             */
+#define HAL_IRDA_ERROR_ORE                  (0x00000008U)          /*!< Overrun error           */
+#define HAL_IRDA_ERROR_DMA                  (0x00000010U)          /*!< DMA transfer error      */
+#define HAL_IRDA_ERROR_BUSY                 (0x00000020U)          /*!< Busy Error              */
 #if (USE_HAL_IRDA_REGISTER_CALLBACKS == 1)
-#define HAL_IRDA_ERROR_INVALID_CALLBACK     ((uint32_t)0x00000040U)          /*!< Invalid Callback error  */
+#define HAL_IRDA_ERROR_INVALID_CALLBACK     (0x00000040U)          /*!< Invalid Callback error  */
 #endif /* USE_HAL_IRDA_REGISTER_CALLBACKS */
-/**
-  * @}
-  */
-
-/** @defgroup IRDA_Word_Length IRDA Word Length
-  * @{
-  */
-#define IRDA_WORDLENGTH_7B                  USART_CR1_M1   /*!< 7-bit long frame */
-#define IRDA_WORDLENGTH_8B                  0x00000000U    /*!< 8-bit long frame */
-#define IRDA_WORDLENGTH_9B                  USART_CR1_M0   /*!< 9-bit long frame */
 /**
   * @}
   */
@@ -312,7 +303,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @}
   */
 
-/** @defgroup IRDA_ClockPrescaler  Clock Prescaler
+/** @defgroup IRDA_ClockPrescaler IRDA Clock Prescaler
   * @{
   */
 #define IRDA_PRESCALER_DIV1    0x00000000U  /*!< fclk_pres = fclk     */
@@ -340,7 +331,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @}
   */
 
-/** @defgroup IRDA_Mode  IRDA Mode
+/** @defgroup IRDA_Mode IRDA Mode
   * @{
   */
 #define IRDA_MODE_DISABLE                   0x00000000U      /*!< Associated UART disabled in IRDA mode */
@@ -349,7 +340,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @}
   */
 
-/** @defgroup IRDA_One_Bit  IRDA One Bit Sampling
+/** @defgroup IRDA_One_Bit IRDA One Bit Sampling
   * @{
   */
 #define IRDA_ONE_BIT_SAMPLE_DISABLE         0x00000000U       /*!< One-bit sampling disabled */
@@ -367,7 +358,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @}
   */
 
-/** @defgroup IRDA_DMA_Rx  IRDA DMA Rx
+/** @defgroup IRDA_DMA_Rx IRDA DMA Rx
   * @{
   */
 #define IRDA_DMA_RX_DISABLE                 0x00000000U       /*!< IRDA DMA RX disabled */
@@ -440,7 +431,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @}
   */
 
-/** @defgroup IRDA_IT_CLEAR_Flags   IRDA Interruption Clear Flags
+/** @defgroup IRDA_IT_CLEAR_Flags IRDA Interruption Clear Flags
   * @{
   */
 #define IRDA_CLEAR_PEF                       USART_ICR_PECF            /*!< Parity Error Clear Flag          */
@@ -453,7 +444,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @}
   */
 
-/** @defgroup IRDA_Interruption_Mask    IRDA interruptions flags mask
+/** @defgroup IRDA_Interruption_Mask IRDA interruptions flags mask
   * @{
   */
 #define IRDA_IT_MASK  0x001FU  /*!< IRDA Interruptions flags mask  */
@@ -466,9 +457,8 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   */
 
 /**
- * @}
- */
-
+  * @}
+  */
 
 /* Exported macros -----------------------------------------------------------*/
 /** @defgroup IRDA_Exported_Macros IRDA Exported Macros
@@ -485,12 +475,12 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
                                                        (__HANDLE__)->RxState = HAL_IRDA_STATE_RESET;     \
                                                        (__HANDLE__)->MspInitCallback = NULL;             \
                                                        (__HANDLE__)->MspDeInitCallback = NULL;           \
-                                                     } while(0)
+                                                     } while(0U)
 #else
 #define __HAL_IRDA_RESET_HANDLE_STATE(__HANDLE__)  do{                                                   \
                                                        (__HANDLE__)->gState = HAL_IRDA_STATE_RESET;      \
                                                        (__HANDLE__)->RxState = HAL_IRDA_STATE_RESET;     \
-                                                     } while(0)
+                                                     } while(0U)
 #endif /*USE_HAL_IRDA_REGISTER_CALLBACKS  */
 
 /** @brief  Flush the IRDA DR register.
@@ -498,10 +488,10 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @retval None
   */
 #define __HAL_IRDA_FLUSH_DRREGISTER(__HANDLE__)                            \
-    do{                                                                    \
-         SET_BIT((__HANDLE__)->Instance->RQR, IRDA_RXDATA_FLUSH_REQUEST); \
-         SET_BIT((__HANDLE__)->Instance->RQR, IRDA_TXDATA_FLUSH_REQUEST); \
-      } while(0)
+  do{                                                                    \
+    SET_BIT((__HANDLE__)->Instance->RQR, IRDA_RXDATA_FLUSH_REQUEST); \
+    SET_BIT((__HANDLE__)->Instance->RQR, IRDA_TXDATA_FLUSH_REQUEST); \
+  } while(0U)
 
 /** @brief  Clear the specified IRDA pending flag.
   * @param  __HANDLE__ specifies the IRDA Handle.
@@ -581,9 +571,14 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   *            @arg @ref IRDA_IT_ERR  Error interrupt(Frame error, noise error, overrun error)
   * @retval None
   */
-#define __HAL_IRDA_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 1)? ((__HANDLE__)->Instance->CR1 |= ((uint32_t)1U << ((__INTERRUPT__) & IRDA_IT_MASK))): \
-                                                           ((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 2)? ((__HANDLE__)->Instance->CR2 |= ((uint32_t)1U << ((__INTERRUPT__) & IRDA_IT_MASK))): \
-                                                           ((__HANDLE__)->Instance->CR3 |= ((uint32_t)1U << ((__INTERRUPT__) & IRDA_IT_MASK))))
+#define __HAL_IRDA_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 1U)? \
+                                                           ((__HANDLE__)->Instance->CR1 |= (1U << \
+                                                               ((__INTERRUPT__) & IRDA_IT_MASK))):\
+                                                           ((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 2U)? \
+                                                           ((__HANDLE__)->Instance->CR2 |= (1U << \
+                                                               ((__INTERRUPT__) & IRDA_IT_MASK))):\
+                                                           ((__HANDLE__)->Instance->CR3 |= (1U << \
+                                                               ((__INTERRUPT__) & IRDA_IT_MASK))))
 
 /** @brief  Disable the specified IRDA interrupt.
   * @param  __HANDLE__ specifies the IRDA Handle.
@@ -597,10 +592,14 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   *            @arg @ref IRDA_IT_ERR  Error interrupt(Frame error, noise error, overrun error)
   * @retval None
   */
-#define __HAL_IRDA_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 1)? ((__HANDLE__)->Instance->CR1 &= ~ ((uint32_t)1U << ((__INTERRUPT__) & IRDA_IT_MASK))): \
-                                                           ((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 2)? ((__HANDLE__)->Instance->CR2 &= ~ ((uint32_t)1U << ((__INTERRUPT__) & IRDA_IT_MASK))): \
-                                                           ((__HANDLE__)->Instance->CR3 &= ~ ((uint32_t)1U << ((__INTERRUPT__) & IRDA_IT_MASK))))
-
+#define __HAL_IRDA_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 1U)? \
+                                                           ((__HANDLE__)->Instance->CR1 &= ~ (1U << \
+                                                               ((__INTERRUPT__) & IRDA_IT_MASK))): \
+                                                           ((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 2U)? \
+                                                           ((__HANDLE__)->Instance->CR2 &= ~ (1U << \
+                                                               ((__INTERRUPT__) & IRDA_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U << \
+                                                               ((__INTERRUPT__) & IRDA_IT_MASK))))
 
 /** @brief  Check whether the specified IRDA interrupt has occurred or not.
   * @param  __HANDLE__ specifies the IRDA Handle.
@@ -616,7 +615,8 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   *            @arg @ref IRDA_IT_PE Parity Error interrupt
   * @retval The new state of __IT__ (SET or RESET).
   */
-#define __HAL_IRDA_GET_IT(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->ISR & (0x01U << (((__INTERRUPT__) & IRDA_ISR_MASK)>> IRDA_ISR_POS))) != 0U) ? SET : RESET)
+#define __HAL_IRDA_GET_IT(__HANDLE__, __INTERRUPT__) \
+  ((((__HANDLE__)->Instance->ISR& (0x01U << (((__INTERRUPT__) & IRDA_ISR_MASK)>>IRDA_ISR_POS))) != 0U) ? SET : RESET)
 
 /** @brief  Check whether the specified IRDA interrupt source is enabled or not.
   * @param  __HANDLE__ specifies the IRDA Handle.
@@ -630,9 +630,10 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   *            @arg @ref IRDA_IT_PE Parity Error interrupt
   * @retval The new state of __IT__ (SET or RESET).
   */
-#define __HAL_IRDA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 0x01U)? (__HANDLE__)->Instance->CR1 : \
-                                                               (((((__INTERRUPT__) & IRDA_CR_MASK) >> IRDA_CR_POS) == 0x02U)? (__HANDLE__)->Instance->CR2 : \
-                                                               (__HANDLE__)->Instance->CR3)) & ((uint32_t)0x01U << (((uint16_t)(__INTERRUPT__)) & IRDA_IT_MASK))) != 0U) ? SET : RESET)
+#define __HAL_IRDA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)                                                          \
+  ((((((((__INTERRUPT__) & IRDA_CR_MASK) >>IRDA_CR_POS) == 0x01U)? (__HANDLE__)->Instance->CR1 :(((((__INTERRUPT__)  \
+      & IRDA_CR_MASK) >> IRDA_CR_POS)== 0x02U)? (__HANDLE__)->Instance->CR2 :(__HANDLE__)->Instance->CR3))           \
+     & (0x01U <<(((uint16_t)(__INTERRUPT__)) & IRDA_IT_MASK))) != 0U) ? SET : RESET)
 
 /** @brief  Clear the specified IRDA ISR flag, in setting the proper ICR register flag.
   * @param  __HANDLE__ specifies the IRDA Handle.
@@ -656,7 +657,6 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   *            @arg @ref IRDA_AUTOBAUD_REQUEST Auto-Baud Rate Request
   *            @arg @ref IRDA_RXDATA_FLUSH_REQUEST Receive Data flush Request
   *            @arg @ref IRDA_TXDATA_FLUSH_REQUEST Transmit data flush Request
-  *
   * @retval None
   */
 #define __HAL_IRDA_SEND_REQ(__HANDLE__, __REQ__) ((__HANDLE__)->Instance->RQR |= (uint16_t)(__REQ__))
@@ -671,7 +671,8 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @param  __HANDLE__ specifies the IRDA Handle.
   * @retval None
   */
-#define __HAL_IRDA_ONE_BIT_SAMPLE_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR3 &= (uint32_t)~((uint32_t)USART_CR3_ONEBIT))
+#define __HAL_IRDA_ONE_BIT_SAMPLE_DISABLE(__HANDLE__) ((__HANDLE__)->Instance->CR3\
+                                                       &= (uint32_t)~((uint32_t)USART_CR3_ONEBIT))
 
 /** @brief  Enable UART/USART associated to IRDA Handle.
   * @param  __HANDLE__ specifies the IRDA Handle.
@@ -694,52 +695,6 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   * @{
   */
 
-/** @brief  Compute the mask to apply to retrieve the received data
-  *         according to the word length and to the parity bits activation.
-  * @param  __HANDLE__ specifies the IRDA Handle.
-  * @retval None, the mask to apply to the associated UART RDR register is stored in (__HANDLE__)->Mask field.
-  */
-#define IRDA_MASK_COMPUTATION(__HANDLE__)                             \
-  do {                                                                \
-  if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_9B)            \
-  {                                                                   \
-     if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)               \
-     {                                                                \
-        (__HANDLE__)->Mask = 0x01FF ;                                 \
-     }                                                                \
-     else                                                             \
-     {                                                                \
-        (__HANDLE__)->Mask = 0x00FF ;                                 \
-     }                                                                \
-  }                                                                   \
-  else if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_8B)       \
-  {                                                                   \
-     if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)               \
-     {                                                                \
-        (__HANDLE__)->Mask = 0x00FF ;                                 \
-     }                                                                \
-     else                                                             \
-     {                                                                \
-        (__HANDLE__)->Mask = 0x007F ;                                 \
-     }                                                                \
-  }                                                                   \
-  else if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_7B)       \
-  {                                                                   \
-     if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)               \
-     {                                                                \
-        (__HANDLE__)->Mask = 0x007F ;                                 \
-     }                                                                \
-     else                                                             \
-     {                                                                \
-        (__HANDLE__)->Mask = 0x003F ;                                 \
-     }                                                                \
-  }                                                                   \
-  else                                                                \
-  {                                                                   \
-    (__HANDLE__)->Mask = 0x0000U;                                     \
-  }                                                                   \
-} while(0)
-
 /** @brief  Ensure that IRDA Baud rate is less or equal to maximum value.
   * @param  __BAUDRATE__ specifies the IRDA Baudrate set by the user.
   * @retval True or False
@@ -752,17 +707,7 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
   */
 #define IS_IRDA_PRESCALER(__PRESCALER__) ((__PRESCALER__) > 0U)
 
-/**
-  * @brief Ensure that IRDA frame length is valid.
-  * @param __LENGTH__ IRDA frame length.
-  * @retval SET (__LENGTH__ is valid) or RESET (__LENGTH__ is invalid)
-  */
-#define IS_IRDA_WORD_LENGTH(__LENGTH__) (((__LENGTH__) == IRDA_WORDLENGTH_7B) || \
-                                         ((__LENGTH__) == IRDA_WORDLENGTH_8B) || \
-                                         ((__LENGTH__) == IRDA_WORDLENGTH_9B))
-
-/**
-  * @brief Ensure that IRDA frame parity is valid.
+/** @brief Ensure that IRDA frame parity is valid.
   * @param __PARITY__ IRDA frame parity.
   * @retval SET (__PARITY__ is valid) or RESET (__PARITY__ is invalid)
   */
@@ -770,81 +715,73 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
                                     ((__PARITY__) == IRDA_PARITY_EVEN) || \
                                     ((__PARITY__) == IRDA_PARITY_ODD))
 
-/**
-  * @brief Ensure that IRDA communication mode is valid.
+/** @brief Ensure that IRDA communication mode is valid.
   * @param __MODE__ IRDA communication mode.
   * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
   */
-#define IS_IRDA_TX_RX_MODE(__MODE__) ((((__MODE__) & (~((uint32_t)(IRDA_MODE_TX_RX)))) == 0x00U) && ((__MODE__) != 0x00U))
+#define IS_IRDA_TX_RX_MODE(__MODE__) ((((__MODE__)\
+                                        & (~((uint32_t)(IRDA_MODE_TX_RX)))) == 0x00U) && ((__MODE__) != 0x00U))
 
-/**
-  * @brief Ensure that IRDA power mode is valid.
+/** @brief Ensure that IRDA power mode is valid.
   * @param __MODE__ IRDA power mode.
   * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
   */
 #define IS_IRDA_POWERMODE(__MODE__) (((__MODE__) == IRDA_POWERMODE_LOWPOWER) || \
                                      ((__MODE__) == IRDA_POWERMODE_NORMAL))
 
-/**
-  * @brief Ensure that IRDA clock Prescaler is valid.
+/** @brief Ensure that IRDA clock Prescaler is valid.
   * @param __CLOCKPRESCALER__ IRDA clock Prescaler value.
   * @retval SET (__CLOCKPRESCALER__ is valid) or RESET (__CLOCKPRESCALER__ is invalid)
   */
 #define IS_IRDA_CLOCKPRESCALER(__CLOCKPRESCALER__) (((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV1) || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV2)   || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV4)   || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV6)   || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV8)   || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV10)  || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV12)  || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV16)  || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV32)  || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV64)  || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV128) || \
-              ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV256))
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV2)   || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV4)   || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV6)   || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV8)   || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV10)  || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV12)  || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV16)  || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV32)  || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV64)  || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV128) || \
+                                                    ((__CLOCKPRESCALER__) == IRDA_PRESCALER_DIV256))
 
-/**
-  * @brief Ensure that IRDA state is valid.
+/** @brief Ensure that IRDA state is valid.
   * @param __STATE__ IRDA state mode.
   * @retval SET (__STATE__ is valid) or RESET (__STATE__ is invalid)
   */
 #define IS_IRDA_STATE(__STATE__) (((__STATE__) == IRDA_STATE_DISABLE) || \
                                   ((__STATE__) == IRDA_STATE_ENABLE))
 
-/**
-  * @brief Ensure that IRDA associated UART/USART mode is valid.
+/** @brief Ensure that IRDA associated UART/USART mode is valid.
   * @param __MODE__ IRDA associated UART/USART mode.
   * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
   */
 #define IS_IRDA_MODE(__MODE__)  (((__MODE__) == IRDA_MODE_DISABLE) || \
                                  ((__MODE__) == IRDA_MODE_ENABLE))
 
-/**
-  * @brief Ensure that IRDA sampling rate is valid.
+/** @brief Ensure that IRDA sampling rate is valid.
   * @param __ONEBIT__ IRDA sampling rate.
   * @retval SET (__ONEBIT__ is valid) or RESET (__ONEBIT__ is invalid)
   */
 #define IS_IRDA_ONE_BIT_SAMPLE(__ONEBIT__)      (((__ONEBIT__) == IRDA_ONE_BIT_SAMPLE_DISABLE) || \
                                                  ((__ONEBIT__) == IRDA_ONE_BIT_SAMPLE_ENABLE))
 
-/**
-  * @brief Ensure that IRDA DMA TX mode is valid.
+/** @brief Ensure that IRDA DMA TX mode is valid.
   * @param __DMATX__ IRDA DMA TX mode.
   * @retval SET (__DMATX__ is valid) or RESET (__DMATX__ is invalid)
   */
 #define IS_IRDA_DMA_TX(__DMATX__)     (((__DMATX__) == IRDA_DMA_TX_DISABLE) || \
                                        ((__DMATX__) == IRDA_DMA_TX_ENABLE))
 
-/**
-  * @brief Ensure that IRDA DMA RX mode is valid.
+/** @brief Ensure that IRDA DMA RX mode is valid.
   * @param __DMARX__ IRDA DMA RX mode.
   * @retval SET (__DMARX__ is valid) or RESET (__DMARX__ is invalid)
   */
 #define IS_IRDA_DMA_RX(__DMARX__) (((__DMARX__) == IRDA_DMA_RX_DISABLE) || \
                                    ((__DMARX__) == IRDA_DMA_RX_ENABLE))
 
-/**
-  * @brief Ensure that IRDA request is valid.
+/** @brief Ensure that IRDA request is valid.
   * @param __PARAM__ IRDA request.
   * @retval SET (__PARAM__ is valid) or RESET (__PARAM__ is invalid)
   */
@@ -852,8 +789,8 @@ typedef  void (*pIRDA_CallbackTypeDef)(IRDA_HandleTypeDef *hirda);  /*!< pointer
                                               ((__PARAM__) == IRDA_RXDATA_FLUSH_REQUEST) || \
                                               ((__PARAM__) == IRDA_TXDATA_FLUSH_REQUEST))
 /**
- * @}
- */
+  * @}
+  */
 
 /* Include IRDA HAL Extended module */
 #include "stm32wbxx_hal_irda_ex.h"
@@ -875,7 +812,8 @@ void HAL_IRDA_MspDeInit(IRDA_HandleTypeDef *hirda);
 
 #if (USE_HAL_IRDA_REGISTER_CALLBACKS == 1)
 /* Callbacks Register/UnRegister functions  ***********************************/
-HAL_StatusTypeDef HAL_IRDA_RegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_CallbackIDTypeDef CallbackID, pIRDA_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_IRDA_RegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_CallbackIDTypeDef CallbackID,
+                                            pIRDA_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_IRDA_REGISTER_CALLBACKS */
 
@@ -888,11 +826,11 @@ HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRD
   */
 
 /* IO operation functions *****************************************************/
-HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, const uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_IRDA_DMAPause(IRDA_HandleTypeDef *hirda);
 HAL_StatusTypeDef HAL_IRDA_DMAResume(IRDA_HandleTypeDef *hirda);
@@ -926,8 +864,8 @@ void HAL_IRDA_AbortReceiveCpltCallback(IRDA_HandleTypeDef *hirda);
   */
 
 /* Peripheral State and Error functions ***************************************/
-HAL_IRDA_StateTypeDef HAL_IRDA_GetState(IRDA_HandleTypeDef *hirda);
-uint32_t              HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda);
+HAL_IRDA_StateTypeDef HAL_IRDA_GetState(const IRDA_HandleTypeDef *hirda);
+uint32_t              HAL_IRDA_GetError(const IRDA_HandleTypeDef *hirda);
 
 /**
   * @}
@@ -951,4 +889,3 @@ uint32_t              HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda);
 
 #endif /* STM32WBxx_HAL_IRDA_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_irda_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_irda_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -33,13 +32,31 @@ extern "C" {
   */
 
 /** @defgroup IRDAEx IRDAEx
+  * @brief IRDA Extended HAL module driver
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
+/** @defgroup IRDAEx_Extended_Exported_Constants IRDAEx Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup IRDAEx_Word_Length IRDAEx Word Length
+  * @{
+  */
+#define IRDA_WORDLENGTH_7B                  USART_CR1_M1   /*!< 7-bit long frame */
+#define IRDA_WORDLENGTH_8B                  0x00000000U    /*!< 8-bit long frame */
+#define IRDA_WORDLENGTH_9B                  USART_CR1_M0   /*!< 9-bit long frame */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
 /* Exported macros -----------------------------------------------------------*/
-/* Exported functions --------------------------------------------------------*/
 
 /* Private macros ------------------------------------------------------------*/
 
@@ -56,8 +73,8 @@ extern "C" {
   do {                                                         \
     if((__HANDLE__)->Instance == USART1)                       \
     {                                                          \
-       switch(__HAL_RCC_GET_USART1_SOURCE())                   \
-       {                                                       \
+      switch(__HAL_RCC_GET_USART1_SOURCE())                    \
+      {                                                        \
         case RCC_USART1CLKSOURCE_PCLK2:                        \
           (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_PCLK2;          \
           break;                                               \
@@ -73,7 +90,7 @@ extern "C" {
         default:                                               \
           (__CLOCKSOURCE__) = IRDA_CLOCKSOURCE_UNDEFINED;      \
           break;                                               \
-       }                                                       \
+      }                                                        \
     }                                                          \
     else                                                       \
     {                                                          \
@@ -81,6 +98,59 @@ extern "C" {
     }                                                          \
   } while(0U)
 
+/** @brief  Compute the mask to apply to retrieve the received data
+  *         according to the word length and to the parity bits activation.
+  * @param  __HANDLE__ specifies the IRDA Handle.
+  * @retval None, the mask to apply to the associated UART RDR register is stored in (__HANDLE__)->Mask field.
+  */
+#define IRDA_MASK_COMPUTATION(__HANDLE__)                             \
+  do {                                                                \
+    if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_9B)          \
+    {                                                                 \
+      if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)              \
+      {                                                               \
+        (__HANDLE__)->Mask = 0x01FFU ;                                \
+      }                                                               \
+      else                                                            \
+      {                                                               \
+        (__HANDLE__)->Mask = 0x00FFU ;                                \
+      }                                                               \
+    }                                                                 \
+    else if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_8B)     \
+    {                                                                 \
+      if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)              \
+      {                                                               \
+        (__HANDLE__)->Mask = 0x00FFU ;                                \
+      }                                                               \
+      else                                                            \
+      {                                                               \
+        (__HANDLE__)->Mask = 0x007FU ;                                \
+      }                                                               \
+    }                                                                 \
+    else if ((__HANDLE__)->Init.WordLength == IRDA_WORDLENGTH_7B)     \
+    {                                                                 \
+      if ((__HANDLE__)->Init.Parity == IRDA_PARITY_NONE)              \
+      {                                                               \
+        (__HANDLE__)->Mask = 0x007FU ;                                \
+      }                                                               \
+      else                                                            \
+      {                                                               \
+        (__HANDLE__)->Mask = 0x003FU ;                                \
+      }                                                               \
+    }                                                                 \
+    else                                                              \
+    {                                                                 \
+      (__HANDLE__)->Mask = 0x0000U;                                   \
+    }                                                                 \
+  } while(0U)
+
+/** @brief Ensure that IRDA frame length is valid.
+  * @param __LENGTH__ IRDA frame length.
+  * @retval SET (__LENGTH__ is valid) or RESET (__LENGTH__ is invalid)
+  */
+#define IS_IRDA_WORD_LENGTH(__LENGTH__) (((__LENGTH__) == IRDA_WORDLENGTH_7B) || \
+                                         ((__LENGTH__) == IRDA_WORDLENGTH_8B) || \
+                                         ((__LENGTH__) == IRDA_WORDLENGTH_9B))
 /**
   * @}
   */
@@ -101,4 +171,3 @@ extern "C" {
 
 #endif /* STM32WBxx_HAL_IRDA_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_iwdg.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_iwdg.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -87,7 +86,6 @@ typedef struct
 #define IWDG_PRESCALER_64               IWDG_PR_PR_2                                    /*!< IWDG prescaler set to 64  */
 #define IWDG_PRESCALER_128              (IWDG_PR_PR_2 | IWDG_PR_PR_0)                   /*!< IWDG prescaler set to 128 */
 #define IWDG_PRESCALER_256              (IWDG_PR_PR_2 | IWDG_PR_PR_1)                   /*!< IWDG prescaler set to 256 */
-
 /**
   * @}
   */
@@ -99,7 +97,6 @@ typedef struct
 /**
   * @}
   */
-
 
 /**
   * @}
@@ -138,7 +135,7 @@ typedef struct
   * @{
   */
 /* Initialization/Start functions  ********************************************/
-HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg);
+HAL_StatusTypeDef     HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg);
 /**
   * @}
   */
@@ -147,7 +144,7 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg);
   * @{
   */
 /* I/O operation functions ****************************************************/
-HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg);
+HAL_StatusTypeDef     HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg);
 /**
   * @}
   */
@@ -238,5 +235,3 @@ HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg);
 #endif
 
 #endif /* STM32WBxx_HAL_IWDG_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_lcd.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_lcd.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -768,5 +767,3 @@ HAL_StatusTypeDef     LCD_WaitForSynchro(LCD_HandleTypeDef *hlcd);
 #endif
 
 #endif /* STM32WBxx_HAL_LCD_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_lptim.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_lptim.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -98,30 +97,30 @@ typedef struct
   */
 typedef struct
 {
-  LPTIM_ClockConfigTypeDef     Clock;               /*!< Specifies the clock parameters */
+  LPTIM_ClockConfigTypeDef     Clock;             /*!< Specifies the clock parameters */
 
-  LPTIM_ULPClockConfigTypeDef  UltraLowPowerClock;  /*!< Specifies the Ultra Low Power clock parameters */
+  LPTIM_ULPClockConfigTypeDef  UltraLowPowerClock;/*!< Specifies the Ultra Low Power clock parameters */
 
-  LPTIM_TriggerConfigTypeDef   Trigger;             /*!< Specifies the Trigger parameters */
+  LPTIM_TriggerConfigTypeDef   Trigger;           /*!< Specifies the Trigger parameters */
 
-  uint32_t                     OutputPolarity;      /*!< Specifies the Output polarity.
-                                                    This parameter can be a value of @ref LPTIM_Output_Polarity */
+  uint32_t                     OutputPolarity;    /*!< Specifies the Output polarity.
+                                                  This parameter can be a value of @ref LPTIM_Output_Polarity */
 
-  uint32_t                     UpdateMode;          /*!< Specifies whether the update of the autoreload and the compare
-                                                    values is done immediately or after the end of current period.
-                                                    This parameter can be a value of @ref LPTIM_Updating_Mode */
+  uint32_t                     UpdateMode;        /*!< Specifies whether the update of the autoreload and the compare
+                                                  values is done immediately or after the end of current period.
+                                                  This parameter can be a value of @ref LPTIM_Updating_Mode */
 
-  uint32_t                     CounterSource;       /*!< Specifies whether the counter is incremented each internal event
-                                                    or each external event.
-                                                    This parameter can be a value of @ref LPTIM_Counter_Source */
+  uint32_t                     CounterSource;     /*!< Specifies whether the counter is incremented each internal event
+                                                  or each external event.
+                                                  This parameter can be a value of @ref LPTIM_Counter_Source */
 
-  uint32_t                     Input1Source;        /*!< Specifies source selected for input1 (GPIO or comparator output).
-                                                    This parameter can be a value of @ref LPTIM_Input1_Source */
+  uint32_t                     Input1Source;      /*!< Specifies source selected for input1 (GPIO or comparator output).
+                                                  This parameter can be a value of @ref LPTIM_Input1_Source */
 
-  uint32_t                     Input2Source;        /*!< Specifies source selected for input2 (GPIO or comparator output).
-                                                    Note: This parameter is used only for encoder feature so is used only
-                                                    for LPTIM1 instance.
-                                                    This parameter can be a value of @ref LPTIM_Input2_Source */
+  uint32_t                     Input2Source;      /*!< Specifies source selected for input2 (GPIO or comparator output).
+                                                  Note: This parameter is used only for encoder feature so is used only
+                                                  for LPTIM1 instance.
+                                                  This parameter can be a value of @ref LPTIM_Input2_Source */
 } LPTIM_InitTypeDef;
 
 /**
@@ -384,10 +383,10 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef *hlptim);  /*!< poin
   */
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
 #define __HAL_LPTIM_RESET_HANDLE_STATE(__HANDLE__) do {                                                        \
-                                                      (__HANDLE__)->State             = HAL_LPTIM_STATE_RESET; \
-                                                      (__HANDLE__)->MspInitCallback   = NULL;                  \
-                                                      (__HANDLE__)->MspDeInitCallback = NULL;                  \
-                                                     } while(0)
+                                                        (__HANDLE__)->State             = HAL_LPTIM_STATE_RESET; \
+                                                        (__HANDLE__)->MspInitCallback   = NULL;                  \
+                                                        (__HANDLE__)->MspDeInitCallback = NULL;                  \
+                                                      } while(0)
 #else
 #define __HAL_LPTIM_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_LPTIM_STATE_RESET)
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
@@ -442,6 +441,7 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef *hlptim);  /*!< poin
   * @brief  Write the passed parameter in the Autoreload register.
   * @param  __HANDLE__ LPTIM handle
   * @param  __VALUE__ Autoreload value
+  *         This parameter must be a value between Min_Data = 0x0001 and Max_Data = 0xFFFF.
   * @retval None
   * @note   The ARR register can only be modified when the LPTIM instance is enabled.
   */
@@ -537,13 +537,16 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef *hlptim);  /*!< poin
   * @retval Interrupt status.
   */
 
-#define __HAL_LPTIM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_LPTIM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->IER\
+                                                                & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 #define __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT()            (EXTI->IMR1 |= LPTIM_EXTI_LINE_LPTIM1)
-#define __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~(LPTIM_EXTI_LINE_LPTIM1))
+#define __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT()           (EXTI->IMR1\
+                                                        &= ~(LPTIM_EXTI_LINE_LPTIM1))
 
 #define __HAL_LPTIM_LPTIM2_EXTI_ENABLE_IT()            (EXTI->IMR1 |= LPTIM_EXTI_LINE_LPTIM2)
-#define __HAL_LPTIM_LPTIM2_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~(LPTIM_EXTI_LINE_LPTIM2))
+#define __HAL_LPTIM_LPTIM2_EXTI_DISABLE_IT()           (EXTI->IMR1\
+                                                        &= ~(LPTIM_EXTI_LINE_LPTIM2))
 
 /**
   * @}
@@ -555,9 +558,9 @@ typedef  void (*pLPTIM_CallbackTypeDef)(LPTIM_HandleTypeDef *hlptim);  /*!< poin
   */
 
 /** @addtogroup LPTIM_Exported_Functions_Group1
- *  @brief    Initialization and Configuration functions.
- * @{
- */
+  *  @brief    Initialization and Configuration functions.
+  * @{
+  */
 /* Initialization/de-initialization functions  ********************************/
 HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim);
 HAL_StatusTypeDef HAL_LPTIM_DeInit(LPTIM_HandleTypeDef *hlptim);
@@ -570,9 +573,9 @@ void HAL_LPTIM_MspDeInit(LPTIM_HandleTypeDef *hlptim);
   */
 
 /** @addtogroup LPTIM_Exported_Functions_Group2
- *  @brief   Start-Stop operation functions.
- * @{
- */
+  *  @brief   Start-Stop operation functions.
+  * @{
+  */
 /* Start/Stop operation functions  *********************************************/
 /* ################################# PWM Mode ################################*/
 /* Blocking mode: Polling */
@@ -626,21 +629,21 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim);
   */
 
 /** @addtogroup LPTIM_Exported_Functions_Group3
- *  @brief  Read operation functions.
- * @{
- */
+  *  @brief  Read operation functions.
+  * @{
+  */
 /* Reading operation functions ************************************************/
-uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim);
-uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim);
-uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim);
+uint32_t HAL_LPTIM_ReadCounter(const LPTIM_HandleTypeDef *hlptim);
+uint32_t HAL_LPTIM_ReadAutoReload(const LPTIM_HandleTypeDef *hlptim);
+uint32_t HAL_LPTIM_ReadCompare(const LPTIM_HandleTypeDef *hlptim);
 /**
   * @}
   */
 
 /** @addtogroup LPTIM_Exported_Functions_Group4
- *  @brief  LPTIM IRQ handler and callback functions.
- * @{
- */
+  *  @brief  LPTIM IRQ handler and callback functions.
+  * @{
+  */
 /* LPTIM IRQ functions  *******************************************************/
 void HAL_LPTIM_IRQHandler(LPTIM_HandleTypeDef *hlptim);
 
@@ -655,19 +658,20 @@ void HAL_LPTIM_DirectionDownCallback(LPTIM_HandleTypeDef *hlptim);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef *lphtim, HAL_LPTIM_CallbackIDTypeDef CallbackID, pLPTIM_CallbackTypeDef pCallback);
-HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef *lphtim, HAL_LPTIM_CallbackIDTypeDef CallbackID);
+HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef *hlptim, HAL_LPTIM_CallbackIDTypeDef CallbackID,
+                                             pLPTIM_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef *hlptim, HAL_LPTIM_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
 /**
   * @}
   */
 
 /** @addtogroup LPTIM_Group5
- *  @brief   Peripheral State functions.
- * @{
- */
+  *  @brief   Peripheral State functions.
+  * @{
+  */
 /* Peripheral State functions  ************************************************/
-HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim);
+HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim);
 /**
   * @}
   */
@@ -760,54 +764,53 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim);
 #define IS_LPTIM_COUNTER_SOURCE(__SOURCE__)     (((__SOURCE__) == LPTIM_COUNTERSOURCE_INTERNAL) || \
                                                  ((__SOURCE__) == LPTIM_COUNTERSOURCE_EXTERNAL))
 
-#define IS_LPTIM_AUTORELOAD(__AUTORELOAD__)     ((__AUTORELOAD__) <= 0x0000FFFFUL)
-
 #define IS_LPTIM_COMPARE(__COMPARE__)           ((__COMPARE__) <= 0x0000FFFFUL)
 
-#define IS_LPTIM_PERIOD(__PERIOD__)             ((__PERIOD__) <= 0x0000FFFFUL)
+#define IS_LPTIM_PERIOD(__PERIOD__)             ((0x00000001UL <= (__PERIOD__)) &&\
+                                                 ((__PERIOD__) <= 0x0000FFFFUL))
 
 #define IS_LPTIM_PULSE(__PULSE__)               ((__PULSE__) <= 0x0000FFFFUL)
 
 #if defined(COMP1)
 #if defined(COMP2)
 #define IS_LPTIM_INPUT1_SOURCE(__INSTANCE__, __SOURCE__)  \
-    ((((__INSTANCE__) == LPTIM1) &&                       \
-     (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1)))        \
-     ||                                                   \
-     (((__INSTANCE__) == LPTIM2) &&                       \
-     (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1) ||       \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP2) ||       \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1_COMP2))))
+  ((((__INSTANCE__) == LPTIM1) &&                       \
+    (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
+     ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1)))        \
+   ||                                                   \
+   (((__INSTANCE__) == LPTIM2) &&                       \
+    (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
+     ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1) ||       \
+     ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP2) ||       \
+     ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1_COMP2))))
 #else
 #define IS_LPTIM_INPUT1_SOURCE(__INSTANCE__, __SOURCE__)  \
-    ((((__INSTANCE__) == LPTIM1) &&                       \
-     (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1)))        \
-     ||                                                   \
-     (((__INSTANCE__) == LPTIM2) &&                       \
-     (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1))))
-#endif
+  ((((__INSTANCE__) == LPTIM1) &&                       \
+    (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
+     ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1)))        \
+   ||                                                   \
+   (((__INSTANCE__) == LPTIM2) &&                       \
+    (((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) ||        \
+     ((__SOURCE__) == LPTIM_INPUT1SOURCE_COMP1))))
+#endif /* COMP2 */
 #else
 #define IS_LPTIM_INPUT1_SOURCE(__INSTANCE__, __SOURCE__)  \
-    ((((__INSTANCE__) == LPTIM1) &&                       \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) )         \
-     ||                                                   \
-     (((__INSTANCE__) == LPTIM2) &&                       \
-      ((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO)))
-#endif
+  ((((__INSTANCE__) == LPTIM1) &&                       \
+    ((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO) )         \
+   ||                                                   \
+   (((__INSTANCE__) == LPTIM2) &&                       \
+    ((__SOURCE__) == LPTIM_INPUT1SOURCE_GPIO)))
+#endif /* COMP1*/
 
 #if defined(COMP2)
 #define IS_LPTIM_INPUT2_SOURCE(__INSTANCE__, __SOURCE__)  \
-     (((__INSTANCE__) == LPTIM1) &&                       \
-     (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO) ||        \
-      ((__SOURCE__) == LPTIM_INPUT2SOURCE_COMP2)))
+  (((__INSTANCE__) == LPTIM1) &&                       \
+   (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO) ||        \
+    ((__SOURCE__) == LPTIM_INPUT2SOURCE_COMP2)))
 #else
 #define IS_LPTIM_INPUT2_SOURCE(__INSTANCE__, __SOURCE__)  \
-     (((__INSTANCE__) == LPTIM1) &&                       \
-     (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO)))
+  (((__INSTANCE__) == LPTIM1) &&                       \
+   (((__SOURCE__) == LPTIM_INPUT2SOURCE_GPIO)))
 #endif
 
 /**
@@ -837,5 +840,3 @@ void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim);
 #endif
 
 #endif /* STM32WBxx_HAL_LPTIM_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pcd.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pcd.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -99,16 +98,16 @@ typedef struct __PCD_HandleTypeDef
 typedef struct
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
 {
-  PCD_TypeDef             *Instance;   /*!< Register base address              */
-  PCD_InitTypeDef         Init;        /*!< PCD required parameters            */
-  __IO uint8_t            USB_Address; /*!< USB Address                        */
-  PCD_EPTypeDef           IN_ep[8];   /*!< IN endpoint parameters             */
-  PCD_EPTypeDef           OUT_ep[8];  /*!< OUT endpoint parameters            */
-  HAL_LockTypeDef         Lock;        /*!< PCD peripheral status              */
-  __IO PCD_StateTypeDef   State;       /*!< PCD communication state            */
-  __IO  uint32_t          ErrorCode;   /*!< PCD Error code                     */
-  uint32_t                Setup[12];   /*!< Setup packet buffer                */
-  PCD_LPM_StateTypeDef    LPM_State;   /*!< LPM State                          */
+  PCD_TypeDef             *Instance;   /*!< Register base address             */
+  PCD_InitTypeDef         Init;        /*!< PCD required parameters           */
+  __IO uint8_t            USB_Address; /*!< USB Address                       */
+  PCD_EPTypeDef           IN_ep[8];    /*!< IN endpoint parameters            */
+  PCD_EPTypeDef           OUT_ep[8];   /*!< OUT endpoint parameters           */
+  HAL_LockTypeDef         Lock;        /*!< PCD peripheral status             */
+  __IO PCD_StateTypeDef   State;       /*!< PCD communication state           */
+  __IO  uint32_t          ErrorCode;   /*!< PCD Error code                    */
+  uint32_t                Setup[12];   /*!< Setup packet buffer               */
+  PCD_LPM_StateTypeDef    LPM_State;   /*!< LPM State                         */
   uint32_t                BESL;
 
 
@@ -188,18 +187,21 @@ typedef struct
 
 /* Exported macros -----------------------------------------------------------*/
 /** @defgroup PCD_Exported_Macros PCD Exported Macros
- *  @brief macros to handle interrupts and specific clock configurations
- * @{
- */
+  *  @brief macros to handle interrupts and specific clock configurations
+  * @{
+  */
+#define __HAL_PCD_ENABLE(__HANDLE__)                       (void)USB_EnableGlobalInt ((__HANDLE__)->Instance)
+#define __HAL_PCD_DISABLE(__HANDLE__)                      (void)USB_DisableGlobalInt ((__HANDLE__)->Instance)
+
+#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__) \
+  ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
 
 
-#define __HAL_PCD_ENABLE(__HANDLE__)                                  (void)USB_EnableGlobalInt ((__HANDLE__)->Instance)
-#define __HAL_PCD_DISABLE(__HANDLE__)                                 (void)USB_DisableGlobalInt ((__HANDLE__)->Instance)
-#define __HAL_PCD_GET_FLAG(__HANDLE__, __INTERRUPT__)                 ((USB_ReadInterrupts((__HANDLE__)->Instance) & (__INTERRUPT__)) == (__INTERRUPT__))
-#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)               (((__HANDLE__)->Instance->ISTR) &= (uint16_t)(~(__INTERRUPT__)))
+#define __HAL_PCD_CLEAR_FLAG(__HANDLE__, __INTERRUPT__)           (((__HANDLE__)->Instance->ISTR)\
+                                                                   &= (uint16_t)(~(__INTERRUPT__)))
 
-#define __HAL_USB_WAKEUP_EXTI_ENABLE_IT()                             EXTI->IMR1 |= USB_WAKEUP_EXTI_LINE
-#define __HAL_USB_WAKEUP_EXTI_DISABLE_IT()                            EXTI->IMR1 &= ~(USB_WAKEUP_EXTI_LINE)
+#define __HAL_USB_WAKEUP_EXTI_ENABLE_IT()                         EXTI->IMR1 |= USB_WAKEUP_EXTI_LINE
+#define __HAL_USB_WAKEUP_EXTI_DISABLE_IT()                        EXTI->IMR1 &= ~(USB_WAKEUP_EXTI_LINE)
 
 
 /**
@@ -233,7 +235,7 @@ typedef enum
   HAL_PCD_SUSPEND_CB_ID      = 0x04,      /*!< USB PCD Suspend callback ID      */
   HAL_PCD_RESUME_CB_ID       = 0x05,      /*!< USB PCD Resume callback ID       */
   HAL_PCD_CONNECT_CB_ID      = 0x06,      /*!< USB PCD Connect callback ID      */
-  HAL_PCD_DISCONNECT_CB_ID  = 0x07,      /*!< USB PCD Disconnect callback ID   */
+  HAL_PCD_DISCONNECT_CB_ID   = 0x07,      /*!< USB PCD Disconnect callback ID   */
 
   HAL_PCD_MSPINIT_CB_ID      = 0x08,      /*!< USB PCD MspInit callback ID      */
   HAL_PCD_MSPDEINIT_CB_ID    = 0x09       /*!< USB PCD MspDeInit callback ID    */
@@ -260,19 +262,29 @@ typedef void (*pPCD_BcdCallbackTypeDef)(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgType
   * @}
   */
 
-HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_CallbackIDTypeDef CallbackID, pPCD_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_CallbackIDTypeDef CallbackID,
+                                           pPCD_CallbackTypeDef pCallback);
+
 HAL_StatusTypeDef HAL_PCD_UnRegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_CallbackIDTypeDef CallbackID);
 
-HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd, pPCD_DataOutStageCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_DataOutStageCallbackTypeDef pCallback);
+
 HAL_StatusTypeDef HAL_PCD_UnRegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd);
 
-HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd, pPCD_DataInStageCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_DataInStageCallbackTypeDef pCallback);
+
 HAL_StatusTypeDef HAL_PCD_UnRegisterDataInStageCallback(PCD_HandleTypeDef *hpcd);
 
-HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd, pPCD_IsoOutIncpltCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_IsoOutIncpltCallbackTypeDef pCallback);
+
 HAL_StatusTypeDef HAL_PCD_UnRegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd);
 
-HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd, pPCD_IsoInIncpltCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_IsoInIncpltCallbackTypeDef pCallback);
+
 HAL_StatusTypeDef HAL_PCD_UnRegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd);
 
 HAL_StatusTypeDef HAL_PCD_RegisterBcdCallback(PCD_HandleTypeDef *hpcd, pPCD_BcdCallbackTypeDef pCallback);
@@ -321,12 +333,13 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
 HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
 HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
-uint32_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
+HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_ActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
 HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
+uint32_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef const *hpcd, uint8_t ep_addr);
 /**
   * @}
   */
@@ -335,7 +348,7 @@ HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd);
 /** @addtogroup PCD_Exported_Functions_Group4 Peripheral State functions
   * @{
   */
-PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef const *hpcd);
 /**
   * @}
   */
@@ -353,7 +366,7 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   */
 
 
-#define  USB_WAKEUP_EXTI_LINE                                         (0x1U << 28)  /*!< USB FS EXTI Line WakeUp Interrupt */
+#define USB_WAKEUP_EXTI_LINE                                          (0x1U << 28)  /*!< USB FS EXTI Line WakeUp Interrupt */
 
 
 /**
@@ -363,10 +376,10 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
 /** @defgroup PCD_EP0_MPS PCD EP0 MPS
   * @{
   */
-#define PCD_EP0MPS_64                                                 DEP0CTL_MPS_64
-#define PCD_EP0MPS_32                                                 DEP0CTL_MPS_32
-#define PCD_EP0MPS_16                                                 DEP0CTL_MPS_16
-#define PCD_EP0MPS_08                                                 DEP0CTL_MPS_8
+#define PCD_EP0MPS_64                                                 EP_MPS_64
+#define PCD_EP0MPS_32                                                 EP_MPS_32
+#define PCD_EP0MPS_16                                                 EP_MPS_16
+#define PCD_EP0MPS_08                                                 EP_MPS_8
 /**
   * @}
   */
@@ -401,21 +414,20 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
 
 /* Private macros ------------------------------------------------------------*/
 /** @defgroup PCD_Private_Macros PCD Private Macros
- * @{
- */
+  * @{
+  */
 
 /********************  Bit definition for USB_COUNTn_RX register  *************/
 #define USB_CNTRX_NBLK_MSK                    (0x1FU << 10)
 #define USB_CNTRX_BLSIZE                      (0x1U << 15)
 
 /* SetENDPOINT */
-#define PCD_SET_ENDPOINT(USBx, bEpNum, wRegValue)  (*(__IO uint16_t *)(&(USBx)->EP0R + ((bEpNum) * 2U)) = (uint16_t)(wRegValue))
+#define PCD_SET_ENDPOINT(USBx, bEpNum, wRegValue) \
+  (*(__IO uint16_t *)(&(USBx)->EP0R + ((bEpNum) * 2U)) = (uint16_t)(wRegValue))
 
 /* GetENDPOINT */
-#define PCD_GET_ENDPOINT(USBx, bEpNum)            (*(__IO uint16_t *)(&(USBx)->EP0R + ((bEpNum) * 2U)))
+#define PCD_GET_ENDPOINT(USBx, bEpNum)             (*(__IO uint16_t *)(&(USBx)->EP0R + ((bEpNum) * 2U)))
 
-/* ENDPOINT transfer */
-#define USB_EP0StartXfer                          USB_EPStartXfer
 
 /**
   * @brief  sets the type in the endpoint register(bits EP_TYPE[1:0])
@@ -424,8 +436,10 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wType Endpoint Type.
   * @retval None
   */
-#define PCD_SET_EPTYPE(USBx, bEpNum, wType) (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                             ((PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EP_T_MASK) | (wType) | USB_EP_CTR_TX | USB_EP_CTR_RX)))
+#define PCD_SET_EPTYPE(USBx, bEpNum, wType) \
+  (PCD_SET_ENDPOINT((USBx), (bEpNum), \
+                    ((PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EP_T_MASK) | (wType) | USB_EP_CTR_TX | USB_EP_CTR_RX)))
+
 
 /**
   * @brief  gets the type in the endpoint register(bits EP_TYPE[1:0])
@@ -442,18 +456,19 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param   bEpNum, bDir
   * @retval None
   */
-#define PCD_FreeUserBuffer(USBx, bEpNum, bDir) do { \
-  if ((bDir) == 0U) \
-  { \
-    /* OUT double buffered endpoint */ \
-    PCD_TX_DTOG((USBx), (bEpNum)); \
-  } \
-  else if ((bDir) == 1U) \
-  { \
-    /* IN double buffered endpoint */ \
-    PCD_RX_DTOG((USBx), (bEpNum)); \
-  } \
-} while(0)
+#define PCD_FREE_USER_BUFFER(USBx, bEpNum, bDir) \
+  do { \
+    if ((bDir) == 0U) \
+    { \
+      /* OUT double buffered endpoint */ \
+      PCD_TX_DTOG((USBx), (bEpNum)); \
+    } \
+    else if ((bDir) == 1U) \
+    { \
+      /* IN double buffered endpoint */ \
+      PCD_RX_DTOG((USBx), (bEpNum)); \
+    } \
+  } while(0)
 
 /**
   * @brief  sets the status for tx transfer (bits STAT_TX[1:0]).
@@ -462,21 +477,22 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wState new state
   * @retval None
   */
-#define PCD_SET_EP_TX_STATUS(USBx, bEpNum, wState) do { \
-   uint16_t _wRegVal; \
-   \
+#define PCD_SET_EP_TX_STATUS(USBx, bEpNum, wState) \
+  do { \
+    uint16_t _wRegVal; \
+    \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPTX_DTOGMASK; \
-   /* toggle first bit ? */ \
-   if ((USB_EPTX_DTOG1 & (wState))!= 0U) \
-   { \
+    /* toggle first bit ? */ \
+    if ((USB_EPTX_DTOG1 & (wState))!= 0U) \
+    { \
       _wRegVal ^= USB_EPTX_DTOG1; \
-   } \
-   /* toggle second bit ?  */ \
-   if ((USB_EPTX_DTOG2 & (wState))!= 0U) \
-   { \
+    } \
+    /* toggle second bit ?  */ \
+    if ((USB_EPTX_DTOG2 & (wState))!= 0U) \
+    { \
       _wRegVal ^= USB_EPTX_DTOG2; \
-   } \
-   PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_RX | USB_EP_CTR_TX)); \
+    } \
+    PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_RX | USB_EP_CTR_TX)); \
   } while(0) /* PCD_SET_EP_TX_STATUS */
 
 /**
@@ -486,19 +502,20 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wState new state
   * @retval None
   */
-#define PCD_SET_EP_RX_STATUS(USBx, bEpNum,wState) do { \
+#define PCD_SET_EP_RX_STATUS(USBx, bEpNum,wState) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPRX_DTOGMASK; \
     /* toggle first bit ? */ \
     if ((USB_EPRX_DTOG1 & (wState))!= 0U) \
     { \
-       _wRegVal ^= USB_EPRX_DTOG1; \
+      _wRegVal ^= USB_EPRX_DTOG1; \
     } \
     /* toggle second bit ? */ \
     if ((USB_EPRX_DTOG2 & (wState))!= 0U) \
     { \
-       _wRegVal ^= USB_EPRX_DTOG2; \
+      _wRegVal ^= USB_EPRX_DTOG2; \
     } \
     PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_RX | USB_EP_CTR_TX)); \
   } while(0) /* PCD_SET_EP_RX_STATUS */
@@ -511,7 +528,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wStatetx new state.
   * @retval None
   */
-#define PCD_SET_EP_TXRX_STATUS(USBx, bEpNum, wStaterx, wStatetx) do { \
+#define PCD_SET_EP_TXRX_STATUS(USBx, bEpNum, wStaterx, wStatetx) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & (USB_EPRX_DTOGMASK | USB_EPTX_STAT); \
@@ -564,10 +582,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bEpNum Endpoint Number.
   * @retval TRUE = endpoint in stall condition.
   */
-#define PCD_GET_EP_TX_STALL_STATUS(USBx, bEpNum) (PCD_GET_EP_TX_STATUS((USBx), (bEpNum)) \
-                                   == USB_EP_TX_STALL)
-#define PCD_GET_EP_RX_STALL_STATUS(USBx, bEpNum) (PCD_GET_EP_RX_STATUS((USBx), (bEpNum)) \
-                                   == USB_EP_RX_STALL)
+#define PCD_GET_EP_TX_STALL_STATUS(USBx, bEpNum) (PCD_GET_EP_TX_STATUS((USBx), (bEpNum)) == USB_EP_TX_STALL)
+#define PCD_GET_EP_RX_STALL_STATUS(USBx, bEpNum) (PCD_GET_EP_RX_STATUS((USBx), (bEpNum)) == USB_EP_RX_STALL)
 
 /**
   * @brief  set & clear EP_KIND bit.
@@ -575,7 +591,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_SET_EP_KIND(USBx, bEpNum) do { \
+#define PCD_SET_EP_KIND(USBx, bEpNum) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK; \
@@ -583,7 +600,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_RX | USB_EP_CTR_TX | USB_EP_KIND)); \
   } while(0) /* PCD_SET_EP_KIND */
 
-#define PCD_CLEAR_EP_KIND(USBx, bEpNum) do { \
+#define PCD_CLEAR_EP_KIND(USBx, bEpNum) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPKIND_MASK; \
@@ -606,8 +624,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_SET_EP_DBUF(USBx, bEpNum)          PCD_SET_EP_KIND((USBx), (bEpNum))
-#define PCD_CLEAR_EP_DBUF(USBx, bEpNum)        PCD_CLEAR_EP_KIND((USBx), (bEpNum))
+#define PCD_SET_BULK_EP_DBUF(USBx, bEpNum)     PCD_SET_EP_KIND((USBx), (bEpNum))
+#define PCD_CLEAR_BULK_EP_DBUF(USBx, bEpNum)   PCD_CLEAR_EP_KIND((USBx), (bEpNum))
 
 /**
   * @brief  Clears bit CTR_RX / CTR_TX in the endpoint register.
@@ -615,7 +633,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_CLEAR_RX_EP_CTR(USBx, bEpNum) do { \
+#define PCD_CLEAR_RX_EP_CTR(USBx, bEpNum) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & (0x7FFFU & USB_EPREG_MASK); \
@@ -623,7 +642,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_TX)); \
   } while(0) /* PCD_CLEAR_RX_EP_CTR */
 
-#define PCD_CLEAR_TX_EP_CTR(USBx, bEpNum) do { \
+#define PCD_CLEAR_TX_EP_CTR(USBx, bEpNum) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & (0xFF7FU & USB_EPREG_MASK); \
@@ -637,7 +657,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_RX_DTOG(USBx, bEpNum) do { \
+#define PCD_RX_DTOG(USBx, bEpNum) \
+  do { \
     uint16_t _wEPVal; \
     \
     _wEPVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK; \
@@ -645,7 +666,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     PCD_SET_ENDPOINT((USBx), (bEpNum), (_wEPVal | USB_EP_CTR_RX | USB_EP_CTR_TX | USB_EP_DTOG_RX)); \
   } while(0) /* PCD_RX_DTOG */
 
-#define PCD_TX_DTOG(USBx, bEpNum) do { \
+#define PCD_TX_DTOG(USBx, bEpNum) \
+  do { \
     uint16_t _wEPVal; \
     \
     _wEPVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK; \
@@ -658,7 +680,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bEpNum Endpoint Number.
   * @retval None
   */
-#define PCD_CLEAR_RX_DTOG(USBx, bEpNum) do { \
+#define PCD_CLEAR_RX_DTOG(USBx, bEpNum) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)); \
@@ -669,7 +692,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     } \
   } while(0) /* PCD_CLEAR_RX_DTOG */
 
-#define PCD_CLEAR_TX_DTOG(USBx, bEpNum) do { \
+#define PCD_CLEAR_TX_DTOG(USBx, bEpNum) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)); \
@@ -687,7 +711,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  bAddr Address.
   * @retval None
   */
-#define PCD_SET_EP_ADDRESS(USBx, bEpNum, bAddr) do { \
+#define PCD_SET_EP_ADDRESS(USBx, bEpNum, bAddr) \
+  do { \
     uint16_t _wRegVal; \
     \
     _wRegVal = (PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK) | (bAddr); \
@@ -703,8 +728,14 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   */
 #define PCD_GET_EP_ADDRESS(USBx, bEpNum) ((uint8_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPADDR_FIELD))
 
-#define PCD_EP_TX_CNT(USBx, bEpNum) ((uint16_t *)((((uint32_t)(USBx)->BTABLE + ((uint32_t)(bEpNum) * 8U) + 2U) * PMA_ACCESS) + ((uint32_t)(USBx) + 0x400U)))
-#define PCD_EP_RX_CNT(USBx, bEpNum) ((uint16_t *)((((uint32_t)(USBx)->BTABLE + ((uint32_t)(bEpNum) * 8U) + 6U) * PMA_ACCESS) + ((uint32_t)(USBx) + 0x400U)))
+#define PCD_EP_TX_CNT(USBx, bEpNum) \
+  ((uint16_t *)((((uint32_t)(USBx)->BTABLE + \
+                  ((uint32_t)(bEpNum) * 8U) + 2U) * PMA_ACCESS) + ((uint32_t)(USBx) + 0x400U)))
+
+#define PCD_EP_RX_CNT(USBx, bEpNum) \
+  ((uint16_t *)((((uint32_t)(USBx)->BTABLE + \
+                  ((uint32_t)(bEpNum) * 8U) + 6U) * PMA_ACCESS) + ((uint32_t)(USBx) + 0x400U)))
+
 
 /**
   * @brief  sets address of the tx/rx buffer.
@@ -713,23 +744,25 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wAddr address to be set (must be word aligned).
   * @retval None
   */
-#define PCD_SET_EP_TX_ADDRESS(USBx, bEpNum, wAddr) do { \
-  __IO uint16_t *_wRegVal; \
-  uint32_t _wRegBase = (uint32_t)USBx; \
-  \
-  _wRegBase += (uint32_t)(USBx)->BTABLE; \
-  _wRegVal = (__IO uint16_t *)(_wRegBase + 0x400U + (((uint32_t)(bEpNum) * 8U) * PMA_ACCESS)); \
-  *_wRegVal = ((wAddr) >> 1) << 1; \
-} while(0) /* PCD_SET_EP_TX_ADDRESS */
+#define PCD_SET_EP_TX_ADDRESS(USBx, bEpNum, wAddr) \
+  do { \
+    __IO uint16_t *_wRegVal; \
+    uint32_t _wRegBase = (uint32_t)USBx; \
+    \
+    _wRegBase += (uint32_t)(USBx)->BTABLE; \
+    _wRegVal = (__IO uint16_t *)(_wRegBase + 0x400U + (((uint32_t)(bEpNum) * 8U) * PMA_ACCESS)); \
+    *_wRegVal = ((wAddr) >> 1) << 1; \
+  } while(0) /* PCD_SET_EP_TX_ADDRESS */
 
-#define PCD_SET_EP_RX_ADDRESS(USBx, bEpNum, wAddr) do { \
-  __IO uint16_t *_wRegVal; \
-  uint32_t _wRegBase = (uint32_t)USBx; \
-  \
-  _wRegBase += (uint32_t)(USBx)->BTABLE; \
-  _wRegVal = (__IO uint16_t *)(_wRegBase + 0x400U + ((((uint32_t)(bEpNum) * 8U) + 4U) * PMA_ACCESS)); \
-  *_wRegVal = ((wAddr) >> 1) << 1; \
-} while(0) /* PCD_SET_EP_RX_ADDRESS */
+#define PCD_SET_EP_RX_ADDRESS(USBx, bEpNum, wAddr) \
+  do { \
+    __IO uint16_t *_wRegVal; \
+    uint32_t _wRegBase = (uint32_t)USBx; \
+    \
+    _wRegBase += (uint32_t)(USBx)->BTABLE; \
+    _wRegVal = (__IO uint16_t *)(_wRegBase + 0x400U + ((((uint32_t)(bEpNum) * 8U) + 4U) * PMA_ACCESS)); \
+    *_wRegVal = ((wAddr) >> 1) << 1; \
+  } while(0) /* PCD_SET_EP_RX_ADDRESS */
 
 /**
   * @brief  Gets address of the tx/rx buffer.
@@ -747,32 +780,37 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wNBlocks no. of Blocks.
   * @retval None
   */
-#define PCD_CALC_BLK32(pdwReg, wCount, wNBlocks) do { \
+#define PCD_CALC_BLK32(pdwReg, wCount, wNBlocks) \
+  do { \
     (wNBlocks) = (wCount) >> 5; \
     if (((wCount) & 0x1fU) == 0U) \
     { \
       (wNBlocks)--; \
     } \
-    *(pdwReg) = (uint16_t)(((wNBlocks) << 10) | USB_CNTRX_BLSIZE); \
+    *(pdwReg) |= (uint16_t)(((wNBlocks) << 10) | USB_CNTRX_BLSIZE); \
   } while(0) /* PCD_CALC_BLK32 */
 
-#define PCD_CALC_BLK2(pdwReg, wCount, wNBlocks) do { \
+#define PCD_CALC_BLK2(pdwReg, wCount, wNBlocks) \
+  do { \
     (wNBlocks) = (wCount) >> 1; \
     if (((wCount) & 0x1U) != 0U) \
     { \
       (wNBlocks)++; \
     } \
-    *(pdwReg) = (uint16_t)((wNBlocks) << 10); \
+    *(pdwReg) |= (uint16_t)((wNBlocks) << 10); \
   } while(0) /* PCD_CALC_BLK2 */
 
-#define PCD_SET_EP_CNT_RX_REG(pdwReg, wCount)  do { \
+#define PCD_SET_EP_CNT_RX_REG(pdwReg, wCount) \
+  do { \
     uint32_t wNBlocks; \
+    \
+    *(pdwReg) &= 0x3FFU; \
+    \
     if ((wCount) == 0U) \
     { \
-      *(pdwReg) &= (uint16_t)~USB_CNTRX_NBLK_MSK; \
       *(pdwReg) |= USB_CNTRX_BLSIZE; \
     } \
-    else if((wCount) <= 62U) \
+    else if ((wCount) <= 62U) \
     { \
       PCD_CALC_BLK2((pdwReg), (wCount), wNBlocks); \
     } \
@@ -782,10 +820,11 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     } \
   } while(0) /* PCD_SET_EP_CNT_RX_REG */
 
-#define PCD_SET_EP_RX_DBUF0_CNT(USBx, bEpNum, wCount) do { \
-     uint32_t _wRegBase = (uint32_t)(USBx); \
-     __IO uint16_t *pdwReg; \
-     \
+#define PCD_SET_EP_RX_DBUF0_CNT(USBx, bEpNum, wCount) \
+  do { \
+    uint32_t _wRegBase = (uint32_t)(USBx); \
+    __IO uint16_t *pdwReg; \
+    \
     _wRegBase += (uint32_t)(USBx)->BTABLE; \
     pdwReg = (__IO uint16_t *)(_wRegBase + 0x400U + ((((uint32_t)(bEpNum) * 8U) + 2U) * PMA_ACCESS)); \
     PCD_SET_EP_CNT_RX_REG(pdwReg, (wCount)); \
@@ -798,23 +837,25 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wCount Counter value.
   * @retval None
   */
-#define PCD_SET_EP_TX_CNT(USBx, bEpNum, wCount) do { \
+#define PCD_SET_EP_TX_CNT(USBx, bEpNum, wCount) \
+  do { \
     uint32_t _wRegBase = (uint32_t)(USBx); \
     __IO uint16_t *_wRegVal; \
     \
     _wRegBase += (uint32_t)(USBx)->BTABLE; \
     _wRegVal = (__IO uint16_t *)(_wRegBase + 0x400U + ((((uint32_t)(bEpNum) * 8U) + 2U) * PMA_ACCESS)); \
     *_wRegVal = (uint16_t)(wCount); \
-} while(0)
+  } while(0)
 
-#define PCD_SET_EP_RX_CNT(USBx, bEpNum, wCount) do { \
+#define PCD_SET_EP_RX_CNT(USBx, bEpNum, wCount) \
+  do { \
     uint32_t _wRegBase = (uint32_t)(USBx); \
     __IO uint16_t *_wRegVal; \
     \
     _wRegBase += (uint32_t)(USBx)->BTABLE; \
     _wRegVal = (__IO uint16_t *)(_wRegBase + 0x400U + ((((uint32_t)(bEpNum) * 8U) + 6U) * PMA_ACCESS)); \
     PCD_SET_EP_CNT_RX_REG(_wRegVal, (wCount)); \
-} while(0)
+  } while(0)
 
 /**
   * @brief  gets counter of the tx buffer.
@@ -832,10 +873,13 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wBuf0Addr buffer 0 address.
   * @retval Counter value
   */
-#define PCD_SET_EP_DBUF0_ADDR(USBx, bEpNum, wBuf0Addr) do { \
+#define PCD_SET_EP_DBUF0_ADDR(USBx, bEpNum, wBuf0Addr) \
+  do { \
     PCD_SET_EP_TX_ADDRESS((USBx), (bEpNum), (wBuf0Addr)); \
   } while(0) /* PCD_SET_EP_DBUF0_ADDR */
-#define PCD_SET_EP_DBUF1_ADDR(USBx, bEpNum, wBuf1Addr) do { \
+
+#define PCD_SET_EP_DBUF1_ADDR(USBx, bEpNum, wBuf1Addr) \
+  do { \
     PCD_SET_EP_RX_ADDRESS((USBx), (bEpNum), (wBuf1Addr)); \
   } while(0) /* PCD_SET_EP_DBUF1_ADDR */
 
@@ -847,7 +891,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wBuf1Addr = buffer 1 address.
   * @retval None
   */
-#define PCD_SET_EP_DBUF_ADDR(USBx, bEpNum, wBuf0Addr, wBuf1Addr) do { \
+#define PCD_SET_EP_DBUF_ADDR(USBx, bEpNum, wBuf0Addr, wBuf1Addr) \
+  do { \
     PCD_SET_EP_DBUF0_ADDR((USBx), (bEpNum), (wBuf0Addr)); \
     PCD_SET_EP_DBUF1_ADDR((USBx), (bEpNum), (wBuf1Addr)); \
   } while(0) /* PCD_SET_EP_DBUF_ADDR */
@@ -870,7 +915,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
   * @param  wCount: Counter value
   * @retval None
   */
-#define PCD_SET_EP_DBUF0_CNT(USBx, bEpNum, bDir, wCount) do { \
+#define PCD_SET_EP_DBUF0_CNT(USBx, bEpNum, bDir, wCount) \
+  do { \
     if ((bDir) == 0U) \
       /* OUT endpoint */ \
     { \
@@ -886,7 +932,8 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     } \
   } while(0) /* SetEPDblBuf0Count*/
 
-#define PCD_SET_EP_DBUF1_CNT(USBx, bEpNum, bDir, wCount) do { \
+#define PCD_SET_EP_DBUF1_CNT(USBx, bEpNum, bDir, wCount) \
+  do { \
     uint32_t _wBase = (uint32_t)(USBx); \
     __IO uint16_t *_wEPRegVal; \
     \
@@ -907,10 +954,11 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
     } \
   } while(0) /* SetEPDblBuf1Count */
 
-#define PCD_SET_EP_DBUF_CNT(USBx, bEpNum, bDir, wCount) do { \
+#define PCD_SET_EP_DBUF_CNT(USBx, bEpNum, bDir, wCount) \
+  do { \
     PCD_SET_EP_DBUF0_CNT((USBx), (bEpNum), (bDir), (wCount)); \
     PCD_SET_EP_DBUF1_CNT((USBx), (bEpNum), (bDir), (wCount)); \
-  } while(0) /* PCD_SET_EP_DBUF_CNT  */
+  } while(0) /* PCD_SET_EP_DBUF_CNT */
 
 /**
   * @brief  Gets buffer 0/1 rx/tx counter for double buffering.
@@ -941,5 +989,3 @@ PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd);
 #endif
 
 #endif /* STM32WBxx_HAL_PCD_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pcd_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pcd_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* __cplusplus */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_hal_def.h"
@@ -48,11 +47,8 @@ extern "C" {
   */
 
 
-
-HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd,
-                                       uint16_t ep_addr,
-                                       uint16_t ep_kind,
-                                       uint32_t pmaadress);
+HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, uint16_t ep_addr,
+                                       uint16_t ep_kind, uint32_t pmaadress);
 
 
 HAL_StatusTypeDef HAL_PCDEx_ActivateLPM(PCD_HandleTypeDef *hpcd);
@@ -85,9 +81,7 @@ void HAL_PCDEx_BCD_Callback(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef msg);
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* __cplusplus */
 
 
 #endif /* STM32WBxx_HAL_PCD_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pka.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pka.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -29,19 +28,19 @@ extern "C" {
 #include "stm32wbxx_hal_def.h"
 
 /** @addtogroup STM32WBxx_HAL_Driver
- * @{
- */
+  * @{
+  */
 
 #if defined(PKA) && defined(HAL_PKA_MODULE_ENABLED)
 
 /** @addtogroup PKA
- * @{
- */
+  * @{
+  */
 
 /* Exported types ------------------------------------------------------------*/
 /** @defgroup PKA_Exported_Types PKA Exported Types
- * @{
- */
+  * @{
+  */
 
 /** @defgroup HAL_state_structure_definition HAL state structure definition
   * @brief  HAL State structures definition
@@ -364,7 +363,7 @@ typedef struct
                                                                   } while(0)
 #else
 #define __HAL_PKA_RESET_HANDLE_STATE(__HANDLE__)                ((__HANDLE__)->State = HAL_PKA_STATE_RESET)
-#endif
+#endif /* USE_HAL_PKA_REGISTER_CALLBACKS */
 
 /** @brief  Enable the specified PKA interrupt.
   * @param  __HANDLE__ specifies the PKA Handle
@@ -397,7 +396,8 @@ typedef struct
   *            @arg @ref PKA_IT_RAMERR RAM error interrupt enable
   * @retval The new state of __INTERRUPT__ (SET or RESET)
   */
-#define __HAL_PKA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      ((((__HANDLE__)->Instance->CR & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_PKA_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)      ((((__HANDLE__)->Instance->CR\
+                                                                   & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Check whether the specified PKA flag is set or not.
   * @param  __HANDLE__ specifies the PKA Handle
@@ -408,7 +408,8 @@ typedef struct
   *            @arg @ref PKA_FLAG_RAMERR RAM error
   * @retval The new state of __FLAG__ (SET or RESET)
   */
-#define __HAL_PKA_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->SR) & (__FLAG__)) == (__FLAG__)) ? SET : RESET)
+#define __HAL_PKA_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->SR)\
+                                                                   & (__FLAG__)) == (__FLAG__)) ? SET : RESET)
 
 /** @brief  Clear the PKA pending flags which are cleared by writing 1 in a specific bit.
   * @param  __HANDLE__ specifies the PKA Handle
@@ -459,7 +460,8 @@ void              HAL_PKA_MspDeInit(PKA_HandleTypeDef *hpka);
 
 #if (USE_HAL_PKA_REGISTER_CALLBACKS == 1)
 /* Callbacks Register/UnRegister functions  ***********************************/
-HAL_StatusTypeDef HAL_PKA_RegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_CallbackIDTypeDef CallbackID, pPKA_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_PKA_RegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_CallbackIDTypeDef CallbackID,
+                                           pPKA_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_PKA_UnRegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_PKA_REGISTER_CALLBACKS */
 
@@ -480,7 +482,8 @@ void HAL_PKA_ModExp_GetResult(PKA_HandleTypeDef *hpka, uint8_t *pRes);
 
 HAL_StatusTypeDef HAL_PKA_ECDSASign(PKA_HandleTypeDef *hpka, PKA_ECDSASignInTypeDef *in, uint32_t Timeout);
 HAL_StatusTypeDef HAL_PKA_ECDSASign_IT(PKA_HandleTypeDef *hpka, PKA_ECDSASignInTypeDef *in);
-void HAL_PKA_ECDSASign_GetResult(PKA_HandleTypeDef *hpka, PKA_ECDSASignOutTypeDef *out, PKA_ECDSASignOutExtParamTypeDef *outExt);
+void HAL_PKA_ECDSASign_GetResult(PKA_HandleTypeDef *hpka, PKA_ECDSASignOutTypeDef *out,
+                                 PKA_ECDSASignOutExtParamTypeDef *outExt);
 
 HAL_StatusTypeDef HAL_PKA_ECDSAVerif(PKA_HandleTypeDef *hpka, PKA_ECDSAVerifInTypeDef *in, uint32_t Timeout);
 HAL_StatusTypeDef HAL_PKA_ECDSAVerif_IT(PKA_HandleTypeDef *hpka, PKA_ECDSAVerifInTypeDef *in);
@@ -563,5 +566,3 @@ uint32_t             HAL_PKA_GetError(PKA_HandleTypeDef *hpka);
 #endif
 
 #endif /* STM32WBxx_HAL_PKA_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pwr.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pwr.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,7 +21,7 @@
 #define STM32WBxx_HAL_PWR_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -56,7 +55,7 @@ typedef struct
 
   uint32_t Mode;           /*!< Mode: Specifies the operating mode for the selected pins.
                                 This parameter can be a value of @ref PWR_PVD_Mode. */
-}PWR_PVDTypeDef;
+} PWR_PVDTypeDef;
 
 /**
   * @}
@@ -86,7 +85,7 @@ typedef struct
 /** @defgroup PWR_PVD_Mode  PWR PVD interrupt and event mode
   * @{
   */
-/* Note: On STM32WB serie, power PVD event is not available on AIEC lines     */
+/* Note: On STM32WB series, power PVD event is not available on AIEC lines     */
 /*       (only interruption is available through AIEC line 16).               */
 #define PWR_PVD_MODE_NORMAL                 (0x00000000U)                           /*!< Basic mode is used */
 
@@ -97,7 +96,7 @@ typedef struct
   * @}
   */
 
-/* Note: On STM32WB serie, power PVD event is not available on AIEC lines     */
+/* Note: On STM32WB series, power PVD event is not available on AIEC lines     */
 /*       (only interruption is available through AIEC line 16).               */
 
 /** @defgroup PWR_Low_Power_Mode_Selection  PWR Low Power Mode Selection
@@ -107,7 +106,7 @@ typedef struct
 #define PWR_LOWPOWERMODE_STOP1              (PWR_CR1_LPMS_0)                      /*!< Stop 1: stop mode with low power regulator */
 #if defined(PWR_SUPPORT_STOP2)
 #define PWR_LOWPOWERMODE_STOP2              (PWR_CR1_LPMS_1)                      /*!< Stop 2: stop mode with low power regulator and VDD12I interruptible digital core domain supply OFF (less peripherals activated than low power mode stop 1 to reduce power consumption)*/
-#endif
+#endif /* PWR_SUPPORT_STOP2 */
 #define PWR_LOWPOWERMODE_STANDBY            (PWR_CR1_LPMS_0 | PWR_CR1_LPMS_1)     /*!< Standby mode */
 #define PWR_LOWPOWERMODE_SHUTDOWN           (PWR_CR1_LPMS_2)                      /*!< Shutdown mode */
 /**
@@ -161,7 +160,7 @@ typedef struct
 /** @defgroup PWR_PVD_Mode_Mask PWR PVD Mode Mask
   * @{
   */
-/* Note: On STM32WB serie, power PVD event is not available on AIEC lines     */
+/* Note: On STM32WB series, power PVD event is not available on AIEC lines     */
 /*       (only interruption is available through AIEC line 16).               */
 #define PVD_MODE_IT               (0x00010000U)  /*!< Mask for interruption yielded by PVD threshold crossing */
 #define PVD_RISING_EDGE           (0x00000001U)  /*!< Mask for rising edge set as PVD trigger                 */
@@ -239,19 +238,19 @@ typedef struct
   */
 #define __HAL_PWR_GET_FLAG(__FLAG__)  ((((__FLAG__) & PWR_FLAG_REG_MASK) == PWR_FLAG_REG_SR1) ?   \
                                        (                                                          \
-                                        PWR->SR1 & (1UL << ((__FLAG__) & 31UL))                   \
+                                           PWR->SR1 & (1UL << ((__FLAG__) & 31UL))                \
                                        )                                                          \
                                        :                                                          \
                                        (                                                          \
-                                        (((__FLAG__) & PWR_FLAG_REG_MASK) == PWR_FLAG_REG_SR2) ? \
-                                        (                                                        \
-                                         PWR->SR2 & (1UL << ((__FLAG__) & 31UL))                 \
-                                        )                                                        \
-                                        :                                                        \
-                                        (                                                        \
-                                         PWR->EXTSCR & (1UL << ((__FLAG__) & 31UL))              \
-                                        )                                                        \
-                                       )                                                          \
+                                           (((__FLAG__) & PWR_FLAG_REG_MASK) == PWR_FLAG_REG_SR2) ? \
+                                           (                                                        \
+                                               PWR->SR2 & (1UL << ((__FLAG__) & 31UL))              \
+                                           )                                                        \
+                                           :                                                        \
+                                           (                                                        \
+                                               PWR->EXTSCR & (1UL << ((__FLAG__) & 31UL))           \
+                                           )                                                        \
+                                       )                                                            \
                                       )
 
 /** @brief  Clear a specific PWR flag.
@@ -292,16 +291,16 @@ typedef struct
   *
   * @retval None
   */
-#define __HAL_PWR_CLEAR_FLAG(__FLAG__)   ((((__FLAG__) & PWR_FLAG_REG_MASK) == PWR_FLAG_REG_EXTSCR) ?                                  \
-                                          (                                                                                            \
-                                           PWR->EXTSCR = (1UL << (((__FLAG__) & PWR_FLAG_EXTSCR_CLR_MASK) >> PWR_FLAG_EXTSCR_CLR_POS)) \
-                                          )                                                                                            \
-                                          :                                                                                            \
-                                          (                                                                                            \
-                                           (((__FLAG__)) == PWR_FLAG_WU) ?                                                             \
-                                           (PWR->SCR = PWR_SCR_CWUF) :                                                                 \
-                                           (PWR->SCR = (1UL << ((__FLAG__) & 31UL)))                                                   \
-                                          )                                                                                            \
+#define __HAL_PWR_CLEAR_FLAG(__FLAG__)   ((((__FLAG__) & PWR_FLAG_REG_MASK) == PWR_FLAG_REG_EXTSCR) ?                                     \
+                                          (                                                                                               \
+                                              PWR->EXTSCR = (1UL << (((__FLAG__) & PWR_FLAG_EXTSCR_CLR_MASK) >> PWR_FLAG_EXTSCR_CLR_POS)) \
+                                          )                                                                                               \
+                                          :                                                                                               \
+                                          (                                                                                               \
+                                              (((__FLAG__)) == PWR_FLAG_WU) ?                                                             \
+                                              (PWR->SCR = PWR_SCR_CWUF) :                                                                 \
+                                              (PWR->SCR = (1UL << ((__FLAG__) & 31UL)))                                                   \
+                                          )                                                                                               \
                                          )
 
 /**
@@ -329,7 +328,7 @@ typedef struct
   */
 #define __HAL_PWR_PVD_EXTIC2_DISABLE_IT()  LL_C2_EXTI_DisableIT_0_31(PWR_EXTI_LINE_PVD)
 
-/* Note: On STM32WB serie, power PVD event is not available on AIEC lines     */
+/* Note: On STM32WB series, power PVD event is not available on AIEC lines     */
 /*       (only interruption is available through AIEC line 16).               */
 
 /**
@@ -512,4 +511,3 @@ void              HAL_PWR_DisableSEVOnPend(void);
 
 #endif /* STM32WBxx_HAL_PWR_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pwr_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_pwr_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,7 +21,7 @@
 #define STM32WBxx_HAL_PWR_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -59,7 +58,7 @@ typedef struct
                            This parameter can be a value of @ref PWREx_PVM_Mode. */
   uint32_t WakeupTarget;   /*!< Specifies the Wakeup Target
                            This parameter can be a value of @ref PWREx_WakeUpTarget_Definition */
-}PWR_PVMTypeDef;
+} PWR_PVMTypeDef;
 
 #if defined(PWR_CR5_SMPSEN)
 /**
@@ -72,8 +71,8 @@ typedef struct
 
   uint32_t OutputVoltage;  /*!< SMPS step down converter output voltage scaling voltage level.
                                 This parameter can be a value of @ref PWREx_SMPS_OUTPUT_VOLTAGE_LEVEL */
-}PWR_SMPSTypeDef;
-#endif
+} PWR_SMPSTypeDef;
+#endif /* PWR_CR5_SMPSEN */
 
 /**
   * @}
@@ -100,26 +99,26 @@ typedef struct
 #define PWR_WAKEUP_PIN1_HIGH            PWR_CR3_EWUP1  /*!< Wakeup pin 1 (with high level polarity) */
 #if defined(PWR_CR3_EWUP2)
 #define PWR_WAKEUP_PIN2_HIGH            PWR_CR3_EWUP2  /*!< Wakeup pin 2 (with high level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #if defined(PWR_CR3_EWUP3)
 #define PWR_WAKEUP_PIN3_HIGH            PWR_CR3_EWUP3  /*!< Wakeup pin 3 (with high level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #define PWR_WAKEUP_PIN4_HIGH            PWR_CR3_EWUP4  /*!< Wakeup pin 4 (with high level polarity) */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_WAKEUP_PIN5_HIGH            PWR_CR3_EWUP5  /*!< Wakeup pin 5 (with high level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP5 */
 
 #define PWR_WAKEUP_PIN1_LOW             ((PWR_CR4_WP1<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP1) /*!< Wakeup pin 1 (with low level polarity) */
 #if defined(PWR_CR3_EWUP2)
 #define PWR_WAKEUP_PIN2_LOW             ((PWR_CR4_WP2<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP2) /*!< Wakeup pin 2 (with low level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #if defined(PWR_CR3_EWUP3)
 #define PWR_WAKEUP_PIN3_LOW             ((PWR_CR4_WP3<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP3) /*!< Wakeup pin 3 (with low level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #define PWR_WAKEUP_PIN4_LOW             ((PWR_CR4_WP4<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP4) /*!< Wakeup pin 4 (with low level polarity) */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_WAKEUP_PIN5_LOW             ((PWR_CR4_WP5<<PWR_WUP_POLARITY_SHIFT) | PWR_CR3_EWUP5) /*!< Wakeup pin 5 (with low level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP5 */
 /**
   * @}
   */
@@ -128,14 +127,14 @@ typedef struct
 #define PWR_WAKEUP_PIN1                 PWR_CR3_EWUP1  /*!< Wakeup pin 1 (with high level polarity) */
 #if defined(PWR_CR3_EWUP2)
 #define PWR_WAKEUP_PIN2                 PWR_CR3_EWUP2  /*!< Wakeup pin 2 (with high level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #if defined(PWR_CR3_EWUP3)
 #define PWR_WAKEUP_PIN3                 PWR_CR3_EWUP3  /*!< Wakeup pin 3 (with high level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #define PWR_WAKEUP_PIN4                 PWR_CR3_EWUP4  /*!< Wakeup pin 4 (with high level polarity) */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_WAKEUP_PIN5                 PWR_CR3_EWUP5  /*!< Wakeup pin 5 (with high level polarity) */
-#endif
+#endif /* PWR_CR3_EWUP5 */
 
 /** @defgroup PWREx_PIN_Polarity PWREx Pin Polarity configuration
   * @{
@@ -151,7 +150,7 @@ typedef struct
   */
 #if defined(PWR_CR2_PVME1)
 #define PWR_PVM_1                  PWR_CR2_PVME1  /*!< Peripheral Voltage Monitoring 1 enable: VDDUSB versus 1.2 V (applicable when USB feature is supported) */
-#endif
+#endif /* PWR_CR2_PVME1 */
 #define PWR_PVM_3                  PWR_CR2_PVME3  /*!< Peripheral Voltage Monitoring 3 enable: VDDA versus 1.62 V */
 /**
   * @}
@@ -190,7 +189,7 @@ typedef struct
 #define PWR_REGULATOR_VOLTAGE_SCALE2       PWR_CR1_VOS_1     /*!< Regulator voltage output range 2 mode, typical output voltage at 1.0 V, system frequency up to 16 MHz */
 #else
 #define PWR_REGULATOR_VOLTAGE_SCALE1       (0x00000200UL)    /*!< Regulator voltage output range 1 mode, typical output voltage at 1.2 V, system frequency up to 64 MHz */
-#endif
+#endif /* PWR_CR1_VOS */
 /**
   * @}
   */
@@ -245,7 +244,7 @@ typedef struct
 #define PWR_GPIO_C   0x00000002U      /*!< GPIO port C */
 #if defined(GPIOD)
 #define PWR_GPIO_D   0x00000003U      /*!< GPIO port D */
-#endif
+#endif /* GPIOD */
 #define PWR_GPIO_E   0x00000004U      /*!< GPIO port E */
 #define PWR_GPIO_H   0x00000007U      /*!< GPIO port H */
 /**
@@ -267,7 +266,7 @@ typedef struct
   */
 /* Note: Literals values are defined from register SR2 bits SMPSF and SMPSBF  */
 /*       but they are also used as register CR5 bits SMPSEN and SMPSBEN,      */
-/*       as used by all SMPS operating mode functions targetting different    */
+/*       as used by all SMPS operating mode functions targeting different    */
 /*       registers:                                                           */
 /*       "LL_PWR_SMPS_SetMode()", "LL_PWR_SMPS_GetMode()"                     */
 /*       and "LL_PWR_SMPS_GetEffectiveMode()".                                */
@@ -315,7 +314,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /** @defgroup PWREx_Flag  PWR Status Flags
   *        Elements values convention: 0000 0000 0XXY YYYYb
@@ -332,19 +331,19 @@ typedef struct
 #define PWR_FLAG_WUF1                       (PWR_FLAG_REG_SR1 | PWR_SR1_WUF1_Pos)    /*!< Wakeup event on wakeup pin 1 */
 #if defined(PWR_CR3_EWUP2)
 #define PWR_FLAG_WUF2                       (PWR_FLAG_REG_SR1 | PWR_SR1_WUF2_Pos)    /*!< Wakeup event on wakeup pin 2 */
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #if defined(PWR_CR3_EWUP3)
 #define PWR_FLAG_WUF3                       (PWR_FLAG_REG_SR1 | PWR_SR1_WUF3_Pos)    /*!< Wakeup event on wakeup pin 3 */
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #define PWR_FLAG_WUF4                       (PWR_FLAG_REG_SR1 | PWR_SR1_WUF4_Pos)    /*!< Wakeup event on wakeup pin 4 */
 #if defined(PWR_CR3_EWUP5)
 #define PWR_FLAG_WUF5                       (PWR_FLAG_REG_SR1 | PWR_SR1_WUF5_Pos)    /*!< Wakeup event on wakeup pin 5 */
-#endif
+#endif /* PWR_CR3_EWUP5 */
 #define PWR_FLAG_WU                         (PWR_FLAG_REG_SR1 | PWR_SR1_WUF)         /*!< Encompass wakeup event on all wakeup pins */
 
 #if defined(PWR_CR5_SMPSEN)
 #define PWR_FLAG_FRCBYPI                    (PWR_FLAG_REG_SR1 | PWR_SR1_SMPSFBF_Pos) /*!< SMPS Forced in Bypass Interrupt Flag */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 #define PWR_FLAG_BHWF                       (PWR_FLAG_REG_SR1 | PWR_SR1_BLEWUF_Pos)  /*!< BLE_Host WakeUp Flag */
 #define PWR_FLAG_RFPHASEI                   (PWR_FLAG_REG_SR1 | PWR_SR1_CRPEF_Pos)   /*!< Radio Phase Interrupt Flag */
 #define PWR_FLAG_BLEACTI                    (PWR_FLAG_REG_SR1 | PWR_SR1_BLEAF_Pos)   /*!< BLE Activity Interrupt Flag */
@@ -356,19 +355,19 @@ typedef struct
 #if defined(PWR_CR5_SMPSEN)
 #define PWR_FLAG_SMPSRDYF                   (PWR_FLAG_REG_SR2 | PWR_SR2_SMPSBF_Pos)  /*!< SMPS Ready Flag */
 #define PWR_FLAG_SMPSBYPF                   (PWR_FLAG_REG_SR2 | PWR_SR2_SMPSF_Pos)   /*!< SMPS Bypass Flag */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 #define PWR_FLAG_REGLPS                     (PWR_FLAG_REG_SR2 | PWR_SR2_REGLPS_Pos)  /*!< Low-power regulator start flag */
 #define PWR_FLAG_REGLPF                     (PWR_FLAG_REG_SR2 | PWR_SR2_REGLPF_Pos)  /*!< Low-power regulator flag */
 
 #if defined(PWR_CR1_VOS)
 #define PWR_FLAG_VOSF                       (PWR_FLAG_REG_SR2 | PWR_SR2_VOSF_Pos)    /*!< Voltage scaling flag */
-#endif
+#endif /* PWR_CR1_VOS */
 #define PWR_FLAG_PVDO                       (PWR_FLAG_REG_SR2 | PWR_SR2_PVDO_Pos)    /*!< Power Voltage Detector output flag */
 
 #if defined(PWR_CR2_PVME1)
 #define PWR_FLAG_PVMO1                      (PWR_FLAG_REG_SR2 | PWR_SR2_PVMO1_Pos)   /*!< Power Voltage Monitoring 1 output flag */
-#endif
+#endif /* PWR_CR2_PVME1 */
 #define PWR_FLAG_PVMO3                      (PWR_FLAG_REG_SR2 | PWR_SR2_PVMO3_Pos)   /*!< Power Voltage Monitoring 3 output flag */
 
 /*------------------------------EXTSCR---------------------------*/
@@ -418,7 +417,7 @@ typedef struct
   */
 #if defined(PWR_CR2_PVME1)
 #define PWR_EXTI_LINE_PVM1  (LL_EXTI_LINE_31)  /*!< External interrupt line 31 Connected to PVM1 */
-#endif
+#endif /* PWR_CR2_PVME1 */
 #define PWR_EXTI_LINE_PVM3  (LL_EXTI_LINE_33)  /*!< External interrupt line 33 Connected to PVM3 */
 /**
   * @}
@@ -427,7 +426,7 @@ typedef struct
 /** @defgroup PWR_PVM_Mode_Mask PWR PVM Mode Mask
   * @{
   */
-/* Note: On STM32WB serie, power PVD event is not available on AIEC lines     */
+/* Note: On STM32WB series, power PVD event is not available on AIEC lines     */
 /*       (only interruption is available through AIEC line 16).               */
 #define PVM_MODE_IT               (0x00010000U)  /*!< Mask for interruption yielded by PVM threshold crossing */
 #define PVM_MODE_EVT              (0x00020000U)  /*!< Mask for event yielded by PVM threshold crossing */
@@ -457,8 +456,8 @@ typedef struct
 
 /* Exported macros -----------------------------------------------------------*/
 /** @defgroup PWREx_Exported_Macros PWR Extended Exported Macros
- * @{
- */
+  * @{
+  */
 
 #if defined(PWR_CR2_PVME1)
 /**
@@ -580,7 +579,7 @@ typedef struct
   */
 #define __HAL_PWR_PVM1_EXTI_CLEAR_FLAG()  LL_EXTI_ClearFlag_0_31(PWR_EXTI_LINE_PVM1)
 
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 /**
   * @brief Enable the PVM3 Extended Interrupt C1 Line.
@@ -725,7 +724,7 @@ typedef struct
                                                             tmpreg = READ_BIT(PWR->CR1, PWR_CR1_VOS);           \
                                                             UNUSED(tmpreg);                                     \
                                                           } while(0)
-#endif
+#endif /* PWR_CR1_VOS */
 
 /**
   * @brief  Wakeup BLE controller from its sleep mode
@@ -767,7 +766,7 @@ typedef struct
                                 ((PIN) == PWR_WAKEUP_PIN4_HIGH) || \
                                 ((PIN) == PWR_WAKEUP_PIN1_LOW) || \
                                 ((PIN) == PWR_WAKEUP_PIN4_LOW))
-#endif
+#endif /* PWR_CR3_EWUP2 */
 
 #define IS_PWR_WAKEUP_PIN_POLARITY(POLARITY)  (((POLARITY) == PWR_PIN_POLARITY_HIGH) || \
                                                ((POLARITY) == PWR_PIN_POLARITY_LOW))
@@ -777,7 +776,7 @@ typedef struct
                                ((TYPE) == PWR_PVM_3))
 #else
 #define IS_PWR_PVM_TYPE(TYPE) ((TYPE) == PWR_PVM_3)
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 #define IS_PWR_PVM_MODE(MODE)  (((MODE) == PWR_PVM_MODE_NORMAL)              ||\
                                 ((MODE) == PWR_PVM_MODE_IT_RISING)           ||\
@@ -793,7 +792,7 @@ typedef struct
 #if defined(PWR_CR1_VOS)
 #define IS_PWR_VOLTAGE_SCALING_RANGE(RANGE) (((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE1) || \
                                              ((RANGE) == PWR_REGULATOR_VOLTAGE_SCALE2))
-#endif
+#endif /* PWR_CR1_VOS */
 
 #define IS_PWR_BATTERY_RESISTOR_SELECT(RESISTOR) (((RESISTOR) == PWR_BATTERY_CHARGING_RESISTOR_5) ||\
                                                   ((RESISTOR) == PWR_BATTERY_CHARGING_RESISTOR_1_5))
@@ -817,7 +816,7 @@ typedef struct
                            ((GPIO) == PWR_GPIO_C) ||\
                            ((GPIO) == PWR_GPIO_E) ||\
                            ((GPIO) == PWR_GPIO_H))
-#endif
+#endif /* GPIOD */
 
 #if defined(PWR_CR5_SMPSEN)
 #define IS_PWR_SMPS_MODE(SMPS_MODE) (((SMPS_MODE) == PWR_SMPS_BYPASS)    ||\
@@ -847,7 +846,7 @@ typedef struct
                                                          ((SMPS_OUTPUT_VOLTAGE) == PWR_SMPS_OUTPUT_VOLTAGE_1V80) ||\
                                                          ((SMPS_OUTPUT_VOLTAGE) == PWR_SMPS_OUTPUT_VOLTAGE_1V85) ||\
                                                          ((SMPS_OUTPUT_VOLTAGE) == PWR_SMPS_OUTPUT_VOLTAGE_1V90))
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 #define IS_PWR_CORE(CPU)  (((CPU) == PWR_CORE_CPU1) || ((CPU) == PWR_CORE_CPU2))
 
@@ -882,7 +881,7 @@ void              HAL_PWREx_DisableInternalWakeUpLine(void);
 #if defined(PWR_CR5_SMPSEN)
 void              HAL_PWREx_EnableBORH_SMPSBypassIT(void);
 void              HAL_PWREx_DisableBORH_SMPSBypassIT(void);
-#endif
+#endif /* PWR_CR5_SMPSEN */
 void              HAL_PWREx_EnableRFPhaseIT(void);
 void              HAL_PWREx_DisableRFPhaseIT(void);
 void              HAL_PWREx_EnableBLEActivityIT(void);
@@ -905,7 +904,7 @@ void              HAL_PWREx_DisablePullUpPullDownConfig(void);
 #if defined(PWR_CR5_SMPSEN)
 void              HAL_PWREx_SetBORConfig(uint32_t BORConfiguration);
 uint32_t          HAL_PWREx_GetBORConfig(void);
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 void              HAL_PWREx_EnableSRAMRetention(void);
 void              HAL_PWREx_DisableSRAMRetention(void);
@@ -916,7 +915,7 @@ void              HAL_PWREx_DisableFlashPowerDown(uint32_t PowerMode);
 #if defined(PWR_CR2_PVME1)
 void              HAL_PWREx_EnablePVM1(void);
 void              HAL_PWREx_DisablePVM1(void);
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 void              HAL_PWREx_EnablePVM3(void);
 void              HAL_PWREx_DisablePVM3(void);
@@ -927,7 +926,7 @@ HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM);
 HAL_StatusTypeDef HAL_PWREx_ConfigSMPS(PWR_SMPSTypeDef *sConfigSMPS);
 void              HAL_PWREx_SMPS_SetMode(uint32_t OperatingMode);
 uint32_t          HAL_PWREx_SMPS_GetEffectiveMode(void);
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /* WakeUp pins configuration functions ****************************************/
 void              HAL_PWREx_EnableWakeUpPin(uint32_t WakeUpPinPolarity, uint32_t wakeupTarget);
@@ -942,14 +941,14 @@ void              HAL_PWREx_EnterSTOP0Mode(uint8_t STOPEntry);
 void              HAL_PWREx_EnterSTOP1Mode(uint8_t STOPEntry);
 #if defined(PWR_SUPPORT_STOP2)
 void              HAL_PWREx_EnterSTOP2Mode(uint8_t STOPEntry);
-#endif
+#endif /* PWR_SUPPORT_STOP2 */
 void              HAL_PWREx_EnterSHUTDOWNMode(void);
 
 void              HAL_PWREx_PVD_PVM_IRQHandler(void);
 
 #if defined(PWR_CR2_PVME1)
 void              HAL_PWREx_PVM1Callback(void);
-#endif
+#endif /* PWR_CR2_PVME1 */
 void              HAL_PWREx_PVM3Callback(void);
 
 /**
@@ -975,4 +974,3 @@ void              HAL_PWREx_PVM3Callback(void);
 
 #endif /* STM32WBxx_HAL_PWR_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_qspi.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_qspi.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -590,13 +589,13 @@ HAL_StatusTypeDef     HAL_QSPI_UnRegisterCallback   (QSPI_HandleTypeDef *hqspi, 
   * @{
   */
 /* Peripheral Control and State functions  ************************************/
-HAL_QSPI_StateTypeDef HAL_QSPI_GetState        (QSPI_HandleTypeDef *hqspi);
-uint32_t              HAL_QSPI_GetError        (QSPI_HandleTypeDef *hqspi);
+HAL_QSPI_StateTypeDef HAL_QSPI_GetState        (const QSPI_HandleTypeDef *hqspi);
+uint32_t              HAL_QSPI_GetError        (const QSPI_HandleTypeDef *hqspi);
 HAL_StatusTypeDef     HAL_QSPI_Abort           (QSPI_HandleTypeDef *hqspi);
 HAL_StatusTypeDef     HAL_QSPI_Abort_IT        (QSPI_HandleTypeDef *hqspi);
 void                  HAL_QSPI_SetTimeout      (QSPI_HandleTypeDef *hqspi, uint32_t Timeout);
 HAL_StatusTypeDef     HAL_QSPI_SetFifoThreshold(QSPI_HandleTypeDef *hqspi, uint32_t Threshold);
-uint32_t              HAL_QSPI_GetFifoThreshold(QSPI_HandleTypeDef *hqspi);
+uint32_t              HAL_QSPI_GetFifoThreshold(const QSPI_HandleTypeDef *hqspi);
 /**
   * @}
   */
@@ -698,12 +697,10 @@ uint32_t              HAL_QSPI_GetFifoThreshold(QSPI_HandleTypeDef *hqspi);
   * @}
   */
 
-#endif /* defined(QUADSPI) || defined(QUADSPI1) || defined(QUADSPI2) */
+#endif /* defined(QUADSPI) */
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* STM32WBxx_HAL_QSPI_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rcc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rcc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* __cplusplus */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_hal_def.h"
@@ -50,6 +49,36 @@ extern "C" {
 #define CRRCR_REG_INDEX           4U
 
 #define RCC_FLAG_MASK             0x1FU
+
+/* Defines Oscillator Masks */
+#if defined(RCC_HSI48_SUPPORT)
+#define RCC_OSCILLATORTYPE_ALL   (RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI |   \
+                                  RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_MSI | \
+                                  RCC_OSCILLATORTYPE_LSI1 | RCC_OSCILLATORTYPE_LSI2 | \
+                                  RCC_OSCILLATORTYPE_LSE)  /*!< All Oscillator to configure */
+#else
+#define RCC_OSCILLATORTYPE_ALL   (RCC_OSCILLATORTYPE_HSE | RCC_OSCILLATORTYPE_HSI |  \
+                                  RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_LSI1 | \
+                                  RCC_OSCILLATORTYPE_LSI2 | RCC_OSCILLATORTYPE_LSE)  /*!< All Oscillator to configure */
+#endif /* RCC_HSI48_SUPPORT */
+
+/** @defgroup RCC_Reset_Flag Reset Flag
+  * @{
+  */
+#define RCC_RESET_FLAG_OBL             RCC_CSR_OBLRSTF    /*!< Option Byte Loader reset flag */
+#define RCC_RESET_FLAG_PIN             RCC_CSR_PINRSTF    /*!< PIN reset flag */
+#define RCC_RESET_FLAG_PWR             RCC_CSR_BORRSTF    /*!< BOR or POR/PDR reset flag */
+#define RCC_RESET_FLAG_SW              RCC_CSR_SFTRSTF    /*!< Software Reset flag */
+#define RCC_RESET_FLAG_IWDG            RCC_CSR_IWDGRSTF   /*!< Independent Watchdog reset flag */
+#define RCC_RESET_FLAG_WWDG            RCC_CSR_WWDGRSTF   /*!< Window watchdog reset flag */
+#define RCC_RESET_FLAG_LPWR            RCC_CSR_LPWRRSTF   /*!< Low power reset flag */
+#define RCC_RESET_FLAG_ALL             (RCC_RESET_FLAG_OBL | RCC_RESET_FLAG_PIN | RCC_RESET_FLAG_PWR | \
+                                        RCC_RESET_FLAG_SW | RCC_RESET_FLAG_IWDG | RCC_RESET_FLAG_WWDG | \
+                                        RCC_RESET_FLAG_LPWR)
+/**
+  * @}
+  */
+
 /**
   * @}
   */
@@ -59,25 +88,8 @@ extern "C" {
   * @{
   */
 
-#if defined(RCC_HSI48_SUPPORT)
-#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__) (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE)                               || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSE)  == RCC_OSCILLATORTYPE_HSE)    || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI)  == RCC_OSCILLATORTYPE_HSI)    || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI48) == RCC_OSCILLATORTYPE_HSI48) || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_MSI)  == RCC_OSCILLATORTYPE_MSI)    || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI1) == RCC_OSCILLATORTYPE_LSI1)   || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI2) == RCC_OSCILLATORTYPE_LSI2)   || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSE)  == RCC_OSCILLATORTYPE_LSE))
-#else
-#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__) (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE)                             || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSE)  == RCC_OSCILLATORTYPE_HSE)  || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_HSI)  == RCC_OSCILLATORTYPE_HSI)  || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_MSI)  == RCC_OSCILLATORTYPE_MSI)  || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI1) == RCC_OSCILLATORTYPE_LSI1) || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSI2) == RCC_OSCILLATORTYPE_LSI2) || \
-                                               (((__OSCILLATOR__) & RCC_OSCILLATORTYPE_LSE)  == RCC_OSCILLATORTYPE_LSE))
-#endif
-
+#define IS_RCC_OSCILLATORTYPE(__OSCILLATOR__)  (((__OSCILLATOR__) == RCC_OSCILLATORTYPE_NONE) || \
+                                                (((__OSCILLATOR__) & ~RCC_OSCILLATORTYPE_ALL) == 0x00U))
 
 #define IS_RCC_HSE(__HSE__)  (((__HSE__) == RCC_HSE_OFF) || ((__HSE__) == RCC_HSE_ON))
 
@@ -100,13 +112,12 @@ extern "C" {
 
 #if defined(RCC_HSI48_SUPPORT)
 #define IS_RCC_HSI48(__HSI48__)  (((__HSI48__) == RCC_HSI48_OFF) || ((__HSI48__) == RCC_HSI48_ON))
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #define IS_RCC_PLL(__PLL__) (((__PLL__) == RCC_PLL_NONE) ||((__PLL__) == RCC_PLL_OFF) || \
                              ((__PLL__) == RCC_PLL_ON))
 
-#define IS_RCC_PLLSOURCE(__SOURCE__) (((__SOURCE__) == RCC_PLLSOURCE_NONE) || \
-                                      ((__SOURCE__) == RCC_PLLSOURCE_MSI)  || \
+#define IS_RCC_PLLSOURCE(__SOURCE__) (((__SOURCE__) == RCC_PLLSOURCE_MSI)  || \
                                       ((__SOURCE__) == RCC_PLLSOURCE_HSI)  || \
                                       ((__SOURCE__) == RCC_PLLSOURCE_HSE))
 
@@ -129,10 +140,11 @@ extern "C" {
 
 #if defined(SAI1)
 #define IS_RCC_PLLSAI1CLOCKOUT_VALUE(__VALUE__) (((((__VALUE__) & RCC_PLLSAI1_ADCCLK) == RCC_PLLSAI1_ADCCLK) || \
-    (((__VALUE__) & RCC_PLLSAI1_SAI1CLK) == RCC_PLLSAI1_SAI1CLK) || \
-    (((__VALUE__) & RCC_PLLSAI1_USBCLK)  == RCC_PLLSAI1_USBCLK)) && \
-    (((__VALUE__) & ~(RCC_PLLSAI1_ADCCLK | RCC_PLLSAI1_SAI1CLK | RCC_PLLSAI1_USBCLK)) == 0U))
-#endif
+                                                  (((__VALUE__) & RCC_PLLSAI1_SAI1CLK) == RCC_PLLSAI1_SAI1CLK) || \
+                                                  (((__VALUE__) & RCC_PLLSAI1_USBCLK)  == RCC_PLLSAI1_USBCLK)) && \
+                                                 (((__VALUE__) & ~(RCC_PLLSAI1_ADCCLK | RCC_PLLSAI1_SAI1CLK | \
+                                                                   RCC_PLLSAI1_USBCLK)) == 0U))
+#endif /* SAI1 */
 #define IS_RCC_MSI_CLOCK_RANGE(__RANGE__) (((__RANGE__) == RCC_MSIRANGE_0)  || \
                                            ((__RANGE__) == RCC_MSIRANGE_1)  || \
                                            ((__RANGE__) == RCC_MSIRANGE_2)  || \
@@ -147,11 +159,11 @@ extern "C" {
                                            ((__RANGE__) == RCC_MSIRANGE_11))
 
 #define IS_RCC_CLOCKTYPE(__CLK__)  ((1U <= (__CLK__)) && ((__CLK__) <= (RCC_CLOCKTYPE_SYSCLK | \
-                                                                         RCC_CLOCKTYPE_HCLK  | \
-                                                                         RCC_CLOCKTYPE_PCLK1 | \
-                                                                         RCC_CLOCKTYPE_PCLK2 | \
-                                                                         RCC_CLOCKTYPE_HCLK2 | \
-                                                                         RCC_CLOCKTYPE_HCLK4)))
+                                                                        RCC_CLOCKTYPE_HCLK  | \
+                                                                        RCC_CLOCKTYPE_PCLK1 | \
+                                                                        RCC_CLOCKTYPE_PCLK2 | \
+                                                                        RCC_CLOCKTYPE_HCLK2 | \
+                                                                        RCC_CLOCKTYPE_HCLK4)))
 
 #define IS_RCC_SYSCLKSOURCE(__SOURCE__) (((__SOURCE__) == RCC_SYSCLKSOURCE_MSI) || \
                                          ((__SOURCE__) == RCC_SYSCLKSOURCE_HSI) || \
@@ -159,10 +171,10 @@ extern "C" {
                                          ((__SOURCE__) == RCC_SYSCLKSOURCE_PLLCLK))
 
 #define IS_RCC_HCLKx(__HCLK__) (((__HCLK__) == RCC_SYSCLK_DIV1)   || ((__HCLK__) == RCC_SYSCLK_DIV2)   || ((__HCLK__) == RCC_SYSCLK_DIV3)   || \
-                               ((__HCLK__) == RCC_SYSCLK_DIV4)   || ((__HCLK__) == RCC_SYSCLK_DIV5)   || ((__HCLK__) == RCC_SYSCLK_DIV6)   || \
-                               ((__HCLK__) == RCC_SYSCLK_DIV8)   || ((__HCLK__) == RCC_SYSCLK_DIV10)  || ((__HCLK__) == RCC_SYSCLK_DIV16)  || \
-                               ((__HCLK__) == RCC_SYSCLK_DIV32)  || ((__HCLK__) == RCC_SYSCLK_DIV64)  || ((__HCLK__) == RCC_SYSCLK_DIV128) || \
-                               ((__HCLK__) == RCC_SYSCLK_DIV256) || ((__HCLK__) == RCC_SYSCLK_DIV512))
+                                ((__HCLK__) == RCC_SYSCLK_DIV4)   || ((__HCLK__) == RCC_SYSCLK_DIV5)   || ((__HCLK__) == RCC_SYSCLK_DIV6)   || \
+                                ((__HCLK__) == RCC_SYSCLK_DIV8)   || ((__HCLK__) == RCC_SYSCLK_DIV10)  || ((__HCLK__) == RCC_SYSCLK_DIV16)  || \
+                                ((__HCLK__) == RCC_SYSCLK_DIV32)  || ((__HCLK__) == RCC_SYSCLK_DIV64)  || ((__HCLK__) == RCC_SYSCLK_DIV128) || \
+                                ((__HCLK__) == RCC_SYSCLK_DIV256) || ((__HCLK__) == RCC_SYSCLK_DIV512))
 
 #define IS_RCC_PCLKx(__PCLK__) (((__PCLK__) == RCC_HCLK_DIV1) || ((__PCLK__) == RCC_HCLK_DIV2) || \
                                 ((__PCLK__) == RCC_HCLK_DIV4) || ((__PCLK__) == RCC_HCLK_DIV8) || \
@@ -174,13 +186,13 @@ extern "C" {
                                          ((__SOURCE__) == RCC_RTCCLKSOURCE_HSE_DIV32))
 
 #if defined(RCC_MCO3_SUPPORT)
-#define IS_RCC_MCO(__MCOX__) (((__MCOX__) == RCC_MCO1) || \
-                              ((__MCOX__) == RCC_MCO2) || \
-                              ((__MCOX__) == RCC_MCO3))
+#define IS_RCC_MCO(__MCOX__) (((__MCOX__) == RCC_MCO1_PA8) || \
+                              ((__MCOX__) == RCC_MCO2_PB6) || \
+                              ((__MCOX__) == RCC_MCO3_PA15))
 #else
-#define IS_RCC_MCO(__MCOX__) (((__MCOX__) == RCC_MCO1) || \
-                              ((__MCOX__) == RCC_MCO2))
-#endif
+#define IS_RCC_MCO(__MCOX__) (((__MCOX__) == RCC_MCO1_PA8) || \
+                              ((__MCOX__) == RCC_MCO2_PB6))
+#endif /* RCC_MCO3_SUPPORT */
 
 #if defined(RCC_HSI48_SUPPORT)
 #define IS_RCC_MCO1SOURCE(__SOURCE__) (((__SOURCE__) == RCC_MCO1SOURCE_NOCLOCK) || \
@@ -203,7 +215,7 @@ extern "C" {
                                        ((__SOURCE__) == RCC_MCO1SOURCE_LSI1)    || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_LSI2)    || \
                                        ((__SOURCE__) == RCC_MCO1SOURCE_LSE))
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #define IS_RCC_MCO2SOURCE(__SOURCE__) IS_RCC_MCO1SOURCE((__SOURCE__))
 #define IS_RCC_MCO3SOURCE(__SOURCE__) IS_RCC_MCO1SOURCE((__SOURCE__))
@@ -299,7 +311,7 @@ typedef struct
 #if defined(RCC_HSI48_SUPPORT)
   uint32_t HSI48State;           /*!< The new state of the HSI48 .
                                       This parameter can be a value of @ref RCC_HSI48_Config                      */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
   RCC_PLLInitTypeDef PLL;        /*!< Main PLL structure parameters                                               */
 
@@ -363,7 +375,7 @@ typedef struct
 #define RCC_OSCILLATORTYPE_MSI         0x00000020U   /*!< MSI to configure                    */
 #if defined(RCC_HSI48_SUPPORT)
 #define RCC_OSCILLATORTYPE_HSI48       0x00000040U   /*!< HSI48 to configure                  */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -427,7 +439,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 /** @defgroup RCC_PLL_Config PLL Config
   * @{
@@ -539,7 +551,7 @@ typedef struct
 #define RCC_PLL_RNGCLK                 RCC_PLLCFGR_PLLQEN      /*!< PLLRNGCLK selection from main PLL */
 #if defined(SAI1)
 #define RCC_PLL_SAI1CLK                RCC_PLLCFGR_PLLPEN      /*!< PLLSAI1CLK selection from main PLL */
-#endif
+#endif /* SAI1 */
 #define RCC_PLL_ADCCLK                 RCC_PLLCFGR_PLLPEN      /*!< PLLADCCLK selection from main PLL */
 /**
   * @}
@@ -555,7 +567,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* SAI1 */
 
 /** @defgroup RCC_MSI_Clock_Range MSI Clock Range
   * @{
@@ -633,8 +645,8 @@ typedef struct
   */
 
 /** @defgroup RCC_APBx_Clock_Source APB1 Clock Source
-* @{
-*/
+  * @{
+  */
 #define RCC_HCLK_DIV1                  LL_RCC_APB1_DIV_1    /*!< HCLK not divided */
 #define RCC_HCLK_DIV2                  LL_RCC_APB1_DIV_2    /*!< HCLK divided by 2 */
 #define RCC_HCLK_DIV4                  LL_RCC_APB1_DIV_4    /*!< HCLK divided by 4 */
@@ -658,13 +670,44 @@ typedef struct
 /** @defgroup RCC_MCO_Index MCO Index
   * @{
   */
-#define RCC_MCO1                       0x00000000U          /*!< MCO1 index */
-#define RCC_MCO2                       0x00000001U          /*!< MCO2 index */
-#if defined(RCC_MCO3_SUPPORT)
-#define RCC_MCO3                       0x00000002U          /*!< MCO3 index */
-#endif
 
-#define RCC_MCO                        RCC_MCO1             /*!< MCO1 to be compliant with other families with 1 MCO*/
+/* @cond */
+/* 32     28      20       16      0
+   --------------------------------
+   | MCO   | GPIO  | GPIO  | GPIO  |
+   | Index |  AF   | Port  |  Pin  |
+   -------------------------------*/
+
+#define RCC_MCO_GPIOPORT_POS   16U
+#define RCC_MCO_GPIOPORT_MASK  (0xFUL << RCC_MCO_GPIOPORT_POS)
+#define RCC_MCO_GPIOAF_POS     20U
+#define RCC_MCO_GPIOAF_MASK    (0xFFUL << RCC_MCO_GPIOAF_POS)
+#define RCC_MCO_INDEX_POS      28U
+#define RCC_MCO_INDEX_MASK     (0x1UL << RCC_MCO_INDEX_POS)
+
+#define RCC_MCO1_INDEX         (0x0UL << RCC_MCO_INDEX_POS)             /*!< MCO1 index */
+#define RCC_MCO2_INDEX         (0x1UL << RCC_MCO_INDEX_POS)             /*!< MCO2 index */
+/* @endcond */
+
+#define RCC_MCO1_PA8           (RCC_MCO1_INDEX | \
+                                (GPIO_AF0_MCO << RCC_MCO_GPIOAF_POS) | (GPIO_GET_INDEX(GPIOA) << RCC_MCO_GPIOPORT_POS) | GPIO_PIN_8)
+#define RCC_MCO1               RCC_MCO1_PA8         /*!< Alias for compatibility */
+
+#define RCC_MCO2_PB6           (RCC_MCO2_INDEX | \
+                                (GPIO_AF0_MCO << RCC_MCO_GPIOAF_POS) | (GPIO_GET_INDEX(GPIOB) << RCC_MCO_GPIOPORT_POS) | GPIO_PIN_6)
+#define RCC_MCO2               RCC_MCO2_PB6         /*!< Alias for compatibility */
+
+#if defined(RCC_MCO3_SUPPORT)
+/* @cond */
+#define RCC_MCO3_INDEX         (0x2UL << RCC_MCO_INDEX_POS)             /*!< MCO3 index */
+/* @endcond */
+
+#define RCC_MCO3_PA15          (RCC_MCO3_INDEX | \
+                                (GPIO_AF6_MCO << RCC_MCO_GPIOAF_POS) | (GPIO_GET_INDEX(GPIOA) << RCC_MCO_GPIOPORT_POS) | GPIO_PIN_15)
+#define RCC_MCO3               RCC_MCO3_PA15        /*!< Alias for compatibility */
+#endif /* RCC_MCO3_SUPPORT */
+
+#define RCC_MCO                RCC_MCO1             /*!< MCO1 to be compliant with other families with 1 MCO*/
 /**
   * @}
   */
@@ -683,7 +726,7 @@ typedef struct
 #define RCC_MCO1SOURCE_LSE             LL_RCC_MCO1SOURCE_LSE              /*!< LSE selection as MCO1 source */
 #if defined(RCC_HSI48_SUPPORT)
 #define RCC_MCO1SOURCE_HSI48           LL_RCC_MCO1SOURCE_HSI48            /*!< HSI48 selection as MCO1 source */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #define RCC_MCO1SOURCE_HSE_BEFORE_STAB LL_RCC_MCO1SOURCE_HSE_BEFORE_STAB  /*!< HSE before stabilization selection as MCO1 source */
 
 /**
@@ -740,12 +783,12 @@ typedef struct
 #define RCC_IT_PLLRDY                  LL_RCC_CIFR_PLLRDYF      /*!< PLL Ready Interrupt flag */
 #if defined(SAI1)
 #define RCC_IT_PLLSAI1RDY              LL_RCC_CIFR_PLLSAI1RDYF  /*!< PLLSAI1 Ready Interrupt flag */
-#endif
+#endif /* SAI1 */
 #define RCC_IT_HSECSS                  LL_RCC_CIFR_CSSF         /*!< HSE Clock Security System Interrupt flag */
 #define RCC_IT_LSECSS                  LL_RCC_CIFR_LSECSSF      /*!< LSE Clock Security System Interrupt flag */
 #if defined(RCC_HSI48_SUPPORT)
 #define RCC_IT_HSI48RDY                LL_RCC_CIFR_HSI48RDYF    /*!< HSI48 Ready Interrupt flag */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -768,7 +811,7 @@ typedef struct
 #define RCC_FLAG_PLLRDY                ((CR_REG_INDEX << 5U) | RCC_CR_PLLRDY_Pos)      /*!< PLL Ready flag */
 #if defined(SAI1)
 #define RCC_FLAG_PLLSAI1RDY            ((CR_REG_INDEX << 5U) | RCC_CR_PLLSAI1RDY_Pos)  /*!< PLLSAI1 Ready flag */
-#endif
+#endif /* SAI1 */
 
 /* Flags in the BDCR register */
 #define RCC_FLAG_LSERDY                ((BDCR_REG_INDEX << 5U) | RCC_BDCR_LSERDY_Pos)  /*!< LSE Ready flag */
@@ -788,7 +831,7 @@ typedef struct
 /* Flags in the CRRCR register */
 #if defined(RCC_HSI48_SUPPORT)
 #define RCC_FLAG_HSI48RDY              ((CRRCR_REG_INDEX << 5U) | RCC_CRRCR_HSI48RDY_Pos) /*!< HSI48 Ready flag */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 /**
   * @}
   */
@@ -834,22 +877,22 @@ typedef struct
 #define __HAL_RCC_DMA1_CLK_ENABLE()            LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_CLK_ENABLE()            LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_CLK_ENABLE()         LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_CRC_CLK_ENABLE()             LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_CLK_ENABLE()             LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_DMA1_CLK_DISABLE()           LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_CLK_DISABLE()           LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_CLK_DISABLE()        LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_CRC_CLK_DISABLE()            LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_CLK_DISABLE()            LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 /**
   * @}
   */
@@ -867,29 +910,29 @@ typedef struct
 #define __HAL_RCC_GPIOC_CLK_ENABLE()           LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_CLK_ENABLE()           LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_CLK_ENABLE()           LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_CLK_ENABLE()           LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_CLK_ENABLE()             LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_CLK_ENABLE()            LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 #define __HAL_RCC_GPIOA_CLK_DISABLE()          LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_GPIOA)
 #define __HAL_RCC_GPIOB_CLK_DISABLE()          LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_GPIOB)
 #define __HAL_RCC_GPIOC_CLK_DISABLE()          LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_CLK_DISABLE()          LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_CLK_DISABLE()          LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_CLK_DISABLE()          LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_CLK_DISABLE()            LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_CLK_DISABLE()           LL_AHB2_GRP1_DisableClock(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 /**
   * @}
@@ -905,7 +948,7 @@ typedef struct
 
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_CLK_ENABLE()         LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_CLK_ENABLE()             LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_CLK_ENABLE()            LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_CLK_ENABLE()             LL_AHB3_GRP1_EnableClock(LL_AHB3_GRP1_PERIPH_RNG)
@@ -915,7 +958,7 @@ typedef struct
 
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_CLK_DISABLE()        LL_AHB3_GRP1_DisableClock(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_CLK_DISABLE()            LL_AHB3_GRP1_DisableClock(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_CLK_DISABLE()           LL_AHB3_GRP1_DisableClock(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_CLK_DISABLE()            LL_AHB3_GRP1_DisableClock(LL_AHB3_GRP1_PERIPH_RNG)
@@ -940,50 +983,50 @@ typedef struct
 #define __HAL_RCC_TIM2_CLK_ENABLE()            LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_CLK_ENABLE()             LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_CLK_ENABLE()            LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_CLK_ENABLE()            LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_CLK_ENABLE()            LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_CLK_ENABLE()             LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_CLK_ENABLE()             LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_CLK_ENABLE()          LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_LPTIM1)
 #define __HAL_RCC_LPTIM2_CLK_ENABLE()          LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_LPTIM2)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_ENABLE()         LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 
 #define __HAL_RCC_RTCAPB_CLK_DISABLE()         LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_RTCAPB)
 #define __HAL_RCC_TIM2_CLK_DISABLE()           LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_CLK_DISABLE()            LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_CLK_DISABLE()           LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_CLK_DISABLE()           LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_CLK_DISABLE()           LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_CLK_DISABLE()            LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_CLK_DISABLE()            LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_CLK_DISABLE()         LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_LPTIM2_CLK_DISABLE()         LL_APB1_GRP2_DisableClock(LL_APB1_GRP2_PERIPH_LPTIM2)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_DISABLE()        LL_APB1_GRP2_DisableClock(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 
 /**
   * @}
@@ -999,7 +1042,7 @@ typedef struct
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_CLK_ENABLE()             LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_CLK_ENABLE()            LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_CLK_ENABLE()            LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_CLK_ENABLE()          LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_USART1)
@@ -1007,11 +1050,11 @@ typedef struct
 #define __HAL_RCC_TIM17_CLK_ENABLE()           LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_CLK_ENABLE()            LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_CLK_DISABLE()            LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_CLK_DISABLE()           LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_CLK_DISABLE()           LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_CLK_DISABLE()         LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_USART1)
@@ -1019,7 +1062,7 @@ typedef struct
 #define __HAL_RCC_TIM17_CLK_DISABLE()          LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_CLK_DISABLE()           LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 /**
   * @}
@@ -1036,22 +1079,22 @@ typedef struct
 #define __HAL_RCC_DMA1_IS_CLK_ENABLED()        LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_IS_CLK_ENABLED()        LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_IS_CLK_ENABLED()     LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_CRC_IS_CLK_ENABLED()         LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_IS_CLK_ENABLED()         LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_DMA1_IS_CLK_DISABLED()       !(LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_DMA1))
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_IS_CLK_DISABLED()       !(LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_DMA2))
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_IS_CLK_DISABLED()    !(LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_DMAMUX1))
 #define __HAL_RCC_CRC_IS_CLK_DISABLED()        !(LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_CRC))
 #if defined(TSC)
 #define __HAL_RCC_TSC_IS_CLK_DISABLED()        !(LL_AHB1_GRP1_IsEnabledClock(LL_AHB1_GRP1_PERIPH_TSC))
-#endif
+#endif /* TSC */
 
 /**
   * @}
@@ -1070,30 +1113,30 @@ typedef struct
 #define __HAL_RCC_GPIOC_IS_CLK_ENABLED()       LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_IS_CLK_ENABLED()       LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_IS_CLK_ENABLED()       LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_IS_CLK_ENABLED()       LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_ENABLED()         LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_IS_CLK_ENABLED()        LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_GPIOA_IS_CLK_DISABLED()      !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOA))
 #define __HAL_RCC_GPIOB_IS_CLK_DISABLED()      !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOB))
 #define __HAL_RCC_GPIOC_IS_CLK_DISABLED()      !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOC))
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_IS_CLK_DISABLED()      !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOD))
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_IS_CLK_DISABLED()      !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOE))
 #define __HAL_RCC_GPIOH_IS_CLK_DISABLED()      !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_GPIOH))
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_DISABLED()        !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_ADC))
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_IS_CLK_DISABLED()       !(LL_AHB2_GRP1_IsEnabledClock(LL_AHB2_GRP1_PERIPH_AES1))
-#endif
+#endif /* AES1 */
 
 /**
   * @}
@@ -1109,7 +1152,7 @@ typedef struct
 
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_IS_CLK_ENABLED()      LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_IS_CLK_ENABLED()          LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_IS_CLK_ENABLED()         LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_IS_CLK_ENABLED()          LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_RNG)
@@ -1119,7 +1162,7 @@ typedef struct
 
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_IS_CLK_DISABLED()     !(LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_QUADSPI))
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_IS_CLK_DISABLED()         !(LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_PKA))
 #define __HAL_RCC_AES2_IS_CLK_DISABLED()        !(LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_AES2))
 #define __HAL_RCC_RNG_IS_CLK_DISABLED()         !(LL_AHB3_GRP1_IsEnabledClock(LL_AHB3_GRP1_PERIPH_RNG))
@@ -1144,52 +1187,52 @@ typedef struct
 #define __HAL_RCC_TIM2_IS_CLK_ENABLED()           LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_IS_CLK_ENABLED()            LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_IS_CLK_ENABLED()           LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_IS_CLK_ENABLED()           LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_IS_CLK_ENABLED()           LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_IS_CLK_ENABLED()            LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_IS_CLK_ENABLED()            LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_IS_CLK_ENABLED()         LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_LPTIM2_IS_CLK_ENABLED()         LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_LPTIM2)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_IS_CLK_ENABLED()        LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 
 #define __HAL_RCC_RTCAPB_IS_CLK_DISABLED()        !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_RTCAPB))
 #define __HAL_RCC_WWDG_IS_CLK_DISABLED()          !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_WWDG))
 #define __HAL_RCC_TIM2_IS_CLK_DISABLED()          !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_TIM2))
 #if defined(LCD)
 #define __HAL_RCC_LCD_IS_CLK_DISABLED()           !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_LCD))
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_IS_CLK_DISABLED()          !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_SPI2))
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_IS_CLK_DISABLED()          !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_I2C1))
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_IS_CLK_DISABLED()          !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_I2C3))
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_IS_CLK_DISABLED()           !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_CRS))
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_IS_CLK_DISABLED()           !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_USB))
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_IS_CLK_DISABLED()        !(LL_APB1_GRP1_IsEnabledClock(LL_APB1_GRP1_PERIPH_LPTIM1))
 
 #define __HAL_RCC_LPTIM2_IS_CLK_DISABLED()        !(LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_LPTIM2))
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_IS_CLK_DISABLED()       !(LL_APB1_GRP2_IsEnabledClock(LL_APB1_GRP2_PERIPH_LPUART1))
-#endif
+#endif /* LPUART1 */
 
 /**
   * @}
@@ -1205,7 +1248,7 @@ typedef struct
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_ENABLED()            LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_IS_CLK_ENABLED()           LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_IS_CLK_ENABLED()           LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_IS_CLK_ENABLED()         LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_USART1)
@@ -1213,12 +1256,12 @@ typedef struct
 #define __HAL_RCC_TIM17_IS_CLK_ENABLED()          LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_IS_CLK_ENABLED()           LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_DISABLED()           !(LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_ADC))
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_IS_CLK_DISABLED()          !(LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_TIM1))
 #define __HAL_RCC_SPI1_IS_CLK_DISABLED()          !(LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SPI1))
 #define __HAL_RCC_USART1_IS_CLK_DISABLED()        !(LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_USART1))
@@ -1226,7 +1269,7 @@ typedef struct
 #define __HAL_RCC_TIM17_IS_CLK_DISABLED()         !(LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_TIM17))
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_IS_CLK_DISABLED()          !(LL_APB2_GRP1_IsEnabledClock(LL_APB2_GRP1_PERIPH_SAI1))
-#endif
+#endif /* SAI1 */
 
 /**
   * @}
@@ -1243,24 +1286,24 @@ typedef struct
 #define __HAL_RCC_C2DMA1_CLK_ENABLE()            LL_C2_AHB1_GRP1_EnableClock(LL_C2_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_CLK_ENABLE()            LL_C2_AHB1_GRP1_EnableClock(LL_C2_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_CLK_ENABLE()         LL_C2_AHB1_GRP1_EnableClock(LL_C2_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_C2SRAM1_CLK_ENABLE()           LL_C2_AHB1_GRP1_EnableClock(LL_C2_AHB1_GRP1_PERIPH_SRAM1)
 #define __HAL_RCC_C2CRC_CLK_ENABLE()             LL_C2_AHB1_GRP1_EnableClock(LL_C2_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_CLK_ENABLE()             LL_C2_AHB1_GRP1_EnableClock(LL_C2_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_C2DMA1_CLK_DISABLE()           LL_C2_AHB1_GRP1_DisableClock(LL_C2_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_CLK_DISABLE()           LL_C2_AHB1_GRP1_DisableClock(LL_C2_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_CLK_DISABLE()        LL_C2_AHB1_GRP1_DisableClock(LL_C2_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_C2SRAM1_CLK_DISABLE()          LL_C2_AHB1_GRP1_DisableClock(LL_C2_AHB1_GRP1_PERIPH_SRAM1)
 #define __HAL_RCC_C2CRC_CLK_DISABLE()            LL_C2_AHB1_GRP1_DisableClock(LL_C2_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_CLK_DISABLE()            LL_C2_AHB1_GRP1_DisableClock(LL_C2_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 /**
   * @}
@@ -1279,30 +1322,30 @@ typedef struct
 #define __HAL_RCC_C2GPIOC_CLK_ENABLE()           LL_C2_AHB2_GRP1_EnableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_CLK_ENABLE()           LL_C2_AHB2_GRP1_EnableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_CLK_ENABLE()           LL_C2_AHB2_GRP1_EnableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_C2GPIOH_CLK_ENABLE()           LL_C2_AHB2_GRP1_EnableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_ENABLE()             LL_C2_AHB2_GRP1_EnableClock(LL_C2_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_CLK_ENABLE()            LL_C2_AHB2_GRP1_EnableClock(LL_C2_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_C2GPIOA_CLK_DISABLE()          LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOA)
 #define __HAL_RCC_C2GPIOB_CLK_DISABLE()          LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOB)
 #define __HAL_RCC_C2GPIOC_CLK_DISABLE()          LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_CLK_DISABLE()          LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_CLK_DISABLE()          LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_C2GPIOH_CLK_DISABLE()          LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_DISABLE()            LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_CLK_DISABLE()           LL_C2_AHB2_GRP1_DisableClock(LL_C2_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 /**
   * @}
@@ -1346,51 +1389,51 @@ typedef struct
 #define __HAL_RCC_C2TIM2_CLK_ENABLE()            LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_C2LCD_CLK_ENABLE()             LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_C2SPI2_CLK_ENABLE()            LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_C2I2C1_CLK_ENABLE()            LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_C2I2C3_CLK_ENABLE()            LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_C2CRS_CLK_ENABLE()             LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_C2USB_CLK_ENABLE()             LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_C2LPTIM1_CLK_ENABLE()          LL_C2_APB1_GRP1_EnableClock(LL_C2_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_C2LPTIM2_CLK_ENABLE()          LL_C2_APB1_GRP2_EnableClock(LL_C2_APB1_GRP2_PERIPH_LPTIM2)
 #if defined(LPUART1)
 #define __HAL_RCC_C2LPUART1_CLK_ENABLE()         LL_C2_APB1_GRP2_EnableClock(LL_C2_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 
 #define __HAL_RCC_C2RTCAPB_CLK_DISABLE()         LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_RTCAPB)
 #define __HAL_RCC_C2TIM2_CLK_DISABLE()           LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_C2LCD_CLK_DISABLE()            LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_C2SPI2_CLK_DISABLE()           LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_C2I2C1_CLK_DISABLE()           LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_C2I2C3_CLK_DISABLE()           LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_C2CRS_CLK_DISABLE()            LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_C2USB_CLK_DISABLE()            LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_C2LPTIM1_CLK_DISABLE()         LL_C2_APB1_GRP1_DisableClock(LL_C2_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_C2LPTIM2_CLK_DISABLE()         LL_C2_APB1_GRP2_DisableClock(LL_C2_APB1_GRP2_PERIPH_LPTIM2)
 #if defined(LPUART1)
 #define __HAL_RCC_C2LPUART1_CLK_DISABLE()        LL_C2_APB1_GRP2_DisableClock(LL_C2_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 
 /**
   * @}
@@ -1406,7 +1449,7 @@ typedef struct
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_ENABLE()             LL_C2_APB2_GRP1_EnableClock(LL_C2_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_C2TIM1_CLK_ENABLE()            LL_C2_APB2_GRP1_EnableClock(LL_C2_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_C2SPI1_CLK_ENABLE()            LL_C2_APB2_GRP1_EnableClock(LL_C2_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_C2USART1_CLK_ENABLE()          LL_C2_APB2_GRP1_EnableClock(LL_C2_APB2_GRP1_PERIPH_USART1)
@@ -1414,11 +1457,11 @@ typedef struct
 #define __HAL_RCC_C2TIM17_CLK_ENABLE()           LL_C2_APB2_GRP1_EnableClock(LL_C2_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_C2SAI1_CLK_ENABLE()            LL_C2_APB2_GRP1_EnableClock(LL_C2_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_DISABLE()            LL_C2_APB2_GRP1_DisableClock(LL_C2_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_C2TIM1_CLK_DISABLE()           LL_C2_APB2_GRP1_DisableClock(LL_C2_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_C2SPI1_CLK_DISABLE()           LL_C2_APB2_GRP1_DisableClock(LL_C2_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_C2USART1_CLK_DISABLE()         LL_C2_APB2_GRP1_DisableClock(LL_C2_APB2_GRP1_PERIPH_USART1)
@@ -1426,7 +1469,7 @@ typedef struct
 #define __HAL_RCC_C2TIM17_CLK_DISABLE()          LL_C2_APB2_GRP1_DisableClock(LL_C2_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_C2SAI1_CLK_DISABLE()           LL_C2_APB2_GRP1_DisableClock(LL_C2_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 /**
   * @}
@@ -1443,12 +1486,12 @@ typedef struct
 #define __HAL_RCC_C2BLE_CLK_ENABLE()           LL_C2_APB3_GRP1_EnableClock(LL_C2_APB3_GRP1_PERIPH_BLE)
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_CLK_ENABLE()           LL_C2_APB3_GRP1_EnableClock(LL_C2_APB3_GRP1_PERIPH_802)
-#endif
+#endif /* RCC_802_SUPPORT */
 
 #define __HAL_RCC_C2BLE_CLK_DISABLE()          LL_C2_APB3_GRP1_DisableClock(LL_C2_APB3_GRP1_PERIPH_BLE)
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_CLK_DISABLE()          LL_C2_APB3_GRP1_DisableClock(LL_C2_APB3_GRP1_PERIPH_802)
-#endif
+#endif /* RCC_802_SUPPORT */
 
 /**
   * @}
@@ -1465,24 +1508,24 @@ typedef struct
 #define __HAL_RCC_C2DMA1_IS_CLK_ENABLED()        LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_IS_CLK_ENABLED()        LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_IS_CLK_ENABLED()     LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_C2SRAM1_IS_CLK_ENABLED()       LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_SRAM1)
 #define __HAL_RCC_C2CRC_IS_CLK_ENABLED()         LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_IS_CLK_ENABLED()         LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_C2DMA1_IS_CLK_DISABLED()       !(LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_DMA1))
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_IS_CLK_DISABLED()       !(LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_DMA2))
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_IS_CLK_DISABLED()    !(LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_DMAMUX1))
 #define __HAL_RCC_C2SRAM1_IS_CLK_DISABLED()      !(LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_SRAM1))
 #define __HAL_RCC_C2CRC_IS_CLK_DISABLED()        !(LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_CRC))
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_IS_CLK_DISABLED()        !(LL_C2_AHB1_GRP1_IsEnabledClock(LL_C2_AHB1_GRP1_PERIPH_TSC))
-#endif
+#endif /* TSC */
 
 /**
   * @}
@@ -1501,30 +1544,30 @@ typedef struct
 #define __HAL_RCC_C2GPIOC_IS_CLK_ENABLED()       LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_IS_CLK_ENABLED()       LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_IS_CLK_ENABLED()       LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_C2GPIOH_IS_CLK_ENABLED()       LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_IS_CLK_ENABLED()         LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_IS_CLK_ENABLED()        LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_C2GPIOA_IS_CLK_DISABLED()      !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOA))
 #define __HAL_RCC_C2GPIOB_IS_CLK_DISABLED()      !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOB))
 #define __HAL_RCC_C2GPIOC_IS_CLK_DISABLED()      !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOC))
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_IS_CLK_DISABLED()      !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOD))
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_IS_CLK_DISABLED()      !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOE))
 #define __HAL_RCC_C2GPIOH_IS_CLK_DISABLED()      !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_GPIOH))
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_IS_CLK_DISABLED()        !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_ADC))
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_IS_CLK_DISABLED()       !(LL_C2_AHB2_GRP1_IsEnabledClock(LL_C2_AHB2_GRP1_PERIPH_AES1))
-#endif
+#endif /* AES1 */
 
 /**
   * @}
@@ -1568,51 +1611,51 @@ typedef struct
 #define __HAL_RCC_C2TIM2_IS_CLK_ENABLED()           LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_C2LCD_IS_CLK_ENABLED()            LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_C2SPI2_IS_CLK_ENABLED()           LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_C2I2C1_IS_CLK_ENABLED()           LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_C2I2C3_IS_CLK_ENABLED()           LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_C2CRS_IS_CLK_ENABLED()            LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_C2USB_IS_CLK_ENABLED()            LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_C2LPTIM1_IS_CLK_ENABLED()         LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_C2LPTIM2_IS_CLK_ENABLED()         LL_C2_APB1_GRP2_IsEnabledClock(LL_C2_APB1_GRP2_PERIPH_LPTIM2)
 #if defined(LPUART1)
 #define __HAL_RCC_C2LPUART1_IS_CLK_ENABLED()        LL_C2_APB1_GRP2_IsEnabledClock(LL_C2_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 
 #define __HAL_RCC_C2RTCAPB_IS_CLK_DISABLED()       !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_RTCAPB))
 #define __HAL_RCC_C2TIM2_IS_CLK_DISABLED()         !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_TIM2))
 #if defined(LCD)
 #define __HAL_RCC_C2LCD_IS_CLK_DISABLED()          !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_LCD))
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_C2SPI2_IS_CLK_DISABLED()         !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_SPI2))
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_C2I2C1_IS_CLK_DISABLED()         !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_I2C1))
 #if defined(I2C3)
 #define __HAL_RCC_C2I2C3_IS_CLK_DISABLED()         !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_I2C3))
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_C2CRS_IS_CLK_DISABLED()          !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_CRS))
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_C2USB_IS_CLK_DISABLED()          !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_USB))
-#endif
+#endif /* USB */
 #define __HAL_RCC_C2LPTIM1_IS_CLK_DISABLED()       !(LL_C2_APB1_GRP1_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_LPTIM1))
 
 #define __HAL_RCC_C2LPTIM2_IS_CLK_DISABLED()       !(LL_C2_APB1_GRP2_IsEnabledClock(LL_C2_APB1_GRP2_PERIPH_LPTIM2))
 #if defined(LPUART1)
 #define __HAL_RCC_C2LPUART1_IS_CLK_DISABLED()      !(LL_C2_APB1_GRP2_IsEnabledClock(LL_C2_APB1_GRP1_PERIPH_LPTIM1))
-#endif
+#endif /* LPUART1*/
 
 /**
   * @}
@@ -1628,7 +1671,7 @@ typedef struct
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_C2ADC_IS_CLK_ENABLED()            LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_C2TIM1_IS_CLK_ENABLED()           LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_C2SPI1_IS_CLK_ENABLED()           LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_C2USART1_IS_CLK_ENABLED()         LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_USART1)
@@ -1636,11 +1679,11 @@ typedef struct
 #define __HAL_RCC_C2TIM17_IS_CLK_ENABLED()          LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_C2SAI1_IS_CLK_ENABLED()           LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_C2ADC_IS_CLK_DISABLED()           !( LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_ADC))
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_C2TIM1_IS_CLK_DISABLED()          !( LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_TIM1))
 #define __HAL_RCC_C2SPI1_IS_CLK_DISABLED()          !( LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_SPI1))
 #define __HAL_RCC_C2USART1_IS_CLK_DISABLED()        !( LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_USART1))
@@ -1648,7 +1691,7 @@ typedef struct
 #define __HAL_RCC_C2TIM17_IS_CLK_DISABLED()         !( LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_TIM17))
 #if defined(SAI1)
 #define __HAL_RCC_C2SAI1_IS_CLK_DISABLED()          !( LL_C2_APB2_GRP1_IsEnabledClock(LL_C2_APB2_GRP1_PERIPH_SAI1))
-#endif
+#endif /* SAI1 */
 
 /**
   * @}
@@ -1666,12 +1709,12 @@ typedef struct
 #define __HAL_RCC_C2BLE_IS_CLK_ENABLED()            LL_C2_APB3_GRP1_IsEnabledClock(LL_C2_APB3_GRP1_PERIPH_BLE)
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_IS_CLK_ENABLED()            LL_C2_APB3_GRP1_IsEnabledClock(LL_C2_APB3_GRP1_PERIPH_802)
-#endif
+#endif /* RCC_802_SUPPORT */
 
 #define __HAL_RCC_C2BLE_IS_CLK_DISABLED()          !(LL_C2_APB3_GRP1_IsEnabledClock(LL_C2_APB3_GRP1_PERIPH_BLE))
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_IS_CLK_DISABLED()          !(LL_C2_APB3_GRP1_IsEnabledClock(LL_C2_APB3_GRP1_PERIPH_802))
-#endif
+#endif /* RCC_802_SUPPORT */
 
 /**
   * @}
@@ -1686,24 +1729,24 @@ typedef struct
 #define __HAL_RCC_DMA1_FORCE_RESET()           LL_AHB1_GRP1_ForceReset(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_FORCE_RESET()           LL_AHB1_GRP1_ForceReset(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_FORCE_RESET()        LL_AHB1_GRP1_ForceReset(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_CRC_FORCE_RESET()            LL_AHB1_GRP1_ForceReset(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_FORCE_RESET()            LL_AHB1_GRP1_ForceReset(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 
 #define __HAL_RCC_AHB1_RELEASE_RESET()         LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_ALL)
 #define __HAL_RCC_DMA1_RELEASE_RESET()         LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_RELEASE_RESET()         LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_RELEASE_RESET()      LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_CRC_RELEASE_RESET()          LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_RELEASE_RESET()          LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 
 /**
@@ -1720,15 +1763,15 @@ typedef struct
 #define __HAL_RCC_GPIOC_FORCE_RESET()          LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_FORCE_RESET()          LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_FORCE_RESET()          LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_FORCE_RESET()          LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_FORCE_RESET()            LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_FORCE_RESET()           LL_AHB2_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_AHB2_RELEASE_RESET()         LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_ALL)
 #define __HAL_RCC_GPIOA_RELEASE_RESET()        LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOA)
@@ -1736,15 +1779,15 @@ typedef struct
 #define __HAL_RCC_GPIOC_RELEASE_RESET()        LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_RELEASE_RESET()        LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_RELEASE_RESET()        LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_RELEASE_RESET()        LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_RELEASE_RESET()          LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_RELEASE_RESET()         LL_AHB2_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 /**
   * @}
@@ -1757,7 +1800,7 @@ typedef struct
 #define __HAL_RCC_AHB3_FORCE_RESET()           LL_AHB3_GRP1_ForceReset(LL_AHB2_GRP1_PERIPH_ALL)
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_FORCE_RESET()        LL_AHB3_GRP1_ForceReset(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_FORCE_RESET()            LL_AHB3_GRP1_ForceReset(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_FORCE_RESET()           LL_AHB3_GRP1_ForceReset(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_FORCE_RESET()            LL_AHB3_GRP1_ForceReset(LL_AHB3_GRP1_PERIPH_RNG)
@@ -1768,7 +1811,7 @@ typedef struct
 #define __HAL_RCC_AHB3_RELEASE_RESET()         LL_AHB3_GRP1_ReleaseReset(LL_AHB2_GRP1_PERIPH_ALL)
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_RELEASE_RESET()      LL_AHB3_GRP1_ReleaseReset(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_RELEASE_RESET()          LL_AHB3_GRP1_ReleaseReset(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_RELEASE_RESET()         LL_AHB3_GRP1_ReleaseReset(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_RELEASE_RESET()          LL_AHB3_GRP1_ReleaseReset(LL_AHB3_GRP1_PERIPH_RNG)
@@ -1788,26 +1831,26 @@ typedef struct
 #define __HAL_RCC_TIM2_FORCE_RESET()           LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_FORCE_RESET()            LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_FORCE_RESET()           LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_FORCE_RESET()           LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_FORCE_RESET()           LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_FORCE_RESET()            LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_FORCE_RESET()            LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_FORCE_RESET()         LL_APB1_GRP1_ForceReset(LL_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_APB1H_FORCE_RESET()          LL_APB1_GRP2_ForceReset(LL_APB1_GRP2_PERIPH_ALL)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_FORCE_RESET()        LL_APB1_GRP2_ForceReset(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 #define __HAL_RCC_LPTIM2_FORCE_RESET()         LL_APB1_GRP2_ForceReset(LL_APB1_GRP2_PERIPH_LPTIM2)
 
 #define __HAL_RCC_APB1_FORCE_RESET() do { \
@@ -1819,32 +1862,32 @@ typedef struct
 #define __HAL_RCC_TIM2_RELEASE_RESET()         LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_RELEASE_RESET()          LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_RELEASE_RESET()         LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_RELEASE_RESET()         LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_RELEASE_RESET()         LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_RELEASE_RESET()          LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_RELEASE_RESET()          LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_RELEASE_RESET()       LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LPTIM1)
 
 #define __HAL_RCC_APB1H_RELEASE_RESET()        LL_APB1_GRP2_ReleaseReset(LL_APB1_GRP2_PERIPH_ALL)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_RELEASE_RESET()      LL_APB1_GRP2_ReleaseReset(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 #define __HAL_RCC_LPTIM2_RELEASE_RESET()       LL_APB1_GRP2_ReleaseReset(LL_APB1_GRP2_PERIPH_LPTIM2)
 
 #define __HAL_RCC_APB1_RELEASE_RESET() do { \
-                                           __HAL_RCC_APB1L_RELEASE_RESET();\
-                                           __HAL_RCC_APB1H_RELEASE_RESET();\
-                                        } while(0U)
+                                            __HAL_RCC_APB1L_RELEASE_RESET();\
+                                            __HAL_RCC_APB1H_RELEASE_RESET();\
+                                          } while(0U)
 /**
   * @}
   */
@@ -1856,7 +1899,7 @@ typedef struct
 #define __HAL_RCC_APB2_FORCE_RESET()           LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_ALL)
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_FORCE_RESET()            LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_FORCE_RESET()           LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_FORCE_RESET()           LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_FORCE_RESET()         LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_USART1)
@@ -1864,12 +1907,12 @@ typedef struct
 #define __HAL_RCC_TIM17_FORCE_RESET()          LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_FORCE_RESET()           LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #define __HAL_RCC_APB2_RELEASE_RESET()         LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_ALL)
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_RELEASE_RESET()          LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_RELEASE_RESET()         LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_RELEASE_RESET()         LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_RELEASE_RESET()       LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_USART1)
@@ -1877,7 +1920,7 @@ typedef struct
 #define __HAL_RCC_TIM17_RELEASE_RESET()        LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_RELEASE_RESET()         LL_APB2_GRP1_ReleaseReset(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 /**
   * @}
   */
@@ -1907,47 +1950,47 @@ typedef struct
 #define __HAL_RCC_DMA1_CLK_SLEEP_ENABLE()       LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_CLK_SLEEP_ENABLE()       LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_CLK_SLEEP_ENABLE()    LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_SRAM1_CLK_SLEEP_ENABLE()      LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_SRAM1)
 #define __HAL_RCC_CRC_CLK_SLEEP_ENABLE()        LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_CLK_SLEEP_ENABLE()        LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_DMA1_CLK_SLEEP_DISABLE()      LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_CLK_SLEEP_DISABLE()      LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_CLK_SLEEP_DISABLE()   LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_SRAM1_CLK_SLEEP_DISABLE()     LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_SRAM1)
 #define __HAL_RCC_CRC_CLK_SLEEP_DISABLE()       LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_TSC_CLK_SLEEP_DISABLE()       LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_C2DMA1_CLK_SLEEP_ENABLE()     LL_C2_AHB1_GRP1_EnableClockSleep(LL_C2_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_CLK_SLEEP_ENABLE()     LL_C2_AHB1_GRP1_EnableClockSleep(LL_C2_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_CLK_SLEEP_ENABLE()  LL_C2_AHB1_GRP1_EnableClockSleep(LL_C2_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_C2SRAM1_CLK_SLEEP_ENABLE()    LL_C2_AHB1_GRP1_EnableClockSleep(LL_C2_AHB1_GRP1_PERIPH_SRAM1)
 #define __HAL_RCC_C2CRC_CLK_SLEEP_ENABLE()      LL_C2_AHB1_GRP1_EnableClockSleep(LL_C2_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_CLK_SLEEP_ENABLE()      LL_C2_AHB1_GRP1_EnableClockSleep(LL_C2_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_C2DMA1_CLK_SLEEP_DISABLE()    LL_C2_AHB1_GRP1_DisableClockSleep(LL_C2_AHB1_GRP1_PERIPH_DMA1)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_CLK_SLEEP_DISABLE()    LL_C2_AHB1_GRP1_DisableClockSleep(LL_C2_AHB1_GRP1_PERIPH_DMA2)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_CLK_SLEEP_DISABLE() LL_C2_AHB1_GRP1_DisableClockSleep(LL_C2_AHB1_GRP1_PERIPH_DMAMUX1)
 #define __HAL_RCC_C2SRAM1_CLK_SLEEP_DISABLE()   LL_C2_AHB1_GRP1_DisableClockSleep(LL_C2_AHB1_GRP1_PERIPH_SRAM1)
 
 #define __HAL_RCC_C2CRC_CLK_SLEEP_DISABLE()     LL_C2_AHB1_GRP1_DisableClockSleep(LL_C2_AHB1_GRP1_PERIPH_CRC)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_CLK_SLEEP_DISABLE()     LL_C2_AHB1_GRP1_DisableClockSleep(LL_C2_AHB1_GRP1_PERIPH_TSC)
-#endif
+#endif /* TSC */
 
 /**
   * @}
@@ -1966,60 +2009,60 @@ typedef struct
 #define __HAL_RCC_GPIOC_CLK_SLEEP_ENABLE()     LL_AHB2_GRP1_EnableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_CLK_SLEEP_ENABLE()     LL_AHB2_GRP1_EnableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_CLK_SLEEP_ENABLE()     LL_AHB2_GRP1_EnableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_CLK_SLEEP_ENABLE()     LL_AHB2_GRP1_EnableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_CLK_SLEEP_ENABLE()       LL_AHB2_GRP1_EnableClockSleep(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_CLK_SLEEP_ENABLE()      LL_AHB2_GRP1_EnableClockSleep(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_GPIOA_CLK_SLEEP_DISABLE()    LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOA)
 #define __HAL_RCC_GPIOB_CLK_SLEEP_DISABLE()    LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOB)
 #define __HAL_RCC_GPIOC_CLK_SLEEP_DISABLE()    LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_CLK_SLEEP_DISABLE()    LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_CLK_SLEEP_DISABLE()    LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_GPIOH_CLK_SLEEP_DISABLE()    LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_CLK_SLEEP_DISABLE()      LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_CLK_SLEEP_DISABLE()     LL_AHB2_GRP1_DisableClockSleep(LL_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_C2GPIOA_CLK_SLEEP_ENABLE()   LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOA)
 #define __HAL_RCC_C2GPIOB_CLK_SLEEP_ENABLE()   LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOB)
 #define __HAL_RCC_C2GPIOC_CLK_SLEEP_ENABLE()   LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_CLK_SLEEP_ENABLE()   LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_CLK_SLEEP_ENABLE()   LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_C2GPIOH_CLK_SLEEP_ENABLE()   LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_SLEEP_ENABLE()     LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_CLK_SLEEP_ENABLE()    LL_C2_AHB2_GRP1_EnableClockSleep(LL_C2_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_C2GPIOA_CLK_SLEEP_DISABLE()  LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOA)
 #define __HAL_RCC_C2GPIOB_CLK_SLEEP_DISABLE()  LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOB)
 #define __HAL_RCC_C2GPIOC_CLK_SLEEP_DISABLE()  LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOC)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_CLK_SLEEP_DISABLE()  LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOD)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_CLK_SLEEP_DISABLE()  LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOE)
 #define __HAL_RCC_C2GPIOH_CLK_SLEEP_DISABLE()  LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_GPIOH)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_SLEEP_DISABLE()    LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_CLK_SLEEP_DISABLE()   LL_C2_AHB2_GRP1_DisableClockSleep(LL_C2_AHB2_GRP1_PERIPH_AES1)
-#endif
+#endif /* AES1 */
 
 /**
   * @}
@@ -2035,7 +2078,7 @@ typedef struct
   */
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_CLK_SLEEP_ENABLE()   LL_AHB3_GRP1_EnableClockSleep(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_CLK_SLEEP_ENABLE()       LL_AHB3_GRP1_EnableClockSleep(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_CLK_SLEEP_ENABLE()      LL_AHB3_GRP1_EnableClockSleep(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_CLK_SLEEP_ENABLE()       LL_AHB3_GRP1_EnableClockSleep(LL_AHB3_GRP1_PERIPH_RNG)
@@ -2044,7 +2087,7 @@ typedef struct
 
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_CLK_SLEEP_DISABLE()  LL_AHB3_GRP1_DisableClockSleep(LL_AHB3_GRP1_PERIPH_QUADSPI)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_CLK_SLEEP_DISABLE()      LL_AHB3_GRP1_DisableClockSleep(LL_AHB3_GRP1_PERIPH_PKA)
 #define __HAL_RCC_AES2_CLK_SLEEP_DISABLE()     LL_AHB3_GRP1_DisableClockSleep(LL_AHB3_GRP1_PERIPH_AES2)
 #define __HAL_RCC_RNG_CLK_SLEEP_DISABLE()      LL_AHB3_GRP1_DisableClockSleep(LL_AHB3_GRP1_PERIPH_RNG)
@@ -2078,99 +2121,99 @@ typedef struct
 #define __HAL_RCC_TIM2_CLK_SLEEP_ENABLE()           LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_CLK_SLEEP_ENABLE()            LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #define __HAL_RCC_RTCAPB_CLK_SLEEP_ENABLE()         LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_RTCAPB)
 #define __HAL_RCC_WWDG_CLK_SLEEP_ENABLE()           LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_WWDG)
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_CLK_SLEEP_ENABLE()           LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_CLK_SLEEP_ENABLE()           LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_CLK_SLEEP_ENABLE()           LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_CLK_SLEEP_ENABLE()            LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_CLK_SLEEP_ENABLE()            LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_CLK_SLEEP_ENABLE()         LL_APB1_GRP1_EnableClockSleep(LL_APB1_GRP1_PERIPH_LPTIM1)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_SLEEP_ENABLE()        LL_APB1_GRP2_EnableClockSleep(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 #define __HAL_RCC_LPTIM2_CLK_SLEEP_ENABLE()         LL_APB1_GRP2_EnableClockSleep(LL_APB1_GRP2_PERIPH_LPTIM2)
 
 #define __HAL_RCC_TIM2_CLK_SLEEP_DISABLE()          LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_LCD_CLK_SLEEP_DISABLE()           LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #define __HAL_RCC_RTCAPB_CLK_SLEEP_DISABLE()        LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_RTCAPB)
 #define __HAL_RCC_WWDG_CLK_SLEEP_DISABLE()          LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_WWDG)
 #if defined(SPI2)
 #define __HAL_RCC_SPI2_CLK_SLEEP_DISABLE()          LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_I2C1_CLK_SLEEP_DISABLE()          LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_I2C3_CLK_SLEEP_DISABLE()          LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_CRS_CLK_SLEEP_DISABLE()           LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_USB_CLK_SLEEP_DISABLE()           LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_LPTIM1_CLK_SLEEP_DISABLE()        LL_APB1_GRP1_DisableClockSleep(LL_APB1_GRP1_PERIPH_LPTIM1)
 #if defined(LPUART1)
 #define __HAL_RCC_LPUART1_CLK_SLEEP_DISABLE()       LL_APB1_GRP2_DisableClockSleep(LL_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 #define __HAL_RCC_LPTIM2_CLK_SLEEP_DISABLE()        LL_APB1_GRP2_DisableClockSleep(LL_APB1_GRP2_PERIPH_LPTIM2)
 
 #define __HAL_RCC_C2TIM2_CLK_SLEEP_ENABLE()         LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_C2LCD_CLK_SLEEP_ENABLE()          LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #define __HAL_RCC_C2RTCAPB_CLK_SLEEP_ENABLE()       LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_RTCAPB)
 #if defined(SPI2)
 #define __HAL_RCC_C2SPI2_CLK_SLEEP_ENABLE()         LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_C2I2C1_CLK_SLEEP_ENABLE()         LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_C2I2C3_CLK_SLEEP_ENABLE()         LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_C2CRS_CLK_SLEEP_ENABLE()          LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_C2USB_CLK_SLEEP_ENABLE()          LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_C2LPTIM1_CLK_SLEEP_ENABLE()       LL_C2_APB1_GRP1_EnableClockSleep(LL_C2_APB1_GRP1_PERIPH_LPTIM1)
 #if defined(LPUART1)
 #define __HAL_RCC_C2LPUART1_CLK_SLEEP_ENABLE()      LL_C2_APB1_GRP2_EnableClockSleep(LL_C2_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 #define __HAL_RCC_C2LPTIM2_CLK_SLEEP_ENABLE()       LL_C2_APB1_GRP2_EnableClockSleep(LL_C2_APB1_GRP2_PERIPH_LPTIM2)
 
 #define __HAL_RCC_C2TIM2_CLK_SLEEP_DISABLE()        LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_TIM2)
 #if defined(LCD)
 #define __HAL_RCC_C2LCD_CLK_SLEEP_DISABLE()         LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_LCD)
-#endif
+#endif /* LCD */
 #define __HAL_RCC_C2RTCAPB_CLK_SLEEP_DISABLE()      LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_RTCAPB)
 #if defined(SPI2)
 #define __HAL_RCC_C2SPI2_CLK_SLEEP_DISABLE()        LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_SPI2)
-#endif
+#endif /* SPI2 */
 #define __HAL_RCC_C2I2C1_CLK_SLEEP_DISABLE()        LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_I2C1)
 #if defined(I2C3)
 #define __HAL_RCC_C2I2C3_CLK_SLEEP_DISABLE()        LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_I2C3)
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define __HAL_RCC_C2CRS_CLK_SLEEP_DISABLE()         LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_CRS)
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define __HAL_RCC_C2USB_CLK_SLEEP_DISABLE()         LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_USB)
-#endif
+#endif /* USB */
 #define __HAL_RCC_C2LPTIM1_CLK_SLEEP_DISABLE()      LL_C2_APB1_GRP1_DisableClockSleep(LL_C2_APB1_GRP1_PERIPH_LPTIM1)
 #if defined(LPUART1)
 #define __HAL_RCC_C2LPUART1_CLK_SLEEP_DISABLE()     LL_C2_APB1_GRP2_DisableClockSleep(LL_C2_APB1_GRP2_PERIPH_LPUART1)
-#endif
+#endif /* LPUART1 */
 #define __HAL_RCC_C2LPTIM2_CLK_SLEEP_DISABLE()      LL_C2_APB1_GRP2_DisableClockSleep(LL_C2_APB1_GRP2_PERIPH_LPTIM2)
 
 /**
@@ -2187,7 +2230,7 @@ typedef struct
   */
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_CLK_SLEEP_ENABLE()            LL_APB2_GRP1_EnableClockSleep(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_CLK_SLEEP_ENABLE()           LL_APB2_GRP1_EnableClockSleep(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_CLK_SLEEP_ENABLE()           LL_APB2_GRP1_EnableClockSleep(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_CLK_SLEEP_ENABLE()         LL_APB2_GRP1_EnableClockSleep(LL_APB2_GRP1_PERIPH_USART1)
@@ -2195,11 +2238,11 @@ typedef struct
 #define __HAL_RCC_TIM17_CLK_SLEEP_ENABLE()          LL_APB2_GRP1_EnableClockSleep(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_CLK_SLEEP_ENABLE()           LL_APB2_GRP1_EnableClockSleep(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_CLK_SLEEP_DISABLE()           LL_APB2_GRP1_DisableClockSleep(LL_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_CLK_SLEEP_DISABLE()          LL_APB2_GRP1_DisableClockSleep(LL_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_SPI1_CLK_SLEEP_DISABLE()          LL_APB2_GRP1_DisableClockSleep(LL_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_USART1_CLK_SLEEP_DISABLE()        LL_APB2_GRP1_DisableClockSleep(LL_APB2_GRP1_PERIPH_USART1)
@@ -2207,11 +2250,11 @@ typedef struct
 #define __HAL_RCC_TIM17_CLK_SLEEP_DISABLE()         LL_APB2_GRP1_DisableClockSleep(LL_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_CLK_SLEEP_DISABLE()          LL_APB2_GRP1_DisableClockSleep(LL_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_SLEEP_ENABLE()          LL_C2_APB2_GRP1_EnableClockSleep(LL_C2_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_C2TIM1_CLK_SLEEP_ENABLE()         LL_C2_APB2_GRP1_EnableClockSleep(LL_C2_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_C2SPI1_CLK_SLEEP_ENABLE()         LL_C2_APB2_GRP1_EnableClockSleep(LL_C2_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_C2USART1_CLK_SLEEP_ENABLE()       LL_C2_APB2_GRP1_EnableClockSleep(LL_C2_APB2_GRP1_PERIPH_USART1)
@@ -2219,11 +2262,11 @@ typedef struct
 #define __HAL_RCC_C2TIM17_CLK_SLEEP_ENABLE()        LL_C2_APB2_GRP1_EnableClockSleep(LL_C2_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_C2SAI1_CLK_SLEEP_ENABLE()         LL_C2_APB2_GRP1_EnableClockSleep(LL_C2_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_C2ADC_CLK_SLEEP_DISABLE()         LL_C2_APB2_GRP1_DisableClockSleep(LL_C2_APB2_GRP1_PERIPH_ADC)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_C2TIM1_CLK_SLEEP_DISABLE()        LL_C2_APB2_GRP1_DisableClockSleep(LL_C2_APB2_GRP1_PERIPH_TIM1)
 #define __HAL_RCC_C2SPI1_CLK_SLEEP_DISABLE()        LL_C2_APB2_GRP1_DisableClockSleep(LL_C2_APB2_GRP1_PERIPH_SPI1)
 #define __HAL_RCC_C2USART1_CLK_SLEEP_DISABLE()      LL_C2_APB2_GRP1_DisableClockSleep(LL_C2_APB2_GRP1_PERIPH_USART1)
@@ -2231,7 +2274,7 @@ typedef struct
 #define __HAL_RCC_C2TIM17_CLK_SLEEP_DISABLE()       LL_C2_APB2_GRP1_DisableClockSleep(LL_C2_APB2_GRP1_PERIPH_TIM17)
 #if defined(SAI1)
 #define __HAL_RCC_C2SAI1_CLK_SLEEP_DISABLE()        LL_C2_APB2_GRP1_DisableClockSleep(LL_C2_APB2_GRP1_PERIPH_SAI1)
-#endif
+#endif /* SAI1 */
 /**
   * @}
   */
@@ -2247,46 +2290,46 @@ typedef struct
 #define __HAL_RCC_DMA1_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA1SMEN) != RESET)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA2SMEN) != RESET)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMAMUX1SMEN) != RESET)
 #define __HAL_RCC_SRAM1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_SRAM1SMEN) != RESET)
 #define __HAL_RCC_CRC_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_CRCSMEN) != RESET)
 #if defined(TSC)
 #define __HAL_RCC_TSC_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_TSCSMEN) != RESET)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_DMA1_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA1SMEN) == RESET)
 #if defined(DMA2)
 #define __HAL_RCC_DMA2_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMA2SMEN) == RESET)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_DMAMUX1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_DMAMUX1SMEN) == RESET)
 #define __HAL_RCC_SRAM1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_SRAM1SMEN) == RESET)
 #define __HAL_RCC_CRC_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_CRCSMEN) == RESET)
 #if defined(TSC)
 #define __HAL_RCC_TSC_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->AHB1SMENR, RCC_AHB1SMENR_TSCSMEN) == RESET)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_C2DMA1_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_DMA1SMEN) != RESET)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_DMA2SMEN) != RESET)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_IS_CLK_SLEEP_ENABLED()  (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_DMAMUX1SMEN) != RESET)
 #define __HAL_RCC_C2SRAM1_IS_CLK_SLEEP_ENABLED()    (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_SRAM1SMEN) != RESET)
 #define __HAL_RCC_C2CRC_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_CRCSMEN) != RESET)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_TSCSMEN) != RESET)
-#endif
+#endif /* TSC */
 
 #define __HAL_RCC_C2DMA1_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_DMA1SMEN) == RESET)
 #if defined(DMA2)
 #define __HAL_RCC_C2DMA2_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_DMA2SMEN) == RESET)
-#endif
+#endif /* DMA2 */
 #define __HAL_RCC_C2DMAMUX1_IS_CLK_SLEEP_DISABLED() (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_DMAMUX1SMEN) == RESET)
 #define __HAL_RCC_C2SRAM1_IS_CLK_SLEEP_DISABLED()   (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_SRAM1SMEN) == RESET)
 #define __HAL_RCC_C2CRC_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_CRCSMEN) == RESET)
 #if defined(TSC)
 #define __HAL_RCC_C2TSC_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->C2AHB1SMENR, RCC_C2AHB1SMENR_TSCSMEN) == RESET)
-#endif
+#endif /* TSC */
 /**
   * @}
   */
@@ -2304,60 +2347,61 @@ typedef struct
 #define __HAL_RCC_GPIOC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOCSMEN) != RESET)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIODSMEN) != RESET)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOESMEN) != RESET)
 #define __HAL_RCC_GPIOH_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOHSMEN) != RESET)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_ADCSMEN)   != RESET)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_AES1SMEN) != RESET)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_GPIOA_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOASMEN) == RESET)
 #define __HAL_RCC_GPIOB_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOBSMEN) == RESET)
 #define __HAL_RCC_GPIOC_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOCSMEN) == RESET)
 #if defined(GPIOD)
 #define __HAL_RCC_GPIOD_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIODSMEN) == RESET)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_GPIOE_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOESMEN) == RESET)
 #define __HAL_RCC_GPIOH_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_GPIOHSMEN) == RESET)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_ADCSMEN)   == RESET)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_AES1_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->AHB2SMENR, RCC_AHB2SMENR_AES1SMEN) == RESET)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_C2GPIOA_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOASMEN) != RESET)
 #define __HAL_RCC_C2GPIOB_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOBSMEN) != RESET)
 #define __HAL_RCC_C2GPIOC_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOCSMEN) != RESET)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIODSMEN) != RESET)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOESMEN) != RESET)
 #define __HAL_RCC_C2GPIOH_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOHSMEN) != RESET)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_ADCSMEN)   != RESET)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_AES1SMEN) != RESET)
-#endif
+#endif /* AES1 */
 
 #define __HAL_RCC_C2GPIOA_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOASMEN) == RESET)
 #define __HAL_RCC_C2GPIOB_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOBSMEN) == RESET)
 #define __HAL_RCC_C2GPIOC_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOCSMEN) == RESET)
 #if defined(GPIOD)
 #define __HAL_RCC_C2GPIOD_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIODSMEN) == RESET)
-#endif
+#endif /* GPIOD */
 #define __HAL_RCC_C2GPIOE_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOESMEN) == RESET)
 #define __HAL_RCC_C2GPIOH_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_GPIOHSMEN) == RESET)
 #if defined(ADC_SUPPORT_5_MSPS)
 #define __HAL_RCC_C2ADC_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_ADCSMEN)   == RESET)
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define __HAL_RCC_C2AES1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->C2AHB2SMENR, RCC_C2AHB2SMENR_AES1SMEN) == RESET)
-#endif
+#endif /* AES1 */
+
 /**
   * @}
   */
@@ -2372,7 +2416,7 @@ typedef struct
   */
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_IS_CLK_SLEEP_ENABLED()   (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_QUADSPISMEN) != RESET)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_PKASMEN) != RESET)
 #define __HAL_RCC_AES2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_AES2SMEN) != RESET)
 #define __HAL_RCC_RNG_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_RNGSMEN) != RESET)
@@ -2381,7 +2425,7 @@ typedef struct
 
 #if defined(QUADSPI)
 #define __HAL_RCC_QUADSPI_IS_CLK_SLEEP_DISABLED()  (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_QUADSPISMEN) == RESET)
-#endif
+#endif /* QUADSPI */
 #define __HAL_RCC_PKA_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_PKASMEN) == RESET)
 #define __HAL_RCC_AES2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_AES2SMEN) == RESET)
 #define __HAL_RCC_RNG_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->AHB3SMENR, RCC_AHB3SMENR_RNGSMEN) == RESET)
@@ -2412,103 +2456,112 @@ typedef struct
   * @note   By default, all peripheral clocks are enabled during SLEEP mode.
   * @{
   */
-#define __HAL_RCC_TIM2_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN) != RESET)
+#define __HAL_RCC_TIM2_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN) != RESET)
 #if defined(LCD)
-#define __HAL_RCC_LCD_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN)  != RESET)
-#endif
-#define __HAL_RCC_RTCAPB_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_RTCAPBSMEN)  != RESET)
-#define __HAL_RCC_WWDG_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN)  != RESET)
+#define __HAL_RCC_LCD_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN)  != RESET)
+#endif /* LCD */
+#define __HAL_RCC_RTCAPB_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_RTCAPBSMEN) != RESET)
+#define __HAL_RCC_WWDG_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN)  != RESET)
 #if defined(SPI2)
-#define __HAL_RCC_SPI2_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN) != RESET)
-#endif
-#define __HAL_RCC_I2C1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN) != RESET)
+#define __HAL_RCC_SPI2_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN) != RESET)
+#endif /* SPI2 */
+#define __HAL_RCC_I2C1_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN) != RESET)
 #if defined(I2C3)
-#define __HAL_RCC_I2C3_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN) != RESET)
-#endif
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN) != RESET)
+#endif /* I2C3 */
 #if defined(CRS)
-#define __HAL_RCC_CRS_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CRSSMEN)  != RESET)
-#endif
+#define __HAL_RCC_CRS_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CRSSMEN)  != RESET)
+#endif /* CRS */
 #if defined(USB)
-#define __HAL_RCC_USB_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USBSMEN)  != RESET)
-#endif
-#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN) != RESET)
+#define __HAL_RCC_USB_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USBSMEN)  != RESET)
+#endif /* USB */
+#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN) != RESET)
 #if defined(LPUART1)
-#define __HAL_RCC_LPUART1_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN) != RESET)
-#endif
-#define __HAL_RCC_LPTIM2_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN) != RESET)
+#define __HAL_RCC_LPUART1_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN) != RESET)
+#endif /* LPUART1 */
+#define __HAL_RCC_LPTIM2_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN) != RESET)
 
-#define __HAL_RCC_TIM2_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN) == RESET)
+#define __HAL_RCC_TIM2_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_TIM2SMEN) == RESET)
 #if defined(LCD)
-#define __HAL_RCC_LCD_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN)  == RESET)
-#endif
-#define __HAL_RCC_RTCAPB_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_RTCAPBSMEN)  == RESET)
-#define __HAL_RCC_WWDG_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN)  == RESET)
+#define __HAL_RCC_LCD_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LCDSMEN)  == RESET)
+#endif /* LCD */
+#define __HAL_RCC_RTCAPB_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_RTCAPBSMEN) == RESET)
+#define __HAL_RCC_WWDG_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_WWDGSMEN) == RESET)
 #if defined(SPI2)
-#define __HAL_RCC_SPI2_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN) == RESET)
-#endif
-#define __HAL_RCC_I2C1_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN) == RESET)
+#define __HAL_RCC_SPI2_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_SPI2SMEN) == RESET)
+#endif /* SPI2 */
+#define __HAL_RCC_I2C1_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C1SMEN) == RESET)
 #if defined(I2C3)
-#define __HAL_RCC_I2C3_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN) == RESET)
-#endif
+#define __HAL_RCC_I2C3_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_I2C3SMEN) == RESET)
+#endif /* I2C3 */
 #if defined(CRS)
-#define __HAL_RCC_CRS_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CRSSMEN)  == RESET)
-#endif
+#define __HAL_RCC_CRS_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_CRSSMEN) == RESET)
+#endif /* CRS */
 #if defined(USB)
-#define __HAL_RCC_USB_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USBSMEN)  == RESET)
-#endif
-#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN) == RESET)
+#define __HAL_RCC_USB_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_USBSMEN) == RESET)
+#endif /* USB */
+#define __HAL_RCC_LPTIM1_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->APB1SMENR1, RCC_APB1SMENR1_LPTIM1SMEN) == RESET)
 #if defined(LPUART1)
-#define __HAL_RCC_LPUART1_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN) == RESET)
-#endif
-#define __HAL_RCC_LPTIM2_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN) == RESET)
+#define __HAL_RCC_LPUART1_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPUART1SMEN) == RESET)
+#endif /* LPUART1 */
+#define __HAL_RCC_LPTIM2_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->APB1SMENR2, RCC_APB1SMENR2_LPTIM2SMEN) == RESET)
 
-#define __HAL_RCC_C2TIM2_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_TIM2SMEN) != RESET)
+#define __HAL_RCC_C2TIM2_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_TIM2SMEN) != RESET)
 #if defined(LCD)
-#define __HAL_RCC_C2LCD_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LCDSMEN)  != RESET)
-#endif
-#define __HAL_RCC_C2RTCAPB_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_RTCAPBSMEN)  != RESET)
+#define __HAL_RCC_C2LCD_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LCDSMEN) != RESET)
+#endif /* LCD */
+#define __HAL_RCC_C2RTCAPB_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_RTCAPBSMEN) \
+                                                        != RESET)
 #if defined(SPI2)
-#define __HAL_RCC_C2SPI2_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_SPI2SMEN) != RESET)
-#endif
-#define __HAL_RCC_C2I2C1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C1SMEN) != RESET)
+#define __HAL_RCC_C2SPI2_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_SPI2SMEN) != RESET)
+#endif /* SPI2 */
+#define __HAL_RCC_C2I2C1_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C1SMEN) != RESET)
 #if defined(I2C3)
-#define __HAL_RCC_C2I2C3_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C3SMEN) != RESET)
-#endif
+#define __HAL_RCC_C2I2C3_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C3SMEN) != RESET)
+#endif /* I2C3 */
 #if defined(CRS)
-#define __HAL_RCC_C2CRS_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_CRSSMEN)  != RESET)
-#endif
+#define __HAL_RCC_C2CRS_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_CRSSMEN) != RESET)
+#endif /* CRS */
 #if defined(USB)
-#define __HAL_RCC_C2USB_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_USBSMEN)  != RESET)
-#endif
-#define __HAL_RCC_C2LPTIM1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LPTIM1SMEN) != RESET)
+#define __HAL_RCC_C2USB_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_USBSMEN) != RESET)
+#endif /* USB */
+#define __HAL_RCC_C2LPTIM1_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LPTIM1SMEN) \
+                                                        != RESET)
 #if defined(LPUART1)
-#define __HAL_RCC_C2LPUART1_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPUART1SMEN) != RESET)
-#endif
-#define __HAL_RCC_C2LPTIM2_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPTIM2SMEN) != RESET)
+#define __HAL_RCC_C2LPUART1_IS_CLK_SLEEP_ENABLED()     (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPUART1SMEN) \
+                                                        != RESET)
+#endif /* LPUART1 */
+#define __HAL_RCC_C2LPTIM2_IS_CLK_SLEEP_ENABLED()      (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPTIM2SMEN) \
+                                                        != RESET)
 
-#define __HAL_RCC_C2TIM2_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_TIM2SMEN) == RESET)
+#define __HAL_RCC_C2TIM2_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_TIM2SMEN) == RESET)
 #if defined(LCD)
-#define __HAL_RCC_C2LCD_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LCDSMEN)  == RESET)
-#endif
-#define __HAL_RCC_C2RTCAPB_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_RTCAPBSMEN)  == RESET)
+#define __HAL_RCC_C2LCD_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LCDSMEN) == RESET)
+#endif /* LCD */
+#define __HAL_RCC_C2RTCAPB_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_RTCAPBSMEN) \
+                                                        == RESET)
 #if defined(SPI2)
-#define __HAL_RCC_C2SPI2_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_SPI2SMEN) == RESET)
-#endif
-#define __HAL_RCC_C2I2C1_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C1SMEN) == RESET)
+#define __HAL_RCC_C2SPI2_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_SPI2SMEN) == RESET)
+#endif /* SPI2 */
+#define __HAL_RCC_C2I2C1_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C1SMEN) == RESET)
 #if defined(I2C3)
-#define __HAL_RCC_C2I2C3_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C3SMEN) == RESET)
-#endif
+#define __HAL_RCC_C2I2C3_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_I2C3SMEN) == RESET)
+#endif /* I2C3 */
 #if defined(CRS)
-#define __HAL_RCC_C2CRS_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_CRSSMEN)  == RESET)
-#endif
+#define __HAL_RCC_C2CRS_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_CRSSMEN) == RESET)
+#endif /* CRS */
 #if defined(USB)
-#define __HAL_RCC_C2USB_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_USBSMEN)  == RESET)
-#endif
-#define __HAL_RCC_C2LPTIM1_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LPTIM1SMEN) == RESET)
+#define __HAL_RCC_C2USB_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_USBSMEN) == RESET)
+#endif /* USB */
+#define __HAL_RCC_C2LPTIM1_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->C2APB1SMENR1, RCC_C2APB1SMENR1_LPTIM1SMEN) \
+                                                        == RESET)
 #if defined(LPUART1)
-#define __HAL_RCC_C2LPUART1_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPUART1SMEN) == RESET)
-#endif
-#define __HAL_RCC_C2LPTIM2_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPTIM2SMEN) == RESET)
+#define __HAL_RCC_C2LPUART1_IS_CLK_SLEEP_DISABLED()    (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPUART1SMEN) \
+                                                        == RESET)
+#endif /* LPUART1 */
+#define __HAL_RCC_C2LPTIM2_IS_CLK_SLEEP_DISABLED()     (READ_BIT(RCC->C2APB1SMENR2, RCC_C2APB1SMENR2_LPTIM2SMEN) \
+                                                        == RESET)
+
 /**
   * @}
   */
@@ -2523,7 +2576,7 @@ typedef struct
   */
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define __HAL_RCC_ADC_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_ADCSMEN) != RESET)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define __HAL_RCC_TIM1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN) != RESET)
 #define __HAL_RCC_SPI1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN) != RESET)
 #define __HAL_RCC_USART1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN) != RESET)
@@ -2531,43 +2584,46 @@ typedef struct
 #define __HAL_RCC_TIM17_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN) != RESET)
 #if defined(SAI1)
 #define __HAL_RCC_SAI1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN) != RESET)
-#endif
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
-#define __HAL_RCC_ADC_IS_CLK_SLEEP_DISABLED()            (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_ADCSMEN) == RESET)
-#endif
-#define __HAL_RCC_TIM1_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN) == RESET)
-#define __HAL_RCC_SPI1_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN) == RESET)
-#define __HAL_RCC_USART1_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN) == RESET)
-#define __HAL_RCC_TIM16_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM16SMEN) == RESET)
-#define __HAL_RCC_TIM17_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN) == RESET)
+#define __HAL_RCC_ADC_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_ADCSMEN) == RESET)
+#endif /* ADC_SUPPORT_2_5_MSPS */
+#define __HAL_RCC_TIM1_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM1SMEN) == RESET)
+#define __HAL_RCC_SPI1_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SPI1SMEN) == RESET)
+#define __HAL_RCC_USART1_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_USART1SMEN) == RESET)
+#define __HAL_RCC_TIM16_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM16SMEN) == RESET)
+#define __HAL_RCC_TIM17_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_TIM17SMEN) == RESET)
 #if defined(SAI1)
-#define __HAL_RCC_SAI1_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN) == RESET)
-#endif
+#define __HAL_RCC_SAI1_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->APB2SMENR, RCC_APB2SMENR_SAI1SMEN) == RESET)
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
-#define __HAL_RCC_C2ADC_IS_CLK_SLEEP_ENABLED()            (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_ADCSMEN) != RESET)
-#endif
-#define __HAL_RCC_C2TIM1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM1SMEN) != RESET)
-#define __HAL_RCC_C2SPI1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SPI1SMEN) != RESET)
-#define __HAL_RCC_C2USART1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_USART1SMEN) != RESET)
-#define __HAL_RCC_C2TIM16_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM16SMEN) != RESET)
-#define __HAL_RCC_C2TIM17_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM17SMEN) != RESET)
+#define __HAL_RCC_C2ADC_IS_CLK_SLEEP_ENABLED()          (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_ADCSMEN) != RESET)
+#endif /* ADC_SUPPORT_2_5_MSPS */
+#define __HAL_RCC_C2TIM1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM1SMEN) != RESET)
+#define __HAL_RCC_C2SPI1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SPI1SMEN) != RESET)
+#define __HAL_RCC_C2USART1_IS_CLK_SLEEP_ENABLED()       (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_USART1SMEN) \
+                                                         != RESET)
+#define __HAL_RCC_C2TIM16_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM16SMEN) != RESET)
+#define __HAL_RCC_C2TIM17_IS_CLK_SLEEP_ENABLED()        (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM17SMEN) != RESET)
 #if defined(SAI1)
-#define __HAL_RCC_C2SAI1_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SAI1SMEN) != RESET)
-#endif
+#define __HAL_RCC_C2SAI1_IS_CLK_SLEEP_ENABLED()         (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SAI1SMEN) != RESET)
+#endif /* SAI1 */
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
-#define __HAL_RCC_C2ADC_IS_CLK_SLEEP_DISABLED()            (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_ADCSMEN) == RESET)
-#endif
-#define __HAL_RCC_C2TIM1_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM1SMEN) == RESET)
-#define __HAL_RCC_C2SPI1_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SPI1SMEN) == RESET)
-#define __HAL_RCC_C2USART1_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_USART1SMEN) == RESET)
-#define __HAL_RCC_C2TIM16_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM16SMEN) == RESET)
-#define __HAL_RCC_C2TIM17_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM17SMEN) == RESET)
+#define __HAL_RCC_C2ADC_IS_CLK_SLEEP_DISABLED()         (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_ADCSMEN) == RESET)
+#endif /* ADC_SUPPORT_2_5_MSPS */
+#define __HAL_RCC_C2TIM1_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM1SMEN) == RESET)
+#define __HAL_RCC_C2SPI1_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SPI1SMEN) == RESET)
+#define __HAL_RCC_C2USART1_IS_CLK_SLEEP_DISABLED()      (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_USART1SMEN) \
+                                                         == RESET)
+#define __HAL_RCC_C2TIM16_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM16SMEN) == RESET)
+#define __HAL_RCC_C2TIM17_IS_CLK_SLEEP_DISABLED()       (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_TIM17SMEN) == RESET)
 #if defined(SAI1)
-#define __HAL_RCC_C2SAI1_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SAI1SMEN) == RESET)
-#endif
+#define __HAL_RCC_C2SAI1_IS_CLK_SLEEP_DISABLED()        (READ_BIT(RCC->C2APB2SMENR, RCC_C2APB2SMENR_SAI1SMEN) == RESET)
+#endif /* SAI1 */
+
 /**
   * @}
   */
@@ -2583,12 +2639,12 @@ typedef struct
 #define __HAL_RCC_C2BLE_CLK_SLEEP_ENABLE()          LL_C2_APB3_GRP1_EnableClockSleep(LL_C2_APB3_GRP1_PERIPH_BLE)
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_CLK_SLEEP_ENABLE()          LL_C2_APB3_GRP1_EnableClockSleep(LL_C2_APB3_GRP1_PERIPH_802)
-#endif
+#endif /* RCC_802_SUPPORT */
 
 #define __HAL_RCC_C2BLE_CLK_SLEEP_DISABLE()         LL_C2_APB3_GRP1_DisableClockSleep(LL_C2_APB3_GRP1_PERIPH_BLE)
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_CLK_SLEEP_DISABLE()         LL_C2_APB3_GRP1_DisableClockSleep(LL_C2_APB3_GRP1_PERIPH_802)
-#endif
+#endif /* RCC_802_SUPPORT */
 /**
   * @}
   */
@@ -2604,12 +2660,12 @@ typedef struct
 #define __HAL_RCC_C2BLE_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB3SMENR, RCC_C2APB3SMENR_BLESMEN) != RESET)
 #if defined(RCC_802_SUPPORT)
 #define __HAL_RCC_C2802_IS_CLK_SLEEP_ENABLED()           (READ_BIT(RCC->C2APB3SMENR, RCC_C2APB3SMENR_802SMEN) != RESET)
-#endif
+#endif /* RCC_802_SUPPORT */
 
-#define __HAL_RCC_C2BLE_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB3SMENR, RCC_C2APB3SMENR_BLESMEN) == RESET)
+#define __HAL_RCC_C2BLE_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB3SMENR, RCC_C2APB3SMENR_BLESMEN) == RESET)
 #if defined(RCC_802_SUPPORT)
-#define __HAL_RCC_C2802_IS_CLK_SLEEP_DISABLED()           (READ_BIT(RCC->C2APB3SMENR, RCC_C2APB3SMENR_802SMEN) == RESET)
-#endif
+#define __HAL_RCC_C2802_IS_CLK_SLEEP_DISABLED()          (READ_BIT(RCC->C2APB3SMENR, RCC_C2APB3SMENR_802SMEN) == RESET)
+#endif /* RCC_802_SUPPORT */
 /**
   * @}
   */
@@ -2679,7 +2735,8 @@ typedef struct
   *         This parameter must be a number between Min_data=0 and Max_Data=127.
   * @retval None
   */
-#define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICALIBRATIONVALUE__)  LL_RCC_HSI_SetCalibTrimming(__HSICALIBRATIONVALUE__)
+#define __HAL_RCC_HSI_CALIBRATIONVALUE_ADJUST(__HSICALIBRATIONVALUE__) \
+  LL_RCC_HSI_SetCalibTrimming(__HSICALIBRATIONVALUE__)
 
 /**
   * @brief    Macros to enable or disable the wakeup the Internal High Speed oscillator (HSI)
@@ -2732,7 +2789,8 @@ typedef struct
   *         This parameter must be a number between 0 and 255.
   * @retval None
   */
-#define __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(__MSICALIBRATIONVALUE__)  LL_RCC_MSI_SetCalibTrimming(__MSICALIBRATIONVALUE__)
+#define __HAL_RCC_MSI_CALIBRATIONVALUE_ADJUST(__MSICALIBRATIONVALUE__) \
+  LL_RCC_MSI_SetCalibTrimming(__MSICALIBRATIONVALUE__)
 
 /**
   * @brief  Macro configures the Internal Multi Speed oscillator (MSI) clock range in run mode
@@ -2829,17 +2887,17 @@ typedef struct
   * @note      (*) Value not defined for all devices
   * @retval None
   */
-#define __HAL_RCC_HSE_CONFIG(__STATE__)                      \
-                    do {                                     \
-                      if((__STATE__) == RCC_HSE_ON)          \
-                      {                                      \
-                       LL_RCC_HSE_Enable();                  \
-                      }                                      \
-                      else                                   \
-                      {                                      \
-                        LL_RCC_HSE_Disable();                \
-                      }                                      \
-                    } while(0U)
+#define __HAL_RCC_HSE_CONFIG(__STATE__)    \
+  do {                                     \
+    if((__STATE__) == RCC_HSE_ON)          \
+    {                                      \
+      LL_RCC_HSE_Enable();                 \
+    }                                      \
+    else                                   \
+    {                                      \
+      LL_RCC_HSE_Disable();                \
+    }                                      \
+  } while(0U)
 
 /** @brief  Macros to enable or disable the HSE Prescaler
   * @note   HSE div2 could be used as Sysclk or PLL entry in Range2
@@ -2868,23 +2926,23 @@ typedef struct
   *            @arg @ref RCC_LSE_BYPASS  LSE oscillator bypassed with external clock.
   * @retval None
   */
-#define __HAL_RCC_LSE_CONFIG(__STATE__)                        \
-                    do {                                       \
-                      if((__STATE__) == RCC_LSE_ON)            \
-                      {                                        \
-                        LL_RCC_LSE_Enable();                   \
-                      }                                        \
-                      else if((__STATE__) == RCC_LSE_BYPASS)   \
-                      {                                        \
-                        LL_RCC_LSE_EnableBypass();             \
-                        LL_RCC_LSE_Enable();                   \
-                      }                                        \
-                      else                                     \
-                      {                                        \
-                        LL_RCC_LSE_Disable();                  \
-                        LL_RCC_LSE_DisableBypass();            \
-                      }                                        \
-                    } while(0U)
+#define __HAL_RCC_LSE_CONFIG(__STATE__)      \
+  do {                                       \
+    if((__STATE__) == RCC_LSE_ON)            \
+    {                                        \
+      LL_RCC_LSE_Enable();                   \
+    }                                        \
+    else if((__STATE__) == RCC_LSE_BYPASS)   \
+    {                                        \
+      LL_RCC_LSE_EnableBypass();             \
+      LL_RCC_LSE_Enable();                   \
+    }                                        \
+    else                                     \
+    {                                        \
+      LL_RCC_LSE_Disable();                  \
+      LL_RCC_LSE_DisableBypass();            \
+    }                                        \
+  } while(0U)
 
 
 #if defined(RCC_HSI48_SUPPORT)
@@ -2964,7 +3022,6 @@ typedef struct
   */
 #define __HAL_RCC_RTC_CONFIG(__RTC_CLKSOURCE__)  LL_RCC_SetRTCClockSource(__RTC_CLKSOURCE__)
 
-
 /** @brief  Macro to get the RTC clock source.
   * @retval The returned value can be one of the following:
   *            @arg @ref RCC_RTCCLKSOURCE_NONE  none clock selected as RTC clock.
@@ -2998,7 +3055,7 @@ typedef struct
   *
   */
 #define __HAL_RCC_PLL_PLLSOURCE_CONFIG(__PLLSOURCE__) \
-                  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (__PLLSOURCE__))
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (__PLLSOURCE__))
 
 /** @brief  Macro to configure the PLL multiplication factor.
   * @note   This function must be used only when the main PLL is disabled.
@@ -3011,7 +3068,7 @@ typedef struct
   *
   */
 #define __HAL_RCC_PLL_PLLM_CONFIG(__PLLM__) \
-                  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLM, (__PLLM__))
+  MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLM, (__PLLM__))
 
 /**
   * @brief  Macro to configure the main PLL clock source, multiplication and division factors.
@@ -3052,19 +3109,19 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_PLL_CONFIG(__PLLSOURCE__, __PLLM__, __PLLN__, __PLLP__, __PLLQ__,__PLLR__ ) \
-                  MODIFY_REG( RCC->PLLCFGR,                                                   \
-                             (RCC_PLLCFGR_PLLSRC                              |               \
-                              RCC_PLLCFGR_PLLM                                |               \
-                              RCC_PLLCFGR_PLLN                                |               \
-                              RCC_PLLCFGR_PLLP                                |               \
-                              RCC_PLLCFGR_PLLQ                                |               \
-                              RCC_PLLCFGR_PLLR),                                              \
-                             ((uint32_t) (__PLLSOURCE__)                      |               \
-                              (uint32_t) (__PLLM__)                           |               \
-                              (uint32_t) ((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) |               \
-                              (uint32_t) (__PLLP__)                           |               \
-                              (uint32_t) (__PLLQ__)                           |               \
-                              (uint32_t) (__PLLR__)))
+  MODIFY_REG( RCC->PLLCFGR,                                                   \
+              (RCC_PLLCFGR_PLLSRC                              |               \
+               RCC_PLLCFGR_PLLM                                |               \
+               RCC_PLLCFGR_PLLN                                |               \
+               RCC_PLLCFGR_PLLP                                |               \
+               RCC_PLLCFGR_PLLQ                                |               \
+               RCC_PLLCFGR_PLLR),                                              \
+              ((uint32_t) (__PLLSOURCE__)                      |               \
+               (uint32_t) (__PLLM__)                           |               \
+               (uint32_t) ((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) |               \
+               (uint32_t) (__PLLP__)                           |               \
+               (uint32_t) (__PLLQ__)                           |               \
+               (uint32_t) (__PLLR__)))
 
 /** @brief  Macro to get the oscillator used as PLL clock source.
   * @retval The oscillator used as PLL clock source. The returned value can be one
@@ -3098,7 +3155,8 @@ typedef struct
   * @brief  Get clock output enable status (RCC_PLL_SYSCLK, RCC_PLL_USBCLK, RCC_PLL_SAI1CLK)
   * @param  __PLLCLOCKOUT__  specifies the output PLL clock to be checked.
   *          This parameter can be one of the following values:
-  *            @arg @ref RCC_PLL_SAI1CLK  This clock is used to generate an accurate clock to achieve high-quality audio performance on SAI interface
+  *            @arg @ref RCC_PLL_SAI1CLK  This clock is used to generate an accurate clock to achieve high-quality
+  *                                       audio performance on SAI interface
   *            @arg @ref RCC_PLL_ADCCLK  same
   *            @arg @ref RCC_PLL_USBCLK  This Clock is used to generate the clock for the USB FS (48 MHz)
   *            @arg @ref RCC_PLL_RNGCLK  same
@@ -3163,7 +3221,7 @@ typedef struct
   *            @arg @ref RCC_MCO1SOURCE_SYSCLK  System  clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_MSI     MSI clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_HSI     HSI clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_HSE     HSE clock selected as MCO sourcee
+  *            @arg @ref RCC_MCO1SOURCE_HSE     HSE clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_PLLCLK  Main PLL clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_LSI1    LSI1 clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_LSI2    LSI2 clock selected as MCO source
@@ -3302,11 +3360,11 @@ typedef struct
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
 #define __HAL_RCC_GET_FLAG(__FLAG__) (((((((__FLAG__) >> 5U) == CR_REG_INDEX) ? RCC->CR :                     \
-                                        ((((__FLAG__) >> 5U) == CRRCR_REG_INDEX) ? RCC->CRRCR :                  \
-                                        ((((__FLAG__) >> 5U) == BDCR_REG_INDEX) ? RCC->BDCR :                   \
-                                        ((((__FLAG__) >> 5U) == CSR_REG_INDEX) ? RCC->CSR : RCC->CIFR)))) &    \
+                                         ((((__FLAG__) >> 5U) == CRRCR_REG_INDEX) ? RCC->CRRCR :                  \
+                                          ((((__FLAG__) >> 5U) == BDCR_REG_INDEX) ? RCC->BDCR :                   \
+                                           ((((__FLAG__) >> 5U) == CSR_REG_INDEX) ? RCC->CSR : RCC->CIFR)))) &    \
                                         (1U << ((__FLAG__) & RCC_FLAG_MASK))) != RESET) \
-                                         ? 1U : 0U)
+                                      ? 1U : 0U)
 
 /**
   * @}
@@ -3361,6 +3419,7 @@ void              HAL_RCC_NMI_IRQHandler(void);
 /* User Callbacks in non blocking mode (IT mode) */
 void              HAL_RCC_CSSCallback(void);
 
+uint32_t          HAL_RCC_GetResetSource(void);
 /**
   * @}
   */
@@ -3382,6 +3441,3 @@ void              HAL_RCC_CSSCallback(void);
 #endif
 
 #endif /* STM32WBxx_HAL_RCC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rcc_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rcc_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -43,17 +42,36 @@ extern "C" {
   * @{
   */
 /* CRS IT Error Mask */
-#define  RCC_CRS_IT_ERROR_MASK                 ((uint32_t)(RCC_CRS_IT_TRIMOVF | RCC_CRS_IT_SYNCERR | RCC_CRS_IT_SYNCMISS))
+#define  RCC_CRS_IT_ERROR_MASK                 ((uint32_t)(RCC_CRS_IT_TRIMOVF |\
+                                                           RCC_CRS_IT_SYNCERR | RCC_CRS_IT_SYNCMISS))
 
 /* CRS Flag Error Mask */
-#define RCC_CRS_FLAG_ERROR_MASK                ((uint32_t)(RCC_CRS_FLAG_TRIMOVF | RCC_CRS_FLAG_SYNCERR | RCC_CRS_FLAG_SYNCMISS))
+#define RCC_CRS_FLAG_ERROR_MASK                ((uint32_t)(RCC_CRS_FLAG_TRIMOVF |\
+                                                           RCC_CRS_FLAG_SYNCERR | RCC_CRS_FLAG_SYNCMISS))
 
 /* RNG closk selection CLK48 clock mask */
 #define CLK48_MASK   0x10000000U
+
+/* Define used for IS_RCC_* macros below */
+#if defined(LPUART1) && defined(I2C3) && defined(SAI1) && defined(USB) && defined(RCC_SMPS_SUPPORT)
+#define RCC_PERIPHCLOCK_ALL             (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_I2C1 | \
+                                         RCC_PERIPHCLK_I2C3 | RCC_PERIPHCLK_LPTIM1 | RCC_PERIPHCLK_LPTIM2 | \
+                                         RCC_PERIPHCLK_SAI1 | RCC_PERIPHCLK_USB | RCC_PERIPHCLK_RNG | \
+                                         RCC_PERIPHCLK_ADC | RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_RFWAKEUP | \
+                                         RCC_PERIPHCLK_SMPS)
+#elif defined(LPUART1)
+#define RCC_PERIPHCLOCK_ALL             (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_LPUART1 | RCC_PERIPHCLK_I2C1 | \
+                                         RCC_PERIPHCLK_LPTIM1 | RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_RNG | \
+                                         RCC_PERIPHCLK_ADC | RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_RFWAKEUP)
+#else
+#define RCC_PERIPHCLOCK_ALL             (RCC_PERIPHCLK_USART1 | RCC_PERIPHCLK_I2C1 | RCC_PERIPHCLK_LPTIM1 | \
+                                         RCC_PERIPHCLK_LPTIM2 | RCC_PERIPHCLK_RNG | RCC_PERIPHCLK_ADC | \
+                                         RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_RFWAKEUP)
+#endif /* LPUART1 */
+
 /**
   * @}
   */
-
 
 /* Private macros ------------------------------------------------------------*/
 /** @addtogroup RCCEx_Private_Macros
@@ -66,157 +84,139 @@ extern "C" {
 #else
 #define IS_RCC_LSCO(__LSCOX__) (((__LSCOX__) == RCC_LSCO1) || \
                                 ((__LSCOX__) == RCC_LSCO2))
-#endif
+#endif /* RCC_LSCO3_SUPPORT */
 
 #define IS_RCC_LSCOSOURCE(__SOURCE__) (((__SOURCE__) == RCC_LSCOSOURCE_LSI) || \
                                        ((__SOURCE__) == RCC_LSCOSOURCE_LSE))
 
-#if defined(LPUART1) && defined(I2C3) && defined(SAI1) && defined(USB) && defined(RCC_SMPS_SUPPORT)
-#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
-               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)   == RCC_PERIPHCLK_USART1)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1)  == RCC_PERIPHCLK_LPUART1) || \
-                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)     == RCC_PERIPHCLK_I2C1)    || \
-                (((__SELECTION__) & RCC_PERIPHCLK_I2C3)     == RCC_PERIPHCLK_I2C3)    || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)   == RCC_PERIPHCLK_LPTIM1)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)   == RCC_PERIPHCLK_LPTIM2)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_SAI1)     == RCC_PERIPHCLK_SAI1)    || \
-                (((__SELECTION__) & RCC_PERIPHCLK_USB)      == RCC_PERIPHCLK_USB)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RNG)      == RCC_PERIPHCLK_RNG)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_ADC)      == RCC_PERIPHCLK_ADC)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RTC)      == RCC_PERIPHCLK_RTC)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RFWAKEUP) == RCC_PERIPHCLK_RFWAKEUP)|| \
-                (((__SELECTION__) & RCC_PERIPHCLK_SMPS)     == RCC_PERIPHCLK_SMPS))
-#elif defined(LPUART1)
-#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
-               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)   == RCC_PERIPHCLK_USART1)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPUART1)  == RCC_PERIPHCLK_LPUART1) || \
-                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)     == RCC_PERIPHCLK_I2C1)    || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)   == RCC_PERIPHCLK_LPTIM1)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)   == RCC_PERIPHCLK_LPTIM2)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RNG)      == RCC_PERIPHCLK_RNG)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_ADC)      == RCC_PERIPHCLK_ADC)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RTC)      == RCC_PERIPHCLK_RTC)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RFWAKEUP) == RCC_PERIPHCLK_RFWAKEUP))
-#else
-#define IS_RCC_PERIPHCLOCK(__SELECTION__)  \
-               ((((__SELECTION__) & RCC_PERIPHCLK_USART1)   == RCC_PERIPHCLK_USART1)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_I2C1)     == RCC_PERIPHCLK_I2C1)    || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM1)   == RCC_PERIPHCLK_LPTIM1)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_LPTIM2)   == RCC_PERIPHCLK_LPTIM2)  || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RNG)      == RCC_PERIPHCLK_RNG)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_ADC)      == RCC_PERIPHCLK_ADC)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RTC)      == RCC_PERIPHCLK_RTC)     || \
-                (((__SELECTION__) & RCC_PERIPHCLK_RFWAKEUP) == RCC_PERIPHCLK_RFWAKEUP))
-#endif
+#define IS_RCC_PERIPHCLOCK(__SELECTION__)   ((((__SELECTION__) & RCC_PERIPHCLOCK_ALL) != 0x00u) && \
+                                             (((__SELECTION__) & ~RCC_PERIPHCLOCK_ALL) == 0x00u))
 
 #define IS_RCC_USART1CLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_USART1CLKSOURCE_PCLK2)  || \
-                ((__SOURCE__) == RCC_USART1CLKSOURCE_SYSCLK) || \
-                ((__SOURCE__) == RCC_USART1CLKSOURCE_LSE)    || \
-                ((__SOURCE__) == RCC_USART1CLKSOURCE_HSI))
+  (((__SOURCE__) == RCC_USART1CLKSOURCE_PCLK2)  || \
+   ((__SOURCE__) == RCC_USART1CLKSOURCE_SYSCLK) || \
+   ((__SOURCE__) == RCC_USART1CLKSOURCE_LSE)    || \
+   ((__SOURCE__) == RCC_USART1CLKSOURCE_HSI))
 
 #if defined(LPUART1)
 #define IS_RCC_LPUART1CLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_LPUART1CLKSOURCE_PCLK1)  || \
-                ((__SOURCE__) == RCC_LPUART1CLKSOURCE_SYSCLK) || \
-                ((__SOURCE__) == RCC_LPUART1CLKSOURCE_LSE)    || \
-                ((__SOURCE__) == RCC_LPUART1CLKSOURCE_HSI))
-#endif
+  (((__SOURCE__) == RCC_LPUART1CLKSOURCE_PCLK1)  || \
+   ((__SOURCE__) == RCC_LPUART1CLKSOURCE_SYSCLK) || \
+   ((__SOURCE__) == RCC_LPUART1CLKSOURCE_LSE)    || \
+   ((__SOURCE__) == RCC_LPUART1CLKSOURCE_HSI))
+#endif /* LPUART1 */
 
 #define IS_RCC_I2C1CLKSOURCE(__SOURCE__)   \
-               (((__SOURCE__) == RCC_I2C1CLKSOURCE_PCLK1) || \
-                ((__SOURCE__) == RCC_I2C1CLKSOURCE_SYSCLK)|| \
-                ((__SOURCE__) == RCC_I2C1CLKSOURCE_HSI))
+  (((__SOURCE__) == RCC_I2C1CLKSOURCE_PCLK1) || \
+   ((__SOURCE__) == RCC_I2C1CLKSOURCE_SYSCLK)|| \
+   ((__SOURCE__) == RCC_I2C1CLKSOURCE_HSI))
 
 #if defined(I2C3)
 #define IS_RCC_I2C3CLKSOURCE(__SOURCE__)   \
-               (((__SOURCE__) == RCC_I2C3CLKSOURCE_PCLK1) || \
-                ((__SOURCE__) == RCC_I2C3CLKSOURCE_SYSCLK)|| \
-                ((__SOURCE__) == RCC_I2C3CLKSOURCE_HSI))
-#endif
+  (((__SOURCE__) == RCC_I2C3CLKSOURCE_PCLK1) || \
+   ((__SOURCE__) == RCC_I2C3CLKSOURCE_SYSCLK)|| \
+   ((__SOURCE__) == RCC_I2C3CLKSOURCE_HSI))
+#endif /* I2C3 */
 
 #if defined(SAI1)
 #define IS_RCC_SAI1CLK(__SOURCE__)                             \
-               (((__SOURCE__) == RCC_SAI1CLKSOURCE_PLLSAI1) || \
-                ((__SOURCE__) == RCC_SAI1CLKSOURCE_PLL)     || \
-                ((__SOURCE__) == RCC_SAI1CLKSOURCE_HSI)     || \
-                ((__SOURCE__) == RCC_SAI1CLKSOURCE_PIN))
-#endif
+  (((__SOURCE__) == RCC_SAI1CLKSOURCE_PLLSAI1) || \
+   ((__SOURCE__) == RCC_SAI1CLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_SAI1CLKSOURCE_HSI)     || \
+   ((__SOURCE__) == RCC_SAI1CLKSOURCE_PIN))
+#endif /* SAI1 */
 
 #define IS_RCC_LPTIM1CLK(__SOURCE__)  \
-               (((__SOURCE__) == RCC_LPTIM1CLKSOURCE_PCLK1) || \
-                ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSI)  || \
-                ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_HSI)  || \
-                ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSE))
+  (((__SOURCE__) == RCC_LPTIM1CLKSOURCE_PCLK1) || \
+   ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSI)  || \
+   ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_HSI)  || \
+   ((__SOURCE__) == RCC_LPTIM1CLKSOURCE_LSE))
 
 #define IS_RCC_LPTIM2CLK(__SOURCE__)  \
-               (((__SOURCE__) == RCC_LPTIM2CLKSOURCE_PCLK1) || \
-                ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSI)  || \
-                ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_HSI)  || \
-                ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSE))
+  (((__SOURCE__) == RCC_LPTIM2CLKSOURCE_PCLK1) || \
+   ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSI)  || \
+   ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_HSI)  || \
+   ((__SOURCE__) == RCC_LPTIM2CLKSOURCE_LSE))
 
 #if defined(RCC_HSI48_SUPPORT)
+#if defined(SAI1)
 #define IS_RCC_RNGCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_RNGCLKSOURCE_HSI48)   || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_PLL)     || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_MSI)     || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_CLK48)   || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_LSI)     || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_LSE))
-#else
+  (((__SOURCE__) == RCC_RNGCLKSOURCE_HSI48)   || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_MSI)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_PLLSAI1) || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_CLK48)   || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_LSI)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_LSE))
+#else /* SAI1 */
 #define IS_RCC_RNGCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_RNGCLKSOURCE_PLL)     || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_MSI)     || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_CLK48)   || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_LSI)     || \
-                ((__SOURCE__) == RCC_RNGCLKSOURCE_LSE))
-#endif
+  (((__SOURCE__) == RCC_RNGCLKSOURCE_HSI48)   || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_MSI)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_CLK48)   || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_LSI)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_LSE))
+#endif /* SAI1 */
+#else /* RCC_HSI48_SUPPORT */
+#define IS_RCC_RNGCLKSOURCE(__SOURCE__)  \
+  (((__SOURCE__) == RCC_RNGCLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_MSI)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_CLK48)   || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_LSI)     || \
+   ((__SOURCE__) == RCC_RNGCLKSOURCE_LSE))
+#endif /* RCC_HSI48_SUPPORT */
 
 #if defined(USB)
 #if defined(SAI1)
 #define IS_RCC_USBCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_USBCLKSOURCE_HSI48)   || \
-                ((__SOURCE__) == RCC_USBCLKSOURCE_PLLSAI1) || \
-                ((__SOURCE__) == RCC_USBCLKSOURCE_PLL)     || \
-                ((__SOURCE__) == RCC_USBCLKSOURCE_MSI))
+  (((__SOURCE__) == RCC_USBCLKSOURCE_HSI48)   || \
+   ((__SOURCE__) == RCC_USBCLKSOURCE_PLLSAI1) || \
+   ((__SOURCE__) == RCC_USBCLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_USBCLKSOURCE_MSI))
 #else
 #define IS_RCC_USBCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_USBCLKSOURCE_HSI48)   || \
-                ((__SOURCE__) == RCC_USBCLKSOURCE_PLL)     || \
-                ((__SOURCE__) == RCC_USBCLKSOURCE_MSI))
-#endif
-#endif
+  (((__SOURCE__) == RCC_USBCLKSOURCE_HSI48)   || \
+   ((__SOURCE__) == RCC_USBCLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_USBCLKSOURCE_MSI))
+#endif /* SAI1 */
+#endif /* USB */
 
 #if defined(STM32WB55xx) || defined (STM32WB5Mxx) || defined(STM32WB35xx)
 #define IS_RCC_ADCCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_ADCCLKSOURCE_NONE)    || \
-                ((__SOURCE__) == RCC_ADCCLKSOURCE_PLL)     || \
-                ((__SOURCE__) == RCC_ADCCLKSOURCE_PLLSAI1) || \
-                ((__SOURCE__) == RCC_ADCCLKSOURCE_SYSCLK))
+  (((__SOURCE__) == RCC_ADCCLKSOURCE_NONE)    || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_PLL)     || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_PLLSAI1) || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_SYSCLK))
+#elif defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#define IS_RCC_ADCCLKSOURCE(__SOURCE__)  \
+  (((__SOURCE__) == RCC_ADCCLKSOURCE_NONE) || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_PLL)  || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_HSI)  || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_SYSCLK))
 #else
 #define IS_RCC_ADCCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_ADCCLKSOURCE_NONE) || \
-                ((__SOURCE__) == RCC_ADCCLKSOURCE_PLL)  || \
-                ((__SOURCE__) == RCC_ADCCLKSOURCE_SYSCLK))
-#endif
+  (((__SOURCE__) == RCC_ADCCLKSOURCE_NONE) || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_PLL)  || \
+   ((__SOURCE__) == RCC_ADCCLKSOURCE_SYSCLK))
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 
 #define IS_RCC_RFWKPCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_RFWKPCLKSOURCE_NONE) || \
-                ((__SOURCE__) == RCC_RFWKPCLKSOURCE_LSE) || \
-                ((__SOURCE__) == RCC_RFWKPCLKSOURCE_HSE_DIV1024))
+  (((__SOURCE__) == RCC_RFWKPCLKSOURCE_NONE) || \
+   ((__SOURCE__) == RCC_RFWKPCLKSOURCE_LSE) || \
+   ((__SOURCE__) == RCC_RFWKPCLKSOURCE_HSE_DIV1024))
 
 #if defined(RCC_SMPS_SUPPORT)
 #define IS_RCC_SMPSCLKDIV(__DIV__)  \
-               (((__DIV__) == RCC_SMPSCLKDIV_RANGE0) || \
-                ((__DIV__) == RCC_SMPSCLKDIV_RANGE1) || \
-                ((__DIV__) == RCC_SMPSCLKDIV_RANGE2) || \
-                ((__DIV__) == RCC_SMPSCLKDIV_RANGE3))
+  (((__DIV__) == RCC_SMPSCLKDIV_RANGE0) || \
+   ((__DIV__) == RCC_SMPSCLKDIV_RANGE1) || \
+   ((__DIV__) == RCC_SMPSCLKDIV_RANGE2) || \
+   ((__DIV__) == RCC_SMPSCLKDIV_RANGE3))
 
 #define IS_RCC_SMPSCLKSOURCE(__SOURCE__)  \
-               (((__SOURCE__) == RCC_SMPSCLKSOURCE_HSI)    || \
-                ((__SOURCE__) == RCC_SMPSCLKSOURCE_MSI)    || \
-                ((__SOURCE__) == RCC_SMPSCLKSOURCE_HSE))
-#endif
+  (((__SOURCE__) == RCC_SMPSCLKSOURCE_HSI)    || \
+   ((__SOURCE__) == RCC_SMPSCLKSOURCE_MSI)    || \
+   ((__SOURCE__) == RCC_SMPSCLKSOURCE_HSE))
+#endif /* RCC_SMPS_SUPPORT */
 
 
 #if defined(SAI1)
@@ -227,7 +227,7 @@ extern "C" {
 #define IS_RCC_PLLSAI1Q_VALUE(__VALUE__)   ((RCC_PLLQ_DIV2 <= (__VALUE__)) && ((__VALUE__) <= RCC_PLLQ_DIV8))
 
 #define IS_RCC_PLLSAI1R_VALUE(__VALUE__)   ((RCC_PLLR_DIV2 <= (__VALUE__)) && ((__VALUE__) <= RCC_PLLR_DIV8))
-#endif
+#endif /* SAI1 */
 
 #define IS_RCC_TRIMOSC(__VALUE__)          ((__VALUE__) == RCC_OSCILLATORTYPE_LSI2)
 
@@ -252,7 +252,7 @@ extern "C" {
 
 #define IS_RCC_CRS_FREQERRORDIR(__DIR__)   (((__DIR__) == RCC_CRS_FREQERRORDIR_UP) || \
                                             ((__DIR__) == RCC_CRS_FREQERRORDIR_DOWN))
-#endif
+#endif /* CRS */
 /**
   * @}
   */
@@ -285,7 +285,7 @@ typedef struct
   uint32_t PLLSAI1ClockOut;  /*!< PLLSAI1ClockOut: specifies PLLSAI1 output clock to be enabled.
                                   This parameter must be a value of @ref RCC_PLLSAI1_Clock_Output */
 } RCC_PLLSAI1InitTypeDef;
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  RCC extended clocks structure definition
@@ -299,7 +299,7 @@ typedef struct
   RCC_PLLSAI1InitTypeDef PLLSAI1;  /*!< PLLSAI1 structure parameters.
                                         This parameter will be used only when PLLSAI1 is selected as Clock
                                         Source for SAI, USB/RNG or ADC */
-#endif
+#endif /* SAI1 */
 
   uint32_t Usart1ClockSelection;   /*!< Specifies USART1 clock source.
                                         This parameter can be a value of @ref RCCEx_USART1_Clock_Source */
@@ -307,7 +307,7 @@ typedef struct
 #if defined(LPUART1)
   uint32_t Lpuart1ClockSelection;  /*!< Specifies LPUART1 clock source.
                                         This parameter can be a value of @ref RCCEx_LPUART1_Clock_Source */
-#endif
+#endif /* LPUART1 */
 
   uint32_t I2c1ClockSelection;     /*!< Specifies I2C1 clock source.
                                         This parameter can be a value of @ref RCCEx_I2C1_Clock_Source */
@@ -315,7 +315,7 @@ typedef struct
 #if defined(I2C3)
   uint32_t I2c3ClockSelection;     /*!< Specifies I2C3 clock source.
                                         This parameter can be a value of @ref RCCEx_I2C3_Clock_Source */
-#endif
+#endif /* I2C3 */
 
   uint32_t Lptim1ClockSelection;   /*!< Specifies LPTIM1 clock source.
                                         This parameter can be a value of @ref RCCEx_LPTIM1_Clock_Source */
@@ -326,12 +326,12 @@ typedef struct
 #if defined(SAI1)
   uint32_t Sai1ClockSelection;     /*!< Specifies SAI1 clock source.
                                         This parameter can be a value of @ref RCCEx_SAI1_Clock_Source */
-#endif
+#endif /* SAI1 */
 
 #if defined(USB)
   uint32_t UsbClockSelection;      /*!< Specifies USB clock source (warning: same source for RNG).
                                         This parameter can be a value of @ref RCCEx_USB_Clock_Source */
-#endif
+#endif /* USB */
 
   uint32_t RngClockSelection;      /*!< Specifies RNG clock source (warning: same source for USB).
                                         This parameter can be a value of @ref RCCEx_RNG_Clock_Source */
@@ -352,7 +352,7 @@ typedef struct
 
   uint32_t SmpsDivSelection;       /*!< Specifies SMPS clock division factor.
                                         This parameter can be a value of @ref RCCEx_SMPS_Clock_Divider */
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 } RCC_PeriphCLKInitTypeDef;
 
@@ -405,7 +405,7 @@ typedef struct
                                        This parameter must be a value of @ref RCCEx_CRS_FreqErrorDirection*/
 
 } RCC_CRSSynchroInfoTypeDef;
-#endif
+#endif /* CRS */
 
 /**
   * @}
@@ -423,7 +423,7 @@ typedef struct
 #define RCC_LSCO2                       0x00000001U          /*!< LSCO2 index */
 #if defined(RCC_LSCO3_SUPPORT)
 #define RCC_LSCO3                       0x00000002U          /*!< LSCO3 index */
-#endif
+#endif /* RCC_LSCO3_SUPPORT */
 /**
   * @}
   */
@@ -444,27 +444,27 @@ typedef struct
 #define RCC_PERIPHCLK_USART1           0x00000001U                    /*!< USART1 Peripheral Clock Selection      */
 #if defined(LPUART1)
 #define RCC_PERIPHCLK_LPUART1          0x00000002U                    /*!< LPUART1 Peripheral Clock Selection     */
-#endif
+#endif /* LPUART1 */
 #define RCC_PERIPHCLK_I2C1             0x00000004U                    /*!< I2C1 Peripheral Clock Selection        */
 #if defined(I2C3)
 #define RCC_PERIPHCLK_I2C3             0x00000008U                    /*!< I2C3 Peripheral Clock Selection        */
-#endif
+#endif /* I2C3 */
 #define RCC_PERIPHCLK_LPTIM1           0x00000010U                    /*!< LPTIM1 Peripheral Clock Selection      */
 #define RCC_PERIPHCLK_LPTIM2           0x00000020U                    /*!< LPTIM2 Peripheral Clock Selection      */
 #if defined(SAI1)
 #define RCC_PERIPHCLK_SAI1             0x00000040U                    /*!< SAI1 Peripheral Clock Selection        */
-#endif
+#endif /* SAI1 */
 #define RCC_PERIPHCLK_CLK48SEL         0x00000100U                    /*!< 48 MHz clock source selection          */
 #if defined(USB)
 #define RCC_PERIPHCLK_USB              RCC_PERIPHCLK_CLK48SEL         /*!< USB Peripheral Clock Selection         */
-#endif
+#endif /* USB */
 #define RCC_PERIPHCLK_RNG              0x00000200U                    /*!< RNG Peripheral Clock Selection         */
 #define RCC_PERIPHCLK_ADC              0x00000400U                    /*!< ADC Peripheral Clock Selection         */
 #define RCC_PERIPHCLK_RTC              0x00000800U                    /*!< RTC Peripheral Clock Selection         */
 #define RCC_PERIPHCLK_RFWAKEUP         0x00001000U                    /*!< RF Wakeup Peripheral Clock Selection   */
 #if defined(RCC_SMPS_SUPPORT)
 #define RCC_PERIPHCLK_SMPS             0x00002000U                    /*!< SMPS Peripheral Clock Selection         */
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 /**
   * @}
   */
@@ -491,7 +491,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* LPUART1 */
 
 /** @defgroup RCCEx_I2C1_Clock_Source I2C1 Clock Source
   * @{
@@ -513,7 +513,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* I2C3 */
 
 #if defined(SAI1)
 /** @defgroup RCCEx_SAI1_Clock_Source SAI1 Clock Source
@@ -526,7 +526,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* SAI1 */
 
 /** @defgroup RCCEx_LPTIM1_Clock_Source LPTIM1 Clock Source
   * @{
@@ -556,6 +556,9 @@ typedef struct
 #define RCC_RNGCLKSOURCE_HSI48         (CLK48_MASK | LL_RCC_CLK48_CLKSOURCE_HSI48)  /*!< HSI48 clock divided by 3 selected as RNG clock    */
 #define RCC_RNGCLKSOURCE_PLL           (CLK48_MASK | LL_RCC_CLK48_CLKSOURCE_PLL)    /*!< PLL "Q" clock divided by 3  selected as RNG clock */
 #define RCC_RNGCLKSOURCE_MSI           (CLK48_MASK | LL_RCC_CLK48_CLKSOURCE_MSI)    /*!< MSI clock divided by 3 selected as RNG clock      */
+#if defined(SAI1)
+#define RCC_RNGCLKSOURCE_PLLSAI1       (CLK48_MASK | LL_RCC_CLK48_CLKSOURCE_PLLSAI1)    /*!< PLLSAI1 "Q" clock selected as RNG clock           */
+#endif /* SAI1 */
 #define RCC_RNGCLKSOURCE_CLK48         LL_RCC_RNG_CLKSOURCE_CLK48                   /*!< CLK48 divided by 3 selected as RNG Clock          */
 #define RCC_RNGCLKSOURCE_LSI           LL_RCC_RNG_CLKSOURCE_LSI                     /*!< LSI clock selected as RNG clock                   */
 #define RCC_RNGCLKSOURCE_LSE           LL_RCC_RNG_CLKSOURCE_LSE                     /*!< LSE clock selected as RNG clock                   */
@@ -570,13 +573,13 @@ typedef struct
 #define RCC_USBCLKSOURCE_HSI48         LL_RCC_USB_CLKSOURCE_HSI48     /*!< HSI48 clock selected as USB clock       */
 #if defined(SAI1)
 #define RCC_USBCLKSOURCE_PLLSAI1       LL_RCC_USB_CLKSOURCE_PLLSAI1   /*!< PLLSAI1 "Q" clock selected as USB clock */
-#endif
+#endif /* SAI1 */
 #define RCC_USBCLKSOURCE_PLL           LL_RCC_USB_CLKSOURCE_PLL       /*!< PLL "Q" clock selected as USB clock     */
 #define RCC_USBCLKSOURCE_MSI           LL_RCC_USB_CLKSOURCE_MSI       /*!< MSI clock selected as USB clock         */
 /**
   * @}
   */
-#endif
+#endif /* USB */
 
 /** @defgroup RCCEx_ADC_Clock_Source ADC Clock Source
   * @{
@@ -585,7 +588,9 @@ typedef struct
 #define RCC_ADCCLKSOURCE_NONE          LL_RCC_ADC_CLKSOURCE_NONE      /*!< None clock selected as ADC clock        */
 #if defined(STM32WB55xx) || defined (STM32WB5Mxx) || defined(STM32WB35xx)
 #define RCC_ADCCLKSOURCE_PLLSAI1       LL_RCC_ADC_CLKSOURCE_PLLSAI1   /*!< PLLSAI1 "R" clock selected as ADC clock */
-#endif
+#elif defined (STM32WB15xx) || defined(STM32WB1Mxx)
+#define RCC_ADCCLKSOURCE_HSI           LL_RCC_ADC_CLKSOURCE_HSI       /*!< HSI clock selected as ADC clock */
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define RCC_ADCCLKSOURCE_PLL           LL_RCC_ADC_CLKSOURCE_PLL       /*!< PLL "P" clock selected as ADC clock     */
 #define RCC_ADCCLKSOURCE_SYSCLK        LL_RCC_ADC_CLKSOURCE_SYSCLK    /*!< SYSCLK clock selected as ADC clock      */
 
@@ -610,6 +615,9 @@ typedef struct
 
 #define RCC_RFWKPCLKSOURCE_NONE          LL_RCC_RFWKP_CLKSOURCE_NONE        /*!< None clock selected as RF system wakeup clock                */
 #define RCC_RFWKPCLKSOURCE_LSE           LL_RCC_RFWKP_CLKSOURCE_LSE         /*!< LSE clock selected as RF system wakeup clock                 */
+#if defined(STM32WB15xx) || defined(STM32WB10xx)
+#define RCC_RFWKPCLKSOURCE_LSI           LL_RCC_RFWKP_CLKSOURCE_LSI         /*!< LSI clock selected as RF system wakeup clock                 */
+#endif /* STM32WB15xx || STM32WB10xx */
 #define RCC_RFWKPCLKSOURCE_HSE_DIV1024   LL_RCC_RFWKP_CLKSOURCE_HSE_DIV1024 /*!< HSE clock divided by 1024 selected as RF system wakeup clock */
 
 /**
@@ -648,7 +656,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 
 /** @defgroup RCCEx_EXTI_LINE_LSECSS  RCC LSE CSS external interrupt line
@@ -775,7 +783,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* CRS */
 
 /**
   * @}
@@ -783,8 +791,8 @@ typedef struct
 
 /* Exported macros -----------------------------------------------------------*/
 /** @defgroup RCCEx_Exported_Macros RCCEx Exported Macros
- * @{
- */
+  * @{
+  */
 
 /*================================================================================================================*/
 
@@ -817,9 +825,9 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_PLLSAI1_CONFIG(__PLLN__, __PLLP__, __PLLQ__, __PLLR__) \
-                  MODIFY_REG(RCC->PLLSAI1CFGR, \
-                             (RCC_PLLSAI1CFGR_PLLN | RCC_PLLSAI1CFGR_PLLP | RCC_PLLSAI1CFGR_PLLQ | RCC_PLLSAI1CFGR_PLLR), \
-                             (((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) | (__PLLP__) | (__PLLQ__) | (__PLLR__)))
+  MODIFY_REG(RCC->PLLSAI1CFGR, \
+             (RCC_PLLSAI1CFGR_PLLN | RCC_PLLSAI1CFGR_PLLP | RCC_PLLSAI1CFGR_PLLQ | RCC_PLLSAI1CFGR_PLLR), \
+             (((__PLLN__) << RCC_PLLCFGR_PLLN_Pos) | (__PLLP__) | (__PLLQ__) | (__PLLR__)))
 
 /**
   * @brief  Macro to configure the PLLSAI1 clock multiplication factor N.
@@ -837,7 +845,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_PLLSAI1_MULN_CONFIG(__PLLN__) \
-                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLN, (__PLLN__) << RCC_PLLSAI1CFGR_PLLN_Pos)
+  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLN, (__PLLN__) << RCC_PLLSAI1CFGR_PLLN_Pos)
 
 
 /** @brief  Macro to configure the PLLSAI1 clock division factor P.
@@ -853,7 +861,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_PLLSAI1_DIVP_CONFIG(__PLLP__) \
-                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLP, (__PLLP__))
+  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLP, (__PLLP__))
 
 
 /** @brief  Macro to configure the PLLSAI1 clock division factor Q.
@@ -869,7 +877,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_PLLSAI1_DIVQ_CONFIG(__PLLQ__) \
-                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLQ, (__PLLQ__))
+  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLQ, (__PLLQ__))
 
 /** @brief  Macro to configure the PLLSAI1 clock division factor R.
   *
@@ -884,7 +892,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_PLLSAI1_DIVR_CONFIG(__PLLR__) \
-                  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLR, (__PLLR__))
+  MODIFY_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLR, (__PLLR__))
 
 /**
   * @brief  Macros to enable the PLLSAI1.
@@ -965,7 +973,7 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_GET_SAI1_SOURCE()  LL_RCC_GetSAIClockSource(LL_RCC_SAI1_CLKSOURCE)
-#endif
+#endif /* SAI1 */
 
 /** @brief  Macro to configure the I2C1 clock (I2C1CLK).
   *
@@ -1005,7 +1013,7 @@ typedef struct
   *            @arg @ref RCC_I2C3CLKSOURCE_SYSCLK  System Clock selected as I2C3 clock
   */
 #define __HAL_RCC_GET_I2C3_SOURCE() LL_RCC_GetI2CClockSource(LL_RCC_I2C3_CLKSOURCE)
-#endif
+#endif /* I2C3 */
 
 /** @brief  Macro to configure the USART1 clock (USART1CLK).
   *
@@ -1049,7 +1057,7 @@ typedef struct
   *            @arg @ref RCC_LPUART1CLKSOURCE_LSE     LSE selected as LPUART1 clock
   */
 #define __HAL_RCC_GET_LPUART1_SOURCE() LL_RCC_GetLPUARTClockSource(LL_RCC_LPUART1_CLKSOURCE)
-#endif
+#endif /* LPUART1 */
 
 /** @brief  Macro to configure the LPTIM1 clock (LPTIM1CLK).
   *
@@ -1103,24 +1111,28 @@ typedef struct
   *            @arg @ref RCC_RNGCLKSOURCE_HSI48         HSI48 clock divided by 3  selected as RNG clock
   *            @arg @ref RCC_RNGCLKSOURCE_PLL           PLL "Q" clock divided by 3  selected as RNG clock
   *            @arg @ref RCC_RNGCLKSOURCE_MSI           MSI clock divided by 3 selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLLSAI1       PLLSAI1 "Q" clock selected as RNG (*)
   *            @arg @ref RCC_RNGCLKSOURCE_CLK48         CLK48 divided by 3 selected as RNG Clock  (default HSI48)
   *            @arg @ref RCC_RNGCLKSOURCE_LSI           LSI clock selected as RNG clock
   *            @arg @ref RCC_RNGCLKSOURCE_LSE           LSE clock selected as RNG clock
+  *
+  *         (*) Value not defined in all devices.
+  *
   * @retval None
   */
 #define __HAL_RCC_RNG_CONFIG(__RNG_CLKSOURCE__)          \
   do {                                                   \
     if (((__RNG_CLKSOURCE__) == RCC_RNGCLKSOURCE_LSI)    \
-     || ((__RNG_CLKSOURCE__) == RCC_RNGCLKSOURCE_LSE)       \
-     || ((__RNG_CLKSOURCE__) == RCC_RNGCLKSOURCE_CLK48))    \
+        || ((__RNG_CLKSOURCE__) == RCC_RNGCLKSOURCE_LSE)    \
+        || ((__RNG_CLKSOURCE__) == RCC_RNGCLKSOURCE_CLK48)) \
     {                                                    \
-     LL_RCC_SetRNGClockSource((__RNG_CLKSOURCE__));         \
+      LL_RCC_SetRNGClockSource((__RNG_CLKSOURCE__));     \
     }                                                    \
     else                                                 \
     {                                                    \
-      uint32_t tmp = (__RNG_CLKSOURCE__) &(~CLK48_MASK);   \
+      uint32_t tmp = (__RNG_CLKSOURCE__) &(~CLK48_MASK); \
       LL_RCC_SetRNGClockSource(RCC_RNGCLKSOURCE_CLK48);  \
-      LL_RCC_SetCLK48ClockSource(tmp);                      \
+      LL_RCC_SetCLK48ClockSource(tmp);                   \
     }                                                    \
   } while(0U)
 
@@ -1157,7 +1169,7 @@ typedef struct
   *            @arg @ref RCC_USBCLKSOURCE_PLL      PLL "Q" clock (PLL48M1CLK) selected as USB clock
   */
 #define __HAL_RCC_GET_USB_SOURCE()  LL_RCC_GetUSBClockSource(LL_RCC_USB_CLKSOURCE)
-#endif
+#endif /* USB */
 
 /** @brief  Macro to configure the ADC interface clock.
   * @param  __ADC_CLKSOURCE__ specifies the ADC digital interface clock source.
@@ -1188,7 +1200,10 @@ typedef struct
   *         This parameter can be one of the following values:
   *            @arg @ref RCC_RFWKPCLKSOURCE_NONE         No clock selected as RFWKP clock
   *            @arg @ref RCC_RFWKPCLKSOURCE_LSE          LSE Clock selected as RFWKP clock
+  *            @arg @ref RCC_RFWKPCLKSOURCE_LSI          LSI Clock selected as RFWKP clock (*)
   *            @arg @ref RCC_RFWKPCLKSOURCE_HSE_DIV1024  HSE div1024 Clock selected as RFWKP clock
+  * @note      (*) Value not defined for all devices
+  *
   * @retval None
   */
 #define __HAL_RCC_RFWAKEUP_CONFIG(__RFWKP_CLKSOURCE__)  LL_RCC_SetRFWKPClockSource(__RFWKP_CLKSOURCE__)
@@ -1197,7 +1212,9 @@ typedef struct
   *         This parameter can be one of the following values:
   *            @arg @ref RCC_RFWKPCLKSOURCE_NONE         No clock selected as RFWKP clock
   *            @arg @ref RCC_RFWKPCLKSOURCE_LSE          LSE Clock selected as RFWKP clock
+  *            @arg @ref RCC_RFWKPCLKSOURCE_LSI          LSI Clock selected as RFWKP clock (*)
   *            @arg @ref RCC_RFWKPCLKSOURCE_HSE_DIV1024  HSE div1024 Clock selected as RFWKP clock
+  * @note      (*) Value not defined for all devices
   */
 #define __HAL_RCC_GET_RFWAKEUP_SOURCE()  LL_RCC_GetRFWKPClockSource()
 
@@ -1254,7 +1271,7 @@ typedef struct
   *            @arg @ref RCC_SMPSCLKSOURCE_STATUS_HSE   HSE Clock selected as SMPS clock
   */
 #define __HAL_RCC_GET_SMPS_SOURCE_STATUS() LL_RCC_GetSMPSClockSource()
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 /** @defgroup RCCEx_Flags_Interrupts_Management Flags Interrupts Management
   * @brief macros to manage the specified RCC Flags and interrupts.
@@ -1287,7 +1304,7 @@ typedef struct
   * @retval TRUE or FALSE.
   */
 #define __HAL_RCC_PLLSAI1_GET_FLAG()  LL_RCC_PLLSAI1_IsReady()
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief Enable the RCC LSE CSS Extended Interrupt C1 Line.
@@ -1447,15 +1464,15 @@ typedef struct
   *              @arg @ref RCC_CRS_IT_SYNCMISS  SYNC missed interrupt
   */
 #define __HAL_RCC_CRS_CLEAR_IT(__INTERRUPT__)  do { \
-                                                 if(((__INTERRUPT__) & RCC_CRS_IT_ERROR_MASK) != RESET) \
-                                                 { \
-                                                   WRITE_REG(CRS->ICR, CRS_ICR_ERRC | ((__INTERRUPT__) & ~RCC_CRS_IT_ERROR_MASK)); \
-                                                 } \
-                                                 else \
-                                                 { \
-                                                   WRITE_REG(CRS->ICR, (__INTERRUPT__)); \
-                                                 } \
-                                               } while(0)
+                                                    if(((__INTERRUPT__) & RCC_CRS_IT_ERROR_MASK) != RESET) \
+                                                    { \
+                                                      WRITE_REG(CRS->ICR, CRS_ICR_ERRC | ((__INTERRUPT__) & ~RCC_CRS_IT_ERROR_MASK)); \
+                                                    } \
+                                                    else \
+                                                    { \
+                                                      WRITE_REG(CRS->ICR, (__INTERRUPT__)); \
+                                                    } \
+                                                  } while(0)
 
 /**
   * @brief  Check whether the specified CRS flag is set or not.
@@ -1487,16 +1504,16 @@ typedef struct
   * @retval None
   */
 #define __HAL_RCC_CRS_CLEAR_FLAG(__FLAG__)     do { \
-                                                 if(((__FLAG__) & RCC_CRS_FLAG_ERROR_MASK) != 0U) \
-                                                 { \
-                                                   WRITE_REG(CRS->ICR, CRS_ICR_ERRC | ((__FLAG__) & ~RCC_CRS_FLAG_ERROR_MASK)); \
-                                                 } \
-                                                 else \
-                                                 { \
-                                                   WRITE_REG(CRS->ICR, (__FLAG__)); \
-                                                 } \
-                                               } while(0)
-#endif
+                                                    if(((__FLAG__) & RCC_CRS_FLAG_ERROR_MASK) != 0U) \
+                                                    { \
+                                                      WRITE_REG(CRS->ICR, CRS_ICR_ERRC | ((__FLAG__) & ~RCC_CRS_FLAG_ERROR_MASK)); \
+                                                    } \
+                                                    else \
+                                                    { \
+                                                      WRITE_REG(CRS->ICR, (__FLAG__)); \
+                                                    } \
+                                                  } while(0)
+#endif /* CRS */
 /**
   * @}
   */
@@ -1520,14 +1537,14 @@ typedef struct
 #define __HAL_RCC_CRS_FREQ_ERROR_COUNTER_DISABLE() LL_CRS_DisableFreqErrorCounter()
 
 /**
-  * @brief  Enable the automatic hardware adjustement of TRIM bits.
+  * @brief  Enable the automatic hardware adjustment of TRIM bits.
   * @note   When the AUTOTRIMEN bit is set the CRS_CFGR register becomes write-protected.
   * @retval None
   */
 #define __HAL_RCC_CRS_AUTOMATIC_CALIB_ENABLE()     LL_CRS_EnableAutoTrimming()
 
 /**
-  * @brief  Enable or disable the automatic hardware adjustement of TRIM bits.
+  * @brief  Enable or disable the automatic hardware adjustment of TRIM bits.
   * @retval None
   */
 #define __HAL_RCC_CRS_AUTOMATIC_CALIB_DISABLE()    LL_CRS_DisableAutoTrimming()
@@ -1547,7 +1564,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* CRS */
 
 /**
   * @}
@@ -1578,7 +1595,7 @@ uint32_t          HAL_RCCEx_GetRngCLKSource(void);
 #if defined(SAI1)
 HAL_StatusTypeDef HAL_RCCEx_EnablePLLSAI1(RCC_PLLSAI1InitTypeDef  *PLLSAI1Init);
 HAL_StatusTypeDef HAL_RCCEx_DisablePLLSAI1(void);
-#endif
+#endif /* SAI1 */
 
 void              HAL_RCCEx_WakeUpStopCLKConfig(uint32_t WakeUpClk);
 
@@ -1622,7 +1639,7 @@ void              HAL_RCCEx_CRS_ErrorCallback(uint32_t Error);
   * @}
   */
 
-#endif
+#endif /* CRS */
 /**
   * @}
   */
@@ -1640,5 +1657,3 @@ void              HAL_RCCEx_CRS_ErrorCallback(uint32_t Error);
 #endif
 
 #endif /* STM32WBxx_HAL_RCC_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rng.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rng.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -81,7 +80,7 @@ typedef enum
 typedef struct  __RNG_HandleTypeDef
 #else
 typedef struct
-#endif /* (USE_HAL_RNG_REGISTER_CALLBACKS) */
+#endif /* USE_HAL_RNG_REGISTER_CALLBACKS */
 {
   RNG_TypeDef                 *Instance;    /*!< Register base address   */
 
@@ -91,7 +90,7 @@ typedef struct
 
   __IO HAL_RNG_StateTypeDef   State;        /*!< RNG communication state */
 
-  __IO  uint32_t              ErrorCode;     /*!< RNG Error code               */
+  __IO  uint32_t              ErrorCode;    /*!< RNG Error code          */
 
   uint32_t                    RandomNumber; /*!< Last Generated RNG Data */
 
@@ -171,14 +170,14 @@ typedef  void (*pRNG_ReadyDataCallbackTypeDef)(RNG_HandleTypeDef *hrng, uint32_t
 /** @defgroup RNG_Error_Definition   RNG Error Definition
   * @{
   */
-#define  HAL_RNG_ERROR_NONE             0x00000000U    /*!< No error             */
+#define  HAL_RNG_ERROR_NONE             0x00000000U    /*!< No error          */
 #if (USE_HAL_RNG_REGISTER_CALLBACKS == 1)
 #define  HAL_RNG_ERROR_INVALID_CALLBACK 0x00000001U    /*!< Invalid Callback error  */
 #endif /* USE_HAL_RNG_REGISTER_CALLBACKS */
-#define  HAL_RNG_ERROR_TIMEOUT          0x00000002U    /*!< Timeout error        */
+#define  HAL_RNG_ERROR_TIMEOUT          0x00000002U    /*!< Timeout error     */
 #define  HAL_RNG_ERROR_BUSY             0x00000004U    /*!< Busy error        */
 #define  HAL_RNG_ERROR_SEED             0x00000008U    /*!< Seed error        */
-#define  HAL_RNG_ERROR_CLOCK            0x00000010U   /*!< Clock error        */
+#define  HAL_RNG_ERROR_CLOCK            0x00000010U    /*!< Clock error       */
 /**
   * @}
   */
@@ -204,7 +203,7 @@ typedef  void (*pRNG_ReadyDataCallbackTypeDef)(RNG_HandleTypeDef *hrng, uint32_t
                                                     } while(0U)
 #else
 #define __HAL_RNG_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RNG_STATE_RESET)
-#endif /*USE_HAL_RNG_REGISTER_CALLBACKS */
+#endif /* USE_HAL_RNG_REGISTER_CALLBACKS */
 
 /**
   * @brief  Enables the RNG peripheral.
@@ -299,7 +298,8 @@ void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_RNG_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_RNG_RegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_CallbackIDTypeDef CallbackID, pRNG_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_RNG_RegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_CallbackIDTypeDef CallbackID,
+                                           pRNG_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_RNG_UnRegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_CallbackIDTypeDef CallbackID);
 
 HAL_StatusTypeDef HAL_RNG_RegisterReadyDataCallback(RNG_HandleTypeDef *hrng, pRNG_ReadyDataCallbackTypeDef pCallback);
@@ -315,7 +315,7 @@ HAL_StatusTypeDef HAL_RNG_UnRegisterReadyDataCallback(RNG_HandleTypeDef *hrng);
   */
 HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t *random32bit);
 HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng);
-uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng);
+uint32_t HAL_RNG_ReadLastRandomNumber(const RNG_HandleTypeDef *hrng);
 
 void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng);
 void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng);
@@ -328,8 +328,8 @@ void HAL_RNG_ReadyDataCallback(RNG_HandleTypeDef *hrng, uint32_t random32bit);
 /** @defgroup RNG_Exported_Functions_Group3 Peripheral State functions
   * @{
   */
-HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng);
-uint32_t             HAL_RNG_GetError(RNG_HandleTypeDef *hrng);
+HAL_RNG_StateTypeDef HAL_RNG_GetState(const RNG_HandleTypeDef *hrng);
+uint32_t             HAL_RNG_GetError(const RNG_HandleTypeDef *hrng);
 /**
   * @}
   */
@@ -346,8 +346,8 @@ uint32_t             HAL_RNG_GetError(RNG_HandleTypeDef *hrng);
                        ((IT) == RNG_IT_SEI))
 
 #define IS_RNG_FLAG(FLAG) (((FLAG) == RNG_FLAG_DRDY) || \
-                            ((FLAG) == RNG_FLAG_CECS) || \
-                            ((FLAG) == RNG_FLAG_SECS))
+                           ((FLAG) == RNG_FLAG_CECS) || \
+                           ((FLAG) == RNG_FLAG_SECS))
 
 /**
   * @brief Verify the RNG Clock Error Detection mode.
@@ -377,4 +377,3 @@ uint32_t             HAL_RNG_GetError(RNG_HandleTypeDef *hrng);
 
 #endif /* STM32WBxx_HAL_RNG_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rtc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rtc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,24 +21,23 @@
 #define STM32WBxx_HAL_RTC_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32wbxx_hal_def.h"
 
-/* Include low level driver */
-#include "stm32wbxx_ll_exti.h"
+#include "stm32wbxx_hal_def.h"
 
 /** @addtogroup STM32WBxx_HAL_Driver
   * @{
   */
 
-/** @defgroup RTC RTC
+/** @addtogroup RTC
   * @{
   */
 
 /* Exported types ------------------------------------------------------------*/
+
 /** @defgroup RTC_Exported_Types RTC Exported Types
   * @{
   */
@@ -54,8 +52,7 @@ typedef enum
   HAL_RTC_STATE_BUSY              = 0x02U,  /*!< RTC process is ongoing              */
   HAL_RTC_STATE_TIMEOUT           = 0x03U,  /*!< RTC timeout state                   */
   HAL_RTC_STATE_ERROR             = 0x04U   /*!< RTC error state                     */
-
-}HAL_RTCStateTypeDef;
+} HAL_RTCStateTypeDef;
 
 /**
   * @brief  RTC Configuration Structure definition
@@ -69,12 +66,12 @@ typedef struct
                                  This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F */
 
   uint32_t SynchPrediv;     /*!< Specifies the RTC Synchronous Predivider value.
-                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7FFF */
+                                 This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x7FFF */
 
   uint32_t OutPut;          /*!< Specifies which signal will be routed to the RTC output.
-                                 This parameter can be a value of @ref RTCEx_Output_selection_Definitions */
+                                 This parameter can be a value of @ref RTC_Output_selection_Definitions */
 
-  uint32_t OutPutRemap;    /*!< Specifies the remap for RTC output.
+  uint32_t OutPutRemap;     /*!< Specifies the remap for RTC output.
                                  This parameter can be a value of @ref  RTC_Output_ALARM_OUT_Remap */
 
   uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.
@@ -82,7 +79,7 @@ typedef struct
 
   uint32_t OutPutType;      /*!< Specifies the RTC Output Pin mode.
                                  This parameter can be a value of @ref RTC_Output_Type_ALARM_OUT */
-}RTC_InitTypeDef;
+} RTC_InitTypeDef;
 
 /**
   * @brief  RTC Time structure definition
@@ -90,7 +87,7 @@ typedef struct
 typedef struct
 {
   uint8_t Hours;            /*!< Specifies the RTC Time Hour.
-                                 This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the RTC_HourFormat_12 is selected.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the RTC_HourFormat_12 is selected
                                  This parameter must be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HourFormat_24 is selected */
 
   uint8_t Minutes;          /*!< Specifies the RTC Time Minutes.
@@ -102,23 +99,22 @@ typedef struct
   uint8_t TimeFormat;       /*!< Specifies the RTC AM/PM Time.
                                  This parameter can be a value of @ref RTC_AM_PM_Definitions */
 
-  uint32_t SubSeconds;     /*!< Specifies the RTC_SSR RTC Sub Second register content.
+  uint32_t SubSeconds;      /*!< Specifies the RTC_SSR RTC Sub Second register content.
                                  This parameter corresponds to a time unit range between [0-1] Second
                                  with [1 Sec / SecondFraction +1] granularity */
 
   uint32_t SecondFraction;  /*!< Specifies the range or granularity of Sub Second register content
-                                 corresponding to Synchronous pre-scaler factor value (PREDIV_S)
+                                 corresponding to Synchronous prescaler factor value (PREDIV_S)
                                  This parameter corresponds to a time unit range between [0-1] Second
                                  with [1 Sec / SecondFraction +1] granularity.
                                  This field will be used only by HAL_RTC_GetTime function */
 
-  uint32_t DayLightSaving;  /*!< Specifies RTC_DayLightSaveOperation: the value of hour adjustment.
-                                 This parameter can be a value of @ref RTC_DayLightSaving_Definitions */
+  uint32_t DayLightSaving;  /*!< This interface is deprecated. To manage Daylight
+                                 Saving Time, please use HAL_RTC_DST_xxx functions */
 
-  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit
-                                 in CR register to store the operation.
-                                 This parameter can be a value of @ref RTC_StoreOperation_Definitions */
-}RTC_TimeTypeDef;
+  uint32_t StoreOperation;  /*!< This interface is deprecated. To manage Daylight
+                                 Saving Time, please use HAL_RTC_DST_xxx functions */
+} RTC_TimeTypeDef;
 
 /**
   * @brief  RTC Date structure definition
@@ -137,7 +133,7 @@ typedef struct
   uint8_t Year;     /*!< Specifies the RTC Date Year.
                          This parameter must be a number between Min_Data = 0 and Max_Data = 99 */
 
-}RTC_DateTypeDef;
+} RTC_DateTypeDef;
 
 /**
   * @brief  RTC Alarm structure definition
@@ -153,7 +149,7 @@ typedef struct
                                       This parameter can be a value of @ref RTC_Alarm_Sub_Seconds_Masks_Definitions */
 
   uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on Date or WeekDay.
-                                     This parameter can be a value of @ref RTC_AlarmDateWeekDay_Definitions */
+                                      This parameter can be a value of @ref RTC_AlarmDateWeekDay_Definitions */
 
   uint8_t AlarmDateWeekDay;      /*!< Specifies the RTC Alarm Date/WeekDay.
                                       If the Alarm Date is selected, this parameter must be set to a value in the 1-31 range.
@@ -161,7 +157,7 @@ typedef struct
 
   uint32_t Alarm;                /*!< Specifies the alarm .
                                       This parameter can be a value of @ref RTC_Alarms_Definitions */
-}RTC_AlarmTypeDef;
+} RTC_AlarmTypeDef;
 
 /**
   * @brief  RTC Handle Structure definition
@@ -170,64 +166,68 @@ typedef struct
 typedef struct __RTC_HandleTypeDef
 #else
 typedef struct
-#endif
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 {
-  RTC_TypeDef               *Instance;  /*!< Register base address    */
+  RTC_TypeDef                 *Instance;  /*!< Register base address    */
 
-  RTC_InitTypeDef           Init;       /*!< RTC required parameters  */
+  RTC_InitTypeDef             Init;       /*!< RTC required parameters  */
 
-  HAL_LockTypeDef           Lock;       /*!< RTC locking object       */
+  HAL_LockTypeDef             Lock;       /*!< RTC locking object       */
 
-  __IO HAL_RTCStateTypeDef  State;      /*!< Time communication state */
+  __IO HAL_RTCStateTypeDef    State;      /*!< Time communication state */
 
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
-  void  (* AlarmAEventCallback)      ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC Alarm A Event callback         */
+  void (* AlarmAEventCallback)      (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Alarm A Event callback         */
 
-  void  (* AlarmBEventCallback)      ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC Alarm B Event callback         */
+  void (* AlarmBEventCallback)      (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Alarm B Event callback         */
 
-  void  (* TimeStampEventCallback)   ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC TimeStamp Event callback       */
+  void (* TimeStampEventCallback)   (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Timestamp Event callback       */
 
-  void  (* WakeUpTimerEventCallback) ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC WakeUpTimer Event callback     */
+  void (* WakeUpTimerEventCallback) (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC WakeUpTimer Event callback     */
 
-  void  (* Tamper1EventCallback)     ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC Tamper 1 Event callback        */
+#if defined(RTC_TAMPER1_SUPPORT)
+  void (* Tamper1EventCallback)     (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Tamper 1 Event callback        */
+#endif /* RTC_TAMPER1_SUPPORT */
 
-  void  (* Tamper2EventCallback)     ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC Tamper 2 Event callback        */
+  void (* Tamper2EventCallback)     (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Tamper 2 Event callback        */
 
-  void  (* Tamper3EventCallback)     ( struct __RTC_HandleTypeDef * hrtc);  /*!< RTC Tamper 3 Event callback        */
+#if defined(RTC_TAMPER3_SUPPORT)
+  void (* Tamper3EventCallback)     (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Tamper 3 Event callback        */
+#endif /* RTC_TAMPER3_SUPPORT */
 
-  void  (* MspInitCallback)         ( struct __RTC_HandleTypeDef * hrtc);   /*!< RTC Msp Init callback              */
+  void (* MspInitCallback)          (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Msp Init callback              */
 
-  void  (* MspDeInitCallback)       ( struct __RTC_HandleTypeDef * hrtc);   /*!< RTC Msp DeInit callback            */
+  void (* MspDeInitCallback)        (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Msp DeInit callback            */
 
-#endif /* (USE_HAL_RTC_REGISTER_CALLBACKS) */
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
-}RTC_HandleTypeDef;
+} RTC_HandleTypeDef;
 
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
 /**
-  * @brief  HAL LPTIM Callback ID enumeration definition
+  * @brief  HAL RTC Callback ID enumeration definition
   */
 typedef enum
 {
-  HAL_RTC_ALARM_A_EVENT_CB_ID           = 0x00U,    /*!< RTC Alarm A Event Callback ID      */
-  HAL_RTC_ALARM_B_EVENT_CB_ID           = 0x01U,    /*!< RTC Alarm B Event Callback ID      */
-  HAL_RTC_TIMESTAMP_EVENT_CB_ID         = 0x02U,    /*!< RTC TimeStamp Event Callback ID    */
-  HAL_RTC_WAKEUPTIMER_EVENT_CB_ID       = 0x03U,    /*!< RTC WakeUp Timer Event Callback ID */
+  HAL_RTC_ALARM_A_EVENT_CB_ID           = 0x00U,    /*!< RTC Alarm A Event Callback ID       */
+  HAL_RTC_ALARM_B_EVENT_CB_ID           = 0x01U,    /*!< RTC Alarm B Event Callback ID       */
+  HAL_RTC_TIMESTAMP_EVENT_CB_ID         = 0x02U,    /*!< RTC Timestamp Event Callback ID     */
+  HAL_RTC_WAKEUPTIMER_EVENT_CB_ID       = 0x03U,    /*!< RTC Wakeup Timer Event Callback ID  */
 #if defined(RTC_TAMPER1_SUPPORT)
-  HAL_RTC_TAMPER1_EVENT_CB_ID           = 0x04U,    /*!< RTC Tamper 1 Callback ID           */
-#endif
-  HAL_RTC_TAMPER2_EVENT_CB_ID           = 0x05U,    /*!< RTC Tamper 2 Callback ID           */
+  HAL_RTC_TAMPER1_EVENT_CB_ID           = 0x04U,    /*!< RTC Tamper 1 Callback ID            */
+#endif /* RTC_TAMPER1_SUPPORT */
+  HAL_RTC_TAMPER2_EVENT_CB_ID           = 0x05U,    /*!< RTC Tamper 2 Callback ID            */
 #if defined(RTC_TAMPER3_SUPPORT)
-  HAL_RTC_TAMPER3_EVENT_CB_ID           = 0x06U,    /*!< RTC Tamper 3 Callback ID           */
-#endif
-  HAL_RTC_MSPINIT_CB_ID                 = 0x0EU,    /*!< RTC Msp Init callback ID           */
-  HAL_RTC_MSPDEINIT_CB_ID               = 0x0FU     /*!< RTC Msp DeInit callback ID         */
-}HAL_RTC_CallbackIDTypeDef;
+  HAL_RTC_TAMPER3_EVENT_CB_ID           = 0x06U,    /*!< RTC Tamper 3 Callback ID            */
+#endif /* RTC_TAMPER3_SUPPORT */
+  HAL_RTC_MSPINIT_CB_ID                 = 0x0EU,    /*!< RTC Msp Init callback ID            */
+  HAL_RTC_MSPDEINIT_CB_ID               = 0x0FU     /*!< RTC Msp DeInit callback ID          */
+} HAL_RTC_CallbackIDTypeDef;
 
 /**
   * @brief  HAL RTC Callback pointer definition
   */
-typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to an RTC callback function */
+typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to an RTC callback function */
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
 /**
@@ -235,6 +235,7 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
   */
 
 /* Exported constants --------------------------------------------------------*/
+
 /** @defgroup RTC_Exported_Constants RTC Exported Constants
   * @{
   */
@@ -242,30 +243,19 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_Hour_Formats RTC Hour Formats
   * @{
   */
-#define RTC_HOURFORMAT_24              ((uint32_t)0x00000000U)
-#define RTC_HOURFORMAT_12              ((uint32_t)RTC_CR_FMT)
-
+#define RTC_HOURFORMAT_24              0x00000000U
+#define RTC_HOURFORMAT_12              RTC_CR_FMT
 /**
   * @}
   */
 
-
-/** @defgroup RTC_Output_Polarity_Definitions RTC Output Polarity Definitions
+/** @defgroup RTC_Output_selection_Definitions RTC Output Selection Definitions
   * @{
   */
-#define RTC_OUTPUT_POLARITY_HIGH       ((uint32_t)0x00000000U)
-#define RTC_OUTPUT_POLARITY_LOW        ((uint32_t)RTC_CR_POL)
-
-/**
-  * @}
-  */
-
-/** @defgroup RTC_Output_Type_ALARM_OUT RTC Output Type ALARM OUT
-  * @{
-  */
-#define RTC_OUTPUT_TYPE_OPENDRAIN      ((uint32_t)0x00000000U)
-#define RTC_OUTPUT_TYPE_PUSHPULL       ((uint32_t)RTC_OR_ALARMOUTTYPE)
-
+#define RTC_OUTPUT_DISABLE             0x00000000U
+#define RTC_OUTPUT_ALARMA              RTC_CR_OSEL_0
+#define RTC_OUTPUT_ALARMB              RTC_CR_OSEL_1
+#define RTC_OUTPUT_WAKEUP              RTC_CR_OSEL
 /**
   * @}
   */
@@ -273,8 +263,28 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_Output_ALARM_OUT_Remap RTC Output ALARM OUT Remap
   * @{
   */
-#define RTC_OUTPUT_REMAP_NONE              ((uint32_t)0x00000000U)
-#define RTC_OUTPUT_REMAP_POS1              ((uint32_t)RTC_OR_OUT_RMP)
+#define RTC_OUTPUT_REMAP_NONE          0x00000000U
+#define RTC_OUTPUT_REMAP_POS1          RTC_OR_OUT_RMP
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Polarity_Definitions RTC Output Polarity Definitions
+  * @{
+  */
+#define RTC_OUTPUT_POLARITY_HIGH       0x00000000U
+#define RTC_OUTPUT_POLARITY_LOW        RTC_CR_POL
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Type_ALARM_OUT RTC Output Type ALARM OUT
+  * @{
+  */
+#define RTC_OUTPUT_TYPE_OPENDRAIN      0x00000000U
+#if defined(RTC_OR_ALARMOUTTYPE)
+#define RTC_OUTPUT_TYPE_PUSHPULL       RTC_OR_ALARMOUTTYPE
+#endif /* RTC_OR_ALARMOUTTYPE */
 /**
   * @}
   */
@@ -282,30 +292,27 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
   * @{
   */
-#define RTC_HOURFORMAT12_AM            ((uint8_t)0x00U)
-#define RTC_HOURFORMAT12_PM            ((uint8_t)0x40U)
-
+#define RTC_HOURFORMAT12_AM            ((uint8_t)0x00)
+#define RTC_HOURFORMAT12_PM            ((uint8_t)0x01)
 /**
   * @}
   */
 
-/** @defgroup RTC_DayLightSaving_Definitions RTC DayLightSaving Definitions
+/** @defgroup RTC_DayLightSaving_Definitions RTC DayLight Saving Definitions
   * @{
   */
-#define RTC_DAYLIGHTSAVING_SUB1H       ((uint32_t)RTC_CR_SUB1H)
-#define RTC_DAYLIGHTSAVING_ADD1H       ((uint32_t)RTC_CR_ADD1H)
-#define RTC_DAYLIGHTSAVING_NONE        ((uint32_t)0x00000000U)
-
+#define RTC_DAYLIGHTSAVING_SUB1H       RTC_CR_SUB1H
+#define RTC_DAYLIGHTSAVING_ADD1H       RTC_CR_ADD1H
+#define RTC_DAYLIGHTSAVING_NONE        0x00000000U
 /**
   * @}
   */
 
-/** @defgroup RTC_StoreOperation_Definitions RTC StoreOperation Definitions
+/** @defgroup RTC_StoreOperation_Definitions RTC Store Operation Definitions
   * @{
   */
-#define RTC_STOREOPERATION_RESET        ((uint32_t)0x00000000U)
-#define RTC_STOREOPERATION_SET          ((uint32_t)RTC_CR_BKP)
-
+#define RTC_STOREOPERATION_RESET        0x00000000U
+#define RTC_STOREOPERATION_SET          RTC_CR_BKP
 /**
   * @}
   */
@@ -313,31 +320,27 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_Input_parameter_format_definitions RTC Input Parameter Format Definitions
   * @{
   */
-#define RTC_FORMAT_BIN   ((uint32_t)0x000000000U)
-#define RTC_FORMAT_BCD   ((uint32_t)0x000000001U)
-
+#define RTC_FORMAT_BIN                  0x00000000U
+#define RTC_FORMAT_BCD                  0x00000001U
 /**
   * @}
   */
 
-/** @defgroup RTC_Month_Date_Definitions RTC Month Date Definitions
+/** @defgroup RTC_Month_Date_Definitions RTC Month Date Definitions (in BCD format)
   * @{
   */
-
-/* Coded in BCD format */
-#define RTC_MONTH_JANUARY              ((uint8_t)0x01U)
-#define RTC_MONTH_FEBRUARY             ((uint8_t)0x02U)
-#define RTC_MONTH_MARCH                ((uint8_t)0x03U)
-#define RTC_MONTH_APRIL                ((uint8_t)0x04U)
-#define RTC_MONTH_MAY                  ((uint8_t)0x05U)
-#define RTC_MONTH_JUNE                 ((uint8_t)0x06U)
-#define RTC_MONTH_JULY                 ((uint8_t)0x07U)
-#define RTC_MONTH_AUGUST               ((uint8_t)0x08U)
-#define RTC_MONTH_SEPTEMBER            ((uint8_t)0x09U)
-#define RTC_MONTH_OCTOBER              ((uint8_t)0x10U)
-#define RTC_MONTH_NOVEMBER             ((uint8_t)0x11U)
-#define RTC_MONTH_DECEMBER             ((uint8_t)0x12U)
-
+#define RTC_MONTH_JANUARY              ((uint8_t)0x01)
+#define RTC_MONTH_FEBRUARY             ((uint8_t)0x02)
+#define RTC_MONTH_MARCH                ((uint8_t)0x03)
+#define RTC_MONTH_APRIL                ((uint8_t)0x04)
+#define RTC_MONTH_MAY                  ((uint8_t)0x05)
+#define RTC_MONTH_JUNE                 ((uint8_t)0x06)
+#define RTC_MONTH_JULY                 ((uint8_t)0x07)
+#define RTC_MONTH_AUGUST               ((uint8_t)0x08)
+#define RTC_MONTH_SEPTEMBER            ((uint8_t)0x09)
+#define RTC_MONTH_OCTOBER              ((uint8_t)0x10)
+#define RTC_MONTH_NOVEMBER             ((uint8_t)0x11)
+#define RTC_MONTH_DECEMBER             ((uint8_t)0x12)
 /**
   * @}
   */
@@ -345,42 +348,38 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_WeekDay_Definitions RTC WeekDay Definitions
   * @{
   */
-#define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01U)
-#define RTC_WEEKDAY_TUESDAY            ((uint8_t)0x02U)
-#define RTC_WEEKDAY_WEDNESDAY          ((uint8_t)0x03U)
-#define RTC_WEEKDAY_THURSDAY           ((uint8_t)0x04U)
-#define RTC_WEEKDAY_FRIDAY             ((uint8_t)0x05U)
-#define RTC_WEEKDAY_SATURDAY           ((uint8_t)0x06U)
-#define RTC_WEEKDAY_SUNDAY             ((uint8_t)0x07U)
-
+#define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01)
+#define RTC_WEEKDAY_TUESDAY            ((uint8_t)0x02)
+#define RTC_WEEKDAY_WEDNESDAY          ((uint8_t)0x03)
+#define RTC_WEEKDAY_THURSDAY           ((uint8_t)0x04)
+#define RTC_WEEKDAY_FRIDAY             ((uint8_t)0x05)
+#define RTC_WEEKDAY_SATURDAY           ((uint8_t)0x06)
+#define RTC_WEEKDAY_SUNDAY             ((uint8_t)0x07)
 /**
   * @}
   */
 
-/** @defgroup RTC_AlarmDateWeekDay_Definitions RTC AlarmDateWeekDay Definitions
+/** @defgroup RTC_AlarmDateWeekDay_Definitions RTC Alarm Date WeekDay Definitions
   * @{
   */
-#define RTC_ALARMDATEWEEKDAYSEL_DATE      ((uint32_t)0x00000000U)
+#define RTC_ALARMDATEWEEKDAYSEL_DATE      0x00000000U
 #define RTC_ALARMDATEWEEKDAYSEL_WEEKDAY   RTC_ALRMAR_WDSEL
-
 /**
   * @}
   */
 
-/** @defgroup RTC_AlarmMask_Definitions RTC AlarmMask Definitions
+/** @defgroup RTC_AlarmMask_Definitions RTC Alarm Mask Definitions
   * @{
   */
-#define RTC_ALARMMASK_NONE             ((uint32_t)0x00000000U)
-#define RTC_ALARMMASK_DATEWEEKDAY       RTC_ALRMAR_MSK4
-#define RTC_ALARMMASK_HOURS             RTC_ALRMAR_MSK3
-#define RTC_ALARMMASK_MINUTES           RTC_ALRMAR_MSK2
-#define RTC_ALARMMASK_SECONDS           RTC_ALRMAR_MSK1
-#define RTC_ALARMMASK_ALL               ((uint32_t) (RTC_ALARMMASK_NONE        | \
-                                                     RTC_ALARMMASK_DATEWEEKDAY | \
-                                                     RTC_ALARMMASK_HOURS       | \
-                                                     RTC_ALARMMASK_MINUTES     | \
-                                                     RTC_ALARMMASK_SECONDS))
-
+#define RTC_ALARMMASK_NONE                0x00000000U
+#define RTC_ALARMMASK_DATEWEEKDAY         RTC_ALRMAR_MSK4
+#define RTC_ALARMMASK_HOURS               RTC_ALRMAR_MSK3
+#define RTC_ALARMMASK_MINUTES             RTC_ALRMAR_MSK2
+#define RTC_ALARMMASK_SECONDS             RTC_ALRMAR_MSK1
+#define RTC_ALARMMASK_ALL                 (RTC_ALARMMASK_DATEWEEKDAY | \
+                                           RTC_ALARMMASK_HOURS       | \
+                                           RTC_ALARMMASK_MINUTES     | \
+                                           RTC_ALARMMASK_SECONDS)
 /**
   * @}
   */
@@ -390,48 +389,45 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
   */
 #define RTC_ALARM_A                       RTC_CR_ALRAE
 #define RTC_ALARM_B                       RTC_CR_ALRBE
-
 /**
   * @}
   */
 
-
-  /** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions RTC Alarm Sub Seconds Masks Definitions
+/** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions RTC Alarm Sub Seconds Masks Definitions
   * @{
   */
-#define RTC_ALARMSUBSECONDMASK_ALL        ((uint32_t)0x00000000U)                                                                 /*!< All Alarm SS fields are masked.
-                                                                                                                                    There is no comparison on sub seconds
-                                                                                                                                    for Alarm */
-#define RTC_ALARMSUBSECONDMASK_SS14_1      RTC_ALRMASSR_MASKSS_0                                                                 /*!< SS[14:1] are don't care in Alarm
-                                                                                                                                    comparison. Only SS[0] is compared.    */
-#define RTC_ALARMSUBSECONDMASK_SS14_2      RTC_ALRMASSR_MASKSS_1                                                                 /*!< SS[14:2] are don't care in Alarm
-                                                                                                                                     comparison. Only SS[1:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_3      ((uint32_t) (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1))                          /*!< SS[14:3] are don't care in Alarm
-                                                                                                                                     comparison. Only SS[2:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_4      RTC_ALRMASSR_MASKSS_2                                                                 /*!< SS[14:4] are don't care in Alarm
-                                                                                                                                     comparison. Only SS[3:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_5      ((uint32_t) (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_2))                          /*!< SS[14:5] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[4:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_6      ((uint32_t) (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2))                          /*!< SS[14:6] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[5:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_7      ((uint32_t) (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2))  /*!< SS[14:7] are don't care in Alarm
-                                                                                                                                `     comparison. Only SS[6:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_8      RTC_ALRMASSR_MASKSS_3                                                                 /*!< SS[14:8] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[7:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_9      ((uint32_t) (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_3))                          /*!< SS[14:9] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[8:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_10     ((uint32_t) (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_3))                          /*!< SS[14:10] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[9:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_11     ((uint32_t) (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_3))  /*!< SS[14:11] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[10:0] are compared */
-#define RTC_ALARMSUBSECONDMASK_SS14_12     ((uint32_t) (RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3))                          /*!< SS[14:12] are don't care in Alarm
-                                                                                                                                      comparison.Only SS[11:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_SS14_13     ((uint32_t) (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3))  /*!< SS[14:13] are don't care in Alarm
-                                                                                                                                      comparison. Only SS[12:0] are compared */
-#define RTC_ALARMSUBSECONDMASK_SS14        ((uint32_t) (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3))  /*!< SS[14] is don't care in Alarm
-                                                                                                                                      comparison.Only SS[13:0] are compared  */
-#define RTC_ALARMSUBSECONDMASK_NONE        RTC_ALRMASSR_MASKSS                                                                   /*!< SS[14:0] are compared and must match
-                                                                                                                                      to activate alarm. */
+/*!< All Alarm SS fields are masked. There is no comparison on sub seconds for Alarm */
+#define RTC_ALARMSUBSECONDMASK_ALL         0x00000000U
+/*!< SS[14:1] are don't care in Alarm comparison. Only SS[0] is compared.     */
+#define RTC_ALARMSUBSECONDMASK_SS14_1      RTC_ALRMASSR_MASKSS_0
+/*!< SS[14:2] are don't care in Alarm comparison. Only SS[1:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_2      RTC_ALRMASSR_MASKSS_1
+/*!< SS[14:3] are don't care in Alarm comparison. Only SS[2:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_3      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1)
+/*!< SS[14:4] are don't care in Alarm comparison. Only SS[3:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_4      RTC_ALRMASSR_MASKSS_2
+/*!< SS[14:5] are don't care in Alarm comparison. Only SS[4:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_5      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_2)
+/*!< SS[14:6] are don't care in Alarm comparison. Only SS[5:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_6      (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2)
+/*!< SS[14:7] are don't care in Alarm comparison. Only SS[6:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_7      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2)
+/*!< SS[14:8] are don't care in Alarm comparison. Only SS[7:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_8      RTC_ALRMASSR_MASKSS_3
+/*!< SS[14:9] are don't care in Alarm comparison. Only SS[8:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_9      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:10] are don't care in Alarm comparison. Only SS[9:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_10     (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:11] are don't care in Alarm comparison. Only SS[10:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_11     (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:12] are don't care in Alarm comparison. Only SS[11:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_12     (RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:13] are don't care in Alarm comparison. Only SS[12:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_13     (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14] is don't care in Alarm comparison. Only SS[13:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14        (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:0] are compared and must match to activate alarm. */
+#define RTC_ALARMSUBSECONDMASK_NONE        RTC_ALRMASSR_MASKSS
 /**
   * @}
   */
@@ -439,16 +435,10 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_Interrupts_Definitions RTC Interrupts Definitions
   * @{
   */
-#define RTC_IT_TS                         ((uint32_t)RTC_CR_TSIE)        /*!< Enable Timestamp Interrupt    */
-#define RTC_IT_WUT                        ((uint32_t)RTC_CR_WUTIE)       /*!< Enable Wakeup timer Interrupt */
-#define RTC_IT_ALRA                       ((uint32_t)RTC_CR_ALRAIE)      /*!< Enable Alarm A Interrupt      */
-#define RTC_IT_ALRB                       ((uint32_t)RTC_CR_ALRBIE)      /*!< Enable Alarm B Interrupt      */
-#define RTC_IT_TAMP                       ((uint32_t)RTC_TAMPCR_TAMPIE)  /*!< Enable all Tamper Interrupt   */
-#if defined(RTC_TAMPER1_SUPPORT)
-#define RTC_IT_TAMP1                      ((uint32_t)RTC_TAMPCR_TAMP1IE) /*!< Enable Tamper 1 Interrupt     */
-#endif
-#define RTC_IT_TAMP2                      ((uint32_t)RTC_TAMPCR_TAMP2IE) /*!< Enable Tamper 2 Interrupt     */
-
+#define RTC_IT_TS                         RTC_CR_TSIE         /*!< Enable Timestamp Interrupt               */
+#define RTC_IT_WUT                        RTC_CR_WUTIE        /*!< Enable Wakeup timer Interrupt            */
+#define RTC_IT_ALRB                       RTC_CR_ALRBIE       /*!< Enable Alarm B Interrupt                 */
+#define RTC_IT_ALRA                       RTC_CR_ALRAIE       /*!< Enable Alarm A Interrupt                 */
 /**
   * @}
   */
@@ -456,26 +446,27 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 /** @defgroup RTC_Flags_Definitions RTC Flags Definitions
   * @{
   */
-#define RTC_FLAG_RECALPF                  ((uint32_t)RTC_ISR_RECALPF)
-#define RTC_FLAG_TAMP2F                   ((uint32_t)RTC_ISR_TAMP2F)
+#define RTC_FLAG_RECALPF                  RTC_ISR_RECALPF     /*!< Recalibration pending flag               */
+#if defined(RTC_TAMPER3_SUPPORT)
+#define RTC_FLAG_TAMP3F                   RTC_ISR_TAMP3F      /*!< Tamper 3 event flag                      */
+#endif /* RTC_TAMPER3_SUPPORT */
+#define RTC_FLAG_TAMP2F                   RTC_ISR_TAMP2F      /*!< Tamper 2 event flag                      */
 #if defined(RTC_TAMPER1_SUPPORT)
-#define RTC_FLAG_TAMP1F                   ((uint32_t)RTC_ISR_TAMP1F)
-#endif
-#define RTC_FLAG_TSOVF                    ((uint32_t)RTC_ISR_TSOVF)
-#define RTC_FLAG_TSF                      ((uint32_t)RTC_ISR_TSF)
-#if defined(RTC_ISR_ITSF)
-#define RTC_FLAG_ITSF                     ((uint32_t)RTC_ISR_ITSF)
-#endif
-#define RTC_FLAG_WUTF                     ((uint32_t)RTC_ISR_WUTF)
-#define RTC_FLAG_ALRBF                    ((uint32_t)RTC_ISR_ALRBF)
-#define RTC_FLAG_ALRAF                    ((uint32_t)RTC_ISR_ALRAF)
-#define RTC_FLAG_INITF                    ((uint32_t)RTC_ISR_INITF)
-#define RTC_FLAG_RSF                      ((uint32_t)RTC_ISR_RSF)
-#define RTC_FLAG_INITS                    ((uint32_t)RTC_ISR_INITS)
-#define RTC_FLAG_SHPF                     ((uint32_t)RTC_ISR_SHPF)
-#define RTC_FLAG_WUTWF                    ((uint32_t)RTC_ISR_WUTWF)
-#define RTC_FLAG_ALRBWF                   ((uint32_t)RTC_ISR_ALRBWF)
-#define RTC_FLAG_ALRAWF                   ((uint32_t)RTC_ISR_ALRAWF)
+#define RTC_FLAG_TAMP1F                   RTC_ISR_TAMP1F      /*!< Tamper 1 event flag                      */
+#endif /* RTC_TAMPER1_SUPPORT */
+#define RTC_FLAG_TSOVF                    RTC_ISR_TSOVF       /*!< Timestamp overflow flag                  */
+#define RTC_FLAG_TSF                      RTC_ISR_TSF         /*!< Timestamp event flag                     */
+#define RTC_FLAG_ITSF                     RTC_ISR_ITSF        /*!< Internal Timestamp event flag            */
+#define RTC_FLAG_WUTF                     RTC_ISR_WUTF        /*!< Wakeup timer event flag                  */
+#define RTC_FLAG_ALRBF                    RTC_ISR_ALRBF       /*!< Alarm B event flag                       */
+#define RTC_FLAG_ALRAF                    RTC_ISR_ALRAF       /*!< Alarm A event flag                       */
+#define RTC_FLAG_INITF                    RTC_ISR_INITF       /*!< RTC in initialization mode flag          */
+#define RTC_FLAG_RSF                      RTC_ISR_RSF         /*!< Register synchronization flag            */
+#define RTC_FLAG_INITS                    RTC_ISR_INITS       /*!< RTC initialization status flag           */
+#define RTC_FLAG_SHPF                     RTC_ISR_SHPF        /*!< Shift operation pending flag             */
+#define RTC_FLAG_WUTWF                    RTC_ISR_WUTWF       /*!< WUTR register write allowance flag       */
+#define RTC_FLAG_ALRBWF                   RTC_ISR_ALRBWF      /*!< ALRMBR register write allowance flag     */
+#define RTC_FLAG_ALRAWF                   RTC_ISR_ALRAWF      /*!< ALRMAR register write allowance flag     */
 /**
   * @}
   */
@@ -485,110 +476,140 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
   */
 
 /* Exported macros -----------------------------------------------------------*/
+
 /** @defgroup RTC_Exported_Macros RTC Exported Macros
   * @{
   */
 
 /** @brief Reset RTC handle state
-  * @param __HANDLE__ RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
-#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) do{\
-                                                      (__HANDLE__)->State = HAL_RTC_STATE_RESET;\
-                                                      (__HANDLE__)->MspInitCallback = NULL;\
-                                                      (__HANDLE__)->MspDeInitCallback = NULL;\
-                                                     }while(0)
+#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) do {                                            \
+                                                      (__HANDLE__)->State = HAL_RTC_STATE_RESET; \
+                                                      (__HANDLE__)->MspInitCallback = NULL;      \
+                                                      (__HANDLE__)->MspDeInitCallback = NULL;    \
+                                                    } while(0U)
 #else
 #define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RTC_STATE_RESET)
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
 /**
   * @brief  Disable the write protection for RTC registers.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__)             \
-                        do{                                       \
-                            (__HANDLE__)->Instance->WPR = 0xCAU;   \
-                            (__HANDLE__)->Instance->WPR = 0x53U;   \
-                          } while(0U)
+#define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__) do {                                       \
+                                                           (__HANDLE__)->Instance->WPR = 0xCAU;  \
+                                                           (__HANDLE__)->Instance->WPR = 0x53U;  \
+                                                         } while(0U)
 
 /**
   * @brief  Enable the write protection for RTC registers.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__)              \
-                        do{                                       \
-                            (__HANDLE__)->Instance->WPR = 0xFFU;   \
-                          } while(0U)
+#define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__) do {                                       \
+                                                          (__HANDLE__)->Instance->WPR = 0xFFU;  \
+                                                        } while(0U)
+
+/**
+  * @brief  Check whether the RTC Calendar is initialized.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_IS_CALENDAR_INITIALIZED(__HANDLE__)                 (((((__HANDLE__)->Instance->ISR) & (RTC_FLAG_INITS)) == RTC_FLAG_INITS) ? 1U : 0U)
 
 /**
   * @brief  Enable the RTC ALARMA peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_ALARMA_ENABLE(__HANDLE__)  ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRAE))
+#define __HAL_RTC_ALARMA_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRAE))
 
 /**
   * @brief  Disable the RTC ALARMA peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_ALARMA_DISABLE(__HANDLE__)  ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRAE))
+#define __HAL_RTC_ALARMA_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRAE))
 
 /**
   * @brief  Enable the RTC ALARMB peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_ALARMB_ENABLE(__HANDLE__)   ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRBE))
+#define __HAL_RTC_ALARMB_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRBE))
 
 /**
   * @brief  Disable the RTC ALARMB peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_ALARMB_DISABLE(__HANDLE__)  ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRBE))
+#define __HAL_RTC_ALARMB_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRBE))
 
 /**
   * @brief  Enable the RTC Alarm interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt sources to be enabled or disabled.
   *          This parameter can be any combination of the following values:
   *             @arg RTC_IT_ALRA: Alarm A interrupt
   *             @arg RTC_IT_ALRB: Alarm B interrupt
   * @retval None
   */
-#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)          ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
 
 /**
   * @brief  Disable the RTC Alarm interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Alarm interrupt sources to be enabled or disabled.
-  *         This parameter can be any combination of the following values:
-  *            @arg RTC_IT_ALRA: Alarm A interrupt
-  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg RTC_IT_ALRA: Alarm A interrupt
+  *             @arg RTC_IT_ALRB: Alarm B interrupt
   * @retval None
   */
-#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__) ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
 
 /**
   * @brief  Check whether the specified RTC Alarm interrupt has occurred or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Alarm interrupt sources to check.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt to check.
   *         This parameter can be:
   *            @arg RTC_IT_ALRA: Alarm A interrupt
   *            @arg RTC_IT_ALRB: Alarm B interrupt
   * @retval None
   */
-#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__)  (((((__HANDLE__)->Instance->ISR)& ((__INTERRUPT__)>> 4U)) != 0U)? 1U : 0U)
+#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__)           (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__) >> 4U)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Get the selected RTC Alarm's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Alarm Flag to check.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ALRAF: Alarm A interrupt flag
+  *            @arg RTC_FLAG_ALRAWF: Alarm A 'write allowed' flag
+  *            @arg RTC_FLAG_ALRBF: Alarm B interrupt flag
+  *            @arg RTC_FLAG_ALRBWF: Alarm B 'write allowed' flag
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Alarm's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Alarm flag to be cleared.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ALRAF
+  *             @arg RTC_FLAG_ALRBF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)                  ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
 
 /**
   * @brief  Check whether the specified RTC Alarm interrupt has been enabled or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Alarm interrupt sources to check.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt sources to check.
   *         This parameter can be:
   *            @arg RTC_IT_ALRA: Alarm A interrupt
   *            @arg RTC_IT_ALRB: Alarm B interrupt
@@ -597,157 +618,88 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 #define __HAL_RTC_ALARM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
 
 /**
-  * @brief  Get the selected RTC Alarm's flag status.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC Alarm Flag sources to check.
-  *         This parameter can be:
-  *            @arg RTC_FLAG_ALRAF
-  *            @arg RTC_FLAG_ALRBF
-  *            @arg RTC_FLAG_ALRAWF
-  *            @arg RTC_FLAG_ALRBWF
-  * @retval None
-  */
-#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)   (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
-
-/**
-  * @brief  Clear the RTC Alarm's pending flags.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC Alarm Flag sources to clear.
-  *          This parameter can be:
-  *             @arg RTC_FLAG_ALRAF
-  *             @arg RTC_FLAG_ALRBF
-  * @retval None
-  */
-#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)   ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT) | ((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
-
-/**
-  * @brief  Enable interrupt on the RTC Alarm associated Exti line by core 1.
+  * @brief  Enable interrupt on the RTC Alarm associated EXTI line.
   * @retval None
   */
 #define __HAL_RTC_ALARM_EXTI_ENABLE_IT()            (EXTI->IMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Enable interrupt on the RTC Alarm associated Exti line by core 2.
+  * @brief  Disable interrupt on the RTC Alarm associated EXTI line.
   * @retval None
   */
-#define __HAL_RTC_ALARM_EXTIC2_ENABLE_IT()          (EXTI->C2IMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+#define __HAL_RTC_ALARM_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Disable interrupt on the RTC Alarm associated Exti line by core 1.
-  * @retval None
-  */
-#define __HAL_RTC_ALARM_EXTI_DISABLE_IT()           (EXTI->IMR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
-
-/**
-  * @brief  Disable interrupt on the RTC Alarm associated Exti line by core 2.
-  * @retval None
-  */
-#define __HAL_RTC_ALARM_EXTIC2_DISABLE_IT()         (EXTI->C2IMR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
-
-
-/**
-  * @brief  Enable event on the RTC Alarm associated Exti line by core 1.
+  * @brief  Enable event on the RTC Alarm associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTI_ENABLE_EVENT()         (EXTI->EMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+#define __HAL_RTC_ALARM_EXTI_ENABLE_EVENT()          (EXTI->EMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Enable event on the RTC Alarm associated Exti line by core 2.
+  * @brief  Disable event on the RTC Alarm associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTIC2_ENABLE_EVENT()        (EXTI->C2EMR1 |= RTC_EXTI_LINE_ALARM_EVENT)
+#define __HAL_RTC_ALARM_EXTI_DISABLE_EVENT()         (EXTI->EMR1 &= ~RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Disable event on the RTC Alarm associated Exti line by core 1.
-  * @retval None.
-  */
-#define __HAL_RTC_ALARM_EXTI_DISABLE_EVENT()         (EXTI->EMR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
-
-/**
-  * @brief  Disable event on the RTC Alarm associated Exti line by core 2.
-  * @retval None.
-  */
-#define __HAL_RTC_ALARM_EXTIC2_DISABLE_EVENT()       (EXTI->C2EMR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
-
-/*----------------------------*/
-/**
-  * @brief  Enable falling edge trigger on the RTC Alarm associated Exti line.
+  * @brief  Enable falling edge trigger on the RTC Alarm associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR1 |= RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Disable falling edge trigger on the RTC Alarm associated Exti line.
+  * @brief  Disable falling edge trigger on the RTC Alarm associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
+#define __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Enable rising edge trigger on the RTC Alarm associated Exti line.
+  * @brief  Enable rising edge trigger on the RTC Alarm associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR1 |= RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Disable rising edge trigger on the RTC Alarm associated Exti line.
+  * @brief  Disable rising edge trigger on the RTC Alarm associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~(RTC_EXTI_LINE_ALARM_EVENT))
-
-
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated Exti line.
+  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
-                                                             __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();  \
-                                                             __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE(); \
-                                                           } while(0U)
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                             \
+                                                               __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();  \
+                                                               __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE(); \
+                                                             } while(0U)
 
 /**
-  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated Exti line.
+  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_FALLING_EDGE() do { \
-                                                             __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE();  \
-                                                             __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE(); \
-                                                           } while(0U)
-
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                              \
+                                                                __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE();  \
+                                                                __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE(); \
+                                                              } while(0U)
 
 /**
-  * @brief Check whether the RTC Alarm associated Exti line interrupt flag is set or notby core 1.
+  * @brief Check whether the RTC Alarm associated EXTI line interrupt flag is set or not.
   * @retval Line Status.
   */
 #define __HAL_RTC_ALARM_EXTI_GET_FLAG()              (EXTI->PR1 & RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief Check whether the RTC Alarm associated Exti line interrupt flag is set or not by core 2.
-  * @retval Line Status.
-  */
-#define __HAL_RTC_ALARM_EXTIC2_GET_FLAG()            (EXTI->PR1 & RTC_EXTI_LINE_ALARM_EVENT)
-
-/**
-  * @brief Clear the RTC Alarm associated Exti line flag.
+  * @brief Clear the RTC Alarm associated EXTI line flag.
   * @retval None.
   */
-#define __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()            (EXTI->PR1 = (RTC_EXTI_LINE_ALARM_EVENT))
+#define __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()            (EXTI->PR1 = RTC_EXTI_LINE_ALARM_EVENT)
 
 /**
-  * @brief Clear the RTC Alarm associated Exti line flag.
-  * @retval None.
-  */
-#define __HAL_RTC_ALARM_EXTIC2_CLEAR_FLAG()          (EXTI->PR1 = (RTC_EXTI_LINE_ALARM_EVENT))
-
-/*----------------------------*/
-/**
-  * @brief Generate a Software interrupt on RTC Alarm associated Exti line.
+  * @brief Generate a Software interrupt on RTC Alarm associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_ALARM_EXTI_GENERATE_SWIT()         (EXTI->SWIER1 |= RTC_EXTI_LINE_ALARM_EVENT)
-/*----------------------------*/
-
-
 /**
   * @}
   */
@@ -756,31 +708,30 @@ typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef * hrtc); /*!< pointer to
 #include "stm32wbxx_hal_rtc_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
-/** @defgroup RTC_Exported_Functions RTC Exported Functions
+
+/** @addtogroup RTC_Exported_Functions
   * @{
   */
 
-/** @defgroup RTC_Exported_Functions_Group1 Initialization and de-initialization functions
+/** @addtogroup RTC_Exported_Functions_Group1
   * @{
   */
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc);
-
-void HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
-void HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
 HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID, pRTC_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID);
-#endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
-
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 /**
   * @}
   */
 
-/** @defgroup RTC_Exported_Functions_Group2 RTC Time and Date functions
+/** @addtogroup RTC_Exported_Functions_Group2
   * @{
   */
 /* RTC Time and Date functions ************************************************/
@@ -792,7 +743,7 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   * @}
   */
 
-/** @defgroup RTC_Exported_Functions_Group3 RTC Alarm functions
+/** @addtogroup RTC_Exported_Functions_Group3
   * @{
   */
 /* RTC Alarm functions ********************************************************/
@@ -807,16 +758,23 @@ void              HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
   * @}
   */
 
-/** @defgroup  RTC_Exported_Functions_Group4 Peripheral Control functions
+/** @addtogroup RTC_Exported_Functions_Group4
   * @{
   */
 /* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc);
+HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef *hrtc);
+
+/* RTC Daylight Saving Time functions *****************************************/
+void              HAL_RTC_DST_Add1Hour(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_DST_Sub1Hour(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_DST_SetStoreOperation(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_DST_ClearStoreOperation(RTC_HandleTypeDef *hrtc);
+uint32_t          HAL_RTC_DST_ReadStoreOperation(RTC_HandleTypeDef *hrtc);
 /**
   * @}
   */
 
-/** @defgroup RTC_Exported_Functions_Group5 Peripheral State functions
+/** @addtogroup RTC_Exported_Functions_Group5
   * @{
   */
 /* Peripheral State functions *************************************************/
@@ -832,28 +790,39 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
+
 /** @defgroup RTC_Private_Constants RTC Private Constants
   * @{
   */
 /* Masks Definition */
-#define RTC_TR_RESERVED_MASK  ((uint32_t) (RTC_TR_PM | RTC_TR_HT | RTC_TR_HU | \
-                                           RTC_TR_MNT | RTC_TR_MNU| RTC_TR_ST | \
-                                           RTC_TR_SU))
-#define RTC_DR_RESERVED_MASK  ((uint32_t) (RTC_DR_YT | RTC_DR_YU | RTC_DR_WDU | \
-                                           RTC_DR_MT | RTC_DR_MU | RTC_DR_DT  | \
-                                           RTC_DR_DU))
-#define RTC_INIT_MASK           ((uint32_t)0xFFFFFFFFU)
+#define RTC_TR_RESERVED_MASK    ((uint32_t)(RTC_TR_HT  | RTC_TR_HU  | \
+                                            RTC_TR_MNT | RTC_TR_MNU | \
+                                            RTC_TR_ST  | RTC_TR_SU  | \
+                                            RTC_TR_PM))
+#define RTC_DR_RESERVED_MASK    ((uint32_t)(RTC_DR_YT | RTC_DR_YU | \
+                                            RTC_DR_MT | RTC_DR_MU | \
+                                            RTC_DR_DT | RTC_DR_DU | \
+                                            RTC_DR_WDU))
+#define RTC_ISR_RESERVED_MASK   ((uint32_t)(RTC_FLAGS_MASK | RTC_ISR_INIT))
+#define RTC_INIT_MASK           0xFFFFFFFFU
 #define RTC_RSF_MASK            ((uint32_t)~(RTC_ISR_INIT | RTC_ISR_RSF))
+#define RTC_FLAGS_MASK          ((uint32_t)(RTC_FLAG_INITF   | RTC_FLAG_INITS  | \
+                                            RTC_FLAG_ALRAF   | RTC_FLAG_ALRAWF | \
+                                            RTC_FLAG_ALRBF   | RTC_FLAG_ALRBWF | \
+                                            RTC_FLAG_WUTF    | RTC_FLAG_WUTWF  | \
+                                            RTC_FLAG_RECALPF | RTC_FLAG_SHPF   | \
+                                            RTC_FLAG_TSF     | RTC_FLAG_TSOVF  | \
+                                            RTC_FLAG_RSF     | RTC_TAMPER_FLAGS_MASK))
 
-#define RTC_TIMEOUT_VALUE  1000U
+#define RTC_TIMEOUT_VALUE       1000U
 
-#define RTC_EXTI_LINE_ALARM_EVENT             (LL_EXTI_LINE_17) /*!< External interrupt line connected to the RTC Alarm event */
-
+#define RTC_EXTI_LINE_ALARM_EVENT  EXTI_IMR1_IM17  /*!< External interrupt line 17 connected to the RTC Alarm event */
 /**
   * @}
   */
 
 /* Private macros ------------------------------------------------------------*/
+
 /** @defgroup RTC_Private_Macros RTC Private Macros
   * @{
   */
@@ -861,18 +830,34 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 /** @defgroup RTC_IS_RTC_Definitions RTC Private macros to check input parameters
   * @{
   */
-
 #define IS_RTC_HOUR_FORMAT(FORMAT)     (((FORMAT) == RTC_HOURFORMAT_12) || \
                                         ((FORMAT) == RTC_HOURFORMAT_24))
+
+#define IS_RTC_OUTPUT(OUTPUT) (((OUTPUT) == RTC_OUTPUT_DISABLE) || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMA)  || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMB)  || \
+                               ((OUTPUT) == RTC_OUTPUT_WAKEUP))
+
+#define IS_RTC_OUTPUT_REMAP(REMAP) (((REMAP) == RTC_OUTPUT_REMAP_NONE) || \
+                                    ((REMAP) == RTC_OUTPUT_REMAP_POS1))
 
 #define IS_RTC_OUTPUT_POL(POL) (((POL) == RTC_OUTPUT_POLARITY_HIGH) || \
                                 ((POL) == RTC_OUTPUT_POLARITY_LOW))
 
+#if defined(RTC_OR_ALARMOUTTYPE)
 #define IS_RTC_OUTPUT_TYPE(TYPE) (((TYPE) == RTC_OUTPUT_TYPE_OPENDRAIN) || \
                                   ((TYPE) == RTC_OUTPUT_TYPE_PUSHPULL))
+#else /* RTC_OR_ALARMOUTTYPE */
+#define IS_RTC_OUTPUT_TYPE(TYPE) ((TYPE) == RTC_OUTPUT_TYPE_OPENDRAIN)
+#endif /* RTC_OR_ALARMOUTTYPE */
 
-#define IS_RTC_OUTPUT_REMAP(REMAP)   (((REMAP) == RTC_OUTPUT_REMAP_NONE) || \
-                                      ((REMAP) == RTC_OUTPUT_REMAP_POS1))
+#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= 0x7FU)
+#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= 0x7FFFU)
+
+#define IS_RTC_HOUR12(HOUR)            (((HOUR) > 0U) && ((HOUR) <= 12U))
+#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= 23U)
+#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= 59U)
+#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= 59U)
 
 #define IS_RTC_HOURFORMAT12(PM)  (((PM) == RTC_HOURFORMAT12_AM) || \
                                   ((PM) == RTC_HOURFORMAT12_PM))
@@ -886,11 +871,9 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 
 #define IS_RTC_FORMAT(FORMAT) (((FORMAT) == RTC_FORMAT_BIN) || ((FORMAT) == RTC_FORMAT_BCD))
 
-#define IS_RTC_YEAR(YEAR)              ((YEAR) <= (uint32_t)99U)
-
-#define IS_RTC_MONTH(MONTH)            (((MONTH) >= (uint32_t)1U) && ((MONTH) <= (uint32_t)12U))
-
-#define IS_RTC_DATE(DATE)              (((DATE) >= (uint32_t)1U) && ((DATE) <= (uint32_t)31U))
+#define IS_RTC_YEAR(YEAR)              ((YEAR) <= 99U)
+#define IS_RTC_MONTH(MONTH)            (((MONTH) >= 1U) && ((MONTH) <= 12U))
+#define IS_RTC_DATE(DATE)              (((DATE) >= 1U) && ((DATE) <= 31U))
 
 #define IS_RTC_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
                                  ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
@@ -900,7 +883,7 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
                                  ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
                                  ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
 
-#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) >(uint32_t)0U) && ((DATE) <= (uint32_t)31U))
+#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) > 0U) && ((DATE) <= 31U))
 
 #define IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
                                                     ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
@@ -913,41 +896,28 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
 #define IS_RTC_ALARM_DATE_WEEKDAY_SEL(SEL) (((SEL) == RTC_ALARMDATEWEEKDAYSEL_DATE) || \
                                             ((SEL) == RTC_ALARMDATEWEEKDAYSEL_WEEKDAY))
 
-#define IS_RTC_ALARM_MASK(MASK)  (((MASK) & ~(RTC_ALARMMASK_ALL)) == 0U)
+#define IS_RTC_ALARM_MASK(MASK)  (((MASK) & ((uint32_t)~RTC_ALARMMASK_ALL)) == 0U)
 
 #define IS_RTC_ALARM(ALARM)      (((ALARM) == RTC_ALARM_A) || ((ALARM) == RTC_ALARM_B))
 
 #define IS_RTC_ALARM_SUB_SECOND_VALUE(VALUE) ((VALUE) <= RTC_ALRMASSR_SS)
 
-#define IS_RTC_ALARM_SUB_SECOND_MASK(MASK)   (((MASK) == RTC_ALARMSUBSECONDMASK_ALL) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_1) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_2) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_3) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_4) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_5) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_6) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_7) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_8) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_9) || \
+#define IS_RTC_ALARM_SUB_SECOND_MASK(MASK)   (((MASK) == RTC_ALARMSUBSECONDMASK_ALL)     || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_1)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_2)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_3)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_4)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_5)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_6)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_7)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_8)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_9)  || \
                                               ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_10) || \
                                               ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_11) || \
                                               ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_12) || \
                                               ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_13) || \
-                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14)    || \
                                               ((MASK) == RTC_ALARMSUBSECONDMASK_NONE))
-
-#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= (uint32_t)0x7FU)
-
-#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= (uint32_t)0x7FFFU)
-
-#define IS_RTC_HOUR12(HOUR)            (((HOUR) > (uint32_t)0U) && ((HOUR) <= (uint32_t)12U))
-
-#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= (uint32_t)23U)
-
-#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= (uint32_t)59U)
-
-#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= (uint32_t)59U)
-
 /**
   * @}
   */
@@ -956,17 +926,18 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
   * @}
   */
 
-/* Private functions -------------------------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
 /** @defgroup RTC_Private_Functions RTC Private Functions
   * @{
   */
-HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef* hrtc);
-uint8_t            RTC_ByteToBcd2(uint8_t Value);
-uint8_t            RTC_Bcd2ToByte(uint8_t Value);
+HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef  RTC_ExitInitMode(RTC_HandleTypeDef *hrtc);
+uint8_t            RTC_ByteToBcd2(uint8_t number);
+uint8_t            RTC_Bcd2ToByte(uint8_t number);
 /**
   * @}
   */
-
 
 /**
   * @}
@@ -981,5 +952,3 @@ uint8_t            RTC_Bcd2ToByte(uint8_t Value);
 #endif
 
 #endif /* STM32WBxx_HAL_RTC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rtc_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_rtc_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,17 +21,18 @@
 #define STM32WBxx_HAL_RTC_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
+
 #include "stm32wbxx_hal_def.h"
 
 /** @addtogroup STM32WBxx_HAL_Driver
   * @{
   */
 
-/** @defgroup RTCEx RTCEx
+/** @addtogroup RTCEx
   * @{
   */
 
@@ -48,19 +48,19 @@
 typedef struct
 {
   uint32_t Tamper;                      /*!< Specifies the Tamper Pin.
-                                             This parameter can be a value of @ref  RTCEx_Tamper_Pins_Definitions */
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pin_Definitions */
 
   uint32_t Interrupt;                   /*!< Specifies the Tamper Interrupt.
-                                             This parameter can be a value of @ref  RTCEx_Tamper_Interrupt_Definitions */
+                                             This parameter can be a value of @ref RTCEx_Tamper_Interrupt_Definitions */
 
   uint32_t Trigger;                     /*!< Specifies the Tamper Trigger.
-                                             This parameter can be a value of @ref  RTCEx_Tamper_Trigger_Definitions */
+                                             This parameter can be a value of @ref RTCEx_Tamper_Trigger_Definitions */
 
   uint32_t NoErase;                     /*!< Specifies the Tamper no erase mode.
-                                             This parameter can be a value of @ref  RTCEx_Tamper_EraseBackUp_Definitions */
+                                             This parameter can be a value of @ref RTCEx_Tamper_EraseBackUp_Definitions */
 
   uint32_t MaskFlag;                     /*!< Specifies the Tamper Flag masking.
-                                             This parameter can be a value of @ref RTCEx_Tamper_MaskFlag_Definitions   */
+                                             This parameter can be a value of @ref RTCEx_Tamper_MaskFlag_Definitions */
 
   uint32_t Filter;                      /*!< Specifies the RTC Filter Tamper.
                                              This parameter can be a value of @ref RTCEx_Tamper_Filter_Definitions */
@@ -72,143 +72,127 @@ typedef struct
                                              This parameter can be a value of @ref RTCEx_Tamper_Pin_Precharge_Duration_Definitions */
 
   uint32_t TamperPullUp;                /*!< Specifies the Tamper PullUp .
-                                             This parameter can be a value of @ref RTCEx_Tamper_Pull_UP_Definitions */
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pull_Up_Definitions */
 
   uint32_t TimeStampOnTamperDetection;  /*!< Specifies the TimeStampOnTamperDetection.
                                              This parameter can be a value of @ref RTCEx_Tamper_TimeStampOnTamperDetection_Definitions */
-}RTC_TamperTypeDef;
+} RTC_TamperTypeDef;
 /**
   * @}
   */
 
 /* Exported constants --------------------------------------------------------*/
+
 /** @defgroup RTCEx_Exported_Constants RTCEx Exported Constants
   * @{
   */
 
-/** @defgroup RTCEx_Output_selection_Definitions RTCEx Output Selection Definition
+/** @defgroup RTCEx_Backup_Registers_Definitions RTCEx Backup Registers Definitions
   * @{
   */
-#define RTC_OUTPUT_DISABLE             ((uint32_t)0x00000000U)
-#define RTC_OUTPUT_ALARMA              ((uint32_t)RTC_CR_OSEL_0)
-#define RTC_OUTPUT_ALARMB              ((uint32_t)RTC_CR_OSEL_1)
-#define RTC_OUTPUT_WAKEUP              ((uint32_t)RTC_CR_OSEL)
-
+#define RTC_BKP_DR0                       0x00000000U
+#define RTC_BKP_DR1                       0x00000001U
+#define RTC_BKP_DR2                       0x00000002U
+#define RTC_BKP_DR3                       0x00000003U
+#define RTC_BKP_DR4                       0x00000004U
+#define RTC_BKP_DR5                       0x00000005U
+#define RTC_BKP_DR6                       0x00000006U
+#define RTC_BKP_DR7                       0x00000007U
+#define RTC_BKP_DR8                       0x00000008U
+#define RTC_BKP_DR9                       0x00000009U
+#define RTC_BKP_DR10                      0x0000000AU
+#define RTC_BKP_DR11                      0x0000000BU
+#define RTC_BKP_DR12                      0x0000000CU
+#define RTC_BKP_DR13                      0x0000000DU
+#define RTC_BKP_DR14                      0x0000000EU
+#define RTC_BKP_DR15                      0x0000000FU
+#define RTC_BKP_DR16                      0x00000010U
+#define RTC_BKP_DR17                      0x00000011U
+#define RTC_BKP_DR18                      0x00000012U
+#define RTC_BKP_DR19                      0x00000013U
 /**
   * @}
   */
 
-/** @defgroup RTCEx_Backup_Registers_Definitions RTCEx Backup Registers Definition
+/** @defgroup RTCEx_Timestamp_Edges_Definitions RTCEx Timestamp Edges Definitions
   * @{
   */
-#define RTC_BKP_DR0                       ((uint32_t)0x00000000U)
-#define RTC_BKP_DR1                       ((uint32_t)0x00000001U)
-#define RTC_BKP_DR2                       ((uint32_t)0x00000002U)
-#define RTC_BKP_DR3                       ((uint32_t)0x00000003U)
-#define RTC_BKP_DR4                       ((uint32_t)0x00000004U)
-#define RTC_BKP_DR5                       ((uint32_t)0x00000005U)
-#define RTC_BKP_DR6                       ((uint32_t)0x00000006U)
-#define RTC_BKP_DR7                       ((uint32_t)0x00000007U)
-#define RTC_BKP_DR8                       ((uint32_t)0x00000008U)
-#define RTC_BKP_DR9                       ((uint32_t)0x00000009U)
-#define RTC_BKP_DR10                      ((uint32_t)0x0000000AU)
-#define RTC_BKP_DR11                      ((uint32_t)0x0000000BU)
-#define RTC_BKP_DR12                      ((uint32_t)0x0000000CU)
-#define RTC_BKP_DR13                      ((uint32_t)0x0000000DU)
-#define RTC_BKP_DR14                      ((uint32_t)0x0000000EU)
-#define RTC_BKP_DR15                      ((uint32_t)0x0000000FU)
-#define RTC_BKP_DR16                      ((uint32_t)0x00000010U)
-#define RTC_BKP_DR17                      ((uint32_t)0x00000011U)
-#define RTC_BKP_DR18                      ((uint32_t)0x00000012U)
-#define RTC_BKP_DR19                      ((uint32_t)0x00000013U)
-
+#define RTC_TIMESTAMPEDGE_RISING          0x00000000U
+#define RTC_TIMESTAMPEDGE_FALLING         RTC_CR_TSEDGE
 /**
   * @}
   */
 
-
-/** @defgroup RTCEx_Time_Stamp_Edges_definitions RTCEx Time Stamp Edges definition
+/** @defgroup RTCEx_Timestamp_Pin_Selection RTC Timestamp Pin Selection
   * @{
   */
-#define RTC_TIMESTAMPEDGE_RISING        ((uint32_t)0x00000000U)
-#define RTC_TIMESTAMPEDGE_FALLING       RTC_CR_TSEDGE
-
+#define RTC_TIMESTAMPPIN_DEFAULT            0x00000000U
 /**
   * @}
   */
 
-/** @defgroup RTCEx_TimeStamp_Pin_Selections RTCEx TimeStamp Pin Selection
-  * @{
-  */
-#define RTC_TIMESTAMPPIN_DEFAULT              ((uint32_t)0x00000000U)
-
-/**
-  * @}
-  */
-
-
-/** @defgroup RTCEx_Tamper_Pins_Definitions RTCEx Tamper Pins Definition
+/** @defgroup RTCEx_Tamper_Pin_Definitions RTCEx Tamper Pins Definitions
   * @{
   */
 #if defined(RTC_TAMPER1_SUPPORT)
-#define RTC_TAMPER_1                       RTC_TAMPCR_TAMP1E
+#define RTC_TAMPER_1                    RTC_TAMPCR_TAMP1E
 #endif /* RTC_TAMPER1_SUPPORT */
-
-#define RTC_TAMPER_2                       RTC_TAMPCR_TAMP2E
-
+#define RTC_TAMPER_2                    RTC_TAMPCR_TAMP2E
 #if defined(RTC_TAMPER3_SUPPORT)
-#define RTC_TAMPER_3                       RTC_TAMPCR_TAMP3E
+#define RTC_TAMPER_3                    RTC_TAMPCR_TAMP3E
 #endif /* RTC_TAMPER3_SUPPORT */
 /**
   * @}
   */
 
+/** @defgroup RTCEx_Tamper_Pin_Selection RTC tamper Pins Selection
+  * @{
+  */
+#define RTC_TAMPERPIN_DEFAULT               0x00000000U
+/**
+  * @}
+  */
 
 /** @defgroup RTCEx_Tamper_Interrupt_Definitions RTCEx Tamper Interrupt Definitions
   * @{
   */
+#define RTC_IT_TAMP                       RTC_TAMPCR_TAMPIE   /*!< Enable global Tamper Interrupt           */
 #if defined(RTC_TAMPER1_SUPPORT)
-#define RTC_TAMPER1_INTERRUPT              RTC_TAMPCR_TAMP1IE
+#define RTC_IT_TAMP1                      RTC_TAMPCR_TAMP1IE  /*!< Enable Tamper 1 Interrupt                */
 #endif /* RTC_TAMPER1_SUPPORT */
-
-
-#define RTC_TAMPER2_INTERRUPT              RTC_TAMPCR_TAMP2IE
-
+#define RTC_IT_TAMP2                      RTC_TAMPCR_TAMP2IE  /*!< Enable Tamper 2 Interrupt                */
 #if defined(RTC_TAMPER3_SUPPORT)
-#define RTC_TAMPER3_INTERRUPT              RTC_TAMPCR_TAMP3IE
+#define RTC_IT_TAMP3                      RTC_TAMPCR_TAMP3IE  /*!< Enable Tamper 3 Interrupt                */
 #endif /* RTC_TAMPER3_SUPPORT */
-#define RTC_ALL_TAMPER_INTERRUPT             RTC_TAMPCR_TAMPIE
 /**
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Trigger_Definitions RTCEx Tamper Trigger Definitions
+/** @defgroup RTCEx_Tamper_Trigger_Definitions RTCEx Tamper Triggers Definitions
   * @{
   */
-#define RTC_TAMPERTRIGGER_RISINGEDGE       ((uint32_t)0x00000000U)
-#define RTC_TAMPERTRIGGER_FALLINGEDGE      ((uint32_t)0x00000002U)
+#define RTC_TAMPERTRIGGER_RISINGEDGE       0x00000000U
+#define RTC_TAMPERTRIGGER_FALLINGEDGE      0x00000002U
 #define RTC_TAMPERTRIGGER_LOWLEVEL         RTC_TAMPERTRIGGER_RISINGEDGE
 #define RTC_TAMPERTRIGGER_HIGHLEVEL        RTC_TAMPERTRIGGER_FALLINGEDGE
-
 /**
   * @}
   */
 
 /** @defgroup RTCEx_Tamper_EraseBackUp_Definitions RTCEx Tamper EraseBackUp Definitions
-* @{
-*/
-#define RTC_TAMPER_ERASE_BACKUP_ENABLE               ((uint32_t)0x00000000U)
-#define RTC_TAMPER_ERASE_BACKUP_DISABLE              ((uint32_t)0x00020000U)
+  * @{
+  */
+#define RTC_TAMPER_ERASE_BACKUP_ENABLE             0x00000000U
+#define RTC_TAMPER_ERASE_BACKUP_DISABLE            0x00020000U
 /**
   * @}
   */
 
 /** @defgroup RTCEx_Tamper_MaskFlag_Definitions RTCEx Tamper MaskFlag Definitions
-* @{
-*/
-#define RTC_TAMPERMASK_FLAG_DISABLE               ((uint32_t)0x00000000U)
-#define RTC_TAMPERMASK_FLAG_ENABLE                ((uint32_t)0x00040000U)
-
+  * @{
+  */
+#define RTC_TAMPERMASK_FLAG_DISABLE                0x00000000U
+#define RTC_TAMPERMASK_FLAG_ENABLE                 0x00040000U
 /**
   * @}
   */
@@ -216,15 +200,16 @@ typedef struct
 /** @defgroup RTCEx_Tamper_Filter_Definitions RTCEx Tamper Filter Definitions
   * @{
   */
-#define RTC_TAMPERFILTER_DISABLE   ((uint32_t)0x00000000U)  /*!< Tamper filter is disabled */
+#define RTC_TAMPERFILTER_DISABLE   0x00000000U             /*!< Tamper filter is disabled */
 
 #define RTC_TAMPERFILTER_2SAMPLE   RTC_TAMPCR_TAMPFLT_0    /*!< Tamper is activated after 2
-                                                                consecutive samples at the active level */
+                                                                 consecutive samples at the active level */
 #define RTC_TAMPERFILTER_4SAMPLE   RTC_TAMPCR_TAMPFLT_1    /*!< Tamper is activated after 4
-                                                                consecutive samples at the active level */
+                                                                 consecutive samples at the active level */
 #define RTC_TAMPERFILTER_8SAMPLE   RTC_TAMPCR_TAMPFLT      /*!< Tamper is activated after 8
-                                                                consecutive samples at the active leve. */
-
+                                                                 consecutive samples at the active level */
+#define RTC_TAMPERFILTER_MASK      RTC_TAMPCR_TAMPFLT      /*!< Masking all bits except those of
+                                                                 field TAMPFLT                           */
 /**
   * @}
   */
@@ -232,24 +217,24 @@ typedef struct
 /** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions RTCEx Tamper Sampling Frequencies Definitions
   * @{
   */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  ((uint32_t)0x00000000U)                                         /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 32768 */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384  RTC_TAMPCR_TAMPFREQ_0                                          /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 16384 */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192   RTC_TAMPCR_TAMPFREQ_1                                          /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 8192  */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096   ((uint32_t) (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_1))   /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 4096  */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048   RTC_TAMPCR_TAMPFREQ_2                                          /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 2048  */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024   ((uint32_t) (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_2))   /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 1024  */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512    ((uint32_t) (RTC_TAMPCR_TAMPFREQ_1 | RTC_TAMPCR_TAMPFREQ_2))   /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 512   */
-#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256    ((uint32_t) (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_1 | \
-                                                 RTC_TAMPCR_TAMPFREQ_2))                                       /*!< Each of the tamper inputs are sampled
-                                                                                                                    with a frequency =  RTCCLK / 256   */
-
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  0x00000000U                                     /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 32768 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384  RTC_TAMPCR_TAMPFREQ_0                           /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 16384 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192   RTC_TAMPCR_TAMPFREQ_1                           /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 8192  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096   (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_1) /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 4096  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048   RTC_TAMPCR_TAMPFREQ_2                           /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 2048  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024   (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_2) /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 1024  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512    (RTC_TAMPCR_TAMPFREQ_1 | RTC_TAMPCR_TAMPFREQ_2) /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 512   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256    RTC_TAMPCR_TAMPFREQ                             /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 256   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_MASK      RTC_TAMPCR_TAMPFREQ                             /*!< Masking all bits except those of
+                                                                                                      field TAMPFREQ                     */
 /**
   * @}
   */
@@ -257,35 +242,36 @@ typedef struct
 /** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions RTCEx Tamper Pin Precharge Duration Definitions
   * @{
   */
-#define RTC_TAMPERPRECHARGEDURATION_1RTCCLK  ((uint32_t)0x00000000U)                                     /*!< Tamper pins are pre-charged before
-                                                                                                            sampling during 1 RTCCLK cycle  */
-#define RTC_TAMPERPRECHARGEDURATION_2RTCCLK  RTC_TAMPCR_TAMPPRCH_0                                      /*!< Tamper pins are pre-charged before
-                                                                                                             sampling during 2 RTCCLK cycles */
-#define RTC_TAMPERPRECHARGEDURATION_4RTCCLK  RTC_TAMPCR_TAMPPRCH_1                                      /*!< Tamper pins are pre-charged before
-                                                                                                             sampling during 4 RTCCLK cycles */
-#define RTC_TAMPERPRECHARGEDURATION_8RTCCLK ((uint32_t)(RTC_TAMPCR_TAMPPRCH_0 | RTC_TAMPCR_TAMPPRCH_1)) /*!< Tamper pins are pre-charged before
-                                                                                                             sampling during 8 RTCCLK cycles */
-
+#define RTC_TAMPERPRECHARGEDURATION_1RTCCLK     0x00000000U             /*!< Tamper pins are pre-charged before
+                                                                              sampling during 1 RTCCLK cycle  */
+#define RTC_TAMPERPRECHARGEDURATION_2RTCCLK     RTC_TAMPCR_TAMPPRCH_0   /*!< Tamper pins are pre-charged before
+                                                                              sampling during 2 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_4RTCCLK     RTC_TAMPCR_TAMPPRCH_1   /*!< Tamper pins are pre-charged before
+                                                                              sampling during 4 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_8RTCCLK     RTC_TAMPCR_TAMPPRCH     /*!< Tamper pins are pre-charged before
+                                                                              sampling during 8 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_MASK        RTC_TAMPCR_TAMPPRCH     /*!< Masking all bits except those of
+                                                                              field TAMPPRCH                  */
 /**
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions RTCEx Tamper TimeStampOnTamperDetection Definitions
+/** @defgroup  RTCEx_Tamper_Pull_Up_Definitions RTCEx Tamper Pull Up Definitions
   * @{
   */
-#define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  RTC_TAMPCR_TAMPTS       /*!< TimeStamp on Tamper Detection event saved        */
-#define RTC_TIMESTAMPONTAMPERDETECTION_DISABLE ((uint32_t)0x00000000U)  /*!< TimeStamp on Tamper Detection event is not saved */
-
+#define RTC_TAMPER_PULLUP_ENABLE  0x00000000U           /*!< Tamper pins are pre-charged before sampling     */
+#define RTC_TAMPER_PULLUP_DISABLE RTC_TAMPCR_TAMPPUDIS   /*!< Tamper pins are not pre-charged before sampling */
+#define RTC_TAMPER_PULLUP_MASK    RTC_TAMPCR_TAMPPUDIS   /*!< Masking all bits except bit TAMPPUDIS           */
 /**
   * @}
   */
 
-/** @defgroup RTCEx_Tamper_Pull_UP_Definitions RTCEx Tamper Pull UP Definitions
+/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions RTCEx Tamper TimeStamp On Tamper Detection Definitions
   * @{
   */
-#define RTC_TAMPER_PULLUP_ENABLE  ((uint32_t)0x00000000U)  /*!< Tamper pins are pre-charged before sampling */
-#define RTC_TAMPER_PULLUP_DISABLE  RTC_TAMPCR_TAMPPUDIS   /*!< Tamper pins pre-charge is disabled          */
-
+#define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  RTC_TAMPCR_TAMPTS  /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TIMESTAMPONTAMPERDETECTION_DISABLE 0x00000000U       /*!< TimeStamp on Tamper Detection event is not saved */
+#define RTC_TIMESTAMPONTAMPERDETECTION_MASK    RTC_TAMPCR_TAMPTS  /*!< Masking all bits except bit TAMPTS               */
 /**
   * @}
   */
@@ -293,77 +279,55 @@ typedef struct
 /** @defgroup RTCEx_Wakeup_Timer_Definitions RTCEx Wakeup Timer Definitions
   * @{
   */
-#define RTC_WAKEUPCLOCK_RTCCLK_DIV16        ((uint32_t)0x00000000U)
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV16        0x00000000U
 #define RTC_WAKEUPCLOCK_RTCCLK_DIV8         RTC_CR_WUCKSEL_0
 #define RTC_WAKEUPCLOCK_RTCCLK_DIV4         RTC_CR_WUCKSEL_1
-#define RTC_WAKEUPCLOCK_RTCCLK_DIV2         ((uint32_t) (RTC_CR_WUCKSEL_0 | RTC_CR_WUCKSEL_1))
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV2         (RTC_CR_WUCKSEL_0 | RTC_CR_WUCKSEL_1)
 #define RTC_WAKEUPCLOCK_CK_SPRE_16BITS      RTC_CR_WUCKSEL_2
-#define RTC_WAKEUPCLOCK_CK_SPRE_17BITS      ((uint32_t) (RTC_CR_WUCKSEL_1 | RTC_CR_WUCKSEL_2))
+#define RTC_WAKEUPCLOCK_CK_SPRE_17BITS      (RTC_CR_WUCKSEL_1 | RTC_CR_WUCKSEL_2)
 /**
   * @}
   */
 
-/** @defgroup RTCEx_Smooth_calib_period_Definitions RTCEx Smooth calib period Definitions
+/** @defgroup RTCEx_Smooth_calib_period_Definitions RTCEx Smooth Calib Period Definitions
   * @{
   */
-#define RTC_SMOOTHCALIB_PERIOD_32SEC   ((uint32_t)0x00000000U)   /*!< If RTCCLK = 32768 Hz, Smooth calibation
-                                                                     period is 32s,  else 2exp20 RTCCLK pulses */
-#define RTC_SMOOTHCALIB_PERIOD_16SEC   RTC_CALR_CALW16          /*!< If RTCCLK = 32768 Hz, Smooth calibation
-                                                                     period is 16s, else 2exp19 RTCCLK pulses */
-#define RTC_SMOOTHCALIB_PERIOD_8SEC    RTC_CALR_CALW8           /*!< If RTCCLK = 32768 Hz, Smooth calibation
-                                                                     period is 8s, else 2exp18 RTCCLK pulses */
-
+#define RTC_SMOOTHCALIB_PERIOD_32SEC   0x00000000U      /*!< If RTCCLK = 32768 Hz, smooth calibration
+                                                              period is 32s, otherwise 2^20 RTCCLK pulses */
+#define RTC_SMOOTHCALIB_PERIOD_16SEC   RTC_CALR_CALW16  /*!< If RTCCLK = 32768 Hz, smooth calibration
+                                                              period is 16s, otherwise 2^19 RTCCLK pulses */
+#define RTC_SMOOTHCALIB_PERIOD_8SEC    RTC_CALR_CALW8   /*!< If RTCCLK = 32768 Hz, smooth calibration
+                                                              period is 8s, otherwise 2^18 RTCCLK pulses  */
 /**
   * @}
   */
 
-/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions RTCEx Smooth calib Plus pulses Definitions
+/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions RTCEx Smooth Calib Plus Pulses Definitions
   * @{
   */
-#define RTC_SMOOTHCALIB_PLUSPULSES_SET    RTC_CALR_CALP            /*!< The number of RTCCLK pulses added
+#define RTC_SMOOTHCALIB_PLUSPULSES_SET    RTC_CALR_CALP           /*!< The number of RTCCLK pulses added
                                                                         during a X -second window = Y - CALM[8:0]
                                                                         with Y = 512, 256, 128 when X = 32, 16, 8 */
-#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  ((uint32_t)0x00000000U)   /*!< The number of RTCCLK pulses subbstited
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  0x00000000U             /*!< The number of RTCCLK pulses subbstited
                                                                         during a 32-second window = CALM[8:0] */
-
-/**
-  * @}
-  */
- /** @defgroup RTCEx_Calib_Output_selection_Definitions RTCEx Calib Output selection Definitions
-  * @{
-  */
-#define RTC_CALIBOUTPUT_512HZ            ((uint32_t)0x00000000U)
-#define RTC_CALIBOUTPUT_1HZ              RTC_CR_COSEL
-
 /**
   * @}
   */
 
-
-/** @defgroup RTCEx_Add_1_Second_Parameter_Definition RTCEx Add 1 Second Parameter Definitions
+/** @defgroup RTCEx_Add_1_Second_Parameter_Definitions RTCEx Add 1 Second Parameter Definitions
   * @{
   */
-#define RTC_SHIFTADD1S_RESET      ((uint32_t)0x00000000U)
+#define RTC_SHIFTADD1S_RESET      0x00000000U
 #define RTC_SHIFTADD1S_SET        RTC_SHIFTR_ADD1S
 /**
   * @}
   */
-  /** @defgroup RTCEx_Interrupts_Definitions RTCEx Interrupts Definitions
-  * @{
-  */
-#if defined(RTC_TAMPER3_SUPPORT)
-#define RTC_IT_TAMP3                      ((uint32_t)RTC_TAMPCR_TAMP3IE)  /*!< Enable Tamper 3 Interrupt     */
-#endif
-/**
-  * @}
-  */
 
-/** @defgroup RTCEx_Flags_Definitions RTCEx Flags Definitions
+/** @defgroup RTCEx_Calib_Output_selection_Definitions RTCEx Calib Output Selection Definitions
   * @{
   */
-#if defined(RTC_TAMPER3_SUPPORT)
-#define RTC_FLAG_TAMP3F                   ((uint32_t)RTC_ISR_TAMP3F)
-#endif
+#define RTC_CALIBOUTPUT_512HZ            0x00000000U
+#define RTC_CALIBOUTPUT_1HZ              RTC_CR_COSEL
 /**
   * @}
   */
@@ -373,277 +337,235 @@ typedef struct
   */
 
 /* Exported macros -----------------------------------------------------------*/
+
 /** @defgroup RTCEx_Exported_Macros RTCEx Exported Macros
   * @{
   */
 
-/* ---------------------------------WAKEUPTIMER---------------------------------*/
-/** @defgroup RTCEx_WakeUp_Timer RTC WakeUp Timer
+/* ---------------------------------WAKEUPTIMER-------------------------------*/
+
+/** @defgroup RTCEx_WakeUp_Timer RTCEx WakeUp Timer
   * @{
   */
+
 /**
   * @brief  Enable the RTC WakeUp Timer peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_ENABLE(__HANDLE__)                      ((__HANDLE__)->Instance->CR |= (RTC_CR_WUTE))
 
 /**
-  * @brief  Disable the RTC WakeUp Timer peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @brief  Disable the RTC Wakeup Timer peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_DISABLE(__HANDLE__)                     ((__HANDLE__)->Instance->CR &= ~(RTC_CR_WUTE))
 
 /**
-  * @brief  Enable the RTC WakeUpTimer interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC WakeUpTimer interrupt sources to be enabled.
+  * @brief  Enable the RTC Wakeup Timer interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup Timer interrupt sources to be enabled or disabled.
   *         This parameter can be:
-  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  *            @arg RTC_IT_WUT: Wakeup Timer interrupt
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
 
 /**
-  * @brief  Disable the RTC WakeUpTimer interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC WakeUpTimer interrupt sources to be disabled.
+  * @brief  Disable the RTC Wakeup Timer interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup Timer interrupt sources to be enabled or disabled.
   *         This parameter can be:
-  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  *            @arg RTC_IT_WUT: Wakeup Timer interrupt
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
 
 /**
-  * @brief  Check whether the specified RTC WakeUpTimer interrupt has occurred or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC WakeUpTimer interrupt to check.
+  * @brief  Check whether the specified RTC Wakeup Timer interrupt has occurred or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup Timer interrupt to check.
   *         This parameter can be:
-  *            @arg RTC_IT_WUT:  WakeUpTimer interrupt
+  *            @arg RTC_IT_WUT: Wakeup Timer interrupt
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)       (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 4U)) != 0U) ? 1U : 0U)
+#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)          (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__) >> 4U)) != 0U) ? 1U : 0U)
 
 /**
-  * @brief  Check whether the specified RTC Wake Up timer interrupt has been enabled or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Wake Up timer interrupt sources to check.
+  * @brief  Check whether the specified RTC Wakeup timer interrupt has been enabled or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup timer interrupt sources to check.
   *         This parameter can be:
-  *            @arg RTC_IT_WUT:  WakeUpTimer interrupt
+  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
 
 /**
-  * @brief  Get the selected RTC WakeUpTimer's flag status.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC WakeUpTimer Flag is pending or not.
+  * @brief  Get the selected RTC Wakeup Timer's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Wakeup Timer flag to check.
   *          This parameter can be:
-  *             @arg RTC_FLAG_WUTF
-  *             @arg RTC_FLAG_WUTWF
+  *             @arg RTC_FLAG_WUTF: Wakeup Timer interrupt flag
+  *             @arg RTC_FLAG_WUTWF: Wakeup Timer 'write allowed' flag
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)   (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)          (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
 
 /**
-  * @brief  Clear the RTC Wake Up timer's pending flags.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC WakeUpTimer Flag to clear.
+  * @brief  Clear the RTC Wakeup timer's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Wakeup Timer Flag to clear.
   *         This parameter can be:
-  *            @arg RTC_FLAG_WUTF
+  *             @arg RTC_FLAG_WUTF: Wakeup Timer interrupt Flag
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__)            ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
 
 /**
-  * @brief  Enable interrupt on the RTC WakeUp Timer associated Exti line of core 1.
+  * @brief  Enable interrupt on the RTC Wakeup Timer associated EXTI line.
   * @retval None
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT()       (EXTI->IMR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Disable interrupt on the RTC WakeUp Timer associated Exti line of core 1.
+  * @brief  Disable interrupt on the RTC Wakeup Timer associated EXTI line.
   * @retval None
   */
-#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT()      (EXTI->IMR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
-
-
-/**
-  * @brief  Enable interrupt on the RTC WakeUp Timer associated Exti line of core 2.
-  * @retval None
-  */
-#define __HAL_RTC_WAKEUPTIMER_EXTIC2_ENABLE_IT()       (EXTI->C2IMR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT()      (EXTI->IMR1 &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Disable interrupt on the RTC WakeUp Timer associated Exti line of core 2.
-  * @retval None
-  */
-#define __HAL_RTC_WAKEUPTIMER_EXTIC2_DISABLE_IT()      (EXTI->C2IMR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
-
-
-/**
-  * @brief  Enable event on the RTC WakeUp Timer associated Exti line of core 1.
+  * @brief  Enable event on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_EVENT()    (EXTI->EMR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Enable event on the RTC WakeUp Timer associated Exti line of core 2.
+  * @brief  Disable event on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_WAKEUPTIMER_EXTIC2_ENABLE_EVENT()    (EXTI->C2EMR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
-
-
-/**
-  * @brief  Disable event on the RTC WakeUp Timer associated Exti line of core 1.
-  * @retval None.
-  */
-#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_EVENT()   (EXTI->EMR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_EVENT()   (EXTI->EMR1 &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Disable event on the RTC WakeUp Timer associated Exti line of core 2.
-  * @retval None.
-  */
-#define __HAL_RTC_WAKEUPTIMER_EXTIC2_DISABLE_EVENT()   (EXTI->C2EMR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
-
-
-/*---------------*/
-/**
-  * @brief  Enable falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @brief  Enable falling edge trigger on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Disable falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @brief  Disable falling edge trigger on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Enable rising edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @brief  Enable rising edge trigger on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Disable rising edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @brief  Disable rising edge trigger on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~(RTC_EXTI_LINE_WAKEUPTIMER_EVENT))
-
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief  Enable rising & falling edge trigger on the RTC WakeUp Timer associated Exti line.
-  * @retval None
+  * @brief  Enable rising & falling edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
   */
-#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
-                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();  \
-                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE(); \
-                                                                 } while(0U)
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                                   \
+                                                                     __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();  \
+                                                                     __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE(); \
+                                                                   } while(0U)
 
 /**
-  * @brief  Disable rising & falling edge trigger on the RTC WakeUp Timer associated Exti line.
+  * @brief  Disable rising & falling edge trigger on the RTC Wakeup Timer associated EXTI line.
   * This parameter can be:
-  * @retval None
+  * @retval None.
   */
-#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
-                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE();  \
-                                                                   __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE(); \
-                                                                  } while(0U)
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                                    \
+                                                                      __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE();  \
+                                                                      __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                    } while(0U)
 
 /**
-  * @brief Check whether the RTC WakeUp Timer associated Exti line interrupt flag is set or not of core 1.
+  * @brief Check whether the RTC Wakeup Timer associated EXTI line interrupt flag is set or not.
   * @retval Line Status.
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG()              (EXTI->PR1 & RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief Check whether the RTC WakeUp Timer associated Exti line interrupt flag is set or not of core 2.
-  * @retval Line Status.
-  */
-#define __HAL_RTC_WAKEUPTIMER_EXTIC2_GET_FLAG()            (EXTI->PR1 & RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
-
-
-
-/**
-  * @brief Clear the RTC WakeUp Timer associated Exti line flag of core 1.
+  * @brief Clear the RTC Wakeup Timer associated EXTI line flag.
   * @retval None.
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG()            (EXTI->PR1 = RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
 
 /**
-  * @brief Clear the RTC WakeUp Timer associated Exti line flag of core 2.
-  * @retval None.
-  */
-#define __HAL_RTC_WAKEUPTIMER_EXTIC2_CLEAR_FLAG()          (EXTI->PR1 = RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
-
-
-/*---------------*/
-/**
-  * @brief Generate a Software interrupt on the RTC WakeUp Timer associated Exti line.
+  * @brief Generate a Software interrupt on the RTC Wakeup Timer associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT()         (EXTI->SWIER1 |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
-/*---------------*/
 
 /**
   * @}
   */
 
 /* ---------------------------------TIMESTAMP---------------------------------*/
-/** @defgroup RTCEx_Timestamp RTC Timestamp
+
+/** @defgroup RTCEx_Timestamp RTCEx Timestamp
   * @{
   */
-/**
-  * @brief  Enable the RTC TimeStamp peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @retval None
-  */
-#define __HAL_RTC_TIMESTAMP_ENABLE(__HANDLE__)                       ((__HANDLE__)->Instance->CR |= (RTC_CR_TSE))
 
 /**
-  * @brief  Disable the RTC TimeStamp peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @brief  Enable the RTC Timestamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_DISABLE(__HANDLE__)                      ((__HANDLE__)->Instance->CR &= ~(RTC_CR_TSE))
+#define __HAL_RTC_TIMESTAMP_ENABLE(__HANDLE__)                        ((__HANDLE__)->Instance->CR |= (RTC_CR_TSE))
 
 /**
-  * @brief  Enable the RTC TimeStamp interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC TimeStamp interrupt source to be enabled.
+  * @brief  Disable the RTC Timestamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE(__HANDLE__)                       ((__HANDLE__)->Instance->CR &= ~(RTC_CR_TSE))
+
+/**
+  * @brief  Enable the RTC Timestamp interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt sources to be enabled or disabled.
   *         This parameter can be:
   *            @arg RTC_IT_TS: TimeStamp interrupt
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
 
 /**
-  * @brief  Disable the RTC TimeStamp interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC TimeStamp interrupt source to be disabled.
+  * @brief  Disable the RTC Timestamp interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt sources to be enabled or disabled.
   *         This parameter can be:
   *            @arg RTC_IT_TS: TimeStamp interrupt
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
 
 /**
-  * @brief  Check whether the specified RTC TimeStamp interrupt has occurred or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC TimeStamp interrupt to check.
+  * @brief  Check whether the specified RTC Timestamp interrupt has occurred or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt to check.
   *         This parameter can be:
   *            @arg RTC_IT_TS: TimeStamp interrupt
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)        (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 4U)) != 0U) ? 1U : 0U)
+#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)         (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__) >> 4U)) != 0U) ? 1U : 0U)
 
 /**
-  * @brief  Check whether the specified RTC Time Stamp interrupt has been enabled or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Time Stamp interrupt source to check.
+  * @brief  Check whether the specified RTC Timestamp interrupt has been enabled or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt source to check.
   *         This parameter can be:
   *            @arg RTC_IT_TS: TimeStamp interrupt
   * @retval None
@@ -651,48 +573,82 @@ typedef struct
 #define __HAL_RTC_TIMESTAMP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
 
 /**
-  * @brief  Get the selected RTC TimeStamp's flag status.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC TimeStamp Flag is pending or not.
+  * @brief  Get the selected RTC Timestamp's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Timestamp flag to check.
   *         This parameter can be:
-  *            @arg RTC_FLAG_TSF
-  *            @arg RTC_FLAG_TSOVF
+  *            @arg RTC_FLAG_TSF: Timestamp interrupt flag
+  *            @arg RTC_FLAG_TSOVF: Timestamp overflow flag
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)     (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)            (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
 
 /**
-  * @brief  Clear the RTC Time Stamp's pending flags.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC TimeStamp Flag to clear.
-  *          This parameter can be:
-  *             @arg RTC_FLAG_TSF
-  *             @arg RTC_FLAG_TSOVF
+  * @brief  Clear the RTC Timestamp's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Timestamp flag to clear.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_TSF: Timestamp interrupt flag
+  *            @arg RTC_FLAG_TSOVF: Timestamp overflow flag
   * @retval None
   */
-#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)   ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)          ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
 
+/**
+  * @brief  Enable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_ITSE))
+
+/**
+  * @brief  Disable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ITSE))
+
+/**
+  * @brief  Get the selected RTC Internal Timestamp's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Internal Timestamp flag is pending or not.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ITSF: Internal Timestamp interrupt flag
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)    (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Internal Timestamp's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Internal Timestamp flag to clear.
+  *          This parameter can be:
+  *            @arg RTC_FLAG_ITSF: Internal Timestamp interrupt flag
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)  ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0003FFFFU)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
 
 /**
   * @}
   */
 
 /* ---------------------------------TAMPER------------------------------------*/
-/** @defgroup RTCEx_Tamper RTC Tamper
+
+/** @defgroup RTCEx_Tamper RTCEx Tamper
   * @{
   */
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
   * @brief  Enable the RTC Tamper1 input detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_TAMPER1_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP1E))
 
 /**
   * @brief  Disable the RTC Tamper1 input detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_TAMPER1_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP1E))
@@ -700,14 +656,14 @@ typedef struct
 
 /**
   * @brief  Enable the RTC Tamper2 input detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_TAMPER2_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP2E))
 
 /**
   * @brief  Disable the RTC Tamper2 input detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_TAMPER2_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP2E))
@@ -715,167 +671,91 @@ typedef struct
 #if defined(RTC_TAMPER3_SUPPORT)
 /**
   * @brief  Enable the RTC Tamper3 input detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_TAMPER3_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP3E))
 
 /**
   * @brief  Disable the RTC Tamper3 input detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
 #define __HAL_RTC_TAMPER3_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP3E))
 #endif /* RTC_TAMPER3_SUPPORT */
 
-
-/**************************************************************************************************/
-
 /**
   * @brief  Enable the RTC Tamper interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Tamper interrupt sources to be enabled.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Tamper interrupt sources to be enabled.
   *          This parameter can be any combination of the following values:
-  *             @arg  RTC_IT_TAMP: All tampers interrupts
-  *             @arg  RTC_IT_TAMP1: Tamper1 interrupt (*)
-  *             @arg  RTC_IT_TAMP2: Tamper2 interrupt
-  *             @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
+  *            @arg RTC_IT_TAMP: Tamper global interrupt
+  *            @arg RTC_IT_TAMP1: Tamper 1 interrupt (*)
+  *            @arg RTC_IT_TAMP2: Tamper 2 interrupt
+  *            @arg RTC_IT_TAMP3: Tamper 3 interrupt (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 #define __HAL_RTC_TAMPER_ENABLE_IT(__HANDLE__, __INTERRUPT__)        ((__HANDLE__)->Instance->TAMPCR |= (__INTERRUPT__))
 
 /**
   * @brief  Disable the RTC Tamper interrupt.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Tamper interrupt sources to be disabled.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Tamper interrupt sources to be disabled.
   *         This parameter can be any combination of the following values:
-  *             @arg  RTC_IT_TAMP: All tampers interrupts
-  *             @arg  RTC_IT_TAMP1: Tamper1 interrupt (*)
-  *             @arg  RTC_IT_TAMP2: Tamper2 interrupt
-  *             @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
+  *            @arg RTC_IT_TAMP: Tamper global interrupt
+  *            @arg RTC_IT_TAMP1: Tamper 1 interrupt (*)
+  *            @arg RTC_IT_TAMP2: Tamper 2 interrupt
+  *            @arg RTC_IT_TAMP3: Tamper 3 interrupt (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 #define __HAL_RTC_TAMPER_DISABLE_IT(__HANDLE__, __INTERRUPT__)       ((__HANDLE__)->Instance->TAMPCR &= ~(__INTERRUPT__))
 
-/**************************************************************************************************/
-
-/**
-  * @brief  Check whether the specified RTC Tamper interrupt has occurred or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Tamper interrupt to check.
-  *         This parameter can be:
-  *             @arg  RTC_IT_TAMP1: Tamper1 interrupt (*)
-  *             @arg  RTC_IT_TAMP2: Tamper2 interrupt
-  *             @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
-  *
-  *         (*)  Value not defined in all devices. \n
-  *
-  * @retval None
-  */
-#if defined(RTC_TAMPER1_SUPPORT) && defined(RTC_TAMPER3_SUPPORT)
-#define __HAL_RTC_TAMPER_GET_IT(__HANDLE__, __INTERRUPT__)    (((__INTERRUPT__) == RTC_IT_TAMP1) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 3U)) != 0U) ? 1U : 0U) : \
-                                                               ((__INTERRUPT__) == RTC_IT_TAMP2) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 5U)) != 0U) ? 1U : 0U) : \
-                                                               ((__INTERRUPT__) == RTC_IT_TAMP3) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 7U)) != 0U) ? 1U : 0U))
-#else
-#define __HAL_RTC_TAMPER_GET_IT(__HANDLE__, __INTERRUPT__)    (((__INTERRUPT__) == RTC_IT_TAMP1) ? (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__)>> 3U)) != 0U) ? 1U : 0U))
-#endif
-
-/**************************************************************************************************/
-
 /**
   * @brief  Check whether the specified RTC Tamper interrupt has been enabled or not.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __INTERRUPT__ specifies the RTC Tamper interrupt source to check.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Tamper interrupt source to check.
   *         This parameter can be:
-  *            @arg  RTC_IT_TAMP: All tampers interrupts
-  *             @arg  RTC_IT_TAMP1: Tamper1 interrupt (*)
-  *             @arg  RTC_IT_TAMP2: Tamper2 interrupt
-  *             @arg  RTC_IT_TAMP3: Tamper3 interrupt (*)
+  *            @arg RTC_IT_TAMP: Tamper global interrupt
+  *            @arg RTC_IT_TAMP1: Tamper 1 interrupt (*)
+  *            @arg RTC_IT_TAMP2: Tamper 2 interrupt
+  *            @arg RTC_IT_TAMP3: Tamper 3 interrupt (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
-#define __HAL_RTC_TAMPER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)    (((((__HANDLE__)->Instance->TAMPCR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
-
+#define __HAL_RTC_TAMPER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->TAMPCR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
 
 /**
   * @brief  Get the selected RTC Tamper's flag status.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC Tamper Flag is pending or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Tamper flag to be checked.
   *          This parameter can be:
-  *             @arg RTC_FLAG_TAMP1F: Tamper1 flag (*)
-  *             @arg RTC_FLAG_TAMP2F: Tamper2 flag
-  *             @arg RTC_FLAG_TAMP3F: Tamper3 flag (*)
+  *             @arg RTC_FLAG_TAMP1F: Tamper 1 interrupt flag (*)
+  *             @arg RTC_FLAG_TAMP2F: Tamper 2 interrupt flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper 3 interrupt flag (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
-#define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)        (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+#define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)               (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
 
 /**
   * @brief  Clear the RTC Tamper's pending flags.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC Tamper Flag to clear.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Tamper Flag to clear.
   *          This parameter can be:
-  *             @arg RTC_FLAG_TAMP1F: Tamper1 flag (*)
-  *             @arg RTC_FLAG_TAMP2F: Tamper2 flag
-  *             @arg RTC_FLAG_TAMP3F: Tamper3 flag (*)
+  *             @arg RTC_FLAG_TAMP1F: Tamper 1 interrupt flag (*)
+  *             @arg RTC_FLAG_TAMP2F: Tamper 2 interrupt flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper 3 interrupt flag (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
-#define __HAL_RTC_TAMPER_CLEAR_FLAG(__HANDLE__, __FLAG__)      ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
-
-
-/**************************************************************************************************/
-
-
-#if defined(RTC_INTERNALTS_SUPPORT)
-/**
-  * @brief  Enable the RTC internal TimeStamp peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @retval None
-  */
-#define __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_ITSE))
-
-/**
-  * @brief  Disable the RTC internal TimeStamp peripheral.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @retval None
-  */
-#define __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ITSE))
-
-/**
-  * @brief  Get the selected RTC Internal Time Stamp's flag status.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC Internal Time Stamp Flag is pending or not.
-  *         This parameter can be:
-  *            @arg RTC_FLAG_ITSF
-  * @retval None
-  */
-#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)    (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
-
-/**
-  * @brief  Clear the RTC Internal Time Stamp's pending flags.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC Internal Time Stamp Flag source to clear.
-  *          This parameter can be:
-  *             @arg RTC_FLAG_ITSF
-  * @retval None
-  */
-#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)  ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
-#endif
-/**************************************************************************************************/
-
+#define __HAL_RTC_TAMPER_CLEAR_FLAG(__HANDLE__, __FLAG__)         ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
 /**
   * @}
   */
@@ -885,179 +765,134 @@ typedef struct
   * @{
   */
 
-/* TAMPER TIMESTAMP EXTI */
-/* --------------------- */
-
 /**
-  * @brief  Enable interrupt on the RTC Tamper and Timestamp associated Exti line of core 1.
+  * @brief  Enable interrupt on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None
   */
 #define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()        (EXTI->IMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Enable interrupt on the RTC Tamper and Timestamp associated Exti line of core 2.
+  * @brief  Disable interrupt on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTIC2_ENABLE_IT()      (EXTI->C2IMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()       (EXTI->IMR1 &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Disable interrupt on the RTC Tamper and Timestamp associated Exti line of core 1.
-  * @retval None
-  */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()       (EXTI->IMR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
-
-/**
-  * @brief  Disable interrupt on the RTC Tamper and Timestamp associated Exti line of core 2.
-  * @retval None
-  */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTIC2_DISABLE_IT()     (EXTI->C2IMR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
-
-/**
-  * @brief  Enable event on the RTC Tamper and Timestamp associated Exti line of core 1.
+  * @brief  Enable event on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_EVENT()    (EXTI->EMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_EVENT()     (EXTI->EMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Enable event on the RTC Tamper and Timestamp associated Exti line of core 2.
+  * @brief  Disable event on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTIC2_ENABLE_EVENT()  (EXTI->C2EMR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_EVENT()    (EXTI->EMR1 &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Disable event on the RTC Tamper and Timestamp associated Exti line of core 1.
-  * @retval None.
-  */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_EVENT()   (EXTI->EMR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
-
-/**
-  * @brief  Disable event on the RTC Tamper and Timestamp associated Exti line of core 2.
-  * @retval None.
-  */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTIC2_DISABLE_EVENT() (EXTI->C2EMR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
-
-/*-----------------*/
-/**
-  * @brief  Enable falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @brief  Enable falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Disable falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @brief  Disable falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR1 &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Enable rising edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @brief  Enable rising edge trigger on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
 #define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Disable rising edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @brief  Disable rising edge trigger on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~(RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT))
-
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR1 &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief  Enable rising & falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @brief  Enable rising & falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
   * @retval None.
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_FALLING_EDGE()  do { \
-                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();  \
-                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE(); \
-                                                                      } while(0U)
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                                        \
+                                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();  \
+                                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE(); \
+                                                                        } while(0U)
 
 /**
-  * @brief  Disable rising & falling edge trigger on the RTC Tamper and Timestamp associated Exti line.
+  * @brief  Disable rising & falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
   * This parameter can be:
   * @retval None.
   */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_FALLING_EDGE()  do { \
-                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE();  \
-                                                                        __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE(); \
-                                                                       } while(0U)
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                                         \
+                                                                           __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE();  \
+                                                                           __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                         } while(0U)
 
 /**
-  * @brief Check whether the RTC Tamper and Timestamp associated Exti line interrupt flag is set or not of core 1.
+  * @brief Check whether the RTC Tamper and Timestamp associated EXTI line interrupt flag is set or not.
   * @retval Line Status.
   */
 #define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()         (EXTI->PR1 & RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief Check whether the RTC Tamper and Timestamp associated Exti line interrupt flag is set or not of core 2.
-  * @retval Line Status.
-  */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTIC2_GET_FLAG()       (EXTI->PR1 & RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
-
-/**
-  * @brief Clear the RTC Tamper and Timestamp associated Exti line flag of core 1.
+  * @brief Clear the RTC Tamper and Timestamp associated EXTI line flag.
   * @retval None.
   */
 #define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()       (EXTI->PR1 = RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
 
 /**
-  * @brief Clear the RTC Tamper and Timestamp associated Exti line flag of core 2.
-  * @retval None.
-  */
-#define __HAL_RTC_TAMPER_TIMESTAMP_EXTIC2_CLEAR_FLAG()     (EXTI->PR1 = RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
-
-/**
-  * @brief Generate a Software interrupt on the RTC Tamper and Timestamp associated Exti line
+  * @brief Generate a Software interrupt on the RTC Tamper and Timestamp associated EXTI line
   * @retval None.
   */
 #define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()    (EXTI->SWIER1 |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
-
-
-
 /**
   * @}
   */
 
-/* ------------------------------Calibration----------------------------------*/
-/** @defgroup RTCEx_Calibration RTC Calibration
+/* ------------------------------CALIBRATION----------------------------------*/
+
+/** @defgroup RTCEx_Calibration RTCEx Calibration
   * @{
   */
 
 /**
   * @brief  Enable the RTC calibration output.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR |= (RTC_CR_COE))
+#define __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR |= (RTC_CR_COE))
 
 /**
   * @brief  Disable the calibration output.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)              ((__HANDLE__)->Instance->CR &= ~(RTC_CR_COE))
-
+#define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR &= ~(RTC_CR_COE))
 
 /**
   * @brief  Enable the clock reference detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_CLOCKREF_DETECTION_ENABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR |= (RTC_CR_REFCKON))
+#define __HAL_RTC_CLOCKREF_DETECTION_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR |= (RTC_CR_REFCKON))
 
 /**
   * @brief  Disable the clock reference detection.
-  * @param __HANDLE__ specifies the RTC handle.
+  * @param  __HANDLE__ specifies the RTC handle.
   * @retval None
   */
-#define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)              ((__HANDLE__)->Instance->CR &= ~(RTC_CR_REFCKON))
-
+#define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR &= ~(RTC_CR_REFCKON))
 
 /**
   * @brief  Get the selected RTC shift operation's flag status.
-  * @param __HANDLE__ specifies the RTC handle.
-  * @param __FLAG__ specifies the RTC shift operation Flag is pending or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC shift operation Flag is pending or not.
   *          This parameter can be:
-  *             @arg RTC_FLAG_SHPF
+  *             @arg RTC_FLAG_SHPF: Shift pending flag
   * @retval None
   */
 #define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
@@ -1070,26 +905,24 @@ typedef struct
   */
 
 /* Exported functions --------------------------------------------------------*/
+
 /** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
   * @{
   */
 
-/* RTC TimeStamp and Tamper functions *****************************************/
-/** @defgroup RTCEx_Exported_Functions_Group1 Extended RTC TimeStamp and Tamper functions
- * @{
- */
-
-HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
-HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin);
+/** @addtogroup RTCEx_Exported_Functions_Group1
+  * @{
+  */
+/* RTC Timestamp and Tamper functions *****************************************/
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin);
 HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc);
-#if defined(RTC_INTERNALTS_SUPPORT)
 HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc);
-#endif
 HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format);
 
-HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
-HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper);
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper);
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper);
 HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper);
 void              HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc);
 
@@ -1113,11 +946,10 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_
   * @}
   */
 
-/* RTC Wake-up functions ******************************************************/
-/** @defgroup RTCEx_Exported_Functions_Group2 Extended RTC Wake-up functions
- * @{
- */
-
+/** @addtogroup RTCEx_Exported_Functions_Group2
+  * @{
+  */
+/* RTC Wakeup functions ******************************************************/
 HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
 HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
 HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc);
@@ -1129,13 +961,12 @@ HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uin
   * @}
   */
 
+/** @addtogroup RTCEx_Exported_Functions_Group3
+  * @{
+  */
 /* Extended Control functions ************************************************/
-/** @defgroup RTCEx_Exported_Functions_Group3 Extended Peripheral Control functions
- * @{
- */
-
-void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
-uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
+void              HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
+uint32_t          HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
 
 HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue);
 HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS);
@@ -1149,10 +980,10 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc);
   * @}
   */
 
+/** @addtogroup RTCEx_Exported_Functions_Group4
+  * @{
+  */
 /* Extended RTC features functions *******************************************/
-/** @defgroup RTCEx_Exported_Functions_Group4 Extended features functions
- * @{
- */
 void              HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc);
 HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
 /**
@@ -1166,47 +997,77 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
+
 /** @defgroup RTCEx_Private_Constants RTCEx Private Constants
   * @{
   */
+#define RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT  EXTI_IMR1_IM18  /*!< External interrupt line 18 Connected to the RTC Tamper and Timestamp event */
+#define RTC_EXTI_LINE_WAKEUPTIMER_EVENT       EXTI_IMR1_IM19  /*!< External interrupt line 19 Connected to the RTC Wakeup event */
+/**
+  * @}
+  */
 
+/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
+  * @{
+  */
 /* Masks Definition */
+#if defined(RTC_TAMPER3_SUPPORT)
+#if defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPER_ENABLE_BITS_MASK         ((uint32_t) (RTC_TAMPER_1 | \
+                                                         RTC_TAMPER_2 | \
+                                                         RTC_TAMPER_3))
 
-#if defined(RTC_TAMPER1_SUPPORT) && defined(RTC_TAMPER3_SUPPORT)
+#define RTC_TAMPER_FLAGS_MASK               ((uint32_t) (RTC_FLAG_TAMP1F | \
+                                                         RTC_FLAG_TAMP2F | \
+                                                         RTC_FLAG_TAMP3F))
+#else /* RTC_TAMPER1_SUPPORT */
+#define RTC_TAMPER_ENABLE_BITS_MASK         ((uint32_t) (RTC_TAMPER_2 | \
+                                                         RTC_TAMPER_3))
 
-#define RTC_FLAGS_MASK          ((uint32_t) (RTC_FLAG_RECALPF | RTC_FLAG_TAMP3F | RTC_FLAG_TAMP2F | \
-                                             RTC_FLAG_TAMP1F| RTC_FLAG_TSOVF | RTC_FLAG_TSF       | \
-                                             RTC_FLAG_WUTF | RTC_FLAG_ALRBF | RTC_FLAG_ALRAF      | \
-                                             RTC_FLAG_INITF | RTC_FLAG_RSF                        | \
-                                             RTC_FLAG_INITS | RTC_FLAG_SHPF | RTC_FLAG_WUTWF      | \
-                                             RTC_FLAG_ALRBWF | RTC_FLAG_ALRAWF))
+#define RTC_TAMPER_FLAGS_MASK               ((uint32_t) (RTC_FLAG_TAMP2F | \
+                                                         RTC_FLAG_TAMP3F))
+#endif /* RTC_TAMPER1_SUPPORT */
+#else /* RTC_TAMPER3_SUPPORT */
+#if defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPER_ENABLE_BITS_MASK         ((uint32_t) (RTC_TAMPER_1 | \
+                                                         RTC_TAMPER_2))
 
-#define RTC_TAMPCR_TAMPXE     ((uint32_t) (RTC_TAMPCR_TAMP3E | RTC_TAMPCR_TAMP2E | RTC_TAMPCR_TAMP1E))
-#define RTC_TAMPCR_TAMPXIE    ((uint32_t) (RTC_TAMPER1_INTERRUPT | RTC_TAMPER2_INTERRUPT | \
-                                           RTC_TAMPER3_INTERRUPT | RTC_ALL_TAMPER_INTERRUPT))
+#define RTC_TAMPER_FLAGS_MASK               ((uint32_t) (RTC_FLAG_TAMP1F | \
+                                                         RTC_FLAG_TAMP2F))
+#else /* RTC_TAMPER1_SUPPORT */
+#define RTC_TAMPER_ENABLE_BITS_MASK                      RTC_TAMPER_2
 
-#else
+#define RTC_TAMPER_FLAGS_MASK                            RTC_FLAG_TAMP2F
+#endif /* RTC_TAMPER1_SUPPORT */
+#endif /* RTC_TAMPER3_SUPPORT */
 
-#define RTC_FLAGS_MASK          ((uint32_t) (RTC_FLAG_RECALPF | RTC_FLAG_TAMP2F                  |  \
-                                             RTC_FLAG_TSOVF | RTC_FLAG_TSF | RTC_FLAG_WUTF       | \
-                                             RTC_FLAG_ALRBF | RTC_FLAG_ALRAF                     | \
-                                             RTC_FLAG_INITF | RTC_FLAG_RSF | RTC_FLAG_INITS      | \
-                                             RTC_FLAG_SHPF | RTC_FLAG_WUTWF |RTC_FLAG_ALRBWF     | \
-                                             RTC_FLAG_ALRAWF))
-
-#define RTC_TAMPCR_TAMPXE     ((uint32_t) (RTC_TAMPCR_TAMP2E))
-#define RTC_TAMPCR_TAMPXIE    ((uint32_t) (RTC_TAMPER2_INTERRUPT | RTC_ALL_TAMPER_INTERRUPT))
-
-#endif
-
-#define RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT  (EXTI_IMR1_IM18)    /*!< External interrupt line 18 Connected to the RTC Tamper and Time Stamp events */
-#define RTC_EXTI_LINE_WAKEUPTIMER_EVENT       (EXTI_IMR1_IM19)    /*!< External interrupt line 19 Connected to the RTC Wakeup event */
-
+#if defined(RTC_TAMPER3_SUPPORT)
+#if defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPER_IT_ENABLE_BITS_MASK      ((uint32_t) (RTC_IT_TAMP1 | \
+                                                         RTC_IT_TAMP2 | \
+                                                         RTC_IT_TAMP3 | \
+                                                         RTC_IT_TAMP))
+#else /* RTC_TAMPER1_SUPPORT */
+#define RTC_TAMPER_IT_ENABLE_BITS_MASK      ((uint32_t) (RTC_IT_TAMP2 | \
+                                                         RTC_IT_TAMP3 | \
+                                                         RTC_IT_TAMP))
+#endif /* RTC_TAMPER1_SUPPORT */
+#else /* RTC_TAMPER3_SUPPORT */
+#if defined(RTC_TAMPER1_SUPPORT)
+#define RTC_TAMPER_IT_ENABLE_BITS_MASK      ((uint32_t) (RTC_IT_TAMP1 | \
+                                                         RTC_IT_TAMP2 | \
+                                                         RTC_IT_TAMP))
+#else /* RTC_TAMPER1_SUPPORT */
+#define RTC_TAMPER_IT_ENABLE_BITS_MASK      ((uint32_t) (RTC_IT_TAMP2 | \
+                                                         RTC_IT_TAMP))
+#endif /* RTC_TAMPER1_SUPPORT */
+#endif /* RTC_TAMPER3_SUPPORT */
 /**
   * @}
   */
 
 /* Private macros ------------------------------------------------------------*/
+
 /** @defgroup RTCEx_Private_Macros RTCEx Private Macros
   * @{
   */
@@ -1214,38 +1075,42 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
 /** @defgroup RTCEx_IS_RTC_Definitions Private macros to check input parameters
   * @{
   */
-
-#define IS_RTC_OUTPUT(OUTPUT) (((OUTPUT) == RTC_OUTPUT_DISABLE) || \
-                               ((OUTPUT) == RTC_OUTPUT_ALARMA)  || \
-                               ((OUTPUT) == RTC_OUTPUT_ALARMB)  || \
-                               ((OUTPUT) == RTC_OUTPUT_WAKEUP))
-
-#define IS_RTC_BKP(BKP)                   ((BKP) < (uint32_t) RTC_BKP_NUMBER)
+#define IS_RTC_BKP(BKP)     ((BKP) < (uint32_t) RTC_BKP_NUMBER)
 
 #define IS_TIMESTAMP_EDGE(EDGE) (((EDGE) == RTC_TIMESTAMPEDGE_RISING) || \
                                  ((EDGE) == RTC_TIMESTAMPEDGE_FALLING))
 
-#define  IS_RTC_TAMPER(TAMPER)  ((((TAMPER) & ((uint32_t)(0xFFFFFFFFU ^ RTC_TAMPCR_TAMPXE))) == 0x00U) && ((TAMPER) != 0U))
+#define IS_RTC_TAMPER(TAMPER) ((((TAMPER) & ((uint32_t)~RTC_TAMPER_ENABLE_BITS_MASK)) == 0x00U) && ((TAMPER) != 0U))
 
-#define IS_RTC_TAMPER_INTERRUPT(INTERRUPT) ((((INTERRUPT) & (uint32_t)(0xFFFFFFFFU ^ RTC_TAMPCR_TAMPXIE)) == 0x00U) && ((INTERRUPT) != 0U))
+#define IS_RTC_TAMPER_PIN(PIN) ((PIN) == RTC_TAMPERPIN_DEFAULT)
 
-#define IS_RTC_TIMESTAMP_PIN(PIN)  (((PIN) == RTC_TIMESTAMPPIN_DEFAULT))
+#define IS_RTC_TIMESTAMP_PIN(PIN) ((PIN) == RTC_TIMESTAMPPIN_DEFAULT)
 
-#define IS_RTC_TAMPER_TRIGGER(TRIGGER) (((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE) || \
+#define IS_RTC_TAMPER_INTERRUPT(INTERRUPT) ((((INTERRUPT) & ((uint32_t)~RTC_TAMPER_IT_ENABLE_BITS_MASK  )) == 0x00U) && ((INTERRUPT) != 0U))
+
+#define IS_RTC_TAMPER_TRIGGER(TRIGGER) (((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE)  || \
                                         ((TRIGGER) == RTC_TAMPERTRIGGER_FALLINGEDGE) || \
-                                        ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL)    || \
                                         ((TRIGGER) == RTC_TAMPERTRIGGER_HIGHLEVEL))
 
-#define IS_RTC_TAMPER_ERASE_MODE(MODE)             (((MODE) == RTC_TAMPER_ERASE_BACKUP_ENABLE) || \
-                                                    ((MODE) == RTC_TAMPER_ERASE_BACKUP_DISABLE))
+#define IS_RTC_TAMPER_ERASE_MODE(MODE)          (((MODE) == RTC_TAMPER_ERASE_BACKUP_ENABLE) || \
+                                                 ((MODE) == RTC_TAMPER_ERASE_BACKUP_DISABLE))
 
-#define IS_RTC_TAMPER_MASKFLAG_STATE(STATE)        (((STATE) == RTC_TAMPERMASK_FLAG_ENABLE) || \
-                                                    ((STATE) == RTC_TAMPERMASK_FLAG_DISABLE))
+#define IS_RTC_TAMPER_MASKFLAG_STATE(STATE)     (((STATE) == RTC_TAMPERMASK_FLAG_ENABLE) || \
+                                                 ((STATE) == RTC_TAMPERMASK_FLAG_DISABLE))
 
 #define IS_RTC_TAMPER_FILTER(FILTER)  (((FILTER) == RTC_TAMPERFILTER_DISABLE) || \
                                        ((FILTER) == RTC_TAMPERFILTER_2SAMPLE) || \
                                        ((FILTER) == RTC_TAMPERFILTER_4SAMPLE) || \
                                        ((FILTER) == RTC_TAMPERFILTER_8SAMPLE))
+
+#define IS_RTC_TAMPER_FILTER_CONFIG_CORRECT(FILTER, TRIGGER)                  \
+                        (  (  ((FILTER) != RTC_TAMPERFILTER_DISABLE)          \
+                           && (  ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL)    \
+                              || ((TRIGGER) == RTC_TAMPERTRIGGER_HIGHLEVEL))) \
+                        || (  ((FILTER) == RTC_TAMPERFILTER_DISABLE)          \
+                           && (  ((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE)  \
+                              || ((TRIGGER) == RTC_TAMPERTRIGGER_FALLINGEDGE))))
 
 #define IS_RTC_TAMPER_SAMPLING_FREQ(FREQ) (((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768)|| \
                                            ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384)|| \
@@ -1254,18 +1119,18 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
                                            ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048) || \
                                            ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024) || \
                                            ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512)  || \
-                                          ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256))
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256))
 
 #define IS_RTC_TAMPER_PRECHARGE_DURATION(DURATION) (((DURATION) == RTC_TAMPERPRECHARGEDURATION_1RTCCLK) || \
                                                     ((DURATION) == RTC_TAMPERPRECHARGEDURATION_2RTCCLK) || \
                                                     ((DURATION) == RTC_TAMPERPRECHARGEDURATION_4RTCCLK) || \
-                                                   ((DURATION) == RTC_TAMPERPRECHARGEDURATION_8RTCCLK))
-
-#define IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(DETECTION) (((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_ENABLE) || \
-                                                              ((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_DISABLE))
+                                                    ((DURATION) == RTC_TAMPERPRECHARGEDURATION_8RTCCLK))
 
 #define IS_RTC_TAMPER_PULLUP_STATE(STATE) (((STATE) == RTC_TAMPER_PULLUP_ENABLE) || \
                                            ((STATE) == RTC_TAMPER_PULLUP_DISABLE))
+
+#define IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(DETECTION) (((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_ENABLE) || \
+                                                              ((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_DISABLE))
 
 #define IS_RTC_WAKEUP_CLOCK(CLOCK) (((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV16)   || \
                                     ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV8)    || \
@@ -1283,31 +1148,15 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
 #define IS_RTC_SMOOTH_CALIB_PLUS(PLUS) (((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_SET) || \
                                         ((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_RESET))
 
-
-/** @defgroup RTCEx_Smooth_calib_Minus_pulses_Definitions RTCEx Smooth calib Minus pulses Definitions
-  * @{
-  */
 #define  IS_RTC_SMOOTH_CALIB_MINUS(VALUE) ((VALUE) <= RTC_CALR_CALM)
-/**
-  * @}
-  */
-
 
 #define IS_RTC_SHIFT_ADD1S(SEL) (((SEL) == RTC_SHIFTADD1S_RESET) || \
                                  ((SEL) == RTC_SHIFTADD1S_SET))
 
-
-
-/** @defgroup RTCEx_Substract_Fraction_Of_Second_Value RTCEx Substract Fraction Of Second Value
-  * @{
-  */
 #define IS_RTC_SHIFT_SUBFS(FS) ((FS) <= RTC_SHIFTR_SUBFS)
-/**
-  * @}
-  */
+
 #define IS_RTC_CALIB_OUTPUT(OUTPUT)  (((OUTPUT) == RTC_CALIBOUTPUT_512HZ) || \
                                       ((OUTPUT) == RTC_CALIBOUTPUT_1HZ))
-
 /**
   * @}
   */
@@ -1315,8 +1164,6 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
 /**
   * @}
   */
-
-
 
 /**
   * @}
@@ -1331,5 +1178,3 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
 #endif
 
 #endif /* STM32WBxx_HAL_RTC_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_sai.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_sai.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -357,6 +356,7 @@ typedef void (*pSAI_CallbackTypeDef)(SAI_HandleTypeDef *hsai);
 #define SAI_AUDIO_FREQUENCY_48K           48000U
 #define SAI_AUDIO_FREQUENCY_44K           44100U
 #define SAI_AUDIO_FREQUENCY_32K           32000U
+#define SAI_AUDIO_FREQUENCY_24K           24000U
 #define SAI_AUDIO_FREQUENCY_22K           22050U
 #define SAI_AUDIO_FREQUENCY_16K           16000U
 #define SAI_AUDIO_FREQUENCY_11K           11025U
@@ -809,8 +809,8 @@ void HAL_SAI_ErrorCallback(SAI_HandleTypeDef *hsai);
   * @{
   */
 /* Peripheral State functions  ************************************************/
-HAL_SAI_StateTypeDef HAL_SAI_GetState(SAI_HandleTypeDef *hsai);
-uint32_t HAL_SAI_GetError(SAI_HandleTypeDef *hsai);
+HAL_SAI_StateTypeDef HAL_SAI_GetState(const SAI_HandleTypeDef *hsai);
+uint32_t HAL_SAI_GetError(const SAI_HandleTypeDef *hsai);
 /**
   * @}
   */
@@ -840,9 +840,10 @@ uint32_t HAL_SAI_GetError(SAI_HandleTypeDef *hsai);
 
 #define IS_SAI_AUDIO_FREQUENCY(AUDIO) (((AUDIO) == SAI_AUDIO_FREQUENCY_192K) || ((AUDIO) == SAI_AUDIO_FREQUENCY_96K) || \
                                        ((AUDIO) == SAI_AUDIO_FREQUENCY_48K)  || ((AUDIO) == SAI_AUDIO_FREQUENCY_44K) || \
-                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_32K)  || ((AUDIO) == SAI_AUDIO_FREQUENCY_22K) || \
-                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_16K)  || ((AUDIO) == SAI_AUDIO_FREQUENCY_11K) || \
-                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_8K)   || ((AUDIO) == SAI_AUDIO_FREQUENCY_MCKDIV))
+                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_32K)  || ((AUDIO) == SAI_AUDIO_FREQUENCY_24K) || \
+                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_22K)  || ((AUDIO) == SAI_AUDIO_FREQUENCY_16K) || \
+                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_11K)  || ((AUDIO) == SAI_AUDIO_FREQUENCY_8K)  || \
+                                       ((AUDIO) == SAI_AUDIO_FREQUENCY_MCKDIV))
 
 #define IS_SAI_BLOCK_MCK_OVERSAMPLING(VALUE) (((VALUE) == SAI_MCK_OVERSAMPLING_DISABLE) || \
                                               ((VALUE) == SAI_MCK_OVERSAMPLING_ENABLE))
@@ -964,5 +965,3 @@ uint32_t HAL_SAI_GetError(SAI_HandleTypeDef *hsai);
 #endif
 
 #endif /* STM32WBxx_HAL_SAI_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_sai_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_sai_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -72,7 +71,8 @@ typedef struct
 /** @addtogroup SAIEx_Exported_Functions_Group1 Peripheral Control functions
   * @{
   */
-HAL_StatusTypeDef HAL_SAIEx_ConfigPdmMicDelay(SAI_HandleTypeDef *hsai, SAIEx_PdmMicDelayParamTypeDef *pdmMicDelay);
+HAL_StatusTypeDef HAL_SAIEx_ConfigPdmMicDelay(const SAI_HandleTypeDef *hsai,
+                                              const SAIEx_PdmMicDelayParamTypeDef *pdmMicDelay);
 /**
   * @}
   */
@@ -104,5 +104,3 @@ HAL_StatusTypeDef HAL_SAIEx_ConfigPdmMicDelay(SAI_HandleTypeDef *hsai, SAIEx_Pdm
 #endif
 
 #endif /* STM32WBxx_HAL_SAI_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smartcard.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smartcard.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -52,7 +51,8 @@ typedef struct
                                            where usart_ker_ckpres is the USART input clock divided by a prescaler */
 
   uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
-                                           This parameter @ref SMARTCARD_Word_Length can only be set to 9 (8 data + 1 parity bits). */
+                                           This parameter @ref SMARTCARD_Word_Length can only be
+                                           set to 9 (8 data + 1 parity bits). */
 
   uint32_t StopBits;                  /*!< Specifies the number of stop bits.
                                            This parameter can be a value of @ref SMARTCARD_Stop_Bits. */
@@ -76,13 +76,14 @@ typedef struct
                                            data bit (MSB) has to be output on the SCLK pin in synchronous mode.
                                            This parameter can be a value of @ref SMARTCARD_Last_Bit */
 
-  uint16_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
-                                           Selecting the single sample method increases the receiver tolerance to clock
-                                           deviations. This parameter can be a value of @ref SMARTCARD_OneBit_Sampling. */
+  uint16_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote
+                                           is selected. Selecting the single sample method increases
+                                           the receiver tolerance to clock deviations. This parameter can be a value
+                                           of @ref SMARTCARD_OneBit_Sampling. */
 
   uint8_t  Prescaler;                 /*!< Specifies the SmartCard Prescaler.
-                                           This parameter can be any value from 0x01 to 0x1F. Prescaler value is multiplied
-                                           by 2 to give the division factor of the source clock frequency */
+                                           This parameter can be any value from 0x01 to 0x1F. Prescaler value is
+                                           multiplied by 2 to give the division factor of the source clock frequency */
 
   uint8_t  GuardTime;                 /*!< Specifies the SmartCard Guard Time applied after stop bits. */
 
@@ -111,7 +112,7 @@ typedef struct
 } SMARTCARD_InitTypeDef;
 
 /**
-  * @brief  SMARTCARD advanced features initalization structure definition
+  * @brief  SMARTCARD advanced features initialization structure definition
   */
 typedef struct
 {
@@ -141,14 +142,16 @@ typedef struct
   uint32_t MSBFirst;                  /*!< Specifies whether MSB is sent first on UART line.
                                            This parameter can be a value of @ref SMARTCARD_MSB_First */
 
-  uint16_t TxCompletionIndication;     /*!< Specifies which transmission completion indication is used: before (when
-                                            relevant flag is available) or once guard time period has elapsed.
-                                           This parameter can be a value of @ref SMARTCARDEx_Transmission_Completion_Indication. */
+  uint16_t TxCompletionIndication;    /*!< Specifies which transmission completion indication is used: before (when
+                                           relevant flag is available) or once guard time period has elapsed.
+                                           This parameter can be a value
+                                           of @ref SMARTCARDEx_Transmission_Completion_Indication. */
 } SMARTCARD_AdvFeatureInitTypeDef;
 
 /**
   * @brief HAL SMARTCARD State definition
-  * @note  HAL SMARTCARD State value is a combination of 2 different substates: gState and RxState (see @ref SMARTCARD_State_Definition).
+  * @note  HAL SMARTCARD State value is a combination of 2 different substates:
+  *        gState and RxState (see @ref SMARTCARD_State_Definition).
   *        - gState contains SMARTCARD state information related to global Handle management
   *          and also information related to Tx operations.
   *          gState value coding follow below described bitmap :
@@ -159,7 +162,7 @@ typedef struct
   *             11 : Error
   *          b5     Peripheral initialization status
   *             0  : Reset (Peripheral not initialized)
-  *             1  : Init done (Peripheral not initialized. HAL SMARTCARD Init function already called)
+  *             1  : Init done (Peripheral initialized. HAL SMARTCARD Init function already called)
   *          b4-b3  (not used)
   *             xx : Should be set to 00
   *          b2     Intrinsic process state
@@ -176,7 +179,7 @@ typedef struct
   *             xx : Should be set to 00
   *          b5     Peripheral initialization status
   *             0  : Reset (Peripheral not initialized)
-  *             1  : Init done (Peripheral not initialized)
+  *             1  : Init done (Peripheral initialized)
   *          b4-b2  (not used)
   *            xxx : Should be set to 000
   *          b1     Rx state
@@ -198,7 +201,7 @@ typedef struct __SMARTCARD_HandleTypeDef
 
   SMARTCARD_AdvFeatureInitTypeDef   AdvancedInit;          /*!< SmartCard advanced features initialization parameters */
 
-  uint8_t                           *pTxBuffPtr;           /*!< Pointer to SmartCard Tx transfer Buffer               */
+  const uint8_t                     *pTxBuffPtr;           /*!< Pointer to SmartCard Tx transfer Buffer               */
 
   uint16_t                          TxXferSize;            /*!< SmartCard Tx Transfer size                            */
 
@@ -215,7 +218,8 @@ typedef struct __SMARTCARD_HandleTypeDef
   uint16_t                          NbTxDataToProcess;     /*!< Number of data to process during TX ISR execution     */
 
   uint32_t                          FifoMode;              /*!< Specifies if the FIFO mode will be used.
-                                                                This parameter can be a value of @ref SMARTCARDEx_FIFO_mode. */
+                                                                This parameter can be a value of
+                                                                @ref SMARTCARDEx_FIFO_mode.                           */
 
   void (*RxISR)(struct __SMARTCARD_HandleTypeDef *huart);  /*!< Function pointer on Rx IRQ handler                    */
 
@@ -227,12 +231,14 @@ typedef struct __SMARTCARD_HandleTypeDef
 
   HAL_LockTypeDef                   Lock;                  /*!< Locking object                                        */
 
-  __IO HAL_SMARTCARD_StateTypeDef   gState;                /*!< SmartCard state information related to global Handle management
-                                                                and also related to Tx operations.
-                                                                This parameter can be a value of @ref HAL_SMARTCARD_StateTypeDef */
+  __IO HAL_SMARTCARD_StateTypeDef   gState;                /*!< SmartCard state information related to global
+                                                                Handle management and also related to Tx operations.
+                                                                This parameter can be a value
+                                                                of @ref HAL_SMARTCARD_StateTypeDef                    */
 
   __IO HAL_SMARTCARD_StateTypeDef   RxState;               /*!< SmartCard state information related to Rx operations.
-                                                                This parameter can be a value of @ref HAL_SMARTCARD_StateTypeDef */
+                                                                This parameter can be a value
+                                                                of @ref HAL_SMARTCARD_StateTypeDef                    */
 
   __IO uint32_t                     ErrorCode;             /*!< SmartCard Error code                                  */
 
@@ -311,23 +317,26 @@ typedef enum
 /** @defgroup SMARTCARD_State_Definition SMARTCARD State Code Definition
   * @{
   */
-#define HAL_SMARTCARD_STATE_RESET            0x00000000U                     /*!< Peripheral is not initialized
-                                                                                  Value is allowed for gState and RxState */
-#define HAL_SMARTCARD_STATE_READY            0x00000020U                     /*!< Peripheral Initialized and ready for use
-                                                                                  Value is allowed for gState and RxState */
+#define HAL_SMARTCARD_STATE_RESET            0x00000000U                     /*!< Peripheral is not initialized. Value
+                                                                                  is allowed for gState and RxState */
+#define HAL_SMARTCARD_STATE_READY            0x00000020U                     /*!< Peripheral Initialized and ready for
+                                                                                  use. Value is allowed for gState
+                                                                                  and RxState                       */
 #define HAL_SMARTCARD_STATE_BUSY             0x00000024U                     /*!< an internal process is ongoing
-                                                                                  Value is allowed for gState only */
+                                                                                  Value is allowed for gState only  */
 #define HAL_SMARTCARD_STATE_BUSY_TX          0x00000021U                     /*!< Data Transmission process is ongoing
-                                                                                  Value is allowed for gState only */
+                                                                                  Value is allowed for gState only  */
 #define HAL_SMARTCARD_STATE_BUSY_RX          0x00000022U                     /*!< Data Reception process is ongoing
                                                                                   Value is allowed for RxState only */
-#define HAL_SMARTCARD_STATE_BUSY_TX_RX       0x00000023U                     /*!< Data Transmission and Reception process is ongoing
-                                                                                  Not to be used for neither gState nor RxState.
-                                                                                  Value is result of combination (Or) between gState and RxState values */
+#define HAL_SMARTCARD_STATE_BUSY_TX_RX       0x00000023U                     /*!< Data Transmission and Reception
+                                                                                  process is ongoing Not to be used for
+                                                                                  neither gState nor RxState.
+                                                                                  Value is result of combination (Or)
+                                                                                  between gState and RxState values */
 #define HAL_SMARTCARD_STATE_TIMEOUT          0x000000A0U                     /*!< Timeout state
-                                                                                  Value is allowed for gState only */
+                                                                                  Value is allowed for gState only  */
 #define HAL_SMARTCARD_STATE_ERROR            0x000000E0U                     /*!< Error
-                                                                                  Value is allowed for gState only */
+                                                                                  Value is allowed for gState only  */
 /**
   * @}
   */
@@ -335,15 +344,15 @@ typedef enum
 /** @defgroup SMARTCARD_Error_Definition SMARTCARD Error Code Definition
   * @{
   */
-#define HAL_SMARTCARD_ERROR_NONE             ((uint32_t)0x00000000U)         /*!< No error                */
-#define HAL_SMARTCARD_ERROR_PE               ((uint32_t)0x00000001U)         /*!< Parity error            */
-#define HAL_SMARTCARD_ERROR_NE               ((uint32_t)0x00000002U)         /*!< Noise error             */
-#define HAL_SMARTCARD_ERROR_FE               ((uint32_t)0x00000004U)         /*!< frame error             */
-#define HAL_SMARTCARD_ERROR_ORE              ((uint32_t)0x00000008U)         /*!< Overrun error           */
-#define HAL_SMARTCARD_ERROR_DMA              ((uint32_t)0x00000010U)         /*!< DMA transfer error      */
-#define HAL_SMARTCARD_ERROR_RTO              ((uint32_t)0x00000020U)         /*!< Receiver TimeOut error  */
+#define HAL_SMARTCARD_ERROR_NONE             (0x00000000U)         /*!< No error                */
+#define HAL_SMARTCARD_ERROR_PE               (0x00000001U)         /*!< Parity error            */
+#define HAL_SMARTCARD_ERROR_NE               (0x00000002U)         /*!< Noise error             */
+#define HAL_SMARTCARD_ERROR_FE               (0x00000004U)         /*!< frame error             */
+#define HAL_SMARTCARD_ERROR_ORE              (0x00000008U)         /*!< Overrun error           */
+#define HAL_SMARTCARD_ERROR_DMA              (0x00000010U)         /*!< DMA transfer error      */
+#define HAL_SMARTCARD_ERROR_RTO              (0x00000020U)         /*!< Receiver TimeOut error  */
 #if (USE_HAL_SMARTCARD_REGISTER_CALLBACKS == 1)
-#define HAL_SMARTCARD_ERROR_INVALID_CALLBACK ((uint32_t)0x00000040U)         /*!< Invalid Callback error  */
+#define HAL_SMARTCARD_ERROR_INVALID_CALLBACK (0x00000040U)         /*!< Invalid Callback error  */
 #endif /* USE_HAL_SMARTCARD_REGISTER_CALLBACKS */
 /**
   * @}
@@ -663,7 +672,8 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_RTO    Receive timeout interrupt
   *            @arg @ref SMARTCARD_IT_TXE    Transmit data register empty interrupt
   *            @arg @ref SMARTCARD_IT_TC     Transmission complete interrupt
-  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard time interrupt (when interruption available)
+  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before
+  *                                          guard time interrupt (when interruption available)
   *            @arg @ref SMARTCARD_IT_RXNE   Receive data register not empty interrupt
   *            @arg @ref SMARTCARD_IT_IDLE   Idle line detection interrupt
   *            @arg @ref SMARTCARD_IT_PE     Parity error interrupt
@@ -676,9 +686,16 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_TXFT   TXFIFO threshold reached interruption
   * @retval None
   */
-#define __HAL_SMARTCARD_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((__INTERRUPT__) & SMARTCARD_CR_MASK) >> SMARTCARD_CR_POS) == 1U)? ((__HANDLE__)->Instance->CR1 |= ((uint32_t)1U << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
-                                                                ((((__INTERRUPT__) & SMARTCARD_CR_MASK) >> SMARTCARD_CR_POS) == 2U)? ((__HANDLE__)->Instance->CR2 |= ((uint32_t)1U << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
-                                                                ((__HANDLE__)->Instance->CR3 |= ((uint32_t)1U << ((__INTERRUPT__) & SMARTCARD_IT_MASK))))
+#define __HAL_SMARTCARD_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((__INTERRUPT__) & SMARTCARD_CR_MASK) >>\
+                                                                  SMARTCARD_CR_POS) == 1U)?\
+                                                                ((__HANDLE__)->Instance->CR1 |= (1UL <<\
+                                                                    ((__INTERRUPT__) & SMARTCARD_IT_MASK))):\
+                                                                ((((__INTERRUPT__) & SMARTCARD_CR_MASK) >>\
+                                                                  SMARTCARD_CR_POS) == 2U)?\
+                                                                ((__HANDLE__)->Instance->CR2 |= (1UL <<\
+                                                                    ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                                ((__HANDLE__)->Instance->CR3 |= (1UL <<\
+                                                                    ((__INTERRUPT__) & SMARTCARD_IT_MASK))))
 
 /** @brief  Disable the specified SmartCard interrupt.
   * @param  __HANDLE__ specifies the SMARTCARD Handle.
@@ -688,7 +705,8 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_RTO    Receive timeout interrupt
   *            @arg @ref SMARTCARD_IT_TXE    Transmit data register empty interrupt
   *            @arg @ref SMARTCARD_IT_TC     Transmission complete interrupt
-  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard time interrupt (when interruption available)
+  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard
+  *                                          time interrupt (when interruption available)
   *            @arg @ref SMARTCARD_IT_RXNE   Receive data register not empty interrupt
   *            @arg @ref SMARTCARD_IT_IDLE   Idle line detection interrupt
   *            @arg @ref SMARTCARD_IT_PE     Parity error interrupt
@@ -701,9 +719,16 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_TXFT   TXFIFO threshold reached interruption
   * @retval None
   */
-#define __HAL_SMARTCARD_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((__INTERRUPT__) & SMARTCARD_CR_MASK) >> SMARTCARD_CR_POS) == 1U)? ((__HANDLE__)->Instance->CR1 &= ~ ((uint32_t)1U << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
-                                                                ((((__INTERRUPT__) & SMARTCARD_CR_MASK) >> SMARTCARD_CR_POS) == 2U)? ((__HANDLE__)->Instance->CR2 &= ~ ((uint32_t)1U << ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
-                                                                ((__HANDLE__)->Instance->CR3 &= ~ ((uint32_t)1U << ((__INTERRUPT__) & SMARTCARD_IT_MASK))))
+#define __HAL_SMARTCARD_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((__INTERRUPT__) & SMARTCARD_CR_MASK) >>\
+                                                                  SMARTCARD_CR_POS) == 1U)?\
+                                                                ((__HANDLE__)->Instance->CR1 &= ~ (1UL <<\
+                                                                    ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                                ((((__INTERRUPT__) & SMARTCARD_CR_MASK) >>\
+                                                                  SMARTCARD_CR_POS) == 2U)?\
+                                                                ((__HANDLE__)->Instance->CR2 &= ~ (1UL <<\
+                                                                    ((__INTERRUPT__) & SMARTCARD_IT_MASK))): \
+                                                                ((__HANDLE__)->Instance->CR3 &= ~ (1UL <<\
+                                                                    ((__INTERRUPT__) & SMARTCARD_IT_MASK))))
 
 /** @brief  Check whether the specified SmartCard interrupt has occurred or not.
   * @param  __HANDLE__ specifies the SMARTCARD Handle.
@@ -713,7 +738,8 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_RTO    Receive timeout interrupt
   *            @arg @ref SMARTCARD_IT_TXE    Transmit data register empty interrupt
   *            @arg @ref SMARTCARD_IT_TC     Transmission complete interrupt
-  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard time interrupt (when interruption available)
+  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard time
+  *                                          interrupt (when interruption available)
   *            @arg @ref SMARTCARD_IT_RXNE   Receive data register not empty interrupt
   *            @arg @ref SMARTCARD_IT_IDLE   Idle line detection interrupt
   *            @arg @ref SMARTCARD_IT_PE     Parity error interrupt
@@ -726,8 +752,10 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_TXFT   TXFIFO threshold reached interruption
   * @retval The new state of __INTERRUPT__ (SET or RESET).
   */
-#define __HAL_SMARTCARD_GET_IT(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->ISR\
-                                                             & ((uint32_t)0x01U << (((__INTERRUPT__) & SMARTCARD_ISR_MASK)>> SMARTCARD_ISR_POS))) != 0U) ? SET : RESET)
+#define __HAL_SMARTCARD_GET_IT(__HANDLE__, __INTERRUPT__) (\
+                                                           (((__HANDLE__)->Instance->ISR & (0x01UL << (((__INTERRUPT__)\
+                                                               & SMARTCARD_ISR_MASK)>> SMARTCARD_ISR_POS)))!= 0U)\
+                                                           ? SET : RESET)
 
 /** @brief  Check whether the specified SmartCard interrupt source is enabled or not.
   * @param  __HANDLE__ specifies the SMARTCARD Handle.
@@ -737,7 +765,8 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_RTO    Receive timeout interrupt
   *            @arg @ref SMARTCARD_IT_TXE    Transmit data register empty interrupt
   *            @arg @ref SMARTCARD_IT_TC     Transmission complete interrupt
-  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard time interrupt (when interruption available)
+  *            @arg @ref SMARTCARD_IT_TCBGT  Transmission complete before guard time
+  *                                          interrupt (when interruption available)
   *            @arg @ref SMARTCARD_IT_RXNE   Receive data register not empty interrupt
   *            @arg @ref SMARTCARD_IT_IDLE   Idle line detection interrupt
   *            @arg @ref SMARTCARD_IT_PE     Parity error interrupt
@@ -750,9 +779,16 @@ typedef enum
   *            @arg @ref SMARTCARD_IT_TXFT   TXFIFO threshold reached interruption
   * @retval The new state of __INTERRUPT__ (SET or RESET).
   */
-#define __HAL_SMARTCARD_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((__INTERRUPT__) & SMARTCARD_CR_MASK) >> SMARTCARD_CR_POS) == 0x01U)? (__HANDLE__)->Instance->CR1 : \
-                                                                     (((((__INTERRUPT__) & SMARTCARD_CR_MASK) >> SMARTCARD_CR_POS) == 0x02U)? (__HANDLE__)->Instance->CR2 : \
-                                                                      (__HANDLE__)->Instance->CR3)) & ((uint32_t)0x01U << (((uint16_t)(__INTERRUPT__)) & SMARTCARD_IT_MASK)))  != 0U) ? SET : RESET)
+#define __HAL_SMARTCARD_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((__INTERRUPT__) & SMARTCARD_CR_MASK) >>\
+                                                                       SMARTCARD_CR_POS) == 0x01U)?\
+                                                                     (__HANDLE__)->Instance->CR1 : \
+                                                                     (((((__INTERRUPT__) & SMARTCARD_CR_MASK) >>\
+                                                                        SMARTCARD_CR_POS) == 0x02U)?\
+                                                                      (__HANDLE__)->Instance->CR2 : \
+                                                                      (__HANDLE__)->Instance->CR3)) &\
+                                                                    (0x01UL << (((uint16_t)(__INTERRUPT__))\
+                                                                                & SMARTCARD_IT_MASK)))  != 0U)\
+                                                                  ? SET : RESET)
 
 /** @brief  Clear the specified SMARTCARD ISR flag, in setting the proper ICR register flag.
   * @param  __HANDLE__ specifies the SMARTCARD Handle.
@@ -1058,7 +1094,8 @@ void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsmartcard);
 #if (USE_HAL_SMARTCARD_REGISTER_CALLBACKS == 1)
 /* Callbacks Register/UnRegister functions  ***********************************/
 HAL_StatusTypeDef HAL_SMARTCARD_RegisterCallback(SMARTCARD_HandleTypeDef *hsmartcard,
-                                                 HAL_SMARTCARD_CallbackIDTypeDef CallbackID, pSMARTCARD_CallbackTypeDef pCallback);
+                                                 HAL_SMARTCARD_CallbackIDTypeDef CallbackID,
+                                                 pSMARTCARD_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsmartcard,
                                                    HAL_SMARTCARD_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_SMARTCARD_REGISTER_CALLBACKS */
@@ -1072,13 +1109,13 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
   * @{
   */
 
-HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size,
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, const uint8_t *pData, uint16_t Size,
                                          uint32_t Timeout);
 HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size,
                                         uint32_t Timeout);
-HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsmartcard, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsmartcard, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SMARTCARD_Receive_DMA(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size);
 /* Transfer Abort functions */
 HAL_StatusTypeDef HAL_SMARTCARD_Abort(SMARTCARD_HandleTypeDef *hsmartcard);
@@ -1105,8 +1142,8 @@ void HAL_SMARTCARD_AbortReceiveCpltCallback(SMARTCARD_HandleTypeDef *hsmartcard)
   * @{
   */
 
-HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(SMARTCARD_HandleTypeDef *hsmartcard);
-uint32_t                   HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsmartcard);
+HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(const SMARTCARD_HandleTypeDef *hsmartcard);
+uint32_t                   HAL_SMARTCARD_GetError(const SMARTCARD_HandleTypeDef *hsmartcard);
 
 /**
   * @}
@@ -1130,4 +1167,3 @@ uint32_t                   HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsmar
 
 #endif /* STM32WBxx_HAL_SMARTCARD_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smartcard_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smartcard_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -335,4 +334,3 @@ HAL_StatusTypeDef HAL_SMARTCARDEx_SetRxFifoThreshold(SMARTCARD_HandleTypeDef *hs
 
 #endif /* STM32WBxx_HAL_SMARTCARD_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smbus.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smbus.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -48,42 +47,43 @@ extern "C" {
 typedef struct
 {
   uint32_t Timing;                 /*!< Specifies the SMBUS_TIMINGR_register value.
-                                     This parameter calculated by referring to SMBUS initialization
-                                            section in Reference manual */
+                                        This parameter calculated by referring to SMBUS initialization section
+                                        in Reference manual */
   uint32_t AnalogFilter;           /*!< Specifies if Analog Filter is enable or not.
-                                     This parameter can be a value of @ref SMBUS_Analog_Filter */
+                                        This parameter can be a value of @ref SMBUS_Analog_Filter */
 
   uint32_t OwnAddress1;            /*!< Specifies the first device own address.
-                                     This parameter can be a 7-bit or 10-bit address. */
+                                        This parameter can be a 7-bit or 10-bit address. */
 
   uint32_t AddressingMode;         /*!< Specifies if 7-bit or 10-bit addressing mode for master is selected.
-                                     This parameter can be a value of @ref SMBUS_addressing_mode */
+                                        This parameter can be a value of @ref SMBUS_addressing_mode */
 
   uint32_t DualAddressMode;        /*!< Specifies if dual addressing mode is selected.
-                                     This parameter can be a value of @ref SMBUS_dual_addressing_mode */
+                                        This parameter can be a value of @ref SMBUS_dual_addressing_mode */
 
   uint32_t OwnAddress2;            /*!< Specifies the second device own address if dual addressing mode is selected
-                                     This parameter can be a 7-bit address. */
+                                        This parameter can be a 7-bit address. */
 
-  uint32_t OwnAddress2Masks;       /*!< Specifies the acknowledge mask address second device own address if dual addressing mode is selected
-                                     This parameter can be a value of @ref SMBUS_own_address2_masks. */
+  uint32_t OwnAddress2Masks;       /*!< Specifies the acknowledge mask address second device own address
+                                        if dual addressing mode is selected
+                                        This parameter can be a value of @ref SMBUS_own_address2_masks. */
 
   uint32_t GeneralCallMode;        /*!< Specifies if general call mode is selected.
-                                     This parameter can be a value of @ref SMBUS_general_call_addressing_mode. */
+                                        This parameter can be a value of @ref SMBUS_general_call_addressing_mode. */
 
   uint32_t NoStretchMode;          /*!< Specifies if nostretch mode is selected.
-                                     This parameter can be a value of @ref SMBUS_nostretch_mode */
+                                        This parameter can be a value of @ref SMBUS_nostretch_mode */
 
   uint32_t PacketErrorCheckMode;   /*!< Specifies if Packet Error Check mode is selected.
-                                     This parameter can be a value of @ref SMBUS_packet_error_check_mode */
+                                        This parameter can be a value of @ref SMBUS_packet_error_check_mode */
 
   uint32_t PeripheralMode;         /*!< Specifies which mode of Periphal is selected.
-                                     This parameter can be a value of @ref SMBUS_peripheral_mode */
+                                        This parameter can be a value of @ref SMBUS_peripheral_mode */
 
   uint32_t SMBusTimeout;           /*!< Specifies the content of the 32 Bits SMBUS_TIMEOUT_register value.
-                                      (Enable bits and different timeout values)
-                                     This parameter calculated by referring to SMBUS initialization
-                                         section in Reference manual */
+                                        (Enable bits and different timeout values)
+                                        This parameter calculated by referring to SMBUS initialization section
+                                        in Reference manual */
 } SMBUS_InitTypeDef;
 /**
   * @}
@@ -100,9 +100,7 @@ typedef struct
 #define HAL_SMBUS_STATE_MASTER_BUSY_RX  (0x00000022U)  /*!< Master Data Reception process is ongoing      */
 #define HAL_SMBUS_STATE_SLAVE_BUSY_TX   (0x00000032U)  /*!< Slave Data Transmission process is ongoing    */
 #define HAL_SMBUS_STATE_SLAVE_BUSY_RX   (0x00000042U)  /*!< Slave Data Reception process is ongoing       */
-#define HAL_SMBUS_STATE_TIMEOUT         (0x00000003U)  /*!< Timeout state                                 */
-#define HAL_SMBUS_STATE_ERROR           (0x00000004U)  /*!< Reception process is ongoing                  */
-#define HAL_SMBUS_STATE_LISTEN          (0x00000008U)   /*!< Address Listen Mode is ongoing                */
+#define HAL_SMBUS_STATE_LISTEN          (0x00000008U)  /*!< Address Listen Mode is ongoing                */
 /**
   * @}
   */
@@ -121,7 +119,7 @@ typedef struct
 #define HAL_SMBUS_ERROR_ALERT           (0x00000040U)    /*!< Alert error          */
 #define HAL_SMBUS_ERROR_PECERR          (0x00000080U)    /*!< PEC error            */
 #if (USE_HAL_SMBUS_REGISTER_CALLBACKS == 1)
-#define HAL_SMBUS_ERROR_INVALID_CALLBACK  (0x00000100U)    /*!< Invalid Callback error */
+#define HAL_SMBUS_ERROR_INVALID_CALLBACK  (0x00000100U)  /*!< Invalid Callback error   */
 #endif /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
 #define HAL_SMBUS_ERROR_INVALID_PARAM    (0x00000200U)   /*!< Invalid Parameters error */
 /**
@@ -159,17 +157,26 @@ typedef struct
   __IO uint32_t                ErrorCode;       /*!< SMBUS Error code                   */
 
 #if (USE_HAL_SMBUS_REGISTER_CALLBACKS == 1)
-  void (* MasterTxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);           /*!< SMBUS Master Tx Transfer completed callback */
-  void (* MasterRxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);           /*!< SMBUS Master Rx Transfer completed callback */
-  void (* SlaveTxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);            /*!< SMBUS Slave Tx Transfer completed callback  */
-  void (* SlaveRxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);            /*!< SMBUS Slave Rx Transfer completed callback  */
-  void (* ListenCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);             /*!< SMBUS Listen Complete callback              */
-  void (* ErrorCallback)(struct __SMBUS_HandleTypeDef *hsmbus);                  /*!< SMBUS Error callback                        */
+  void (* MasterTxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Master Tx Transfer completed callback */
+  void (* MasterRxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Master Rx Transfer completed callback */
+  void (* SlaveTxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Slave Tx Transfer completed callback  */
+  void (* SlaveRxCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Slave Rx Transfer completed callback  */
+  void (* ListenCpltCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Listen Complete callback              */
+  void (* ErrorCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Error callback                        */
 
-  void (* AddrCallback)(struct __SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode);  /*!< SMBUS Slave Address Match callback */
+  void (* AddrCallback)(struct __SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode);
+  /*!< SMBUS Slave Address Match callback */
 
-  void (* MspInitCallback)(struct __SMBUS_HandleTypeDef *hsmbus);                /*!< SMBUS Msp Init callback                     */
-  void (* MspDeInitCallback)(struct __SMBUS_HandleTypeDef *hsmbus);              /*!< SMBUS Msp DeInit callback                   */
+  void (* MspInitCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Msp Init callback                     */
+  void (* MspDeInitCallback)(struct __SMBUS_HandleTypeDef *hsmbus);
+  /*!< SMBUS Msp DeInit callback                   */
 
 #endif  /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
 } SMBUS_HandleTypeDef;
@@ -195,8 +202,11 @@ typedef enum
 /**
   * @brief  HAL SMBUS Callback pointer definition
   */
-typedef  void (*pSMBUS_CallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus); /*!< pointer to an SMBUS callback function */
-typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode); /*!< pointer to an SMBUS Address Match callback function */
+typedef  void (*pSMBUS_CallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus);
+/*!< pointer to an SMBUS callback function */
+typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection,
+                                            uint16_t AddrMatchCode);
+/*!< pointer to an SMBUS Address Match callback function */
 
 #endif /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
 /**
@@ -358,8 +368,10 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
 #define SMBUS_IT_ADDRI                          I2C_CR1_ADDRIE
 #define SMBUS_IT_RXI                            I2C_CR1_RXIE
 #define SMBUS_IT_TXI                            I2C_CR1_TXIE
-#define SMBUS_IT_TX                             (SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_TXI)
-#define SMBUS_IT_RX                             (SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_NACKI | SMBUS_IT_RXI)
+#define SMBUS_IT_TX                             (SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_STOPI | \
+                                                 SMBUS_IT_NACKI | SMBUS_IT_TXI)
+#define SMBUS_IT_RX                             (SMBUS_IT_ERRI | SMBUS_IT_TCI | SMBUS_IT_NACKI | \
+                                                 SMBUS_IT_RXI)
 #define SMBUS_IT_ALERT                          (SMBUS_IT_ERRI)
 #define SMBUS_IT_ADDR                           (SMBUS_IT_ADDRI | SMBUS_IT_STOPI | SMBUS_IT_NACKI)
 /**
@@ -407,14 +419,14 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
   * @retval None
   */
 #if (USE_HAL_SMBUS_REGISTER_CALLBACKS == 1)
-#define __HAL_SMBUS_RESET_HANDLE_STATE(__HANDLE__)           do{                                                   \
-                                                                (__HANDLE__)->State = HAL_SMBUS_STATE_RESET;       \
-                                                                (__HANDLE__)->MspInitCallback = NULL;            \
-                                                                (__HANDLE__)->MspDeInitCallback = NULL;          \
-                                                             } while(0)
+#define __HAL_SMBUS_RESET_HANDLE_STATE(__HANDLE__)           do{                                               \
+                                                                 (__HANDLE__)->State = HAL_SMBUS_STATE_RESET;  \
+                                                                 (__HANDLE__)->MspInitCallback = NULL;            \
+                                                                 (__HANDLE__)->MspDeInitCallback = NULL;          \
+                                                               } while(0)
 #else
 #define __HAL_SMBUS_RESET_HANDLE_STATE(__HANDLE__)         ((__HANDLE__)->State = HAL_SMBUS_STATE_RESET)
-#endif
+#endif /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
 
 /** @brief  Enable the specified SMBUS interrupts.
   * @param  __HANDLE__ specifies the SMBUS Handle.
@@ -462,7 +474,8 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
   *
   * @retval The new state of __IT__ (SET or RESET).
   */
-#define __HAL_SMBUS_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_SMBUS_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) \
+  ((((__HANDLE__)->Instance->CR1 & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Check whether the specified SMBUS flag is set or not.
   * @param  __HANDLE__ specifies the SMBUS Handle.
@@ -488,12 +501,15 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
   * @retval The new state of __FLAG__ (SET or RESET).
   */
 #define SMBUS_FLAG_MASK  (0x0001FFFFU)
-#define __HAL_SMBUS_GET_FLAG(__HANDLE__, __FLAG__) (((((__HANDLE__)->Instance->ISR) & ((__FLAG__) & SMBUS_FLAG_MASK)) == ((__FLAG__) & SMBUS_FLAG_MASK)) ? SET : RESET)
+#define __HAL_SMBUS_GET_FLAG(__HANDLE__, __FLAG__) \
+  (((((__HANDLE__)->Instance->ISR) & ((__FLAG__) & SMBUS_FLAG_MASK)) == \
+    ((__FLAG__) & SMBUS_FLAG_MASK)) ? SET : RESET)
 
 /** @brief  Clear the SMBUS pending flags which are cleared by writing 1 in a specific bit.
   * @param  __HANDLE__ specifies the SMBUS Handle.
   * @param  __FLAG__ specifies the flag to clear.
   *          This parameter can be any combination of the following values:
+  *            @arg @ref SMBUS_FLAG_TXE     Transmit data register empty
   *            @arg @ref SMBUS_FLAG_ADDR    Address matched (slave mode)
   *            @arg @ref SMBUS_FLAG_AF      NACK received flag
   *            @arg @ref SMBUS_FLAG_STOPF   STOP detection flag
@@ -506,7 +522,9 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
   *
   * @retval None
   */
-#define __HAL_SMBUS_CLEAR_FLAG(__HANDLE__, __FLAG__) ((__HANDLE__)->Instance->ICR = (__FLAG__))
+#define __HAL_SMBUS_CLEAR_FLAG(__HANDLE__, __FLAG__)  (((__FLAG__) == SMBUS_FLAG_TXE) ? \
+                                                       ((__HANDLE__)->Instance->ISR |= (__FLAG__)) : \
+                                                       ((__HANDLE__)->Instance->ICR = (__FLAG__)))
 
 /** @brief  Enable the specified SMBUS peripheral.
   * @param  __HANDLE__ specifies the SMBUS Handle.
@@ -539,15 +557,15 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
   */
 
 #define IS_SMBUS_ANALOG_FILTER(FILTER)                  (((FILTER) == SMBUS_ANALOGFILTER_ENABLE) || \
-                                                          ((FILTER) == SMBUS_ANALOGFILTER_DISABLE))
+                                                         ((FILTER) == SMBUS_ANALOGFILTER_DISABLE))
 
 #define IS_SMBUS_DIGITAL_FILTER(FILTER)                 ((FILTER) <= 0x0000000FU)
 
 #define IS_SMBUS_ADDRESSING_MODE(MODE)                  (((MODE) == SMBUS_ADDRESSINGMODE_7BIT)  || \
-                                                          ((MODE) == SMBUS_ADDRESSINGMODE_10BIT))
+                                                         ((MODE) == SMBUS_ADDRESSINGMODE_10BIT))
 
 #define IS_SMBUS_DUAL_ADDRESS(ADDRESS)                  (((ADDRESS) == SMBUS_DUALADDRESS_DISABLE) || \
-                                                          ((ADDRESS) == SMBUS_DUALADDRESS_ENABLE))
+                                                         ((ADDRESS) == SMBUS_DUALADDRESS_ENABLE))
 
 #define IS_SMBUS_OWN_ADDRESS2_MASK(MASK)                (((MASK) == SMBUS_OA2_NOMASK)    || \
                                                          ((MASK) == SMBUS_OA2_MASK01)    || \
@@ -565,47 +583,58 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
                                                          ((STRETCH) == SMBUS_NOSTRETCH_ENABLE))
 
 #define IS_SMBUS_PEC(PEC)                               (((PEC) == SMBUS_PEC_DISABLE) || \
-                                                          ((PEC) == SMBUS_PEC_ENABLE))
+                                                         ((PEC) == SMBUS_PEC_ENABLE))
 
-#define IS_SMBUS_PERIPHERAL_MODE(MODE)                  (((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_HOST)    || \
-                                                          ((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE)  || \
-                                                          ((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP))
+#define IS_SMBUS_PERIPHERAL_MODE(MODE)                  (((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_HOST)   || \
+                                                         ((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE)  || \
+                                                         ((MODE) == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP))
 
-#define IS_SMBUS_TRANSFER_MODE(MODE)                    (((MODE) == SMBUS_RELOAD_MODE)                           || \
-                                                          ((MODE) == SMBUS_AUTOEND_MODE)                         || \
-                                                          ((MODE) == SMBUS_SOFTEND_MODE)                         || \
-                                                          ((MODE) == SMBUS_SENDPEC_MODE)                         || \
-                                                          ((MODE) == (SMBUS_RELOAD_MODE | SMBUS_SENDPEC_MODE))   || \
-                                                          ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))  || \
-                                                          ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_RELOAD_MODE))   || \
-                                                          ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE | SMBUS_RELOAD_MODE )))
+#define IS_SMBUS_TRANSFER_MODE(MODE)                 (((MODE) == SMBUS_RELOAD_MODE)                          || \
+                                                      ((MODE) == SMBUS_AUTOEND_MODE)                         || \
+                                                      ((MODE) == SMBUS_SOFTEND_MODE)                         || \
+                                                      ((MODE) == SMBUS_SENDPEC_MODE)                         || \
+                                                      ((MODE) == (SMBUS_RELOAD_MODE | SMBUS_SENDPEC_MODE))   || \
+                                                      ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE))  || \
+                                                      ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_RELOAD_MODE))   || \
+                                                      ((MODE) == (SMBUS_AUTOEND_MODE | SMBUS_SENDPEC_MODE | \
+                                                                  SMBUS_RELOAD_MODE )))
 
 
 #define IS_SMBUS_TRANSFER_REQUEST(REQUEST)              (((REQUEST) == SMBUS_GENERATE_STOP)              || \
-                                                          ((REQUEST) == SMBUS_GENERATE_START_READ)       || \
-                                                          ((REQUEST) == SMBUS_GENERATE_START_WRITE)      || \
-                                                          ((REQUEST) == SMBUS_NO_STARTSTOP))
+                                                         ((REQUEST) == SMBUS_GENERATE_START_READ)        || \
+                                                         ((REQUEST) == SMBUS_GENERATE_START_WRITE)       || \
+                                                         ((REQUEST) == SMBUS_NO_STARTSTOP))
 
 
-#define IS_SMBUS_TRANSFER_OPTIONS_REQUEST(REQUEST)      (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST)        || \
-                                                          ((REQUEST) == SMBUS_FIRST_FRAME)                       || \
-                                                          ((REQUEST) == SMBUS_NEXT_FRAME)                        || \
-                                                          ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_NO_PEC)       || \
-                                                          ((REQUEST) == SMBUS_LAST_FRAME_NO_PEC)                 || \
-                                                          ((REQUEST) == SMBUS_FIRST_FRAME_WITH_PEC)              || \
-                                                          ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC)     || \
-                                                          ((REQUEST) == SMBUS_LAST_FRAME_WITH_PEC))
+#define IS_SMBUS_TRANSFER_OPTIONS_REQUEST(REQUEST)   (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST)       || \
+                                                      ((REQUEST) == SMBUS_FIRST_FRAME)                       || \
+                                                      ((REQUEST) == SMBUS_NEXT_FRAME)                        || \
+                                                      ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_NO_PEC)       || \
+                                                      ((REQUEST) == SMBUS_LAST_FRAME_NO_PEC)                 || \
+                                                      ((REQUEST) == SMBUS_FIRST_FRAME_WITH_PEC)              || \
+                                                      ((REQUEST) == SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC)     || \
+                                                      ((REQUEST) == SMBUS_LAST_FRAME_WITH_PEC))
 
-#define IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST) (((REQUEST) == SMBUS_OTHER_FRAME_NO_PEC)                || \
-                                                          ((REQUEST) == SMBUS_OTHER_AND_LAST_FRAME_NO_PEC)       || \
-                                                          ((REQUEST) == SMBUS_OTHER_FRAME_WITH_PEC)              || \
+#define IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(REQUEST) (((REQUEST) == SMBUS_OTHER_FRAME_NO_PEC)             || \
+                                                          ((REQUEST) == SMBUS_OTHER_AND_LAST_FRAME_NO_PEC)    || \
+                                                          ((REQUEST) == SMBUS_OTHER_FRAME_WITH_PEC)           || \
                                                           ((REQUEST) == SMBUS_OTHER_AND_LAST_FRAME_WITH_PEC))
 
-#define SMBUS_RESET_CR1(__HANDLE__)                       ((__HANDLE__)->Instance->CR1 &= (uint32_t)~((uint32_t)(I2C_CR1_SMBHEN | I2C_CR1_SMBDEN | I2C_CR1_PECEN)))
-#define SMBUS_RESET_CR2(__HANDLE__)                       ((__HANDLE__)->Instance->CR2 &= (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_RD_WRN)))
+#define SMBUS_RESET_CR1(__HANDLE__)                    ((__HANDLE__)->Instance->CR1 &= \
+                                                        (uint32_t)~((uint32_t)(I2C_CR1_SMBHEN | I2C_CR1_SMBDEN | \
+                                                                               I2C_CR1_PECEN)))
+#define SMBUS_RESET_CR2(__HANDLE__)                    ((__HANDLE__)->Instance->CR2 &= \
+                                                        (uint32_t)~((uint32_t)(I2C_CR2_SADD | I2C_CR2_HEAD10R | \
+                                                                               I2C_CR2_NBYTES | I2C_CR2_RELOAD | \
+                                                                               I2C_CR2_RD_WRN)))
 
-#define SMBUS_GENERATE_START(__ADDMODE__,__ADDRESS__)     (((__ADDMODE__) == SMBUS_ADDRESSINGMODE_7BIT) ? (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)) : \
-                                                                  (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
+#define SMBUS_GENERATE_START(__ADDMODE__,__ADDRESS__)     (((__ADDMODE__) == SMBUS_ADDRESSINGMODE_7BIT) ? \
+                                                           (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | \
+                                                                       (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & \
+                                                                      (~I2C_CR2_RD_WRN)) : \
+                                                           (uint32_t)((((uint32_t)(__ADDRESS__) & \
+                                                                        (I2C_CR2_SADD)) | (I2C_CR2_ADD10) | \
+                                                                       (I2C_CR2_START)) & (~I2C_CR2_RD_WRN)))
 
 #define SMBUS_GET_ADDR_MATCH(__HANDLE__)                  (((__HANDLE__)->Instance->ISR & I2C_ISR_ADDCODE) >> 17U)
 #define SMBUS_GET_DIR(__HANDLE__)                         (((__HANDLE__)->Instance->ISR & I2C_ISR_DIR) >> 16U)
@@ -613,7 +642,8 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
 #define SMBUS_GET_PEC_MODE(__HANDLE__)                    ((__HANDLE__)->Instance->CR2 & I2C_CR2_PECBYTE)
 #define SMBUS_GET_ALERT_ENABLED(__HANDLE__)                ((__HANDLE__)->Instance->CR1 & I2C_CR1_ALERTEN)
 
-#define SMBUS_CHECK_FLAG(__ISR__, __FLAG__)             ((((__ISR__) & ((__FLAG__) & SMBUS_FLAG_MASK)) == ((__FLAG__) & SMBUS_FLAG_MASK)) ? SET : RESET)
+#define SMBUS_CHECK_FLAG(__ISR__, __FLAG__)             ((((__ISR__) & ((__FLAG__) & SMBUS_FLAG_MASK)) == \
+                                                          ((__FLAG__) & SMBUS_FLAG_MASK)) ? SET : RESET)
 #define SMBUS_CHECK_IT_SOURCE(__CR1__, __IT__)          ((((__CR1__) & (__IT__)) == (__IT__)) ? SET : RESET)
 
 #define IS_SMBUS_OWN_ADDRESS1(ADDRESS1)                         ((ADDRESS1) <= 0x000003FFU)
@@ -623,14 +653,17 @@ typedef  void (*pSMBUS_AddrCallbackTypeDef)(SMBUS_HandleTypeDef *hsmbus, uint8_t
   * @}
   */
 
+/* Include SMBUS HAL Extended module */
+#include "stm32wbxx_hal_smbus_ex.h"
+
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup SMBUS_Exported_Functions SMBUS Exported Functions
   * @{
   */
 
 /** @addtogroup SMBUS_Exported_Functions_Group1 Initialization and de-initialization functions
- * @{
- */
+  * @{
+  */
 
 /* Initialization and de-initialization functions  ****************************/
 HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus);
@@ -642,10 +675,14 @@ HAL_StatusTypeDef HAL_SMBUS_ConfigDigitalFilter(SMBUS_HandleTypeDef *hsmbus, uin
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_SMBUS_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SMBUS_CallbackIDTypeDef CallbackID, pSMBUS_CallbackTypeDef pCallback);
-HAL_StatusTypeDef HAL_SMBUS_UnRegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SMBUS_CallbackIDTypeDef CallbackID);
+HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus,
+                                             HAL_SMBUS_CallbackIDTypeDef CallbackID,
+                                             pSMBUS_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_SMBUS_UnRegisterCallback(SMBUS_HandleTypeDef *hsmbus,
+                                               HAL_SMBUS_CallbackIDTypeDef CallbackID);
 
-HAL_StatusTypeDef HAL_SMBUS_RegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus, pSMBUS_AddrCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_SMBUS_RegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus,
+                                                 pSMBUS_AddrCallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_SMBUS_UnRegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus);
 #endif /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
 /**
@@ -653,28 +690,33 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus);
   */
 
 /** @addtogroup SMBUS_Exported_Functions_Group2 Input and Output operation functions
- * @{
- */
+  * @{
+  */
 
 /* IO operation functions  *****************************************************/
 /** @addtogroup Blocking_mode_Polling Blocking mode Polling
- * @{
- */
+  * @{
+  */
 /******* Blocking mode: Polling */
-HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials,
+                                          uint32_t Timeout);
 /**
   * @}
   */
 
 /** @addtogroup Non-Blocking_mode_Interrupt Non-Blocking mode Interrupt
- * @{
- */
+  * @{
+  */
 /******* Non-Blocking mode: Interrupt */
-HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress,
+                                               uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress,
+                                              uint8_t *pData, uint16_t Size, uint32_t XferOptions);
 HAL_StatusTypeDef HAL_SMBUS_Master_Abort_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress);
-HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
-HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size,
+                                              uint32_t XferOptions);
+HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size,
+                                             uint32_t XferOptions);
 
 HAL_StatusTypeDef HAL_SMBUS_EnableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
 HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus);
@@ -685,8 +727,8 @@ HAL_StatusTypeDef HAL_SMBUS_DisableListen_IT(SMBUS_HandleTypeDef *hsmbus);
   */
 
 /** @addtogroup SMBUS_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
- * @{
- */
+  * @{
+  */
 /******* SMBUS IRQHandler and Callbacks used in non blocking modes (Interrupt) */
 void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus);
 void HAL_SMBUS_ER_IRQHandler(SMBUS_HandleTypeDef *hsmbus);
@@ -703,12 +745,12 @@ void HAL_SMBUS_ErrorCallback(SMBUS_HandleTypeDef *hsmbus);
   */
 
 /** @addtogroup SMBUS_Exported_Functions_Group3 Peripheral State and Errors functions
- *  @{
- */
+  *  @{
+  */
 
 /* Peripheral State and Errors functions  **************************************************/
-uint32_t HAL_SMBUS_GetState(SMBUS_HandleTypeDef *hsmbus);
-uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus);
+uint32_t HAL_SMBUS_GetState(const SMBUS_HandleTypeDef *hsmbus);
+uint32_t HAL_SMBUS_GetError(const SMBUS_HandleTypeDef *hsmbus);
 
 /**
   * @}
@@ -745,5 +787,3 @@ uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus);
 
 
 #endif /* STM32WBxx_HAL_SMBUS_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smbus_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_smbus_ex.h
@@ -1,0 +1,147 @@
+/**
+  ******************************************************************************
+  * @file    stm32wbxx_hal_smbus_ex.h
+  * @author  MCD Application Team
+  * @brief   Header file of SMBUS HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32WBxx_HAL_SMBUS_EX_H
+#define STM32WBxx_HAL_SMBUS_EX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32wbxx_hal_def.h"
+
+/** @addtogroup STM32WBxx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup SMBUSEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup SMBUSEx_Exported_Constants SMBUS Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup SMBUSEx_FastModePlus SMBUS Extended Fast Mode Plus
+  * @{
+  */
+#define SMBUS_FMP_NOT_SUPPORTED           0xAAAA0000U                                     /*!< Fast Mode Plus not supported       */
+#define SMBUS_FASTMODEPLUS_PB6            SYSCFG_CFGR1_I2C_PB6_FMP                        /*!< Enable Fast Mode Plus on PB6       */
+#define SMBUS_FASTMODEPLUS_PB7            SYSCFG_CFGR1_I2C_PB7_FMP                        /*!< Enable Fast Mode Plus on PB7       */
+#define SMBUS_FASTMODEPLUS_PB8            SYSCFG_CFGR1_I2C_PB8_FMP                        /*!< Enable Fast Mode Plus on PB8       */
+#define SMBUS_FASTMODEPLUS_PB9            SYSCFG_CFGR1_I2C_PB9_FMP                        /*!< Enable Fast Mode Plus on PB9       */
+#define SMBUS_FASTMODEPLUS_I2C1           SYSCFG_CFGR1_I2C1_FMP                           /*!< Enable Fast Mode Plus on I2C1 pins */
+#if defined(SYSCFG_CFGR1_I2C3_FMP)
+#define SMBUS_FASTMODEPLUS_I2C3           SYSCFG_CFGR1_I2C3_FMP                           /*!< Enable Fast Mode Plus on I2C3 pins */
+#else
+#define SMBUS_FASTMODEPLUS_I2C3           (uint32_t)(0x00000400U | SMBUS_FMP_NOT_SUPPORTED) /*!< Fast Mode Plus I2C3 not supported  */
+#endif /* SYSCFG_CFGR1_I2C3_FMP */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup SMBUSEx_Exported_Macros SMBUS Extended Exported Macros
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup SMBUSEx_Exported_Functions SMBUS Extended Exported Functions
+  * @{
+  */
+
+/** @addtogroup SMBUSEx_Exported_Functions_Group2 WakeUp Mode Functions
+  * @{
+  */
+/* Peripheral Control functions  ************************************************/
+HAL_StatusTypeDef HAL_SMBUSEx_EnableWakeUp(SMBUS_HandleTypeDef *hsmbus);
+HAL_StatusTypeDef HAL_SMBUSEx_DisableWakeUp(SMBUS_HandleTypeDef *hsmbus);
+/**
+  * @}
+  */
+
+/** @addtogroup SMBUSEx_Exported_Functions_Group3 Fast Mode Plus Functions
+  * @{
+  */
+void HAL_SMBUSEx_EnableFastModePlus(uint32_t ConfigFastModePlus);
+void HAL_SMBUSEx_DisableFastModePlus(uint32_t ConfigFastModePlus);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup SMBUSEx_Private_Constants SMBUS Extended Private Constants
+  * @{
+  */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup SMBUSEx_Private_Macro SMBUS Extended Private Macros
+  * @{
+  */
+#define IS_SMBUS_FASTMODEPLUS(__CONFIG__) ((((__CONFIG__) & (SMBUS_FASTMODEPLUS_PB6))  == SMBUS_FASTMODEPLUS_PB6)   || \
+                                           (((__CONFIG__) & (SMBUS_FASTMODEPLUS_PB7))  == SMBUS_FASTMODEPLUS_PB7)   || \
+                                           (((__CONFIG__) & (SMBUS_FASTMODEPLUS_PB8))  == SMBUS_FASTMODEPLUS_PB8)   || \
+                                           (((__CONFIG__) & (SMBUS_FASTMODEPLUS_PB9))  == SMBUS_FASTMODEPLUS_PB9)   || \
+                                           (((__CONFIG__) & (SMBUS_FASTMODEPLUS_I2C1)) == SMBUS_FASTMODEPLUS_I2C1)  || \
+                                           (((__CONFIG__) & (SMBUS_FASTMODEPLUS_I2C3)) == SMBUS_FASTMODEPLUS_I2C3))
+/**
+  * @}
+  */
+
+/* Private Functions ---------------------------------------------------------*/
+/** @defgroup SMBUSEx_Private_Functions SMBUS Extended Private Functions
+  * @{
+  */
+/* Private functions are defined in stm32wbxx_hal_smbus_ex.c file */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32WBxx_HAL_SMBUS_EX_H */

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_spi.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_spi.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -119,7 +118,7 @@ typedef struct __SPI_HandleTypeDef
 
   SPI_InitTypeDef            Init;           /*!< SPI communication parameters             */
 
-  uint8_t                    *pTxBuffPtr;    /*!< Pointer to SPI Tx transfer Buffer        */
+  const uint8_t              *pTxBuffPtr;    /*!< Pointer to SPI Tx transfer Buffer        */
 
   uint16_t                   TxXferSize;     /*!< SPI Tx Transfer size                     */
 
@@ -427,11 +426,12 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   * @retval None
   */
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1U)
-#define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__)                do{                                                  \
-                                                                    (__HANDLE__)->State = HAL_SPI_STATE_RESET;       \
-                                                                    (__HANDLE__)->MspInitCallback = NULL;            \
-                                                                    (__HANDLE__)->MspDeInitCallback = NULL;          \
-                                                                  } while(0)
+#define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__)      \
+  do{                                                 \
+    (__HANDLE__)->State = HAL_SPI_STATE_RESET;        \
+    (__HANDLE__)->MspInitCallback = NULL;             \
+    (__HANDLE__)->MspDeInitCallback = NULL;           \
+  } while(0)
 #else
 #define __HAL_SPI_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_SPI_STATE_RESET)
 #endif /* USE_HAL_SPI_REGISTER_CALLBACKS */
@@ -534,7 +534,7 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
     __IO uint32_t tmpreg_fre = 0x00U;              \
     tmpreg_fre = (__HANDLE__)->Instance->SR;       \
     UNUSED(tmpreg_fre);                            \
-  }while(0U)
+  } while(0U)
 
 /** @brief  Enable the SPI peripheral.
   * @param  __HANDLE__ specifies the SPI Handle.
@@ -578,8 +578,11 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   *         This parameter can be SPI where x: 1, 2, or 3 to select the SPI peripheral.
   * @retval None
   */
-#define SPI_RESET_CRC(__HANDLE__) do{CLEAR_BIT((__HANDLE__)->Instance->CR1, SPI_CR1_CRCEN);\
-                                       SET_BIT((__HANDLE__)->Instance->CR1, SPI_CR1_CRCEN);}while(0U)
+#define SPI_RESET_CRC(__HANDLE__)                           \
+  do{                                                       \
+    CLEAR_BIT((__HANDLE__)->Instance->CR1, SPI_CR1_CRCEN);  \
+    SET_BIT((__HANDLE__)->Instance->CR1, SPI_CR1_CRCEN);    \
+  } while(0U)
 
 /** @brief  Check whether the specified SPI flag is set or not.
   * @param  __SR__  copy of SPI SR register.
@@ -597,7 +600,7 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   * @retval SET or RESET.
   */
 #define SPI_CHECK_FLAG(__SR__, __FLAG__) ((((__SR__) & ((__FLAG__) & SPI_FLAG_MASK)) == \
-                                          ((__FLAG__) & SPI_FLAG_MASK)) ? SET : RESET)
+                                           ((__FLAG__) & SPI_FLAG_MASK)) ? SET : RESET)
 
 /** @brief  Check whether the specified SPI Interrupt is set or not.
   * @param  __CR2__  copy of SPI CR2 register.
@@ -609,7 +612,7 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   * @retval SET or RESET.
   */
 #define SPI_CHECK_IT_SOURCE(__CR2__, __INTERRUPT__) ((((__CR2__) & (__INTERRUPT__)) == \
-                                                     (__INTERRUPT__)) ? SET : RESET)
+                                                      (__INTERRUPT__)) ? SET : RESET)
 
 /** @brief  Checks if SPI Mode parameter is in allowed range.
   * @param  __MODE__ specifies the SPI Mode.
@@ -747,7 +750,7 @@ typedef  void (*pSPI_CallbackTypeDef)(SPI_HandleTypeDef *hspi); /*!< pointer to 
   */
 #define IS_SPI_CRC_POLYNOMIAL(__POLYNOMIAL__) (((__POLYNOMIAL__) >= 0x1U)    && \
                                                ((__POLYNOMIAL__) <= 0xFFFFU) && \
-                                              (((__POLYNOMIAL__)&0x1U) != 0U))
+                                               (((__POLYNOMIAL__)&0x1U) != 0U))
 
 /** @brief  Checks if DMA handle is valid.
   * @param  __HANDLE__ specifies a DMA Handle.
@@ -778,7 +781,8 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef *hspi);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1U)
-HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID, pSPI_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_SPI_RegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID,
+                                           pSPI_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_SPI_UnRegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_SPI_REGISTER_CALLBACKS */
 /**
@@ -789,17 +793,17 @@ HAL_StatusTypeDef HAL_SPI_UnRegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Ca
   * @{
   */
 /* I/O operation functions  ***************************************************/
-HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size,
-                                          uint32_t Timeout);
-HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
+                                          uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData,
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
                                              uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData,
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
                                               uint16_t Size);
 HAL_StatusTypeDef HAL_SPI_DMAPause(SPI_HandleTypeDef *hspi);
 HAL_StatusTypeDef HAL_SPI_DMAResume(SPI_HandleTypeDef *hspi);
@@ -825,8 +829,8 @@ void HAL_SPI_AbortCpltCallback(SPI_HandleTypeDef *hspi);
   * @{
   */
 /* Peripheral State and Error functions ***************************************/
-HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi);
-uint32_t             HAL_SPI_GetError(SPI_HandleTypeDef *hspi);
+HAL_SPI_StateTypeDef HAL_SPI_GetState(const SPI_HandleTypeDef *hspi);
+uint32_t             HAL_SPI_GetError(const SPI_HandleTypeDef *hspi);
 /**
   * @}
   */
@@ -849,4 +853,3 @@ uint32_t             HAL_SPI_GetError(SPI_HandleTypeDef *hspi);
 
 #endif /* STM32WBxx_HAL_SPI_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_spi_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_spi_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -49,7 +48,7 @@ extern "C" {
 /** @addtogroup SPIEx_Exported_Functions_Group1
   * @{
   */
-HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(const SPI_HandleTypeDef *hspi);
 /**
   * @}
   */
@@ -72,4 +71,3 @@ HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi);
 
 #endif /* STM32WBxx_HAL_SPI_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_tim.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_tim.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -65,8 +64,10 @@ typedef struct
                                     This means in PWM mode that (N+1) corresponds to:
                                         - the number of PWM periods in edge-aligned mode
                                         - the number of half PWM period in center-aligned mode
-                                     GP timers: this parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF.
-                                     Advanced timers: this parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF. */
+                                     GP timers: this parameter must be a number between Min_Data = 0x00 and
+                                     Max_Data = 0xFF.
+                                     Advanced timers: this parameter must be a number between Min_Data = 0x0000 and
+                                     Max_Data = 0xFFFF. */
 
   uint32_t AutoReloadPreload;  /*!< Specifies the auto-reload preload.
                                    This parameter can be a value of @ref TIM_AutoReloadPreload */
@@ -218,7 +219,8 @@ typedef struct
   uint32_t ClearInputPolarity;   /*!< TIM Clear Input polarity
                                       This parameter can be a value of @ref TIM_ClearInput_Polarity */
   uint32_t ClearInputPrescaler;  /*!< TIM Clear Input prescaler
-                                      This parameter must be 0: When OCRef clear feature is used with ETR source, ETR prescaler must be off */
+                                      This parameter must be 0: When OCRef clear feature is used with ETR source,
+                                      ETR prescaler must be off */
   uint32_t ClearInputFilter;     /*!< TIM Clear Input filter
                                       This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
 } TIM_ClearInputConfigTypeDef;
@@ -268,32 +270,32 @@ typedef struct
   */
 typedef struct
 {
-  uint32_t OffStateRunMode;      /*!< TIM off state in run mode
-                                      This parameter can be a value of @ref TIM_OSSR_Off_State_Selection_for_Run_mode_state */
-  uint32_t OffStateIDLEMode;     /*!< TIM off state in IDLE mode
-                                      This parameter can be a value of @ref TIM_OSSI_Off_State_Selection_for_Idle_mode_state */
-  uint32_t LockLevel;            /*!< TIM Lock level
-                                      This parameter can be a value of @ref TIM_Lock_level */
-  uint32_t DeadTime;             /*!< TIM dead Time
-                                      This parameter can be a number between Min_Data = 0x00 and Max_Data = 0xFF */
-  uint32_t BreakState;           /*!< TIM Break State
-                                      This parameter can be a value of @ref TIM_Break_Input_enable_disable */
-  uint32_t BreakPolarity;        /*!< TIM Break input polarity
-                                      This parameter can be a value of @ref TIM_Break_Polarity */
-  uint32_t BreakFilter;          /*!< Specifies the break input filter.
-                                      This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
-  uint32_t BreakAFMode;          /*!< Specifies the alternate function mode of the break input.
-                                      This parameter can be a value of @ref TIM_Break_Input_AF_Mode */
-  uint32_t Break2State;          /*!< TIM Break2 State
-                                      This parameter can be a value of @ref TIM_Break2_Input_enable_disable */
-  uint32_t Break2Polarity;       /*!< TIM Break2 input polarity
-                                      This parameter can be a value of @ref TIM_Break2_Polarity */
-  uint32_t Break2Filter;         /*!< TIM break2 input filter.
-                                      This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
-  uint32_t Break2AFMode;         /*!< Specifies the alternate function mode of the break2 input.
-                                      This parameter can be a value of @ref TIM_Break2_Input_AF_Mode */
-  uint32_t AutomaticOutput;      /*!< TIM Automatic Output Enable state
-                                      This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+  uint32_t OffStateRunMode;      /*!< TIM off state in run mode, This parameter can be a value of @ref TIM_OSSR_Off_State_Selection_for_Run_mode_state */
+
+  uint32_t OffStateIDLEMode;     /*!< TIM off state in IDLE mode, This parameter can be a value of @ref TIM_OSSI_Off_State_Selection_for_Idle_mode_state */
+
+  uint32_t LockLevel;            /*!< TIM Lock level, This parameter can be a value of @ref TIM_Lock_level */
+
+  uint32_t DeadTime;             /*!< TIM dead Time, This parameter can be a number between Min_Data = 0x00 and Max_Data = 0xFF */
+
+  uint32_t BreakState;           /*!< TIM Break State, This parameter can be a value of @ref TIM_Break_Input_enable_disable */
+
+  uint32_t BreakPolarity;        /*!< TIM Break input polarity, This parameter can be a value of @ref TIM_Break_Polarity */
+
+  uint32_t BreakFilter;          /*!< Specifies the break input filter.This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+
+  uint32_t BreakAFMode;          /*!< Specifies the alternate function mode of the break input.This parameter can be a value of @ref TIM_Break_Input_AF_Mode */
+
+  uint32_t Break2State;          /*!< TIM Break2 State, This parameter can be a value of @ref TIM_Break2_Input_enable_disable */
+
+  uint32_t Break2Polarity;       /*!< TIM Break2 input polarity, This parameter can be a value of @ref TIM_Break2_Polarity */
+
+  uint32_t Break2Filter;         /*!< TIM break2 input filter.This parameter can be a number between Min_Data = 0x0 and Max_Data = 0xF */
+
+  uint32_t Break2AFMode;         /*!< Specifies the alternate function mode of the break2 input.This parameter can be a value of @ref TIM_Break2_Input_AF_Mode */
+
+  uint32_t AutomaticOutput;      /*!< TIM Automatic Output Enable state, This parameter can be a value of @ref TIM_AOE_Bit_Set_Reset */
+
 } TIM_BreakDeadTimeConfigTypeDef;
 
 /**
@@ -400,29 +402,28 @@ typedef struct
   */
 typedef enum
 {
-  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                              */
-  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                            */
-  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                */
-  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                              */
-  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                */
-  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                              */
-  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                               */
-  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                             */
-  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                         */
-  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                       */
-  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                           */
-  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                         */
-  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
-  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
+  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                               */
+  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                             */
+  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                 */
+  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                               */
+  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                 */
+  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                               */
+  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                                */
+  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                              */
+  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                          */
+  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                        */
+  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                            */
+  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                          */
+  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                      */
+  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                      */
   , HAL_TIM_PERIOD_ELAPSED_CB_ID          = 0x0EU   /*!< TIM Period Elapsed Callback ID                             */
   , HAL_TIM_PERIOD_ELAPSED_HALF_CB_ID     = 0x0FU   /*!< TIM Period Elapsed half complete Callback ID               */
   , HAL_TIM_TRIGGER_CB_ID                 = 0x10U   /*!< TIM Trigger Callback ID                                    */
   , HAL_TIM_TRIGGER_HALF_CB_ID            = 0x11U   /*!< TIM Trigger half complete Callback ID                      */
-
   , HAL_TIM_IC_CAPTURE_CB_ID              = 0x12U   /*!< TIM Input Capture Callback ID                              */
   , HAL_TIM_IC_CAPTURE_HALF_CB_ID         = 0x13U   /*!< TIM Input Capture half complete Callback ID                */
   , HAL_TIM_OC_DELAY_ELAPSED_CB_ID        = 0x14U   /*!< TIM Output Compare Delay Elapsed Callback ID               */
-  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID           */
+  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID                         */
   , HAL_TIM_PWM_PULSE_FINISHED_HALF_CB_ID = 0x16U   /*!< TIM PWM Pulse Finished half complete Callback ID           */
   , HAL_TIM_ERROR_CB_ID                   = 0x17U   /*!< TIM Error Callback ID                                      */
   , HAL_TIM_COMMUTATION_CB_ID             = 0x18U   /*!< TIM Commutation Callback ID                                */
@@ -664,10 +665,8 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 /** @defgroup TIM_Input_Capture_Selection TIM Input Capture Selection
   * @{
   */
-#define TIM_ICSELECTION_DIRECTTI           TIM_CCMR1_CC1S_0                     /*!< TIM Input 1, 2, 3 or 4 is selected to be
-                                                                                     connected to IC1, IC2, IC3 or IC4, respectively */
-#define TIM_ICSELECTION_INDIRECTTI         TIM_CCMR1_CC1S_1                     /*!< TIM Input 1, 2, 3 or 4 is selected to be
-                                                                                     connected to IC2, IC1, IC4 or IC3, respectively */
+#define TIM_ICSELECTION_DIRECTTI           TIM_CCMR1_CC1S_0                     /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to IC1, IC2, IC3 or IC4, respectively */
+#define TIM_ICSELECTION_INDIRECTTI         TIM_CCMR1_CC1S_1                     /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to IC2, IC1, IC4 or IC3, respectively */
 #define TIM_ICSELECTION_TRC                TIM_CCMR1_CC1S                       /*!< TIM Input 1, 2, 3 or 4 is selected to be connected to TRC */
 /**
   * @}
@@ -741,6 +740,15 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
   * @}
   */
 
+/** @defgroup TIM_CC_DMA_Request CCx DMA request selection
+  * @{
+  */
+#define TIM_CCDMAREQUEST_CC                 0x00000000U                         /*!< CCx DMA request sent when capture or compare match event occurs */
+#define TIM_CCDMAREQUEST_UPDATE             TIM_CR2_CCDS                        /*!< CCx DMA requests sent when update event occurs */
+/**
+  * @}
+  */
+
 /** @defgroup TIM_Flag_definition TIM Flag Definition
   * @{
   */
@@ -781,16 +789,16 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 /** @defgroup TIM_Clock_Source TIM Clock Source
   * @{
   */
-#define TIM_CLOCKSOURCE_ETRMODE2    TIM_SMCR_ETPS_1      /*!< External clock source mode 2                          */
 #define TIM_CLOCKSOURCE_INTERNAL    TIM_SMCR_ETPS_0      /*!< Internal clock source                                 */
+#define TIM_CLOCKSOURCE_ETRMODE1    TIM_TS_ETRF          /*!< External clock source mode 1 (ETRF)                   */
+#define TIM_CLOCKSOURCE_ETRMODE2    TIM_SMCR_ETPS_1      /*!< External clock source mode 2                          */
+#define TIM_CLOCKSOURCE_TI1ED       TIM_TS_TI1F_ED       /*!< External clock source mode 1 (TTI1FP1 + edge detect.) */
+#define TIM_CLOCKSOURCE_TI1         TIM_TS_TI1FP1        /*!< External clock source mode 1 (TTI1FP1)                */
+#define TIM_CLOCKSOURCE_TI2         TIM_TS_TI2FP2        /*!< External clock source mode 1 (TTI2FP2)                */
 #define TIM_CLOCKSOURCE_ITR0        TIM_TS_ITR0          /*!< External clock source mode 1 (ITR0)                   */
 #define TIM_CLOCKSOURCE_ITR1        TIM_TS_ITR1          /*!< External clock source mode 1 (ITR1)                   */
 #define TIM_CLOCKSOURCE_ITR2        TIM_TS_ITR2          /*!< External clock source mode 1 (ITR2)                   */
 #define TIM_CLOCKSOURCE_ITR3        TIM_TS_ITR3          /*!< External clock source mode 1 (ITR3)                   */
-#define TIM_CLOCKSOURCE_TI1ED       TIM_TS_TI1F_ED       /*!< External clock source mode 1 (TTI1FP1 + edge detect.) */
-#define TIM_CLOCKSOURCE_TI1         TIM_TS_TI1FP1        /*!< External clock source mode 1 (TTI1FP1)                */
-#define TIM_CLOCKSOURCE_TI2         TIM_TS_TI2FP2        /*!< External clock source mode 1 (TTI2FP2)                */
-#define TIM_CLOCKSOURCE_ETRMODE1    TIM_TS_ETRF          /*!< External clock source mode 1 (ETRF)                   */
 /**
   * @}
   */
@@ -924,19 +932,18 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
   * @{
   */
 #define TIM_AUTOMATICOUTPUT_DISABLE        0x00000000U                          /*!< MOE can be set only by software */
-#define TIM_AUTOMATICOUTPUT_ENABLE         TIM_BDTR_AOE                         /*!< MOE can be set by software or automatically at the next update event
-                                                                                    (if none of the break inputs BRK and BRK2 is active) */
+#define TIM_AUTOMATICOUTPUT_ENABLE         TIM_BDTR_AOE                         /*!< MOE can be set by software or automatically at the next update event (if none of the break inputs BRK and BRK2 is active) */
 /**
   * @}
   */
 
-/** @defgroup TIM_Group_Channel5 Group Channel 5 and Channel 1, 2 or 3
+/** @defgroup TIM_Group_Channel5 TIM Group Channel 5 and Channel 1, 2 or 3
   * @{
   */
-#define TIM_GROUPCH5_NONE                  0x00000000U                          /* !< No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC */
-#define TIM_GROUPCH5_OC1REFC               TIM_CCR5_GC5C1                       /* !< OC1REFC is the logical AND of OC1REFC and OC5REF    */
-#define TIM_GROUPCH5_OC2REFC               TIM_CCR5_GC5C2                       /* !< OC2REFC is the logical AND of OC2REFC and OC5REF    */
-#define TIM_GROUPCH5_OC3REFC               TIM_CCR5_GC5C3                       /* !< OC3REFC is the logical AND of OC3REFC and OC5REF    */
+#define TIM_GROUPCH5_NONE                  0x00000000U                          /*!< No effect of OC5REF on OC1REFC, OC2REFC and OC3REFC */
+#define TIM_GROUPCH5_OC1REFC               TIM_CCR5_GC5C1                       /*!< OC1REFC is the logical AND of OC1REFC and OC5REF    */
+#define TIM_GROUPCH5_OC2REFC               TIM_CCR5_GC5C2                       /*!< OC2REFC is the logical AND of OC2REFC and OC5REF    */
+#define TIM_GROUPCH5_OC3REFC               TIM_CCR5_GC5C3                       /*!< OC3REFC is the logical AND of OC3REFC and OC5REF    */
 /**
   * @}
   */
@@ -1016,8 +1023,8 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define TIM_OCMODE_RETRIGERRABLE_OPM2      (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)                     /*!< Retrigerrable OPM mode 2               */
 #define TIM_OCMODE_COMBINED_PWM1           (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)                     /*!< Combined PWM mode 1                    */
 #define TIM_OCMODE_COMBINED_PWM2           (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2)  /*!< Combined PWM mode 2                    */
-#define TIM_OCMODE_ASSYMETRIC_PWM1         (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)  /*!< Asymmetric PWM mode 1                  */
-#define TIM_OCMODE_ASSYMETRIC_PWM2         TIM_CCMR1_OC1M                                            /*!< Asymmetric PWM mode 2                  */
+#define TIM_OCMODE_ASYMMETRIC_PWM1         (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)  /*!< Asymmetric PWM mode 1                  */
+#define TIM_OCMODE_ASYMMETRIC_PWM2         TIM_CCMR1_OC1M                                            /*!< Asymmetric PWM mode 2                  */
 /**
   * @}
   */
@@ -1073,24 +1080,24 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 /** @defgroup TIM_DMA_Burst_Length TIM DMA Burst Length
   * @{
   */
-#define TIM_DMABURSTLENGTH_1TRANSFER       0x00000000U                          /*!< The transfer is done to 1 register starting trom TIMx_CR1 + TIMx_DCR.DBA   */
-#define TIM_DMABURSTLENGTH_2TRANSFERS      0x00000100U                          /*!< The transfer is done to 2 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_3TRANSFERS      0x00000200U                          /*!< The transfer is done to 3 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_4TRANSFERS      0x00000300U                          /*!< The transfer is done to 4 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_5TRANSFERS      0x00000400U                          /*!< The transfer is done to 5 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_6TRANSFERS      0x00000500U                          /*!< The transfer is done to 6 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_7TRANSFERS      0x00000600U                          /*!< The transfer is done to 7 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_8TRANSFERS      0x00000700U                          /*!< The transfer is done to 8 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_9TRANSFERS      0x00000800U                          /*!< The transfer is done to 9 registers starting trom TIMx_CR1 + TIMx_DCR.DBA  */
-#define TIM_DMABURSTLENGTH_10TRANSFERS     0x00000900U                          /*!< The transfer is done to 10 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_11TRANSFERS     0x00000A00U                          /*!< The transfer is done to 11 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_12TRANSFERS     0x00000B00U                          /*!< The transfer is done to 12 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_13TRANSFERS     0x00000C00U                          /*!< The transfer is done to 13 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_14TRANSFERS     0x00000D00U                          /*!< The transfer is done to 14 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_15TRANSFERS     0x00000E00U                          /*!< The transfer is done to 15 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_16TRANSFERS     0x00000F00U                          /*!< The transfer is done to 16 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_17TRANSFERS     0x00001000U                          /*!< The transfer is done to 17 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
-#define TIM_DMABURSTLENGTH_18TRANSFERS     0x00001100U                          /*!< The transfer is done to 18 registers starting trom TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_1TRANSFER       0x00000000U                          /*!< The transfer is done to 1 register starting from TIMx_CR1 + TIMx_DCR.DBA   */
+#define TIM_DMABURSTLENGTH_2TRANSFERS      0x00000100U                          /*!< The transfer is done to 2 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_3TRANSFERS      0x00000200U                          /*!< The transfer is done to 3 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_4TRANSFERS      0x00000300U                          /*!< The transfer is done to 4 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_5TRANSFERS      0x00000400U                          /*!< The transfer is done to 5 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_6TRANSFERS      0x00000500U                          /*!< The transfer is done to 6 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_7TRANSFERS      0x00000600U                          /*!< The transfer is done to 7 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_8TRANSFERS      0x00000700U                          /*!< The transfer is done to 8 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_9TRANSFERS      0x00000800U                          /*!< The transfer is done to 9 registers starting from TIMx_CR1 + TIMx_DCR.DBA  */
+#define TIM_DMABURSTLENGTH_10TRANSFERS     0x00000900U                          /*!< The transfer is done to 10 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_11TRANSFERS     0x00000A00U                          /*!< The transfer is done to 11 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_12TRANSFERS     0x00000B00U                          /*!< The transfer is done to 12 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_13TRANSFERS     0x00000C00U                          /*!< The transfer is done to 13 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_14TRANSFERS     0x00000D00U                          /*!< The transfer is done to 14 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_15TRANSFERS     0x00000E00U                          /*!< The transfer is done to 15 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_16TRANSFERS     0x00000F00U                          /*!< The transfer is done to 16 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_17TRANSFERS     0x00001000U                          /*!< The transfer is done to 17 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
+#define TIM_DMABURSTLENGTH_18TRANSFERS     0x00001100U                          /*!< The transfer is done to 18 registers starting from TIMx_CR1 + TIMx_DCR.DBA */
 /**
   * @}
   */
@@ -1225,7 +1232,8 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
   * @brief  Disable the TIM main Output.
   * @param  __HANDLE__ TIM handle
   * @retval None
-  * @note The Main Output Enable of a timer instance is disabled only if all the CCx and CCxN channels have been disabled
+  * @note The Main Output Enable of a timer instance is disabled only if all the CCx and CCxN channels have been
+  *       disabled
   */
 #define __HAL_TIM_MOE_DISABLE(__HANDLE__) \
   do { \
@@ -1392,7 +1400,8 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 
 /**
   * @brief  Force a continuous copy of the update interrupt flag (UIF) into the timer counter register (bit 31).
-  * @note This allows both the counter value and a potential roll-over condition signalled by the UIFCPY flag to be read in an atomic way.
+  * @note This allows both the counter value and a potential roll-over condition signalled by the UIFCPY flag to be read
+  *       in an atomic way.
   * @param  __HANDLE__ TIM handle.
   * @retval None
 mode.
@@ -1419,8 +1428,8 @@ mode.
   * @brief  Indicates whether or not the TIM Counter is used as downcounter.
   * @param  __HANDLE__ TIM handle.
   * @retval False (Counter used as upcounter) or True (Counter used as downcounter)
-  * @note This macro is particularly useful to get the counting mode when the timer operates in Center-aligned mode or Encoder
-mode.
+  * @note This macro is particularly useful to get the counting mode when the timer operates in Center-aligned mode
+  *       or Encoder mode.
   */
 #define __HAL_TIM_IS_TIM_COUNTING_DOWN(__HANDLE__)    (((__HANDLE__)->Instance->CR1 &(TIM_CR1_DIR)) == (TIM_CR1_DIR))
 
@@ -1434,7 +1443,8 @@ mode.
 
 /**
   * @brief  Set the TIM Counter Register value on runtime.
-  * Note Please check if the bit 31 of CNT register is used as UIF copy or not, this may affect the counter range in case of 32 bits counter TIM instance.
+  * Note Please check if the bit 31 of CNT register is used as UIF copy or not, this may affect the counter range in
+  *      case of 32 bits counter TIM instance.
   *      Bit 31 of CNT can be enabled/disabled using __HAL_TIM_UIFREMAP_ENABLE()/__HAL_TIM_UIFREMAP_DISABLE() macros.
   * @param  __HANDLE__ TIM handle.
   * @param  __COUNTER__ specifies the Counter register new value.
@@ -1496,7 +1506,8 @@ mode.
 #define __HAL_TIM_GET_CLOCKDIVISION(__HANDLE__)  ((__HANDLE__)->Instance->CR1 & TIM_CR1_CKD)
 
 /**
-  * @brief  Set the TIM Input Capture prescaler on runtime without calling another time HAL_TIM_IC_ConfigChannel() function.
+  * @brief  Set the TIM Input Capture prescaler on runtime without calling another time HAL_TIM_IC_ConfigChannel()
+  *         function.
   * @param  __HANDLE__ TIM handle.
   * @param  __CHANNEL__ TIM Channels to be configured.
   *          This parameter can be one of the following values:
@@ -1718,6 +1729,17 @@ mode.
     TIM_SET_CAPTUREPOLARITY((__HANDLE__), (__CHANNEL__), (__POLARITY__)); \
   }while(0)
 
+/** @brief  Select the Capture/compare DMA request source.
+  * @param  __HANDLE__ specifies the TIM Handle.
+  * @param  __CCDMA__ specifies Capture/compare DMA request source
+  *          This parameter can be one of the following values:
+  *            @arg TIM_CCDMAREQUEST_CC: CCx DMA request generated on Capture/Compare event
+  *            @arg TIM_CCDMAREQUEST_UPDATE: CCx DMA request generated on Update event
+  * @retval None
+  */
+#define __HAL_TIM_SELECT_CCDMAREQUEST(__HANDLE__, __CCDMA__)    \
+  MODIFY_REG((__HANDLE__)->Instance->CR2, TIM_CR2_CCDS, (__CCDMA__))
+
 /**
   * @}
   */
@@ -1729,7 +1751,8 @@ mode.
   */
 /* The counter of a timer instance is disabled only if all the CCx and CCxN
    channels have been disabled */
-#define TIM_CCER_CCxE_MASK  ((uint32_t)(TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E))
+#define TIM_CCER_CCxE_MASK  ((uint32_t)(TIM_CCER_CC1E | TIM_CCER_CC2E | TIM_CCER_CC3E | TIM_CCER_CC4E | \
+                                        TIM_CCER_CC5E | TIM_CCER_CC6E))
 #define TIM_CCER_CCxNE_MASK ((uint32_t)(TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE))
 /**
   * @}
@@ -1779,7 +1802,7 @@ mode.
                                             ((__MODE__) == TIM_COUNTERMODE_CENTERALIGNED3))
 
 #define IS_TIM_UIFREMAP_MODE(__MODE__)     (((__MODE__) == TIM_UIFREMAP_DISABLE) || \
-                                            ((__MODE__) == TIM_UIFREMAP_ENALE))
+                                            ((__MODE__) == TIM_UIFREMAP_ENABLE))
 
 #define IS_TIM_CLOCKDIVISION_DIV(__DIV__)  (((__DIV__) == TIM_CLOCKDIVISION_DIV1) || \
                                             ((__DIV__) == TIM_CLOCKDIVISION_DIV2) || \
@@ -1819,6 +1842,10 @@ mode.
                                             ((__PRESCALER__) == TIM_ICPSC_DIV4) || \
                                             ((__PRESCALER__) == TIM_ICPSC_DIV8))
 
+#define IS_TIM_CCX_CHANNEL(__INSTANCE__, __CHANNEL__) (IS_TIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) && \
+                                                       ((__CHANNEL__) != (TIM_CHANNEL_5)) && \
+                                                       ((__CHANNEL__) != (TIM_CHANNEL_6)))
+
 #define IS_TIM_OPM_MODE(__MODE__)          (((__MODE__) == TIM_OPMODE_SINGLE) || \
                                             ((__MODE__) == TIM_OPMODE_REPETITIVE))
 
@@ -1839,20 +1866,24 @@ mode.
 #define IS_TIM_OPM_CHANNELS(__CHANNEL__)   (((__CHANNEL__) == TIM_CHANNEL_1) || \
                                             ((__CHANNEL__) == TIM_CHANNEL_2))
 
+#define IS_TIM_PERIOD(__HANDLE__, __PERIOD__) ((IS_TIM_32B_COUNTER_INSTANCE(((__HANDLE__)->Instance)) == 0U) ? \
+                                               (((__PERIOD__) > 0U) && ((__PERIOD__) <= 0x0000FFFFU)) :        \
+                                               ((__PERIOD__) > 0U))
+
 #define IS_TIM_COMPLEMENTARY_CHANNELS(__CHANNEL__) (((__CHANNEL__) == TIM_CHANNEL_1) || \
                                                     ((__CHANNEL__) == TIM_CHANNEL_2) || \
                                                     ((__CHANNEL__) == TIM_CHANNEL_3))
 
 #define IS_TIM_CLOCKSOURCE(__CLOCK__) (((__CLOCK__) == TIM_CLOCKSOURCE_INTERNAL) || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE1) || \
                                        ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE2) || \
-                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR0)     || \
-                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR1)     || \
-                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR2)     || \
-                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR3)     || \
                                        ((__CLOCK__) == TIM_CLOCKSOURCE_TI1ED)    || \
                                        ((__CLOCK__) == TIM_CLOCKSOURCE_TI1)      || \
                                        ((__CLOCK__) == TIM_CLOCKSOURCE_TI2)      || \
-                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ETRMODE1))
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR0)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR1)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR2)     || \
+                                       ((__CLOCK__) == TIM_CLOCKSOURCE_ITR3))
 
 #define IS_TIM_CLOCKPOLARITY(__POLARITY__) (((__POLARITY__) == TIM_CLOCKPOLARITY_INVERTED)    || \
                                             ((__POLARITY__) == TIM_CLOCKPOLARITY_NONINVERTED) || \
@@ -1889,7 +1920,6 @@ mode.
                                             ((__LEVEL__) == TIM_LOCKLEVEL_3))
 
 #define IS_TIM_BREAK_FILTER(__BRKFILTER__) ((__BRKFILTER__) <= 0xFUL)
-
 
 #define IS_TIM_BREAK_STATE(__STATE__)      (((__STATE__) == TIM_BREAK_ENABLE) || \
                                             ((__STATE__) == TIM_BREAK_DISABLE))
@@ -1957,8 +1987,8 @@ mode.
                                    ((__MODE__) == TIM_OCMODE_PWM2)               || \
                                    ((__MODE__) == TIM_OCMODE_COMBINED_PWM1)      || \
                                    ((__MODE__) == TIM_OCMODE_COMBINED_PWM2)      || \
-                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM1)    || \
-                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM2))
+                                   ((__MODE__) == TIM_OCMODE_ASYMMETRIC_PWM1)    || \
+                                   ((__MODE__) == TIM_OCMODE_ASYMMETRIC_PWM2))
 
 #define IS_TIM_OC_MODE(__MODE__)  (((__MODE__) == TIM_OCMODE_TIMING)             || \
                                    ((__MODE__) == TIM_OCMODE_ACTIVE)             || \
@@ -1969,13 +1999,13 @@ mode.
                                    ((__MODE__) == TIM_OCMODE_RETRIGERRABLE_OPM1) || \
                                    ((__MODE__) == TIM_OCMODE_RETRIGERRABLE_OPM2))
 
-#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
-                                                 ((__SELECTION__) == TIM_TS_ITR1) || \
-                                                 ((__SELECTION__) == TIM_TS_ITR2) || \
-                                                 ((__SELECTION__) == TIM_TS_ITR3) || \
+#define IS_TIM_TRIGGER_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR1)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR2)    || \
+                                                 ((__SELECTION__) == TIM_TS_ITR3)    || \
                                                  ((__SELECTION__) == TIM_TS_TI1F_ED) || \
-                                                 ((__SELECTION__) == TIM_TS_TI1FP1) || \
-                                                 ((__SELECTION__) == TIM_TS_TI2FP2) || \
+                                                 ((__SELECTION__) == TIM_TS_TI1FP1)  || \
+                                                 ((__SELECTION__) == TIM_TS_TI2FP2)  || \
                                                  ((__SELECTION__) == TIM_TS_ETRF))
 
 #define IS_TIM_INTERNAL_TRIGGEREVENT_SELECTION(__SELECTION__) (((__SELECTION__) == TIM_TS_ITR0) || \
@@ -2073,14 +2103,15 @@ mode.
    ((__CHANNEL__) == TIM_CHANNEL_5) ? ((__HANDLE__)->ChannelState[4] = (__CHANNEL_STATE__)) :\
    ((__HANDLE__)->ChannelState[5] = (__CHANNEL_STATE__)))
 
-#define TIM_CHANNEL_STATE_SET_ALL(__HANDLE__,  __CHANNEL_STATE__) do { \
-  (__HANDLE__)->ChannelState[0]  = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelState[1]  = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelState[2]  = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelState[3]  = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelState[4]  = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelState[5]  = (__CHANNEL_STATE__);  \
- } while(0)
+#define TIM_CHANNEL_STATE_SET_ALL(__HANDLE__,  __CHANNEL_STATE__)\
+  do {\
+    (__HANDLE__)->ChannelState[0]  = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelState[1]  = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelState[2]  = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelState[3]  = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelState[4]  = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelState[5]  = (__CHANNEL_STATE__);  \
+  } while(0)
 
 #define TIM_CHANNEL_N_STATE_GET(__HANDLE__, __CHANNEL__)\
   (((__CHANNEL__) == TIM_CHANNEL_1) ? (__HANDLE__)->ChannelNState[0] :\
@@ -2094,12 +2125,13 @@ mode.
    ((__CHANNEL__) == TIM_CHANNEL_3) ? ((__HANDLE__)->ChannelNState[2] = (__CHANNEL_STATE__)) :\
    ((__HANDLE__)->ChannelNState[3] = (__CHANNEL_STATE__)))
 
-#define TIM_CHANNEL_N_STATE_SET_ALL(__HANDLE__,  __CHANNEL_STATE__) do { \
-  (__HANDLE__)->ChannelNState[0] = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelNState[1] = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelNState[2] = (__CHANNEL_STATE__);  \
-  (__HANDLE__)->ChannelNState[3] = (__CHANNEL_STATE__);  \
- } while(0)
+#define TIM_CHANNEL_N_STATE_SET_ALL(__HANDLE__,  __CHANNEL_STATE__)\
+  do {\
+    (__HANDLE__)->ChannelNState[0] = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelNState[1] = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelNState[2] = (__CHANNEL_STATE__);  \
+    (__HANDLE__)->ChannelNState[3] = (__CHANNEL_STATE__);  \
+  } while(0)
 
 /**
   * @}
@@ -2130,7 +2162,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop(TIM_HandleTypeDef *htim);
 HAL_StatusTypeDef HAL_TIM_Base_Start_IT(TIM_HandleTypeDef *htim);
 HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim);
 /* Non-Blocking mode: DMA */
-HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, const uint32_t *pData, uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_Base_Stop_DMA(TIM_HandleTypeDef *htim);
 /**
   * @}
@@ -2152,7 +2184,8 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
 HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 /* Non-Blocking mode: DMA */
-HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                       uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
 /**
   * @}
@@ -2174,7 +2207,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel);
 HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 /* Non-Blocking mode: DMA */
-HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                        uint16_t Length);
 HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
 /**
   * @}
@@ -2226,7 +2260,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   * @{
   */
 /* Timer Encoder functions ****************************************************/
-HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef *sConfig);
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim, const TIM_Encoder_InitTypeDef *sConfig);
 HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim);
 void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim);
 void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim);
@@ -2259,31 +2293,36 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim);
   * @{
   */
 /* Control functions  *********************************************************/
-HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef *sConfig, uint32_t Channel);
-HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OC_InitTypeDef *sConfig, uint32_t Channel);
-HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef *sConfig, uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim, const TIM_OC_InitTypeDef *sConfig,
+                                           uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim, const TIM_OC_InitTypeDef *sConfig,
+                                            uint32_t Channel);
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, const TIM_IC_InitTypeDef *sConfig,
+                                           uint32_t Channel);
 HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim, TIM_OnePulse_InitTypeDef *sConfig,
                                                  uint32_t OutputChannel,  uint32_t InputChannel);
-HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim, TIM_ClearInputConfigTypeDef *sClearInputConfig,
+HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
+                                           const TIM_ClearInputConfigTypeDef *sClearInputConfig,
                                            uint32_t Channel);
-HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef *sClockSourceConfig);
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, const TIM_ClockConfigTypeDef *sClockSourceConfig);
 HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_Selection);
-HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef *sSlaveConfig);
-HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef *sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig);
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig);
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                              uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength);
+                                              uint32_t BurstRequestSrc, const uint32_t  *BurstBuffer,
+                                              uint32_t  BurstLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                                   uint32_t BurstRequestSrc, uint32_t *BurstBuffer, uint32_t BurstLength,
-                                                   uint32_t DataLength);
+                                                   uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
+                                                   uint32_t BurstLength,  uint32_t DataLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                              uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                                  uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength,
-                                                  uint32_t  DataLength);
+                                                  uint32_t BurstRequestSrc, uint32_t  *BurstBuffer,
+                                                  uint32_t  BurstLength, uint32_t  DataLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc);
 HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventSource);
-uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel);
+uint32_t HAL_TIM_ReadCapturedValue(const TIM_HandleTypeDef *htim, uint32_t Channel);
 /**
   * @}
   */
@@ -2320,17 +2359,17 @@ HAL_StatusTypeDef HAL_TIM_UnRegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Ca
   * @{
   */
 /* Peripheral State functions  ************************************************/
-HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim);
-HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim);
-HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim);
-HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim);
-HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim);
-HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(const TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(const TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(const TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(const TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(const TIM_HandleTypeDef *htim);
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(const TIM_HandleTypeDef *htim);
 
 /* Peripheral Channel state functions  ************************************************/
-HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(TIM_HandleTypeDef *htim);
-HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(TIM_HandleTypeDef *htim,  uint32_t Channel);
-HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(TIM_HandleTypeDef *htim);
+HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(const TIM_HandleTypeDef *htim);
+HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(const TIM_HandleTypeDef *htim,  uint32_t Channel);
+HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(const TIM_HandleTypeDef *htim);
 /**
   * @}
   */
@@ -2344,9 +2383,9 @@ HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(TIM_HandleTypeDef *htim);
 /** @defgroup TIM_Private_Functions TIM Private Functions
   * @{
   */
-void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure);
+void TIM_Base_SetConfig(TIM_TypeDef *TIMx, const TIM_Base_InitTypeDef *Structure);
 void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection, uint32_t TIM_ICFilter);
-void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config);
 void TIM_ETR_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ExtTRGPrescaler,
                        uint32_t TIM_ExtTRGPolarity, uint32_t ExtTRGFilter);
 
@@ -2378,5 +2417,3 @@ void TIM_ResetCallback(TIM_HandleTypeDef *htim);
 #endif
 
 #endif /* STM32WBxx_HAL_TIM_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_tim_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_tim_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -71,8 +70,7 @@ typedef struct
                                 This parameter can be a value of @ref TIMEx_Break_Input_Source_Enable */
   uint32_t Polarity;       /*!< Specifies the break input source polarity.
                                 This parameter can be a value of @ref TIMEx_Break_Input_Source_Polarity */
-}
-TIMEx_BreakInputConfigTypeDef;
+} TIMEx_BreakInputConfigTypeDef;
 
 /**
   * @}
@@ -87,59 +85,59 @@ TIMEx_BreakInputConfigTypeDef;
 /** @defgroup TIMEx_Remap TIM Extended Remapping
   * @{
   */
-#define TIM_TIM1_ETR_GPIO           0x00000000U                                           /* !< TIM1_ETR is not connected to I/O      */
-#define TIM_TIM1_ETR_ADC1_AWD1      TIM1_OR_ETR_ADC1_RMP_0                                /* !< TIM1_ETR is connected to ADC1 AWD1    */
+#define TIM_TIM1_ETR_GPIO           0x00000000U                                           /*!< TIM1_ETR is not connected to I/O      */
+#define TIM_TIM1_ETR_ADC1_AWD1      TIM1_OR_ETR_ADC1_RMP_0                                /*!< TIM1_ETR is connected to ADC1 AWD1    */
 #if defined(ADC_SUPPORT_5_MSPS)
-#define TIM_TIM1_ETR_ADC1_AWD2      TIM1_OR_ETR_ADC1_RMP_1                                /* !< TIM1_ETR is connected to ADC1 AWD2    */
-#define TIM_TIM1_ETR_ADC1_AWD3      (TIM1_OR_ETR_ADC1_RMP_0 | TIM1_OR_ETR_ADC1_RMP_1)     /* !< TIM1_ETR is connected to ADC1 AWD3    */
+#define TIM_TIM1_ETR_ADC1_AWD2      TIM1_OR_ETR_ADC1_RMP_1                                /*!< TIM1_ETR is connected to ADC1 AWD2    */
+#define TIM_TIM1_ETR_ADC1_AWD3      (TIM1_OR_ETR_ADC1_RMP_0 | TIM1_OR_ETR_ADC1_RMP_1)     /*!< TIM1_ETR is connected to ADC1 AWD3    */
 #endif
 #if defined(COMP1)
-#define TIM_TIM1_ETR_COMP1          TIM1_AF1_ETRSEL_0                                     /* !< TIM1_ETR is connected to COMP1 output */
+#define TIM_TIM1_ETR_COMP1          TIM1_AF1_ETRSEL_0                                     /*!< TIM1_ETR is connected to COMP1 output */
 #endif /* COMP1 */
 #if defined(COMP2)
-#define TIM_TIM1_ETR_COMP2          TIM1_AF1_ETRSEL_1                                     /* !< TIM1_ETR is connected to COMP2 output */
+#define TIM_TIM1_ETR_COMP2          TIM1_AF1_ETRSEL_1                                     /*!< TIM1_ETR is connected to COMP2 output */
 #endif /* COMP2 */
 
-#define TIM_TIM1_TI1_GPIO           0x00000000U                                           /* !< TIM1 Input capture 1 is connected to I/0      */
-#define TIM_TIM1_TI1_COMP1         TIM1_OR_TI1_RMP                                        /* !< TIM1 Input capture 1is connected to COMP1 OUT */
+#define TIM_TIM1_TI1_GPIO           0x00000000U                                           /*!< TIM1 Input capture 1 is connected to I/0      */
+#define TIM_TIM1_TI1_COMP1         TIM1_OR_TI1_RMP                                        /*!< TIM1 Input capture 1is connected to COMP1 OUT */
 
-#define TIM_TIM2_ITR_NC             0x00000000U                                           /* !< TIM2 Internal trigger ITR is not connected          */
+#define TIM_TIM2_ITR_NC             0x00000000U                                           /*!< TIM2 Internal trigger ITR is not connected          */
 #if defined(USB)
-#define TIM_TIM2_ITR_USB            TIM2_OR_ITR1_RMP                                      /* !< TIM2 Internal trigger ITR is connected to USBFS SOF */
+#define TIM_TIM2_ITR_USB            TIM2_OR_ITR1_RMP                                      /*!< TIM2 Internal trigger ITR is connected to USBFS SOF */
 #endif /* USB */
 
-#define TIM_TIM2_ETR_GPIO           0x00000000U                                           /* !< TIM2 External trigger ETR is connected to I/O */
-#define TIM_TIM2_ETR_LSE            TIM2_OR_ETR_RMP                                       /* !< TIM2 External trigger ETR is connected to LSE */
+#define TIM_TIM2_ETR_GPIO           0x00000000U                                           /*!< TIM2 External trigger ETR is connected to I/O */
+#define TIM_TIM2_ETR_LSE            TIM2_OR_ETR_RMP                                       /*!< TIM2 External trigger ETR is connected to LSE */
 #if defined(COMP1)
-#define TIM_TIM2_ETR_COMP1          TIM2_AF1_ETRSEL_0                                     /* !< TIM2_ETR is connected to COMP1 output         */
+#define TIM_TIM2_ETR_COMP1          TIM2_AF1_ETRSEL_0                                     /*!< TIM2_ETR is connected to COMP1 output         */
 #endif /* COMP1 */
 #if defined(COMP2)
-#define TIM_TIM2_ETR_COMP2          TIM2_AF1_ETRSEL_1                                     /* !< TIM2_ETR is connected to COMP2 output         */
+#define TIM_TIM2_ETR_COMP2          TIM2_AF1_ETRSEL_1                                     /*!< TIM2_ETR is connected to COMP2 output         */
 #endif /* COMP2 */
 
-#define TIM_TIM2_TI4_GPIO           0x00000000U                                           /* !< TIM2_TI4 is connected to I/O                 */
+#define TIM_TIM2_TI4_GPIO           0x00000000U                                           /*!< TIM2_TI4 is connected to I/O                 */
 #if defined(COMP1)
-#define TIM_TIM2_TI4_COMP1          TIM2_OR_TI4_RMP_0                                     /* !< TIM2_TI4 is connected to COMP1 OUT           */
+#define TIM_TIM2_TI4_COMP1          TIM2_OR_TI4_RMP_0                                     /*!< TIM2_TI4 is connected to COMP1 OUT           */
 #endif /* COMP1 */
 #if defined(COMP2)
-#define TIM_TIM2_TI4_COMP2          TIM2_OR_TI4_RMP_1                                     /* !< TIM2_TI4 is connected to COMP1 OUT           */
+#define TIM_TIM2_TI4_COMP2          TIM2_OR_TI4_RMP_1                                     /*!< TIM2_TI4 is connected to COMP1 OUT           */
 #endif /* COMP2 */
 #if defined(COMP1) && defined(COMP2)
-#define TIM_TIM2_TI4_COMP1_COMP2    (TIM2_OR_TI4_RMP_0 | TIM2_OR_TI4_RMP_1)               /* !< TIM2_TI4 is connected to COMP1 and COMP2 OUT */
+#define TIM_TIM2_TI4_COMP1_COMP2    (TIM2_OR_TI4_RMP_0 | TIM2_OR_TI4_RMP_1)               /*!< TIM2_TI4 is connected to COMP1 and COMP2 OUT */
 #endif /* COMP1 && COMP2 */
 
 #if defined(TIM16)
-#define TIM_TIM16_TI1_GPIO          0x00000000U                                           /* !< TIM16_TI1 is connected to I/O       */
-#define TIM_TIM16_TI1_LSI           TIM16_OR_TI1_RMP_0                                    /* !< TIM16_TI1 is connected to LSI Clock */
-#define TIM_TIM16_TI1_LSE           TIM16_OR_TI1_RMP_1                                    /* !< TIM16_TI1 is connected to LSE Clock */
-#define TIM_TIM16_TI1_RTC           (TIM16_OR_TI1_RMP_0 | TIM16_OR_TI1_RMP_1)             /* !< TIM16_TI1 is connected to RTC       */
+#define TIM_TIM16_TI1_GPIO          0x00000000U                                           /*!< TIM16_TI1 is connected to I/O       */
+#define TIM_TIM16_TI1_LSI           TIM16_OR_TI1_RMP_0                                    /*!< TIM16_TI1 is connected to LSI Clock */
+#define TIM_TIM16_TI1_LSE           TIM16_OR_TI1_RMP_1                                    /*!< TIM16_TI1 is connected to LSE Clock */
+#define TIM_TIM16_TI1_RTC           (TIM16_OR_TI1_RMP_0 | TIM16_OR_TI1_RMP_1)             /*!< TIM16_TI1 is connected to RTC       */
 #endif /* TIM16 */
 
 #if defined(TIM17)
-#define TIM_TIM17_TI1_GPIO          0x00000000U                                           /* !< TIM17_TI1 is connected to I/O       */
-#define TIM_TIM17_TI1_MSI           TIM17_OR_TI1_RMP_0                                    /* !< TIM17_TI1 is connected to MSI       */
-#define TIM_TIM17_TI1_HSE           TIM17_OR_TI1_RMP_1                                    /* !< TIM17_TI1 is connected to HSE/32    */
-#define TIM_TIM17_TI1_MCO           (TIM17_OR_TI1_RMP_0 | TIM17_OR_TI1_RMP_1)             /* !< TIM17_TI1 is connected to MCO       */
+#define TIM_TIM17_TI1_GPIO          0x00000000U                                           /*!< TIM17_TI1 is connected to I/O       */
+#define TIM_TIM17_TI1_MSI           TIM17_OR_TI1_RMP_0                                    /*!< TIM17_TI1 is connected to MSI       */
+#define TIM_TIM17_TI1_HSE           TIM17_OR_TI1_RMP_1                                    /*!< TIM17_TI1 is connected to HSE/32    */
+#define TIM_TIM17_TI1_MCO           (TIM17_OR_TI1_RMP_0 | TIM17_OR_TI1_RMP_1)             /*!< TIM17_TI1 is connected to MCO       */
 #endif /* TIM17 */
 /**
   * @}
@@ -148,8 +146,8 @@ TIMEx_BreakInputConfigTypeDef;
 /** @defgroup TIMEx_Break_Input TIM Extended Break input
   * @{
   */
-#define TIM_BREAKINPUT_BRK     0x00000001U                                      /* !< Timer break input  */
-#define TIM_BREAKINPUT_BRK2    0x00000002U                                      /* !< Timer break2 input */
+#define TIM_BREAKINPUT_BRK     0x00000001U                                      /*!< Timer break input  */
+#define TIM_BREAKINPUT_BRK2    0x00000002U                                      /*!< Timer break2 input */
 /**
   * @}
   */
@@ -157,12 +155,12 @@ TIMEx_BreakInputConfigTypeDef;
 /** @defgroup TIMEx_Break_Input_Source TIM Extended Break input source
   * @{
   */
-#define TIM_BREAKINPUTSOURCE_BKIN     0x00000001U                               /* !< An external source (GPIO) is connected to the BKIN pin  */
+#define TIM_BREAKINPUTSOURCE_BKIN     0x00000001U                               /*!< An external source (GPIO) is connected to the BKIN pin  */
 #if defined(COMP1)
-#define TIM_BREAKINPUTSOURCE_COMP1    0x00000002U                               /* !< The COMP1 output is connected to the break input */
+#define TIM_BREAKINPUTSOURCE_COMP1    0x00000002U                               /*!< The COMP1 output is connected to the break input */
 #endif /* COMP1 */
 #if defined(COMP2)
-#define TIM_BREAKINPUTSOURCE_COMP2    0x00000004U                               /* !< The COMP2 output is connected to the break input */
+#define TIM_BREAKINPUTSOURCE_COMP2    0x00000004U                               /*!< The COMP2 output is connected to the break input */
 #endif /* COMP2 */
 /**
   * @}
@@ -171,8 +169,8 @@ TIMEx_BreakInputConfigTypeDef;
 /** @defgroup TIMEx_Break_Input_Source_Enable TIM Extended Break input source enabling
   * @{
   */
-#define TIM_BREAKINPUTSOURCE_DISABLE     0x00000000U                            /* !< Break input source is disabled */
-#define TIM_BREAKINPUTSOURCE_ENABLE      0x00000001U                            /* !< Break input source is enabled */
+#define TIM_BREAKINPUTSOURCE_DISABLE     0x00000000U                            /*!< Break input source is disabled */
+#define TIM_BREAKINPUTSOURCE_ENABLE      0x00000001U                            /*!< Break input source is enabled */
 /**
   * @}
   */
@@ -180,8 +178,8 @@ TIMEx_BreakInputConfigTypeDef;
 /** @defgroup TIMEx_Break_Input_Source_Polarity TIM Extended Break input polarity
   * @{
   */
-#define TIM_BREAKINPUTSOURCE_POLARITY_LOW     0x00000001U                       /* !< Break input source is active low */
-#define TIM_BREAKINPUTSOURCE_POLARITY_HIGH    0x00000000U                       /* !< Break input source is active_high */
+#define TIM_BREAKINPUTSOURCE_POLARITY_LOW     0x00000001U                       /*!< Break input source is active low */
+#define TIM_BREAKINPUTSOURCE_POLARITY_HIGH    0x00000000U                       /*!< Break input source is active_high */
 /**
   * @}
   */
@@ -211,6 +209,14 @@ TIMEx_BreakInputConfigTypeDef;
    || (((__INSTANCE__) == TIM2)  && ((((__REMAP__) & 0xFFFE3FF0U) == 0x00000000U)))  \
    || (((__INSTANCE__) == TIM16) && ((((__REMAP__) & 0xFFFFFFFCU) == 0x00000000U)))  \
    || (((__INSTANCE__) == TIM17) && ((((__REMAP__) & 0xFFFFFFFCU) == 0x00000000U))))
+#elif defined(STM32WB10xx)
+#define IS_TIM_REMAP(__INSTANCE__, __REMAP__)                                             \
+  ((((__INSTANCE__) == TIM1)  && ((((__REMAP__) & 0xFFFFFFFCU) == 0x00000000U)))  \
+   || (((__INSTANCE__) == TIM2)  && ((((__REMAP__) & 0xFFFFFFFDU) == 0x00000000U))))
+#elif defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#define IS_TIM_REMAP(__INSTANCE__, __REMAP__)                                             \
+  ((((__INSTANCE__) == TIM1)  && ((((__REMAP__) & 0xFFFF3FECU) == 0x00000000U)))  \
+   || (((__INSTANCE__) == TIM2)  && ((((__REMAP__) & 0xFFFF3FF0U) == 0x00000000U))))
 #else
 #define IS_TIM_REMAP(__INSTANCE__, __REMAP__)                                             \
   ((((__INSTANCE__) == TIM1)  && ((((__REMAP__) & 0xFFFFFFFCU) == 0x00000000U)))  \
@@ -261,7 +267,7 @@ TIMEx_BreakInputConfigTypeDef;
   * @{
   */
 /*  Timer Hall Sensor functions  **********************************************/
-HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSensor_InitTypeDef *sConfig);
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, const TIM_HallSensor_InitTypeDef *sConfig);
 HAL_StatusTypeDef HAL_TIMEx_HallSensor_DeInit(TIM_HandleTypeDef *htim);
 
 void HAL_TIMEx_HallSensor_MspInit(TIM_HandleTypeDef *htim);
@@ -294,7 +300,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
 HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 
 /* Non-Blocking mode: DMA */
-HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                          uint16_t Length);
 HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
 /**
   * @}
@@ -313,7 +320,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel);
 /* Non-Blocking mode: DMA */
-HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length);
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                           uint16_t Length);
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel);
 /**
   * @}
@@ -347,16 +355,16 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigCommutEvent_IT(TIM_HandleTypeDef *htim, uint32
 HAL_StatusTypeDef HAL_TIMEx_ConfigCommutEvent_DMA(TIM_HandleTypeDef *htim, uint32_t  InputTrigger,
                                                   uint32_t  CommutationSource);
 HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
-                                                        TIM_MasterConfigTypeDef *sMasterConfig);
+                                                        const TIM_MasterConfigTypeDef *sMasterConfig);
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
-                                                TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig);
+                                                const TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig);
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim, uint32_t BreakInput,
-                                             TIMEx_BreakInputConfigTypeDef *sBreakInputConfig);
+                                             const TIMEx_BreakInputConfigTypeDef *sBreakInputConfig);
 HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t Channels);
 HAL_StatusTypeDef HAL_TIMEx_RemapConfig(TIM_HandleTypeDef *htim, uint32_t Remap);
 
 HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t BreakInput);
-HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(TIM_HandleTypeDef *htim, uint32_t BreakInput);
+HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(const TIM_HandleTypeDef *htim, uint32_t BreakInput);
 /**
   * @}
   */
@@ -379,8 +387,8 @@ void HAL_TIMEx_Break2Callback(TIM_HandleTypeDef *htim);
   * @{
   */
 /* Extended Peripheral State functions  ***************************************/
-HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim);
-HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(TIM_HandleTypeDef *htim,  uint32_t ChannelN);
+HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(const TIM_HandleTypeDef *htim);
+HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(const TIM_HandleTypeDef *htim,  uint32_t ChannelN);
 /**
   * @}
   */
@@ -391,7 +399,7 @@ HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(TIM_HandleTypeDef *htim, 
 /* End of exported functions -------------------------------------------------*/
 
 /* Private functions----------------------------------------------------------*/
-/** @addtogroup TIMEx_Private_Functions TIMEx Private Functions
+/** @addtogroup TIMEx_Private_Functions TIM Extended Private Functions
   * @{
   */
 void TIMEx_DMACommutationCplt(DMA_HandleTypeDef *hdma);
@@ -415,5 +423,3 @@ void TIMEx_DMACommutationHalfCplt(DMA_HandleTypeDef *hdma);
 
 
 #endif /* STM32WBxx_HAL_TIM_EX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_tsc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_tsc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -187,22 +186,38 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
 /** @defgroup TSC_CTPulseHL_Config CTPulse High Length
   * @{
   */
-#define TSC_CTPH_1CYCLE         0x00000000UL                                                    /*!< Charge transfer pulse high during 1 cycle (PGCLK)   */
-#define TSC_CTPH_2CYCLES        TSC_CR_CTPH_0                                                   /*!< Charge transfer pulse high during 2 cycles (PGCLK)  */
-#define TSC_CTPH_3CYCLES        TSC_CR_CTPH_1                                                   /*!< Charge transfer pulse high during 3 cycles (PGCLK)  */
-#define TSC_CTPH_4CYCLES        (TSC_CR_CTPH_1 | TSC_CR_CTPH_0)                                 /*!< Charge transfer pulse high during 4 cycles (PGCLK)  */
-#define TSC_CTPH_5CYCLES        TSC_CR_CTPH_2                                                   /*!< Charge transfer pulse high during 5 cycles (PGCLK)  */
-#define TSC_CTPH_6CYCLES        (TSC_CR_CTPH_2 | TSC_CR_CTPH_0)                                 /*!< Charge transfer pulse high during 6 cycles (PGCLK)  */
-#define TSC_CTPH_7CYCLES        (TSC_CR_CTPH_2 | TSC_CR_CTPH_1)                                 /*!< Charge transfer pulse high during 7 cycles (PGCLK)  */
-#define TSC_CTPH_8CYCLES        (TSC_CR_CTPH_2 | TSC_CR_CTPH_1 | TSC_CR_CTPH_0)                 /*!< Charge transfer pulse high during 8 cycles (PGCLK)  */
-#define TSC_CTPH_9CYCLES        TSC_CR_CTPH_3                                                   /*!< Charge transfer pulse high during 9 cycles (PGCLK)  */
-#define TSC_CTPH_10CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_0)                                 /*!< Charge transfer pulse high during 10 cycles (PGCLK) */
-#define TSC_CTPH_11CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_1)                                 /*!< Charge transfer pulse high during 11 cycles (PGCLK) */
-#define TSC_CTPH_12CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_1 | TSC_CR_CTPH_0)                 /*!< Charge transfer pulse high during 12 cycles (PGCLK) */
-#define TSC_CTPH_13CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2)                                 /*!< Charge transfer pulse high during 13 cycles (PGCLK) */
-#define TSC_CTPH_14CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2 | TSC_CR_CTPH_0)                 /*!< Charge transfer pulse high during 14 cycles (PGCLK) */
-#define TSC_CTPH_15CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2 | TSC_CR_CTPH_1)                 /*!< Charge transfer pulse high during 15 cycles (PGCLK) */
-#define TSC_CTPH_16CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2 | TSC_CR_CTPH_1 | TSC_CR_CTPH_0) /*!< Charge transfer pulse high during 16 cycles (PGCLK) */
+#define TSC_CTPH_1CYCLE         0x00000000UL
+/*!< Charge transfer pulse high during 1 cycle (PGCLK)   */
+#define TSC_CTPH_2CYCLES        TSC_CR_CTPH_0
+/*!< Charge transfer pulse high during 2 cycles (PGCLK)  */
+#define TSC_CTPH_3CYCLES        TSC_CR_CTPH_1
+/*!< Charge transfer pulse high during 3 cycles (PGCLK)  */
+#define TSC_CTPH_4CYCLES        (TSC_CR_CTPH_1 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 4 cycles (PGCLK)  */
+#define TSC_CTPH_5CYCLES        TSC_CR_CTPH_2
+/*!< Charge transfer pulse high during 5 cycles (PGCLK)  */
+#define TSC_CTPH_6CYCLES        (TSC_CR_CTPH_2 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 6 cycles (PGCLK)  */
+#define TSC_CTPH_7CYCLES        (TSC_CR_CTPH_2 | TSC_CR_CTPH_1)
+/*!< Charge transfer pulse high during 7 cycles (PGCLK)  */
+#define TSC_CTPH_8CYCLES        (TSC_CR_CTPH_2 | TSC_CR_CTPH_1 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 8 cycles (PGCLK)  */
+#define TSC_CTPH_9CYCLES        TSC_CR_CTPH_3
+/*!< Charge transfer pulse high during 9 cycles (PGCLK)  */
+#define TSC_CTPH_10CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 10 cycles (PGCLK) */
+#define TSC_CTPH_11CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_1)
+/*!< Charge transfer pulse high during 11 cycles (PGCLK) */
+#define TSC_CTPH_12CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_1 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 12 cycles (PGCLK) */
+#define TSC_CTPH_13CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2)
+/*!< Charge transfer pulse high during 13 cycles (PGCLK) */
+#define TSC_CTPH_14CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 14 cycles (PGCLK) */
+#define TSC_CTPH_15CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2 | TSC_CR_CTPH_1)
+/*!< Charge transfer pulse high during 15 cycles (PGCLK) */
+#define TSC_CTPH_16CYCLES       (TSC_CR_CTPH_3 | TSC_CR_CTPH_2 | TSC_CR_CTPH_1 | TSC_CR_CTPH_0)
+/*!< Charge transfer pulse high during 16 cycles (PGCLK) */
 /**
   * @}
   */
@@ -210,22 +225,38 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
 /** @defgroup TSC_CTPulseLL_Config CTPulse Low Length
   * @{
   */
-#define TSC_CTPL_1CYCLE         0x00000000UL                                                     /*!< Charge transfer pulse low during 1 cycle (PGCLK)   */
-#define TSC_CTPL_2CYCLES        TSC_CR_CTPL_0                                                    /*!< Charge transfer pulse low during 2 cycles (PGCLK)  */
-#define TSC_CTPL_3CYCLES        TSC_CR_CTPL_1                                                    /*!< Charge transfer pulse low during 3 cycles (PGCLK)  */
-#define TSC_CTPL_4CYCLES        (TSC_CR_CTPL_1 | TSC_CR_CTPL_0)                                  /*!< Charge transfer pulse low during 4 cycles (PGCLK)  */
-#define TSC_CTPL_5CYCLES        TSC_CR_CTPL_2                                                    /*!< Charge transfer pulse low during 5 cycles (PGCLK)  */
-#define TSC_CTPL_6CYCLES        (TSC_CR_CTPL_2 | TSC_CR_CTPL_0)                                  /*!< Charge transfer pulse low during 6 cycles (PGCLK)  */
-#define TSC_CTPL_7CYCLES        (TSC_CR_CTPL_2 | TSC_CR_CTPL_1)                                  /*!< Charge transfer pulse low during 7 cycles (PGCLK)  */
-#define TSC_CTPL_8CYCLES        (TSC_CR_CTPL_2 | TSC_CR_CTPL_1 | TSC_CR_CTPL_0)                  /*!< Charge transfer pulse low during 8 cycles (PGCLK)  */
-#define TSC_CTPL_9CYCLES        TSC_CR_CTPL_3                                                    /*!< Charge transfer pulse low during 9 cycles (PGCLK)  */
-#define TSC_CTPL_10CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_0)                                  /*!< Charge transfer pulse low during 10 cycles (PGCLK) */
-#define TSC_CTPL_11CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_1)                                  /*!< Charge transfer pulse low during 11 cycles (PGCLK) */
-#define TSC_CTPL_12CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_1 | TSC_CR_CTPL_0)                  /*!< Charge transfer pulse low during 12 cycles (PGCLK) */
-#define TSC_CTPL_13CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2)                                  /*!< Charge transfer pulse low during 13 cycles (PGCLK) */
-#define TSC_CTPL_14CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2 | TSC_CR_CTPL_0)                  /*!< Charge transfer pulse low during 14 cycles (PGCLK) */
-#define TSC_CTPL_15CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2 | TSC_CR_CTPL_1)                  /*!< Charge transfer pulse low during 15 cycles (PGCLK) */
-#define TSC_CTPL_16CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2 | TSC_CR_CTPL_1 | TSC_CR_CTPL_0)  /*!< Charge transfer pulse low during 16 cycles (PGCLK) */
+#define TSC_CTPL_1CYCLE         0x00000000UL
+/*!< Charge transfer pulse low during 1 cycle (PGCLK)   */
+#define TSC_CTPL_2CYCLES        TSC_CR_CTPL_0
+/*!< Charge transfer pulse low during 2 cycles (PGCLK)  */
+#define TSC_CTPL_3CYCLES        TSC_CR_CTPL_1
+/*!< Charge transfer pulse low during 3 cycles (PGCLK)  */
+#define TSC_CTPL_4CYCLES        (TSC_CR_CTPL_1 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 4 cycles (PGCLK)  */
+#define TSC_CTPL_5CYCLES        TSC_CR_CTPL_2
+/*!< Charge transfer pulse low during 5 cycles (PGCLK)  */
+#define TSC_CTPL_6CYCLES        (TSC_CR_CTPL_2 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 6 cycles (PGCLK)  */
+#define TSC_CTPL_7CYCLES        (TSC_CR_CTPL_2 | TSC_CR_CTPL_1)
+/*!< Charge transfer pulse low during 7 cycles (PGCLK)  */
+#define TSC_CTPL_8CYCLES        (TSC_CR_CTPL_2 | TSC_CR_CTPL_1 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 8 cycles (PGCLK)  */
+#define TSC_CTPL_9CYCLES        TSC_CR_CTPL_3
+/*!< Charge transfer pulse low during 9 cycles (PGCLK)  */
+#define TSC_CTPL_10CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 10 cycles (PGCLK) */
+#define TSC_CTPL_11CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_1)
+/*!< Charge transfer pulse low during 11 cycles (PGCLK) */
+#define TSC_CTPL_12CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_1 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 12 cycles (PGCLK) */
+#define TSC_CTPL_13CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2)
+/*!< Charge transfer pulse low during 13 cycles (PGCLK) */
+#define TSC_CTPL_14CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 14 cycles (PGCLK) */
+#define TSC_CTPL_15CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2 | TSC_CR_CTPL_1)
+/*!< Charge transfer pulse low during 15 cycles (PGCLK) */
+#define TSC_CTPL_16CYCLES       (TSC_CR_CTPL_3 | TSC_CR_CTPL_2 | TSC_CR_CTPL_1 | TSC_CR_CTPL_0)
+/*!< Charge transfer pulse low during 16 cycles (PGCLK) */
 /**
   * @}
   */
@@ -289,8 +320,11 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
 /** @defgroup TSC_Acquisition_Mode Acquisition Mode
   * @{
   */
-#define TSC_ACQ_MODE_NORMAL     0x00000000UL  /*!< Normal acquisition mode (acquisition starts as soon as START bit is set)                                                              */
-#define TSC_ACQ_MODE_SYNCHRO    TSC_CR_AM     /*!< Synchronized acquisition mode (acquisition starts if START bit is set and when the selected signal is detected on the SYNC input pin) */
+#define TSC_ACQ_MODE_NORMAL     0x00000000UL
+/*!< Normal acquisition mode (acquisition starts as soon as START bit is set) */
+#define TSC_ACQ_MODE_SYNCHRO    TSC_CR_AM
+/*!< Synchronized acquisition mode (acquisition starts if START bit is set and
+when the selected signal is detected on the SYNC input pin) */
 /**
   * @}
   */
@@ -377,14 +411,14 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @retval None
   */
 #if (USE_HAL_TSC_REGISTER_CALLBACKS == 1)
-#define __HAL_TSC_RESET_HANDLE_STATE(__HANDLE__)                   do{                                                   \
-                                                                       (__HANDLE__)->State = HAL_TSC_STATE_RESET;       \
-                                                                       (__HANDLE__)->MspInitCallback = NULL;            \
-                                                                       (__HANDLE__)->MspDeInitCallback = NULL;          \
+#define __HAL_TSC_RESET_HANDLE_STATE(__HANDLE__)                   do{                                             \
+                                                                       (__HANDLE__)->State = HAL_TSC_STATE_RESET;  \
+                                                                       (__HANDLE__)->MspInitCallback = NULL;       \
+                                                                       (__HANDLE__)->MspDeInitCallback = NULL;     \
                                                                      } while(0)
 #else
 #define __HAL_TSC_RESET_HANDLE_STATE(__HANDLE__)                   ((__HANDLE__)->State = HAL_TSC_STATE_RESET)
-#endif
+#endif /* (USE_HAL_TSC_REGISTER_CALLBACKS == 1) */
 
 /**
   * @brief Enable the TSC peripheral.
@@ -463,7 +497,9 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @param  __INTERRUPT__ TSC interrupt
   * @retval SET or RESET
   */
-#define __HAL_TSC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)         ((((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET : RESET)
+#define __HAL_TSC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)         ((((__HANDLE__)->Instance->IER\
+                                                                      & (__INTERRUPT__)) == (__INTERRUPT__)) ? SET :\
+                                                                    RESET)
 
 /**
   * @brief Check whether the specified TSC flag is set or not.
@@ -471,7 +507,8 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @param  __FLAG__ TSC flag
   * @retval SET or RESET
   */
-#define __HAL_TSC_GET_FLAG(__HANDLE__, __FLAG__)                   ((((__HANDLE__)->Instance->ISR & (__FLAG__)) == (__FLAG__)) ? SET : RESET)
+#define __HAL_TSC_GET_FLAG(__HANDLE__, __FLAG__)                   ((((__HANDLE__)->Instance->ISR\
+                                                                      & (__FLAG__)) == (__FLAG__)) ? SET : RESET)
 
 /**
   * @brief Clear the TSC's pending flag.
@@ -495,7 +532,8 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @param  __GX_IOY_MASK__ IOs mask
   * @retval None
   */
-#define __HAL_TSC_DISABLE_HYSTERESIS(__HANDLE__, __GX_IOY_MASK__)  ((__HANDLE__)->Instance->IOHCR &= (~(__GX_IOY_MASK__)))
+#define __HAL_TSC_DISABLE_HYSTERESIS(__HANDLE__, __GX_IOY_MASK__)  ((__HANDLE__)->Instance->IOHCR\
+                                                                    &= (~(__GX_IOY_MASK__)))
 
 /**
   * @brief Open analog switch on a group of IOs.
@@ -503,7 +541,8 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @param  __GX_IOY_MASK__ IOs mask
   * @retval None
   */
-#define __HAL_TSC_OPEN_ANALOG_SWITCH(__HANDLE__, __GX_IOY_MASK__)  ((__HANDLE__)->Instance->IOASCR &= (~(__GX_IOY_MASK__)))
+#define __HAL_TSC_OPEN_ANALOG_SWITCH(__HANDLE__, __GX_IOY_MASK__)  ((__HANDLE__)->Instance->IOASCR\
+                                                                    &= (~(__GX_IOY_MASK__)))
 
 /**
   * @brief Close analog switch on a group of IOs.
@@ -527,7 +566,8 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @param  __GX_IOY_MASK__ IOs mask
   * @retval None
   */
-#define __HAL_TSC_DISABLE_CHANNEL(__HANDLE__, __GX_IOY_MASK__)     ((__HANDLE__)->Instance->IOCCR &= (~(__GX_IOY_MASK__)))
+#define __HAL_TSC_DISABLE_CHANNEL(__HANDLE__, __GX_IOY_MASK__)     ((__HANDLE__)->Instance->IOCCR\
+                                                                    &= (~(__GX_IOY_MASK__)))
 
 /**
   * @brief Enable a group of IOs in sampling mode.
@@ -567,7 +607,8 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
   * @retval SET or RESET
   */
 #define __HAL_TSC_GET_GROUP_STATUS(__HANDLE__, __GX_INDEX__) \
-((((__HANDLE__)->Instance->IOGCSR & (uint32_t)(1UL << (((__GX_INDEX__) & 0xFUL) + 16UL))) == (uint32_t)(1UL << (((__GX_INDEX__) & 0xFUL) + 16UL))) ? TSC_GROUP_COMPLETED : TSC_GROUP_ONGOING)
+  ((((__HANDLE__)->Instance->IOGCSR & (uint32_t)(1UL << (((__GX_INDEX__) & 0xFUL) + 16UL))) == \
+    (uint32_t)(1UL << (((__GX_INDEX__) & 0xFUL) + 16UL))) ? TSC_GROUP_COMPLETED : TSC_GROUP_ONGOING)
 
 /**
   * @}
@@ -613,7 +654,8 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
                                          ((__VALUE__) == TSC_CTPL_15CYCLES) || \
                                          ((__VALUE__) == TSC_CTPL_16CYCLES))
 
-#define IS_TSC_SS(__VALUE__)            (((FunctionalState)(__VALUE__) == DISABLE) || ((FunctionalState)(__VALUE__) == ENABLE))
+#define IS_TSC_SS(__VALUE__)            (((FunctionalState)(__VALUE__) == DISABLE)\
+                                         || ((FunctionalState)(__VALUE__) == ENABLE))
 
 #define IS_TSC_SSD(__VALUE__)           (((__VALUE__) == 0UL) || (((__VALUE__) > 0UL) && ((__VALUE__) < 128UL)))
 
@@ -628,23 +670,35 @@ typedef  void (*pTSC_CallbackTypeDef)(TSC_HandleTypeDef *htsc); /*!< pointer to 
                                          ((__VALUE__) == TSC_PG_PRESC_DIV64) || \
                                          ((__VALUE__) == TSC_PG_PRESC_DIV128))
 
+#define IS_TSC_PG_PRESC_VS_CTPL(__PGPSC__, __CTPL__)    ((((__PGPSC__) == TSC_PG_PRESC_DIV1) && \
+                                                          (((__CTPL__) == TSC_CTPL_1CYCLE) ||   \
+                                                           ((__CTPL__) > TSC_CTPL_2CYCLES))) ||   \
+                                                         (((__PGPSC__) == TSC_PG_PRESC_DIV2) && \
+                                                          ((__CTPL__) > TSC_CTPL_1CYCLE))  ||   \
+                                                         (((__PGPSC__) > TSC_PG_PRESC_DIV2)  && \
+                                                          (((__CTPL__) == TSC_CTPL_1CYCLE) ||   \
+                                                           ((__CTPL__) > TSC_CTPL_1CYCLE))))
+
 #define IS_TSC_MCV(__VALUE__)           (((__VALUE__) == TSC_MCV_255)  || \
                                          ((__VALUE__) == TSC_MCV_511)  || \
                                          ((__VALUE__) == TSC_MCV_1023) || \
                                          ((__VALUE__) == TSC_MCV_2047) || \
                                          ((__VALUE__) == TSC_MCV_4095) || \
                                          ((__VALUE__) == TSC_MCV_8191) || \
-                                          ((__VALUE__) == TSC_MCV_16383))
+                                         ((__VALUE__) == TSC_MCV_16383))
 
 #define IS_TSC_IODEF(__VALUE__)         (((__VALUE__) == TSC_IODEF_OUT_PP_LOW) || ((__VALUE__) == TSC_IODEF_IN_FLOAT))
 
-#define IS_TSC_SYNC_POL(__VALUE__)      (((__VALUE__) == TSC_SYNC_POLARITY_FALLING) || ((__VALUE__) == TSC_SYNC_POLARITY_RISING))
+#define IS_TSC_SYNC_POL(__VALUE__)      (((__VALUE__) == TSC_SYNC_POLARITY_FALLING)\
+                                         || ((__VALUE__) == TSC_SYNC_POLARITY_RISING))
 
 #define IS_TSC_ACQ_MODE(__VALUE__)      (((__VALUE__) == TSC_ACQ_MODE_NORMAL) || ((__VALUE__) == TSC_ACQ_MODE_SYNCHRO))
 
-#define IS_TSC_MCE_IT(__VALUE__)        (((FunctionalState)(__VALUE__) == DISABLE) || ((FunctionalState)(__VALUE__) == ENABLE))
+#define IS_TSC_MCE_IT(__VALUE__)        (((FunctionalState)(__VALUE__) == DISABLE)\
+                                         || ((FunctionalState)(__VALUE__) == ENABLE))
 
-#define IS_TSC_GROUP_INDEX(__VALUE__)   (((__VALUE__) == 0UL) || (((__VALUE__) > 0UL) && ((__VALUE__) < (uint32_t)TSC_NB_OF_GROUPS)))
+#define IS_TSC_GROUP_INDEX(__VALUE__)   (((__VALUE__) == 0UL)\
+                                         || (((__VALUE__) > 0UL) && ((__VALUE__) < (uint32_t)TSC_NB_OF_GROUPS)))
 
 #define IS_TSC_GROUP(__VALUE__)         (((__VALUE__) == 0UL)                               ||\
                                          (((__VALUE__) & TSC_GROUP1_IO1) == TSC_GROUP1_IO1) ||\
@@ -695,7 +749,8 @@ void HAL_TSC_MspDeInit(TSC_HandleTypeDef *htsc);
 
 /* Callbacks Register/UnRegister functions  ***********************************/
 #if (USE_HAL_TSC_REGISTER_CALLBACKS == 1)
-HAL_StatusTypeDef HAL_TSC_RegisterCallback(TSC_HandleTypeDef *htsc, HAL_TSC_CallbackIDTypeDef CallbackID, pTSC_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_TSC_RegisterCallback(TSC_HandleTypeDef *htsc, HAL_TSC_CallbackIDTypeDef CallbackID,
+                                           pTSC_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_TSC_UnRegisterCallback(TSC_HandleTypeDef *htsc, HAL_TSC_CallbackIDTypeDef CallbackID);
 #endif /* USE_HAL_TSC_REGISTER_CALLBACKS */
 /**
@@ -711,8 +766,8 @@ HAL_StatusTypeDef HAL_TSC_Start_IT(TSC_HandleTypeDef *htsc);
 HAL_StatusTypeDef HAL_TSC_Stop(TSC_HandleTypeDef *htsc);
 HAL_StatusTypeDef HAL_TSC_Stop_IT(TSC_HandleTypeDef *htsc);
 HAL_StatusTypeDef HAL_TSC_PollForAcquisition(TSC_HandleTypeDef *htsc);
-TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(TSC_HandleTypeDef *htsc, uint32_t gx_index);
-uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef *htsc, uint32_t gx_index);
+TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(const TSC_HandleTypeDef *htsc, uint32_t gx_index);
+uint32_t HAL_TSC_GroupGetValue(const TSC_HandleTypeDef *htsc, uint32_t gx_index);
 /**
   * @}
   */
@@ -721,7 +776,7 @@ uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef *htsc, uint32_t gx_index);
   * @{
   */
 /* Peripheral Control functions ***********************************************/
-HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef *htsc, TSC_IOConfigTypeDef *config);
+HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef *htsc, const TSC_IOConfigTypeDef *config);
 HAL_StatusTypeDef HAL_TSC_IODischarge(TSC_HandleTypeDef *htsc, FunctionalState choice);
 /**
   * @}
@@ -737,8 +792,8 @@ HAL_TSC_StateTypeDef HAL_TSC_GetState(TSC_HandleTypeDef *htsc);
   */
 
 /** @addtogroup TSC_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
- * @{
- */
+  * @{
+  */
 /******* TSC IRQHandler and Callbacks used in Interrupt mode */
 void HAL_TSC_IRQHandler(TSC_HandleTypeDef *htsc);
 void HAL_TSC_ConvCpltCallback(TSC_HandleTypeDef *htsc);
@@ -765,5 +820,3 @@ void HAL_TSC_ErrorCallback(TSC_HandleTypeDef *htsc);
 #endif
 
 #endif /* STM32WBxx_HAL_TSC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_uart.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_uart.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -46,53 +45,54 @@ extern "C" {
   */
 typedef struct
 {
-  uint32_t BaudRate;                  /*!< This member configures the UART communication baud rate.
-                                           The baud rate register is computed using the following formula:
+  uint32_t BaudRate;                /*!< This member configures the UART communication baud rate.
+                                         The baud rate register is computed using the following formula:
 #if defined(LPUART1)
-                                           LPUART:
-                                           =======
-                                              Baud Rate Register = ((256 * lpuart_ker_ckpres) / ((huart->Init.BaudRate)))
-                                           where lpuart_ker_ck_pres is the UART input clock divided by a prescaler
-                                           UART:
-                                           =====
+                                         @note For LPUART :
+                                         Baud Rate Register = ((256 * lpuart_ker_ckpres) / ((huart->Init.BaudRate)))
+                                         where lpuart_ker_ck_pres is the UART input clock divided by a prescaler.
+                                         @note For UART :
 #endif
-                                           - If oversampling is 16 or in LIN mode,
-                                              Baud Rate Register = ((uart_ker_ckpres) / ((huart->Init.BaudRate)))
-                                           - If oversampling is 8,
-                                              Baud Rate Register[15:4] = ((2 * uart_ker_ckpres) / ((huart->Init.BaudRate)))[15:4]
-                                              Baud Rate Register[3] =  0
-                                              Baud Rate Register[2:0] =  (((2 * uart_ker_ckpres) / ((huart->Init.BaudRate)))[3:0]) >> 1
-                                           where uart_ker_ck_pres is the UART input clock divided by a prescaler */
+                                         - If oversampling is 16 or in LIN mode,
+                                            Baud Rate Register = ((uart_ker_ckpres) / ((huart->Init.BaudRate)))
+                                         - If oversampling is 8,
+                                            Baud Rate Register[15:4] = ((2 * uart_ker_ckpres) /
+                                            ((huart->Init.BaudRate)))[15:4]
+                                            Baud Rate Register[3] =  0
+                                            Baud Rate Register[2:0] =  (((2 * uart_ker_ckpres) /
+                                            ((huart->Init.BaudRate)))[3:0]) >> 1
+                                         where uart_ker_ck_pres is the UART input clock divided by a prescaler */
 
-  uint32_t WordLength;                /*!< Specifies the number of data bits transmitted or received in a frame.
-                                           This parameter can be a value of @ref UARTEx_Word_Length. */
+  uint32_t WordLength;              /*!< Specifies the number of data bits transmitted or received in a frame.
+                                         This parameter can be a value of @ref UARTEx_Word_Length. */
 
-  uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
-                                           This parameter can be a value of @ref UART_Stop_Bits. */
+  uint32_t StopBits;                /*!< Specifies the number of stop bits transmitted.
+                                         This parameter can be a value of @ref UART_Stop_Bits. */
 
-  uint32_t Parity;                    /*!< Specifies the parity mode.
-                                           This parameter can be a value of @ref UART_Parity
-                                           @note When parity is enabled, the computed parity is inserted
-                                                 at the MSB position of the transmitted data (9th bit when
-                                                 the word length is set to 9 data bits; 8th bit when the
-                                                 word length is set to 8 data bits). */
+  uint32_t Parity;                  /*!< Specifies the parity mode.
+                                         This parameter can be a value of @ref UART_Parity
+                                         @note When parity is enabled, the computed parity is inserted
+                                               at the MSB position of the transmitted data (9th bit when
+                                               the word length is set to 9 data bits; 8th bit when the
+                                               word length is set to 8 data bits). */
 
-  uint32_t Mode;                      /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
-                                           This parameter can be a value of @ref UART_Mode. */
+  uint32_t Mode;                    /*!< Specifies whether the Receive or Transmit mode is enabled or disabled.
+                                         This parameter can be a value of @ref UART_Mode. */
 
-  uint32_t HwFlowCtl;                 /*!< Specifies whether the hardware flow control mode is enabled
-                                           or disabled.
-                                           This parameter can be a value of @ref UART_Hardware_Flow_Control. */
+  uint32_t HwFlowCtl;               /*!< Specifies whether the hardware flow control mode is enabled
+                                         or disabled.
+                                         This parameter can be a value of @ref UART_Hardware_Flow_Control. */
 
-  uint32_t OverSampling;              /*!< Specifies whether the Over sampling 8 is enabled or disabled, to achieve higher speed (up to f_PCLK/8).
-                                           This parameter can be a value of @ref UART_Over_Sampling. */
+  uint32_t OverSampling;            /*!< Specifies whether the Over sampling 8 is enabled or disabled,
+                                         to achieve higher speed (up to f_PCLK/8).
+                                         This parameter can be a value of @ref UART_Over_Sampling. */
 
-  uint32_t OneBitSampling;            /*!< Specifies whether a single sample or three samples' majority vote is selected.
-                                           Selecting the single sample method increases the receiver tolerance to clock
-                                           deviations. This parameter can be a value of @ref UART_OneBit_Sampling. */
+  uint32_t OneBitSampling;          /*!< Specifies whether a single sample or three samples' majority vote is selected.
+                                         Selecting the single sample method increases the receiver tolerance to clock
+                                         deviations. This parameter can be a value of @ref UART_OneBit_Sampling. */
 
-  uint32_t ClockPrescaler;            /*!< Specifies the prescaler value used to divide the UART clock source.
-                                           This parameter can be a value of @ref UART_ClockPrescaler. */
+  uint32_t ClockPrescaler;          /*!< Specifies the prescaler value used to divide the UART clock source.
+                                         This parameter can be a value of @ref UART_ClockPrescaler. */
 
 } UART_InitTypeDef;
 
@@ -103,7 +103,8 @@ typedef struct
 {
   uint32_t AdvFeatureInit;        /*!< Specifies which advanced UART features is initialized. Several
                                        Advanced Features may be initialized at the same time .
-                                       This parameter can be a value of @ref UART_Advanced_Features_Initialization_Type. */
+                                       This parameter can be a value of
+                                       @ref UART_Advanced_Features_Initialization_Type. */
 
   uint32_t TxPinLevelInvert;      /*!< Specifies whether the TX pin active level is inverted.
                                        This parameter can be a value of @ref UART_Tx_Inv. */
@@ -137,7 +138,8 @@ typedef struct
 
 /**
   * @brief HAL UART State definition
-  * @note  HAL UART State value is a combination of 2 different substates: gState and RxState (see @ref UART_State_Definition).
+  * @note  HAL UART State value is a combination of 2 different substates:
+  *        gState and RxState (see @ref UART_State_Definition).
   *        - gState contains UART state information related to global Handle management
   *          and also information related to Tx operations.
   *          gState value coding follow below described bitmap :
@@ -148,7 +150,7 @@ typedef struct
   *             11 : Error
   *          b5     Peripheral initialization status
   *             0  : Reset (Peripheral not initialized)
-  *             1  : Init done (Peripheral not initialized. HAL UART Init function already called)
+  *             1  : Init done (Peripheral initialized. HAL UART Init function already called)
   *          b4-b3  (not used)
   *             xx : Should be set to 00
   *          b2     Intrinsic process state
@@ -165,7 +167,7 @@ typedef struct
   *             xx : Should be set to 00
   *          b5     Peripheral initialization status
   *             0  : Reset (Peripheral not initialized)
-  *             1  : Init done (Peripheral not initialized)
+  *             1  : Init done (Peripheral initialized)
   *          b4-b2  (not used)
   *            xxx : Should be set to 000
   *          b1     Rx state
@@ -190,6 +192,28 @@ typedef enum
 } UART_ClockSourceTypeDef;
 
 /**
+  * @brief HAL UART Reception type definition
+  * @note  HAL UART Reception type value aims to identify which type of Reception is ongoing.
+  *        This parameter can be a value of @ref UART_Reception_Type_Values :
+  *           HAL_UART_RECEPTION_STANDARD         = 0x00U,
+  *           HAL_UART_RECEPTION_TOIDLE           = 0x01U,
+  *           HAL_UART_RECEPTION_TORTO            = 0x02U,
+  *           HAL_UART_RECEPTION_TOCHARMATCH      = 0x03U,
+  */
+typedef uint32_t HAL_UART_RxTypeTypeDef;
+
+/**
+  * @brief HAL UART Rx Event type definition
+  * @note  HAL UART Rx Event type value aims to identify which type of Event has occurred
+  *        leading to call of the RxEvent callback.
+  *        This parameter can be a value of @ref UART_RxEvent_Type_Values :
+  *           HAL_UART_RXEVENT_TC                 = 0x00U,
+  *           HAL_UART_RXEVENT_HT                 = 0x01U,
+  *           HAL_UART_RXEVENT_IDLE               = 0x02U,
+  */
+typedef uint32_t HAL_UART_RxEventTypeTypeDef;
+
+/**
   * @brief  UART handle Structure definition
   */
 typedef struct __UART_HandleTypeDef
@@ -200,7 +224,7 @@ typedef struct __UART_HandleTypeDef
 
   UART_AdvFeatureInitTypeDef AdvancedInit;           /*!< UART Advanced Features initialization parameters */
 
-  uint8_t                  *pTxBuffPtr;              /*!< Pointer to UART Tx transfer Buffer */
+  const uint8_t            *pTxBuffPtr;              /*!< Pointer to UART Tx transfer Buffer */
 
   uint16_t                 TxXferSize;               /*!< UART Tx Transfer size              */
 
@@ -221,6 +245,10 @@ typedef struct __UART_HandleTypeDef
 
   uint16_t                 NbTxDataToProcess;        /*!< Number of data to process during TX ISR execution */
 
+  __IO HAL_UART_RxTypeTypeDef ReceptionType;         /*!< Type of ongoing reception          */
+
+  __IO HAL_UART_RxEventTypeTypeDef RxEventType;      /*!< Type of Rx Event                   */
+
   void (*RxISR)(struct __UART_HandleTypeDef *huart); /*!< Function pointer on Rx IRQ handler */
 
   void (*TxISR)(struct __UART_HandleTypeDef *huart); /*!< Function pointer on Tx IRQ handler */
@@ -232,11 +260,11 @@ typedef struct __UART_HandleTypeDef
   HAL_LockTypeDef           Lock;                    /*!< Locking object                     */
 
   __IO HAL_UART_StateTypeDef    gState;              /*!< UART state information related to global Handle management
-                                                          and also related to Tx operations.
-                                                          This parameter can be a value of @ref HAL_UART_StateTypeDef */
+                                                          and also related to Tx operations. This parameter
+                                                          can be a value of @ref HAL_UART_StateTypeDef */
 
-  __IO HAL_UART_StateTypeDef    RxState;             /*!< UART state information related to Rx operations.
-                                                          This parameter can be a value of @ref HAL_UART_StateTypeDef */
+  __IO HAL_UART_StateTypeDef    RxState;             /*!< UART state information related to Rx operations. This
+                                                          parameter can be a value of @ref HAL_UART_StateTypeDef */
 
   __IO uint32_t                 ErrorCode;           /*!< UART Error code                    */
 
@@ -252,6 +280,7 @@ typedef struct __UART_HandleTypeDef
   void (* WakeupCallback)(struct __UART_HandleTypeDef *huart);            /*!< UART Wakeup Callback                  */
   void (* RxFifoFullCallback)(struct __UART_HandleTypeDef *huart);        /*!< UART Rx Fifo Full Callback            */
   void (* TxFifoEmptyCallback)(struct __UART_HandleTypeDef *huart);       /*!< UART Tx Fifo Empty Callback           */
+  void (* RxEventCallback)(struct __UART_HandleTypeDef *huart, uint16_t Pos); /*!< UART Reception Event Callback     */
 
   void (* MspInitCallback)(struct __UART_HandleTypeDef *huart);           /*!< UART Msp Init callback                */
   void (* MspDeInitCallback)(struct __UART_HandleTypeDef *huart);         /*!< UART Msp DeInit callback              */
@@ -285,7 +314,9 @@ typedef enum
 /**
   * @brief  HAL UART Callback pointer definition
   */
-typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer to an UART callback function */
+typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart); /*!< pointer to an UART callback function */
+typedef  void (*pUART_RxEventCallbackTypeDef)
+(struct __UART_HandleTypeDef *huart, uint16_t Pos); /*!< pointer to a UART Rx Event specific callback function */
 
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 
@@ -312,8 +343,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 #define  HAL_UART_STATE_BUSY_RX       0x00000022U    /*!< Data Reception process is ongoing
                                                           Value is allowed for RxState only */
 #define  HAL_UART_STATE_BUSY_TX_RX    0x00000023U    /*!< Data Transmission and Reception process is ongoing
-                                                          Not to be used for neither gState nor RxState.
-                                                          Value is result of combination (Or) between gState and RxState values */
+                                                          Not to be used for neither gState nor RxState.Value is result
+                                                          of combination (Or) between gState and RxState values */
 #define  HAL_UART_STATE_TIMEOUT       0x000000A0U    /*!< Timeout state
                                                           Value is allowed for gState only */
 #define  HAL_UART_STATE_ERROR         0x000000E0U    /*!< Error
@@ -325,16 +356,16 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_Error_Definition   UART Error Definition
   * @{
   */
-#define  HAL_UART_ERROR_NONE             ((uint32_t)0x00000000U)    /*!< No error                */
-#define  HAL_UART_ERROR_PE               ((uint32_t)0x00000001U)    /*!< Parity error            */
-#define  HAL_UART_ERROR_NE               ((uint32_t)0x00000002U)    /*!< Noise error             */
-#define  HAL_UART_ERROR_FE               ((uint32_t)0x00000004U)    /*!< Frame error             */
-#define  HAL_UART_ERROR_ORE              ((uint32_t)0x00000008U)    /*!< Overrun error           */
-#define  HAL_UART_ERROR_DMA              ((uint32_t)0x00000010U)    /*!< DMA transfer error      */
-#define  HAL_UART_ERROR_RTO              ((uint32_t)0x00000020U)    /*!< Receiver Timeout error  */
+#define  HAL_UART_ERROR_NONE             (0x00000000U)    /*!< No error                */
+#define  HAL_UART_ERROR_PE               (0x00000001U)    /*!< Parity error            */
+#define  HAL_UART_ERROR_NE               (0x00000002U)    /*!< Noise error             */
+#define  HAL_UART_ERROR_FE               (0x00000004U)    /*!< Frame error             */
+#define  HAL_UART_ERROR_ORE              (0x00000008U)    /*!< Overrun error           */
+#define  HAL_UART_ERROR_DMA              (0x00000010U)    /*!< DMA transfer error      */
+#define  HAL_UART_ERROR_RTO              (0x00000020U)    /*!< Receiver Timeout error  */
 
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-#define  HAL_UART_ERROR_INVALID_CALLBACK ((uint32_t)0x00000040U)    /*!< Invalid Callback error  */
+#define  HAL_UART_ERROR_INVALID_CALLBACK (0x00000040U)    /*!< Invalid Callback error  */
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 /**
   * @}
@@ -431,10 +462,14 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_AutoBaud_Rate_Mode    UART Advanced Feature AutoBaud Rate Mode
   * @{
   */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    0x00000000U           /*!< Auto Baud rate detection on start bit            */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE USART_CR2_ABRMODE_0   /*!< Auto Baud rate detection on falling edge         */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   USART_CR2_ABRMODE_1   /*!< Auto Baud rate detection on 0x7F frame detection */
-#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   USART_CR2_ABRMODE     /*!< Auto Baud rate detection on 0x55 frame detection */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONSTARTBIT    0x00000000U           /*!< Auto Baud rate detection
+                                                                              on start bit              */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ONFALLINGEDGE USART_CR2_ABRMODE_0   /*!< Auto Baud rate detection
+                                                                              on falling edge           */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X7FFRAME   USART_CR2_ABRMODE_1   /*!< Auto Baud rate detection
+                                                                              on 0x7F frame detection   */
+#define UART_ADVFEATURE_AUTOBAUDRATE_ON0X55FRAME   USART_CR2_ABRMODE     /*!< Auto Baud rate detection
+                                                                              on 0x55 frame detection   */
 /**
   * @}
   */
@@ -596,8 +631,10 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_MSB_First   UART Advanced Feature MSB First
   * @{
   */
-#define UART_ADVFEATURE_MSBFIRST_DISABLE    0x00000000U             /*!< Most significant bit sent/received first disable */
-#define UART_ADVFEATURE_MSBFIRST_ENABLE     USART_CR2_MSBFIRST      /*!< Most significant bit sent/received first enable  */
+#define UART_ADVFEATURE_MSBFIRST_DISABLE    0x00000000U             /*!< Most significant bit sent/received
+                                                                         first disable                      */
+#define UART_ADVFEATURE_MSBFIRST_ENABLE     USART_CR2_MSBFIRST      /*!< Most significant bit sent/received
+                                                                         first enable                       */
 /**
   * @}
   */
@@ -623,7 +660,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_CR2_ADDRESS_LSB_POS    UART Address-matching LSB Position In CR2 Register
   * @{
   */
-#define UART_CR2_ADDRESS_LSB_POS             24U                                /*!< UART address-matching LSB position in CR2 register */
+#define UART_CR2_ADDRESS_LSB_POS             24U             /*!< UART address-matching LSB position in CR2 register */
 /**
   * @}
   */
@@ -631,9 +668,10 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_WakeUp_from_Stop_Selection   UART WakeUp From Stop Selection
   * @{
   */
-#define UART_WAKEUP_ON_ADDRESS              0x00000000U             /*!< UART wake-up on address                         */
-#define UART_WAKEUP_ON_STARTBIT             USART_CR3_WUS_1         /*!< UART wake-up on start bit                       */
-#define UART_WAKEUP_ON_READDATA_NONEMPTY    USART_CR3_WUS           /*!< UART wake-up on receive data register not empty or RXFIFO is not empty */
+#define UART_WAKEUP_ON_ADDRESS              0x00000000U             /*!< UART wake-up on address                     */
+#define UART_WAKEUP_ON_STARTBIT             USART_CR3_WUS_1         /*!< UART wake-up on start bit                   */
+#define UART_WAKEUP_ON_READDATA_NONEMPTY    USART_CR3_WUS           /*!< UART wake-up on receive data register
+                                                                         not empty or RXFIFO is not empty            */
 /**
   * @}
   */
@@ -650,7 +688,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_CR1_DEAT_ADDRESS_LSB_POS    UART Driver Enable Assertion Time LSB Position In CR1 Register
   * @{
   */
-#define UART_CR1_DEAT_ADDRESS_LSB_POS       21U      /*!< UART Driver Enable assertion time LSB position in CR1 register */
+#define UART_CR1_DEAT_ADDRESS_LSB_POS       21U      /*!< UART Driver Enable assertion time LSB
+                                                          position in CR1 register */
 /**
   * @}
   */
@@ -658,7 +697,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_CR1_DEDT_ADDRESS_LSB_POS    UART Driver Enable DeAssertion Time LSB Position In CR1 Register
   * @{
   */
-#define UART_CR1_DEDT_ADDRESS_LSB_POS       16U      /*!< UART Driver Enable de-assertion time LSB position in CR1 register */
+#define UART_CR1_DEDT_ADDRESS_LSB_POS       16U      /*!< UART Driver Enable de-assertion time LSB
+                                                          position in CR1 register */
 /**
   * @}
   */
@@ -733,28 +773,28 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *           - ZZZZ  : Flag position in the ISR register(4bits)
   * @{
   */
-#define UART_IT_PE                          0x0028U                  /*!< UART parity error interruption                 */
-#define UART_IT_TXE                         0x0727U                  /*!< UART transmit data register empty interruption */
-#define UART_IT_TXFNF                       0x0727U                  /*!< UART TX FIFO not full interruption             */
-#define UART_IT_TC                          0x0626U                  /*!< UART transmission complete interruption        */
-#define UART_IT_RXNE                        0x0525U                  /*!< UART read data register not empty interruption */
-#define UART_IT_RXFNE                       0x0525U                  /*!< UART RXFIFO not empty interruption             */
-#define UART_IT_IDLE                        0x0424U                  /*!< UART idle interruption                         */
-#define UART_IT_LBD                         0x0846U                  /*!< UART LIN break detection interruption          */
-#define UART_IT_CTS                         0x096AU                  /*!< UART CTS interruption                          */
-#define UART_IT_CM                          0x112EU                  /*!< UART character match interruption              */
-#define UART_IT_WUF                         0x1476U                  /*!< UART wake-up from stop mode interruption       */
-#define UART_IT_RXFF                        0x183FU                  /*!< UART RXFIFO full interruption                  */
-#define UART_IT_TXFE                        0x173EU                  /*!< UART TXFIFO empty interruption                 */
-#define UART_IT_RXFT                        0x1A7CU                  /*!< UART RXFIFO threshold reached interruption     */
-#define UART_IT_TXFT                        0x1B77U                  /*!< UART TXFIFO threshold reached interruption     */
-#define UART_IT_RTO                         0x0B3AU                  /*!< UART receiver timeout interruption             */
+#define UART_IT_PE                          0x0028U              /*!< UART parity error interruption                 */
+#define UART_IT_TXE                         0x0727U              /*!< UART transmit data register empty interruption */
+#define UART_IT_TXFNF                       0x0727U              /*!< UART TX FIFO not full interruption             */
+#define UART_IT_TC                          0x0626U              /*!< UART transmission complete interruption        */
+#define UART_IT_RXNE                        0x0525U              /*!< UART read data register not empty interruption */
+#define UART_IT_RXFNE                       0x0525U              /*!< UART RXFIFO not empty interruption             */
+#define UART_IT_IDLE                        0x0424U              /*!< UART idle interruption                         */
+#define UART_IT_LBD                         0x0846U              /*!< UART LIN break detection interruption          */
+#define UART_IT_CTS                         0x096AU              /*!< UART CTS interruption                          */
+#define UART_IT_CM                          0x112EU              /*!< UART character match interruption              */
+#define UART_IT_WUF                         0x1476U              /*!< UART wake-up from stop mode interruption       */
+#define UART_IT_RXFF                        0x183FU              /*!< UART RXFIFO full interruption                  */
+#define UART_IT_TXFE                        0x173EU              /*!< UART TXFIFO empty interruption                 */
+#define UART_IT_RXFT                        0x1A7CU              /*!< UART RXFIFO threshold reached interruption     */
+#define UART_IT_TXFT                        0x1B77U              /*!< UART TXFIFO threshold reached interruption     */
+#define UART_IT_RTO                         0x0B3AU              /*!< UART receiver timeout interruption             */
 
-#define UART_IT_ERR                         0x0060U                  /*!< UART error interruption         */
+#define UART_IT_ERR                         0x0060U              /*!< UART error interruption                        */
 
-#define UART_IT_ORE                         0x0300U                  /*!< UART overrun error interruption */
-#define UART_IT_NE                          0x0200U                  /*!< UART noise error interruption   */
-#define UART_IT_FE                          0x0100U                  /*!< UART frame error interruption   */
+#define UART_IT_ORE                         0x0300U              /*!< UART overrun error interruption                */
+#define UART_IT_NE                          0x0200U              /*!< UART noise error interruption                  */
+#define UART_IT_FE                          0x0100U              /*!< UART frame error interruption                  */
 /**
   * @}
   */
@@ -778,6 +818,26 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @}
   */
 
+/** @defgroup UART_Reception_Type_Values  UART Reception type values
+  * @{
+  */
+#define HAL_UART_RECEPTION_STANDARD          (0x00000000U)             /*!< Standard reception                       */
+#define HAL_UART_RECEPTION_TOIDLE            (0x00000001U)             /*!< Reception till completion or IDLE event  */
+#define HAL_UART_RECEPTION_TORTO             (0x00000002U)             /*!< Reception till completion or RTO event   */
+#define HAL_UART_RECEPTION_TOCHARMATCH       (0x00000003U)             /*!< Reception till completion or CM event    */
+/**
+  * @}
+  */
+
+/** @defgroup UART_RxEvent_Type_Values  UART RxEvent type values
+  * @{
+  */
+#define HAL_UART_RXEVENT_TC                  (0x00000000U)             /*!< RxEvent linked to Transfer Complete event */
+#define HAL_UART_RXEVENT_HT                  (0x00000001U)             /*!< RxEvent linked to Half Transfer event     */
+#define HAL_UART_RXEVENT_IDLE                (0x00000002U)             /*!< RxEvent linked to IDLE event              */
+/**
+  * @}
+  */
 
 /**
   * @}
@@ -929,10 +989,15 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_ERR   Error interrupt (frame error, noise error, overrun error)
   * @retval None
   */
-#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)? ((__HANDLE__)->Instance->CR1 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)? ((__HANDLE__)->Instance->CR2 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((__HANDLE__)->Instance->CR3 |= (1U << ((__INTERRUPT__) & UART_IT_MASK))))
-
+#define __HAL_UART_ENABLE_IT(__HANDLE__, __INTERRUPT__)   (\
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)?\
+                                                           ((__HANDLE__)->Instance->CR1 |= (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)?\
+                                                           ((__HANDLE__)->Instance->CR2 |= (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 |= (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))))
 
 /** @brief  Disable the specified UART interrupt.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -957,9 +1022,15 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_ERR   Error interrupt (Frame error, noise error, overrun error)
   * @retval None
   */
-#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)? ((__HANDLE__)->Instance->CR1 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)? ((__HANDLE__)->Instance->CR2 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))): \
-                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U << ((__INTERRUPT__) & UART_IT_MASK))))
+#define __HAL_UART_DISABLE_IT(__HANDLE__, __INTERRUPT__)  (\
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U)?\
+                                                           ((__HANDLE__)->Instance->CR1 &= ~ (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U)?\
+                                                           ((__HANDLE__)->Instance->CR2 &= ~ (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))): \
+                                                           ((__HANDLE__)->Instance->CR3 &= ~ (1U <<\
+                                                               ((__INTERRUPT__) & UART_IT_MASK))))
 
 /** @brief  Check whether the specified UART interrupt has occurred or not.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -1010,9 +1081,13 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   *            @arg @ref UART_IT_ERR   Error interrupt (Frame error, noise error, overrun error)
   * @retval The new state of __INTERRUPT__ (SET or RESET).
   */
-#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U) ? (__HANDLE__)->Instance->CR1 : \
-                                                                (((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U) ? (__HANDLE__)->Instance->CR2 : \
-                                                                 (__HANDLE__)->Instance->CR3)) & (1U << (((uint16_t)(__INTERRUPT__)) & UART_IT_MASK)))  != RESET) ? SET : RESET)
+#define __HAL_UART_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__) ((((((((uint8_t)(__INTERRUPT__)) >> 5U) == 1U) ?\
+                                                                (__HANDLE__)->Instance->CR1 : \
+                                                                (((((uint8_t)(__INTERRUPT__)) >> 5U) == 2U) ?\
+                                                                 (__HANDLE__)->Instance->CR2 : \
+                                                                 (__HANDLE__)->Instance->CR3)) & (1U <<\
+                                                                     (((uint16_t)(__INTERRUPT__)) &\
+                                                                      UART_IT_MASK)))  != RESET) ? SET : RESET)
 
 /** @brief  Clear the specified UART ISR flag, in setting the proper ICR register flag.
   * @param  __HANDLE__ specifies the UART Handle.
@@ -1079,15 +1154,16 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
-#define __HAL_UART_HWCONTROL_CTS_ENABLE(__HANDLE__)        \
-  do{                                                      \
-    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE);  \
-    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_CTSE;        \
+#define __HAL_UART_HWCONTROL_CTS_ENABLE(__HANDLE__)               \
+  do{                                                             \
+    ATOMIC_SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE);  \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_CTSE;               \
   } while(0U)
 
 /** @brief  Disable CTS flow control.
@@ -1097,15 +1173,16 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying CTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
-#define __HAL_UART_HWCONTROL_CTS_DISABLE(__HANDLE__)        \
-  do{                                                       \
-    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE); \
-    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_CTSE);      \
+#define __HAL_UART_HWCONTROL_CTS_DISABLE(__HANDLE__)               \
+  do{                                                              \
+    ATOMIC_CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_CTSE); \
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_CTSE);             \
   } while(0U)
 
 /** @brief  Enable RTS flow control.
@@ -1115,15 +1192,16 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
-#define __HAL_UART_HWCONTROL_RTS_ENABLE(__HANDLE__)       \
-  do{                                                     \
-    SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE); \
-    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_RTSE;       \
+#define __HAL_UART_HWCONTROL_RTS_ENABLE(__HANDLE__)              \
+  do{                                                            \
+    ATOMIC_SET_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE); \
+    (__HANDLE__)->Init.HwFlowCtl |= USART_CR3_RTSE;              \
   } while(0U)
 
 /** @brief  Disable RTS flow control.
@@ -1133,15 +1211,16 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @note   As macro is expected to be used for modifying RTS Hw flow control feature activation, without need
   *         for USART instance Deinit/Init, following conditions for macro call should be fulfilled :
   *           - UART instance should have already been initialised (through call of HAL_UART_Init() )
-  *           - macro could only be called when corresponding UART instance is disabled (i.e. __HAL_UART_DISABLE(__HANDLE__))
-  *             and should be followed by an Enable macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
+  *           - macro could only be called when corresponding UART instance is disabled
+  *             (i.e. __HAL_UART_DISABLE(__HANDLE__)) and should be followed by an Enable
+  *              macro (i.e. __HAL_UART_ENABLE(__HANDLE__)).
   * @param  __HANDLE__ specifies the UART Handle.
   * @retval None
   */
-#define __HAL_UART_HWCONTROL_RTS_DISABLE(__HANDLE__)       \
-  do{                                                      \
-    CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE);\
-    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_RTSE);     \
+#define __HAL_UART_HWCONTROL_RTS_DISABLE(__HANDLE__)              \
+  do{                                                             \
+    ATOMIC_CLEAR_BIT((__HANDLE__)->Instance->CR3, USART_CR3_RTSE);\
+    (__HANDLE__)->Init.HwFlowCtl &= ~(USART_CR3_RTSE);            \
   } while(0U)
 /**
   * @}
@@ -1151,7 +1230,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /** @defgroup UART_Private_Macros   UART Private Macros
   * @{
   */
-/** @brief  Get UART clok division factor from clock prescaler value.
+/** @brief  Get UART clock division factor from clock prescaler value.
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval UART clock division factor
   */
@@ -1166,8 +1245,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
    ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV16)  ? 16U :      \
    ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV32)  ? 32U :      \
    ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV64)  ? 64U :      \
-   ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV128) ? 128U :     \
-   ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV256) ? 256U : 1U)
+   ((__CLOCKPRESCALER__) == UART_PRESCALER_DIV128) ? 128U : 256U)
 
 #if defined(LPUART1)
 /** @brief  BRR division operation to set BRR register with LPUART.
@@ -1176,9 +1254,11 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval Division result
   */
-#define UART_DIV_LPUART(__PCLK__, __BAUD__, __CLOCKPRESCALER__)      ((uint32_t)((((((uint64_t)(__PCLK__))/(UARTPrescTable[(__CLOCKPRESCALER__)]))*256U)\
-                                                                      + (uint32_t)((__BAUD__)/2U)) / (__BAUD__)))
-#endif
+#define UART_DIV_LPUART(__PCLK__, __BAUD__, __CLOCKPRESCALER__)                        \
+  ((uint32_t)((((((uint64_t)(__PCLK__))/(UARTPrescTable[(__CLOCKPRESCALER__)]))*256U)+ \
+               (uint32_t)((__BAUD__)/2U)) / (__BAUD__))                                \
+  )
+#endif /* LPUART1 */
 
 /** @brief  BRR division operation to set BRR register in 8-bit oversampling mode.
   * @param  __PCLK__ UART clock.
@@ -1186,8 +1266,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval Division result
   */
-#define UART_DIV_SAMPLING8(__PCLK__, __BAUD__, __CLOCKPRESCALER__)   (((((__PCLK__)/UARTPrescTable[(__CLOCKPRESCALER__)])*2U)\
-                                                                       + ((__BAUD__)/2U)) / (__BAUD__))
+#define UART_DIV_SAMPLING8(__PCLK__, __BAUD__, __CLOCKPRESCALER__)                        \
+  (((((__PCLK__)/UARTPrescTable[(__CLOCKPRESCALER__)])*2U) + ((__BAUD__)/2U)) / (__BAUD__))
 
 /** @brief  BRR division operation to set BRR register in 16-bit oversampling mode.
   * @param  __PCLK__ UART clock.
@@ -1195,8 +1275,8 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param  __CLOCKPRESCALER__ UART prescaler value.
   * @retval Division result
   */
-#define UART_DIV_SAMPLING16(__PCLK__, __BAUD__, __CLOCKPRESCALER__)  ((((__PCLK__)/UARTPrescTable[(__CLOCKPRESCALER__)])\
-                                                                       + ((__BAUD__)/2U)) / (__BAUD__))
+#define UART_DIV_SAMPLING16(__PCLK__, __BAUD__, __CLOCKPRESCALER__)                       \
+  ((((__PCLK__)/UARTPrescTable[(__CLOCKPRESCALER__)]) + ((__BAUD__)/2U)) / (__BAUD__))
 
 #if defined(LPUART1)
 /** @brief  Check whether or not UART instance is Low Power UART.
@@ -1204,7 +1284,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @retval SET (instance is LPUART) or RESET (instance isn't LPUART)
   */
 #define UART_INSTANCE_LOWPOWER(__HANDLE__) (IS_LPUART_INSTANCE((__HANDLE__)->Instance))
-#endif
+#endif /* LPUART1 */
 
 /** @brief  Check UART Baud rate.
   * @param  __BAUDRATE__ Baudrate specified by the user.
@@ -1244,7 +1324,7 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   */
 #define IS_LPUART_STOPBITS(__STOPBITS__) (((__STOPBITS__) == UART_STOPBITS_1) || \
                                           ((__STOPBITS__) == UART_STOPBITS_2))
-#endif
+#endif /* LPUART1 */
 
 /**
   * @brief Ensure that UART frame parity is valid.
@@ -1441,8 +1521,9 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
   * @param __AUTOBAUDRATE__ UART auto Baud rate state.
   * @retval SET (__AUTOBAUDRATE__ is valid) or RESET (__AUTOBAUDRATE__ is invalid)
   */
-#define IS_UART_ADVFEATURE_AUTOBAUDRATE(__AUTOBAUDRATE__)  (((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
-                                                            ((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
+#define IS_UART_ADVFEATURE_AUTOBAUDRATE(__AUTOBAUDRATE__) (((__AUTOBAUDRATE__) == \
+                                                            UART_ADVFEATURE_AUTOBAUDRATE_DISABLE) || \
+                                                           ((__AUTOBAUDRATE__) == UART_ADVFEATURE_AUTOBAUDRATE_ENABLE))
 
 /**
   * @brief Ensure that UART DMA enabling or disabling on error setting is valid.
@@ -1518,12 +1599,6 @@ typedef  void (*pUART_CallbackTypeDef)(UART_HandleTypeDef *huart);  /*!< pointer
 /* Include UART HAL Extended module */
 #include "stm32wbxx_hal_uart_ex.h"
 
-
-/* Prescaler Table used in BRR computation macros.
-   Declared as extern here to allow use of private UART macros, outside of HAL UART fonctions */
-extern const uint16_t UARTPrescTable[12];
-
-
 /* Exported functions --------------------------------------------------------*/
 /** @addtogroup UART_Exported_Functions UART Exported Functions
   * @{
@@ -1547,6 +1622,9 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UART_RegisterCallback(UART_HandleTypeDef *huart, HAL_UART_CallbackIDTypeDef CallbackID,
                                             pUART_CallbackTypeDef pCallback);
 HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UART_CallbackIDTypeDef CallbackID);
+
+HAL_StatusTypeDef HAL_UART_RegisterRxEventCallback(UART_HandleTypeDef *huart, pUART_RxEventCallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_UART_UnRegisterRxEventCallback(UART_HandleTypeDef *huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 
 /**
@@ -1558,11 +1636,11 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
   */
 
 /* IO operation functions *****************************************************/
-HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, const uint8_t *pData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
-HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, const uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
 HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart);
@@ -1584,6 +1662,8 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart);
 void HAL_UART_AbortCpltCallback(UART_HandleTypeDef *huart);
 void HAL_UART_AbortTransmitCpltCallback(UART_HandleTypeDef *huart);
 void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart);
+
+void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size);
 
 /**
   * @}
@@ -1614,8 +1694,8 @@ HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart);
   */
 
 /* Peripheral State and Errors functions  **************************************************/
-HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart);
-uint32_t              HAL_UART_GetError(UART_HandleTypeDef *huart);
+HAL_UART_StateTypeDef HAL_UART_GetState(const UART_HandleTypeDef *huart);
+uint32_t              HAL_UART_GetError(const UART_HandleTypeDef *huart);
 
 /**
   * @}
@@ -1630,14 +1710,27 @@ uint32_t              HAL_UART_GetError(UART_HandleTypeDef *huart);
   * @{
   */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-void UART_InitCallbacksToDefault(UART_HandleTypeDef *huart);
+void              UART_InitCallbacksToDefault(UART_HandleTypeDef *huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_t Flag, FlagStatus Status,
                                               uint32_t Tickstart, uint32_t Timeout);
-void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+void              UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
+HAL_StatusTypeDef UART_Start_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef UART_Start_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
 
+/**
+  * @}
+  */
+
+/* Private variables -----------------------------------------------------------*/
+/** @defgroup UART_Private_variables UART Private variables
+  * @{
+  */
+/* Prescaler Table used in BRR computation macros.
+   Declared as extern here to allow use of private UART macros, outside of HAL UART functions */
+extern const uint16_t UARTPrescTable[12];
 /**
   * @}
   */
@@ -1656,4 +1749,3 @@ void UART_AdvFeatureConfig(UART_HandleTypeDef *huart);
 
 #endif /* STM32WBxx_HAL_UART_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_uart_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_uart_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -99,12 +98,12 @@ typedef struct
   * @brief    UART TXFIFO threshold level
   * @{
   */
-#define UART_TXFIFO_THRESHOLD_1_8   0x00000000U                               /*!< TXFIFO reaches 1/8 of its depth */
-#define UART_TXFIFO_THRESHOLD_1_4   USART_CR3_TXFTCFG_0                       /*!< TXFIFO reaches 1/4 of its depth */
-#define UART_TXFIFO_THRESHOLD_1_2   USART_CR3_TXFTCFG_1                       /*!< TXFIFO reaches 1/2 of its depth */
-#define UART_TXFIFO_THRESHOLD_3_4   (USART_CR3_TXFTCFG_0|USART_CR3_TXFTCFG_1) /*!< TXFIFO reaches 3/4 of its depth */
-#define UART_TXFIFO_THRESHOLD_7_8   USART_CR3_TXFTCFG_2                       /*!< TXFIFO reaches 7/8 of its depth */
-#define UART_TXFIFO_THRESHOLD_8_8   (USART_CR3_TXFTCFG_2|USART_CR3_TXFTCFG_0) /*!< TXFIFO becomes empty            */
+#define UART_TXFIFO_THRESHOLD_1_8   0x00000000U                               /*!< TX FIFO reaches 1/8 of its depth */
+#define UART_TXFIFO_THRESHOLD_1_4   USART_CR3_TXFTCFG_0                       /*!< TX FIFO reaches 1/4 of its depth */
+#define UART_TXFIFO_THRESHOLD_1_2   USART_CR3_TXFTCFG_1                       /*!< TX FIFO reaches 1/2 of its depth */
+#define UART_TXFIFO_THRESHOLD_3_4   (USART_CR3_TXFTCFG_0|USART_CR3_TXFTCFG_1) /*!< TX FIFO reaches 3/4 of its depth */
+#define UART_TXFIFO_THRESHOLD_7_8   USART_CR3_TXFTCFG_2                       /*!< TX FIFO reaches 7/8 of its depth */
+#define UART_TXFIFO_THRESHOLD_8_8   (USART_CR3_TXFTCFG_2|USART_CR3_TXFTCFG_0) /*!< TX FIFO becomes empty            */
 /**
   * @}
   */
@@ -113,12 +112,12 @@ typedef struct
   * @brief    UART RXFIFO threshold level
   * @{
   */
-#define UART_RXFIFO_THRESHOLD_1_8   0x00000000U                               /*!< RXFIFO FIFO reaches 1/8 of its depth */
-#define UART_RXFIFO_THRESHOLD_1_4   USART_CR3_RXFTCFG_0                       /*!< RXFIFO FIFO reaches 1/4 of its depth */
-#define UART_RXFIFO_THRESHOLD_1_2   USART_CR3_RXFTCFG_1                       /*!< RXFIFO FIFO reaches 1/2 of its depth */
-#define UART_RXFIFO_THRESHOLD_3_4   (USART_CR3_RXFTCFG_0|USART_CR3_RXFTCFG_1) /*!< RXFIFO FIFO reaches 3/4 of its depth */
-#define UART_RXFIFO_THRESHOLD_7_8   USART_CR3_RXFTCFG_2                       /*!< RXFIFO FIFO reaches 7/8 of its depth */
-#define UART_RXFIFO_THRESHOLD_8_8   (USART_CR3_RXFTCFG_2|USART_CR3_RXFTCFG_0) /*!< RXFIFO FIFO becomes full             */
+#define UART_RXFIFO_THRESHOLD_1_8   0x00000000U                               /*!< RX FIFO reaches 1/8 of its depth */
+#define UART_RXFIFO_THRESHOLD_1_4   USART_CR3_RXFTCFG_0                       /*!< RX FIFO reaches 1/4 of its depth */
+#define UART_RXFIFO_THRESHOLD_1_2   USART_CR3_RXFTCFG_1                       /*!< RX FIFO reaches 1/2 of its depth */
+#define UART_RXFIFO_THRESHOLD_3_4   (USART_CR3_RXFTCFG_0|USART_CR3_RXFTCFG_1) /*!< RX FIFO reaches 3/4 of its depth */
+#define UART_RXFIFO_THRESHOLD_7_8   USART_CR3_RXFTCFG_2                       /*!< RX FIFO reaches 7/8 of its depth */
+#define UART_RXFIFO_THRESHOLD_8_8   (USART_CR3_RXFTCFG_2|USART_CR3_RXFTCFG_0) /*!< RX FIFO becomes full             */
 /**
   * @}
   */
@@ -173,6 +172,14 @@ HAL_StatusTypeDef HAL_UARTEx_EnableFifoMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UARTEx_DisableFifoMode(UART_HandleTypeDef *huart);
 HAL_StatusTypeDef HAL_UARTEx_SetTxFifoThreshold(UART_HandleTypeDef *huart, uint32_t Threshold);
 HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint32_t Threshold);
+
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint16_t *RxLen,
+                                           uint32_t Timeout);
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+
+HAL_UART_RxEventTypeTypeDef HAL_UARTEx_GetRxEventType(const UART_HandleTypeDef *huart);
+
 
 /**
   * @}
@@ -384,4 +391,3 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
 
 #endif /* STM32WBxx_HAL_UART_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_usart.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_usart.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -120,7 +119,7 @@ typedef struct __USART_HandleTypeDef
 
   USART_InitTypeDef             Init;                    /*!< USART communication parameters      */
 
-  uint8_t                       *pTxBuffPtr;             /*!< Pointer to USART Tx transfer Buffer */
+  const uint8_t                 *pTxBuffPtr;             /*!< Pointer to USART Tx transfer Buffer */
 
   uint16_t                      TxXferSize;              /*!< USART Tx Transfer size              */
 
@@ -225,6 +224,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 #if (USE_HAL_USART_REGISTER_CALLBACKS == 1)
 #define HAL_USART_ERROR_INVALID_CALLBACK ((uint32_t)0x00000040U)    /*!< Invalid Callback error    */
 #endif /* USE_HAL_USART_REGISTER_CALLBACKS */
+#define  HAL_USART_ERROR_RTO              ((uint32_t)0x00000080U)    /*!< Receiver Timeout error  */
 /**
   * @}
   */
@@ -256,15 +256,6 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 #define USART_MODE_RX                       USART_CR1_RE                    /*!< RX mode        */
 #define USART_MODE_TX                       USART_CR1_TE                    /*!< TX mode        */
 #define USART_MODE_TX_RX                    (USART_CR1_TE |USART_CR1_RE)    /*!< RX and TX mode */
-/**
-  * @}
-  */
-
-/** @defgroup USART_Over_Sampling USART Over Sampling
-  * @{
-  */
-#define USART_OVERSAMPLING_16               0x00000000U         /*!< Oversampling by 16 */
-#define USART_OVERSAMPLING_8                USART_CR1_OVER8     /*!< Oversampling by 8  */
 /**
   * @}
   */
@@ -349,6 +340,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 #define USART_FLAG_UDR                      USART_ISR_UDR           /*!< SPI slave underrun error flag              */
 #define USART_FLAG_TXE                      USART_ISR_TXE_TXFNF     /*!< USART transmit data register empty         */
 #define USART_FLAG_TXFNF                    USART_ISR_TXE_TXFNF     /*!< USART TXFIFO not full                      */
+#define USART_FLAG_RTOF                     USART_ISR_RTOF          /*!< USART receiver timeout flag                */
 #define USART_FLAG_TC                       USART_ISR_TC            /*!< USART transmission complete                */
 #define USART_FLAG_RXNE                     USART_ISR_RXNE_RXFNE    /*!< USART read data register not empty         */
 #define USART_FLAG_RXFNE                    USART_ISR_RXNE_RXFNE    /*!< USART RXFIFO not empty                     */
@@ -403,6 +395,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 #define USART_CLEAR_TCF                       USART_ICR_TCCF            /*!< Transmission Complete Clear Flag    */
 #define USART_CLEAR_UDRF                      USART_ICR_UDRCF           /*!< SPI slave underrun error Clear Flag */
 #define USART_CLEAR_TXFECF                    USART_ICR_TXFECF          /*!< TXFIFO Empty Clear Flag             */
+#define USART_CLEAR_RTOF                      USART_ICR_RTOCF           /*!< USART receiver timeout clear flag  */
 /**
   * @}
   */
@@ -413,6 +406,8 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 #define USART_IT_MASK                             0x001FU     /*!< USART interruptions flags mask */
 #define USART_CR_MASK                             0x00E0U     /*!< USART control register mask */
 #define USART_CR_POS                              5U          /*!< USART control register position */
+#define USART_ISR_MASK                            0x1F00U     /*!< USART ISR register mask         */
+#define USART_ISR_POS                             8U          /*!< USART ISR register position     */
 /**
   * @}
   */
@@ -457,6 +452,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
   *            @arg @ref USART_FLAG_TC    Transmission Complete flag
   *            @arg @ref USART_FLAG_RXNE  Receive data register not empty flag
   *            @arg @ref USART_FLAG_RXFNE RXFIFO not empty flag
+  *            @arg @ref USART_FLAG_RTOF  Receiver Timeout flag
   *            @arg @ref USART_FLAG_IDLE  Idle Line detection flag
   *            @arg @ref USART_FLAG_ORE   OverRun Error flag
   *            @arg @ref USART_FLAG_NE    Noise Error flag
@@ -477,6 +473,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
   *            @arg @ref USART_CLEAR_IDLEF    IDLE line detected Clear Flag
   *            @arg @ref USART_CLEAR_TXFECF   TXFIFO empty clear Flag
   *            @arg @ref USART_CLEAR_TCF      Transmission Complete Clear Flag
+  *            @arg @ref USART_CLEAR_RTOF     Receiver Timeout clear flag
   *            @arg @ref USART_CLEAR_UDRF     SPI slave underrun error Clear Flag
   * @retval None
   */
@@ -589,7 +586,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
   *            @arg @ref USART_IT_PE    Parity Error interrupt
   * @retval The new state of __INTERRUPT__ (SET or RESET).
   */
-#define __HAL_USART_GET_IT(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->ISR & ((uint32_t)1 << ((__INTERRUPT__)>> 0x08))) != RESET) ? SET : RESET)
+#define __HAL_USART_GET_IT(__HANDLE__, __INTERRUPT__) ((((__HANDLE__)->Instance->ISR & ((uint32_t)0x01U << (((__INTERRUPT__) & USART_ISR_MASK)>> USART_ISR_POS))) != 0U) ? SET : RESET)
 
 /** @brief  Check whether the specified USART interrupt source is enabled or not.
   * @param  __HANDLE__ specifies the USART Handle.
@@ -626,6 +623,7 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
   *            @arg @ref USART_CLEAR_NEF      Noise detected Clear Flag
   *            @arg @ref USART_CLEAR_OREF     Overrun Error Clear Flag
   *            @arg @ref USART_CLEAR_IDLEF    IDLE line detected Clear Flag
+  *            @arg @ref USART_CLEAR_RTOF     Receiver timeout clear flag
   *            @arg @ref USART_CLEAR_TXFECF   TXFIFO empty clear Flag
   *            @arg @ref USART_CLEAR_TCF      Transmission Complete Clear Flag
   * @retval None
@@ -770,14 +768,6 @@ typedef  void (*pUSART_CallbackTypeDef)(USART_HandleTypeDef *husart);  /*!< poin
 #define IS_USART_MODE(__MODE__) ((((__MODE__) & 0xFFFFFFF3U) == 0x00U) && ((__MODE__) != 0x00U))
 
 /**
-  * @brief Ensure that USART oversampling is valid.
-  * @param __SAMPLING__ USART oversampling.
-  * @retval SET (__SAMPLING__ is valid) or RESET (__SAMPLING__ is invalid)
-  */
-#define IS_USART_OVERSAMPLING(__SAMPLING__) (((__SAMPLING__) == USART_OVERSAMPLING_16) || \
-                                             ((__SAMPLING__) == USART_OVERSAMPLING_8))
-
-/**
   * @brief Ensure that USART clock state is valid.
   * @param __CLOCK__ USART clock state.
   * @retval SET (__CLOCK__ is valid) or RESET (__CLOCK__ is invalid)
@@ -870,15 +860,15 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
   */
 
 /* IO operation functions *****************************************************/
-HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint16_t Size, uint32_t Timeout);
 HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
-HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout);
+HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint16_t Size);
 HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size);
-HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData,  uint16_t Size);
-HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint8_t *pRxData,  uint16_t Size);
+HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint16_t Size);
 HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pRxData, uint16_t Size);
-HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
+HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint8_t *pRxData, uint16_t Size);
 HAL_StatusTypeDef HAL_USART_DMAPause(USART_HandleTypeDef *husart);
 HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart);
 HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart);
@@ -904,8 +894,8 @@ void HAL_USART_AbortCpltCallback(USART_HandleTypeDef *husart);
   */
 
 /* Peripheral State and Error functions ***************************************/
-HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart);
-uint32_t               HAL_USART_GetError(USART_HandleTypeDef *husart);
+HAL_USART_StateTypeDef HAL_USART_GetState(const USART_HandleTypeDef *husart);
+uint32_t               HAL_USART_GetError(const USART_HandleTypeDef *husart);
 
 /**
   * @}
@@ -929,4 +919,3 @@ uint32_t               HAL_USART_GetError(USART_HandleTypeDef *husart);
 
 #endif /* STM32WBxx_HAL_USART_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_usart_ex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_usart_ex.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -45,9 +44,9 @@ extern "C" {
 /** @defgroup USARTEx_Word_Length USARTEx Word Length
   * @{
   */
-#define USART_WORDLENGTH_7B                  ((uint32_t)USART_CR1_M1)   /*!< 7-bit long USART frame */
-#define USART_WORDLENGTH_8B                  0x00000000U                /*!< 8-bit long USART frame */
-#define USART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M0)   /*!< 9-bit long USART frame */
+#define USART_WORDLENGTH_7B                  (USART_CR1_M1)   /*!< 7-bit long USART frame */
+#define USART_WORDLENGTH_8B                  (0x00000000U)    /*!< 8-bit long USART frame */
+#define USART_WORDLENGTH_9B                  (USART_CR1_M0)   /*!< 9-bit long USART frame */
 /**
   * @}
   */
@@ -130,45 +129,44 @@ extern "C" {
   */
 #define USART_MASK_COMPUTATION(__HANDLE__)                            \
   do {                                                                \
-  if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_9B)           \
-  {                                                                   \
-     if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)              \
-     {                                                                \
+    if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_9B)         \
+    {                                                                 \
+      if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)             \
+      {                                                               \
         (__HANDLE__)->Mask = 0x01FFU;                                 \
-     }                                                                \
-     else                                                             \
-     {                                                                \
+      }                                                               \
+      else                                                            \
+      {                                                               \
         (__HANDLE__)->Mask = 0x00FFU;                                 \
-     }                                                                \
-  }                                                                   \
-  else if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_8B)      \
-  {                                                                   \
-     if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)              \
-     {                                                                \
+      }                                                               \
+    }                                                                 \
+    else if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_8B)    \
+    {                                                                 \
+      if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)             \
+      {                                                               \
         (__HANDLE__)->Mask = 0x00FFU;                                 \
-     }                                                                \
-     else                                                             \
-     {                                                                \
+      }                                                               \
+      else                                                            \
+      {                                                               \
         (__HANDLE__)->Mask = 0x007FU;                                 \
-     }                                                                \
-  }                                                                   \
-  else if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_7B)      \
-  {                                                                   \
-     if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)              \
-     {                                                                \
+      }                                                               \
+    }                                                                 \
+    else if ((__HANDLE__)->Init.WordLength == USART_WORDLENGTH_7B)    \
+    {                                                                 \
+      if ((__HANDLE__)->Init.Parity == USART_PARITY_NONE)             \
+      {                                                               \
         (__HANDLE__)->Mask = 0x007FU;                                 \
-     }                                                                \
-     else                                                             \
-     {                                                                \
+      }                                                               \
+      else                                                            \
+      {                                                               \
         (__HANDLE__)->Mask = 0x003FU;                                 \
-     }                                                                \
-  }                                                                   \
-  else                                                                \
-  {                                                                   \
-    (__HANDLE__)->Mask = 0x0000U;                                     \
-  }                                                                   \
-} while(0U)
-
+      }                                                               \
+    }                                                                 \
+    else                                                              \
+    {                                                                 \
+      (__HANDLE__)->Mask = 0x0000U;                                   \
+    }                                                                 \
+  } while(0U)
 
 /**
   * @brief Ensure that USART frame length is valid.
@@ -282,4 +280,3 @@ HAL_StatusTypeDef HAL_USARTEx_SetRxFifoThreshold(USART_HandleTypeDef *husart, ui
 
 #endif /* STM32WBxx_HAL_USART_EX_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_wwdg.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_hal_wwdg.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -192,7 +191,7 @@ typedef void (*pWWDG_CallbackTypeDef)(WWDG_HandleTypeDef *hppp);  /*!< pointer t
 
 /**
   * @brief  Enable the WWDG early wakeup interrupt.
-  * @param  __HANDLE__: WWDG handle
+  * @param  __HANDLE__     WWDG handle
   * @param  __INTERRUPT__  specifies the interrupt to enable.
   *         This parameter can be one of the following values:
   *            @arg WWDG_IT_EWI: Early wakeup interrupt
@@ -305,5 +304,3 @@ void                  HAL_WWDG_EarlyWakeupCallback(WWDG_HandleTypeDef *hwwdg);
 #endif
 
 #endif /* STM32WBxx_HAL_WWDG_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_adc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_adc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -53,7 +52,7 @@ extern "C" {
 
 /* Internal register offset for ADC group regular sequencer configuration */
 /* (offset placed into a spare area of literal definition) */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* No register ADC_SQRx on this ADC peripheral version */
 #else
 #define ADC_SQR1_REGOFFSET                 (0x00000000UL)
@@ -68,7 +67,7 @@ extern "C" {
 
 /* Definition of ADC group regular sequencer bits information to be inserted  */
 /* into ADC group regular sequencer ranks literals definition.                */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_REG_RANK_1_SQRX_BITOFFSET_POS  ( 0UL) /* Value equivalent to bitfield "ADC_CHSELR_SQ1" position in register */
 #define ADC_REG_RANK_2_SQRX_BITOFFSET_POS  ( 4UL) /* Value equivalent to bitfield "ADC_CHSELR_SQ2" position in register */
 #define ADC_REG_RANK_3_SQRX_BITOFFSET_POS  ( 8UL) /* Value equivalent to bitfield "ADC_CHSELR_SQ3" position in register */
@@ -191,14 +190,14 @@ extern "C" {
 /* - channel sampling time defined by SMPRx register offset                   */
 /*   and SMPx bits positions into SMPRx register                              */
 #define ADC_CHANNEL_ID_NUMBER_MASK         (ADC_CFGR_AWD1CH)
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_CHANNEL_ID_BITFIELD_MASK       (ADC_CHSELR_CHSEL)
 #else
 #define ADC_CHANNEL_ID_BITFIELD_MASK       (ADC_AWD2CR_AWD2CH)
 #endif
 #define ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS (26UL)/* Value equivalent to bitfield "ADC_CHANNEL_ID_NUMBER_MASK" position in register */
-#if defined(ADC_SUPPORT_2_5_MSPS)
-#define ADC_CHANNEL_ID_NUMBER_MASK_SEQ     (ADC_CHSELR_SQ1 << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) /* Value equivalent to ADC_CHANNEL_ID_NUMBER_MASK with reduced range: on this STM32 serie, ADC group regular sequencer, if set to mode "fully configurable", can contain channels with a restricted channel number. Refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). */
+#if  defined(ADC_SUPPORT_2_5_MSPS)
+#define ADC_CHANNEL_ID_NUMBER_MASK_SEQ     (ADC_CHSELR_SQ1 << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) /* Value equivalent to ADC_CHANNEL_ID_NUMBER_MASK with reduced range: on this STM32 series, ADC group regular sequencer, if set to mode "fully configurable", can contain channels with a restricted channel number. Refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). */
 #endif
 #define ADC_CHANNEL_ID_MASK                (ADC_CHANNEL_ID_NUMBER_MASK | ADC_CHANNEL_ID_BITFIELD_MASK | ADC_CHANNEL_ID_INTERNAL_CH_MASK)
 /* Equivalent mask of ADC_CHANNEL_NUMBER_MASK aligned on register LSB (bit 0) */
@@ -243,7 +242,7 @@ extern "C" {
 
 /* Definition of channels ID bitfield information to be inserted into         */
 /* channels literals definition.                                              */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_CHANNEL_0_BITFIELD             (ADC_CHSELR_CHSEL0)
 #define ADC_CHANNEL_1_BITFIELD             (ADC_CHSELR_CHSEL1)
 #define ADC_CHANNEL_2_BITFIELD             (ADC_CHSELR_CHSEL2)
@@ -283,7 +282,7 @@ extern "C" {
 #define ADC_CHANNEL_16_BITFIELD            (ADC_AWD2CR_AWD2CH_16)
 #define ADC_CHANNEL_17_BITFIELD            (ADC_AWD2CR_AWD2CH_17)
 #define ADC_CHANNEL_18_BITFIELD            (ADC_AWD2CR_AWD2CH_18)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /* Definition of channels sampling time information to be inserted into       */
 /* channels literals definition.                                              */
@@ -308,7 +307,7 @@ extern "C" {
 #define ADC_CHANNEL_18_SMP                 (ADC_SMPR2_REGOFFSET | ((24UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP18" position in register */
 
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /* Internal mask for ADC channel sampling time:                               */
 /* To select into literals LL_ADC_SAMPLINGTIME_x                              */
 /* the relevant bits for:                                                     */
@@ -321,7 +320,8 @@ extern "C" {
 #define ADC_SAMPLING_TIME_SMP_MASK         (ADC_SMPR_SMP2 | ADC_SMPR_SMP1)
 #define ADC_SAMPLING_TIME_SMP_SHIFT_MASK   (ADC_SMPR_SMP2_BITOFFSET_POS | ADC_SMPR_SMP1_BITOFFSET_POS)
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
+
 /* Internal mask for ADC mode single or differential ended:                   */
 /* To select into literals LL_ADC_SINGLE_ENDED or LL_ADC_SINGLE_DIFFERENTIAL  */
 /* the relevant bits for:                                                     */
@@ -358,14 +358,14 @@ extern "C" {
 #define ADC_AWD_CRX_REGOFFSET_MASK         (ADC_AWD_CR1_REGOFFSET | ADC_AWD_CR2_REGOFFSET | ADC_AWD_CR3_REGOFFSET)
 #define ADC_AWD_CRX_REGOFFSET_BITOFFSET_POS (20UL)
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_AWD_CR1_CHANNEL_MASK           (ADC_CFGR1_AWD1CH | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL)
 #define ADC_AWD_CR_ALL_CHANNEL_MASK        (ADC_AWD_CR1_CHANNEL_MASK)
 #else
 #define ADC_AWD_CR1_CHANNEL_MASK           (ADC_CFGR_AWD1CH | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL)
 #define ADC_AWD_CR23_CHANNEL_MASK          (ADC_AWD2CR_AWD2CH)
 #define ADC_AWD_CR_ALL_CHANNEL_MASK        (ADC_AWD_CR1_CHANNEL_MASK | ADC_AWD_CR23_CHANNEL_MASK)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 #define ADC_AWD_CRX_REGOFFSET_POS          (20UL) /* Position of bits ADC_AWD_CRx_REGOFFSET in ADC_AWD_CRX_REGOFFSET_MASK */
 
@@ -387,12 +387,11 @@ extern "C" {
 #define ADC_OFR4_REGOFFSET                 (0x00000003UL)
 #define ADC_OFRx_REGOFFSET_MASK            (ADC_OFR1_REGOFFSET | ADC_OFR2_REGOFFSET | ADC_OFR3_REGOFFSET | ADC_OFR4_REGOFFSET)
 
-
 /* ADC registers bits positions */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_CFGR1_RES_BITOFFSET_POS        ( 3UL) /* Value equivalent to bitfield "ADC_CFGR1_RES" position in register */
 #define ADC_CFGR1_AWDSGL_BITOFFSET_POS     (22UL) /* Value equivalent to bitfield "ADC_CFGR1_AWDSGL" position in register */
-#define ADC_TR1_HT1_BITOFFSET_POS          (16UL) /* Value equivalent to bitfield "ADC_TR1_HT1" position in register */
+#define ADC_TR_HT_BITOFFSET_POS            (16UL) /* Value equivalent to bitfield "ADC_TR_HT" position in register */
 #define ADC_CHSELR_CHSEL0_BITOFFSET_POS    ( 0UL) /* Value equivalent to bitfield "ADC_CHSELR_CHSEL0" position in register */
 #define ADC_CHSELR_CHSEL1_BITOFFSET_POS    ( 1UL) /* Value equivalent to bitfield "ADC_CHSELR_CHSEL1" position in register */
 #define ADC_CHSELR_CHSEL2_BITOFFSET_POS    ( 2UL) /* Value equivalent to bitfield "ADC_CHSELR_CHSEL2" position in register */
@@ -423,15 +422,15 @@ extern "C" {
 #define ADC_CFGR_AWD1EN_BITOFFSET_POS      (23UL) /* Value equivalent to bitfield "ADC_CFGR_AWD1EN" position in register */
 #define ADC_CFGR_JAWD1EN_BITOFFSET_POS     (24UL) /* Value equivalent to bitfield "ADC_CFGR_JAWD1EN" position in register */
 #define ADC_TR1_HT1_BITOFFSET_POS          (16UL) /* Value equivalent to bitfield "ADC_TR1_HT1" position in register */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 
 /* ADC registers bits groups */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define ADC_CR_BITS_PROPERTY_RS            (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN) /* ADC register CR bits with HW property "rs": Software can read as well as set this bit. Writing '0' has no effect on the bit value. */
 #else
 #define ADC_CR_BITS_PROPERTY_RS            (ADC_CR_ADCAL | ADC_CR_JADSTP | ADC_CR_ADSTP | ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN) /* ADC register CR bits with HW property "rs": Software can read as well as set this bit. Writing '0' has no effect on the bit value. */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 
 /* ADC internal channels related definitions */
@@ -492,7 +491,7 @@ typedef struct
 {
   uint32_t CommonClock;                 /*!< Set parameter common to several ADC: Clock source and prescaler.
                                              This parameter can be a value of @ref ADC_LL_EC_COMMON_CLOCK_SOURCE
-                                             @note On this STM32 serie, if ADC group injected is used, some
+                                             @note On this STM32 series, if ADC group injected is used, some
                                                    clock ratio constraints between ADC clock and AHB clock
                                                    must be respected. Refer to reference manual.
 
@@ -522,17 +521,17 @@ typedef struct
   */
 typedef struct
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t Clock;                       /*!< Set ADC instance clock source and prescaler.
                                              This parameter can be a value of @ref ADC_LL_EC_CLOCK_SOURCE
-                                             @note On this STM32 serie, this parameter has some clock ratio constraints:
+                                             @note On this STM32 series, this parameter has some clock ratio constraints:
                                                    ADC clock synchronous (from PCLK) with prescaler 1 must be enabled only if PCLK has a 50% duty clock cycle
                                                    (APB prescaler configured inside the RCC must be bypassed and the system clock must by 50% duty cycle).
 
                                              This feature can be modified afterwards using unitary function @ref LL_ADC_SetClock().
                                              For more details, refer to description of this function. */
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   uint32_t Resolution;                  /*!< Set ADC resolution.
                                              This parameter can be a value of @ref ADC_LL_EC_RESOLUTION
 
@@ -573,7 +572,7 @@ typedef struct
 {
   uint32_t TriggerSource;               /*!< Set ADC group regular conversion trigger source: internal (SW start) or from external peripheral (timer event, external interrupt line).
                                              This parameter can be a value of @ref ADC_LL_EC_REG_TRIGGER_SOURCE
-                                             @note On this STM32 serie, setting trigger source to external trigger also set trigger polarity to rising edge
+                                             @note On this STM32 series, setting trigger source to external trigger also set trigger polarity to rising edge
                                                    (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value).
                                                    In case of need to modify trigger edge, use function @ref LL_ADC_REG_SetTriggerEdge().
 
@@ -610,7 +609,7 @@ typedef struct
 
 } LL_ADC_REG_InitTypeDef;
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -636,7 +635,7 @@ typedef struct
 {
   uint32_t TriggerSource;               /*!< Set ADC group injected conversion trigger source: internal (SW start) or from external peripheral (timer event, external interrupt line).
                                              This parameter can be a value of @ref ADC_LL_EC_INJ_TRIGGER_SOURCE
-                                             @note On this STM32 serie, setting trigger source to external trigger also set trigger polarity to rising edge
+                                             @note On this STM32 series, setting trigger source to external trigger also set trigger polarity to rising edge
                                                    (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value).
                                                    In case of need to modify trigger edge, use function @ref LL_ADC_INJ_SetTriggerEdge().
 
@@ -678,10 +677,10 @@ typedef struct
   * @{
   */
 #define LL_ADC_FLAG_ADRDY                  ADC_ISR_ADRDY      /*!< ADC flag ADC instance ready */
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_FLAG_CCRDY                  ADC_ISR_CCRDY      /*!< ADC flag ADC channel configuration ready */
 #else
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define LL_ADC_FLAG_EOC                    ADC_ISR_EOC        /*!< ADC flag ADC group regular end of unitary conversion */
 #define LL_ADC_FLAG_EOS                    ADC_ISR_EOS        /*!< ADC flag ADC group regular end of sequence conversions */
 #define LL_ADC_FLAG_OVR                    ADC_ISR_OVR        /*!< ADC flag ADC group regular overrun */
@@ -692,9 +691,9 @@ typedef struct
 #define LL_ADC_FLAG_AWD1                   ADC_ISR_AWD1       /*!< ADC flag ADC analog watchdog 1 */
 #define LL_ADC_FLAG_AWD2                   ADC_ISR_AWD2       /*!< ADC flag ADC analog watchdog 2 */
 #define LL_ADC_FLAG_AWD3                   ADC_ISR_AWD3       /*!< ADC flag ADC analog watchdog 3 */
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_FLAG_EOCAL                  ADC_ISR_EOCAL      /*!< ADC flag end of calibration */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -704,10 +703,10 @@ typedef struct
   * @{
   */
 #define LL_ADC_IT_ADRDY                    ADC_IER_ADRDYIE    /*!< ADC interruption ADC instance ready */
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_IT_CCRDY                    ADC_IER_CCRDYIE    /*!< ADC interruption channel configuration ready */
 #else
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define LL_ADC_IT_EOC                      ADC_IER_EOCIE      /*!< ADC interruption ADC group regular end of unitary conversion */
 #define LL_ADC_IT_EOS                      ADC_IER_EOSIE      /*!< ADC interruption ADC group regular end of sequence conversions */
 #define LL_ADC_IT_OVR                      ADC_IER_OVRIE      /*!< ADC interruption ADC group regular overrun */
@@ -718,9 +717,9 @@ typedef struct
 #define LL_ADC_IT_AWD1                     ADC_IER_AWD1IE     /*!< ADC interruption ADC analog watchdog 1 */
 #define LL_ADC_IT_AWD2                     ADC_IER_AWD2IE     /*!< ADC interruption ADC analog watchdog 2 */
 #define LL_ADC_IT_AWD3                     ADC_IER_AWD3IE     /*!< ADC interruption ADC analog watchdog 3 */
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_IT_EOCAL                    ADC_IER_EOCALIE    /*!< ADC interruption ADC end of calibration */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -739,11 +738,11 @@ typedef struct
 /** @defgroup ADC_LL_EC_COMMON_CLOCK_SOURCE  ADC common - Clock source
   * @{
   */
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_CLOCK_SYNC_PCLK_DIV1        (ADC_CCR_CKMODE_0)                                    /*!< ADC synchronous clock derived from AHB clock without prescaler */
 #define LL_ADC_CLOCK_SYNC_PCLK_DIV2        (ADC_CCR_CKMODE_1                   )                 /*!< ADC synchronous clock derived from AHB clock with prescaler division by 2 */
 #define LL_ADC_CLOCK_SYNC_PCLK_DIV4        (ADC_CCR_CKMODE_1 | ADC_CCR_CKMODE_0)                 /*!< ADC synchronous clock derived from AHB clock with prescaler division by 4 */
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 #define LL_ADC_CLOCK_ASYNC_DIV1            (0x00000000UL)                                        /*!< ADC asynchronous clock without prescaler */
 #define LL_ADC_CLOCK_ASYNC_DIV2            (ADC_CCR_PRESC_0)                                     /*!< ADC asynchronous clock with prescaler division by 2   */
 #define LL_ADC_CLOCK_ASYNC_DIV4            (ADC_CCR_PRESC_1                  )                   /*!< ADC asynchronous clock with prescaler division by 4   */
@@ -776,7 +775,7 @@ typedef struct
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /** @defgroup ADC_LL_EC_CLOCK_SOURCE  ADC instance - Clock source
   * @{
   */
@@ -787,7 +786,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /** @defgroup ADC_LL_EC_RESOLUTION  ADC instance - Resolution
   * @{
@@ -813,13 +812,13 @@ typedef struct
   * @{
   */
 #define LL_ADC_LP_MODE_NONE                (0x00000000UL)                      /*!< No ADC low power mode activated */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_LP_AUTOWAIT                 (ADC_CFGR1_WAIT)                    /*!< ADC low power mode auto delay: Dynamic low power mode, ADC conversions are performed only when necessary (when previous ADC conversion data is read). See description with function @ref LL_ADC_SetLowPowerMode(). */
 #define LL_ADC_LP_AUTOPOWEROFF             (ADC_CFGR1_AUTOFF)                  /*!< ADC low power mode auto power-off: the ADC automatically powers-off after a ADC conversion and automatically wakes up when a new ADC conversion is triggered (with startup time between trigger and start of sampling). See description with function @ref LL_ADC_SetLowPowerMode(). */
 #define LL_ADC_LP_AUTOWAIT_AUTOPOWEROFF    (ADC_CFGR1_WAIT | ADC_CFGR1_AUTOFF) /*!< ADC low power modes auto wait and auto power-off combined. See description with function @ref LL_ADC_SetLowPowerMode(). */
 #else
 #define LL_ADC_LP_AUTOWAIT                 (ADC_CFGR_AUTDLY)                   /*!< ADC low power mode auto delay: Dynamic low power mode, ADC conversions are performed only when necessary (when previous ADC conversion data is read). See description with function @ref LL_ADC_SetLowPowerMode(). */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -833,7 +832,7 @@ typedef struct
   * @}
   */
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /** @defgroup ADC_LL_EC_SAMPLINGTIME_COMMON  ADC instance - Sampling time common to a group of channels
 * @{
 */
@@ -843,7 +842,7 @@ typedef struct
   * @}
   */
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /** @defgroup ADC_LL_EC_OFFSET_NB  ADC instance - Offset number
   * @{
   */
@@ -868,10 +867,10 @@ typedef struct
   * @{
   */
 #define LL_ADC_GROUP_REGULAR               (0x00000001UL) /*!< ADC group regular (available on all STM32 devices) */
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_GROUP_INJECTED              (0x00000002UL) /*!< ADC group injected (not available on all STM32 devices)*/
 #define LL_ADC_GROUP_REGULAR_INJECTED      (0x00000003UL) /*!< ADC both groups regular and injected */
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -879,7 +878,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_CHANNEL  ADC instance - Channel number
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_CHANNEL_0                   (ADC_CHANNEL_0_NUMBER  | ADC_CHANNEL_0_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN0  */
 #define LL_ADC_CHANNEL_1                   (ADC_CHANNEL_1_NUMBER  | ADC_CHANNEL_1_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN1  */
 #define LL_ADC_CHANNEL_2                   (ADC_CHANNEL_2_NUMBER  | ADC_CHANNEL_2_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN2  */
@@ -926,7 +925,7 @@ typedef struct
 #define LL_ADC_CHANNEL_TEMPSENSOR          (LL_ADC_CHANNEL_17 | ADC_CHANNEL_ID_INTERNAL_CH)  /*!< ADC internal channel connected to Temperature sensor. */
 #define LL_ADC_CHANNEL_VBAT                (LL_ADC_CHANNEL_18 | ADC_CHANNEL_ID_INTERNAL_CH)  /*!< ADC internal channel connected to Vbat/2: Vbat voltage through a divider ladder of factor 1/2 to have Vbat always below Vdda. */
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -952,7 +951,7 @@ typedef struct
 #define LL_ADC_REG_TRIG_EXT_TIM2_TRGO      (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                     /*!< ADC group regular conversion trigger from external peripheral: TIM2 TRGO. Trigger edge set to rising edge (default setting). */
 #define LL_ADC_REG_TRIG_EXT_TIM2_CH2       (ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                         /*!< ADC group regular conversion trigger from external peripheral: TIM2 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define LL_ADC_REG_TRIG_EXT_EXTI_LINE11    (ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                         /*!< ADC group regular conversion trigger from external peripheral: external interrupt line 11. Trigger edge set to rising edge (default setting). */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -997,7 +996,7 @@ typedef struct
   * @}
   */
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /** @defgroup ADC_LL_EC_REG_SEQ_MODE  ADC group regular - Sequencer configuration flexibility
 * @{
 */
@@ -1007,7 +1006,7 @@ typedef struct
   * @}
   */
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /** @defgroup ADC_LL_EC_REG_SEQ_SCAN_LENGTH  ADC group regular - Sequencer scan length
   * @{
   */
@@ -1037,27 +1036,27 @@ typedef struct
 #define LL_ADC_REG_SEQ_SCAN_ENABLE_14RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2                | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 14 ranks in the sequence */
 #define LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2 | ADC_SQR1_L_1               ) /*!< ADC group regular sequencer enable with 15 ranks in the sequence */
 #define LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2 | ADC_SQR1_L_1 | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 16 ranks in the sequence */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /** @defgroup ADC_LL_EC_REG_SEQ_SCAN_DIRECTION  ADC group regular - Sequencer scan direction
   * @{
   */
-#define LL_ADC_REG_SEQ_SCAN_DIR_FORWARD    (0x00000000UL)         /*!< On this STM32 serie, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction forward: from lowest channel number to highest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer). On some other STM32 families, this setting is not available and the default scan direction is forward. */
-#define LL_ADC_REG_SEQ_SCAN_DIR_BACKWARD   (ADC_CFGR1_SCANDIR)    /*!< On this STM32 serie, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction backward: from highest channel number to lowest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer) */
+#define LL_ADC_REG_SEQ_SCAN_DIR_FORWARD    (0x00000000UL)         /*!< On this STM32 series, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction forward: from lowest channel number to highest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer). On some other STM32 families, this setting is not available and the default scan direction is forward. */
+#define LL_ADC_REG_SEQ_SCAN_DIR_BACKWARD   (ADC_CFGR1_SCANDIR)    /*!< On this STM32 series, parameter relevant only is sequencer set to mode not fully configurable, refer to function @ref LL_ADC_REG_SetSequencerConfigurable(). ADC group regular sequencer scan direction backward: from highest channel number to lowest channel number (scan of all ranks, ADC conversion of ranks with channels enabled in sequencer) */
 /**
   * @}
   */
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /** @defgroup ADC_LL_EC_REG_SEQ_DISCONT_MODE  ADC group regular - Sequencer discontinuous mode
   * @{
   */
 #define LL_ADC_REG_SEQ_DISCONT_DISABLE     (0x00000000UL)                                                               /*!< ADC group regular sequencer discontinuous mode disable */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_REG_SEQ_DISCONT_1RANK       (ADC_CFGR1_DISCEN)                                                               /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every rank */
 #else
 #define LL_ADC_REG_SEQ_DISCONT_1RANK       (                                                               ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every rank */
@@ -1076,7 +1075,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_SEQ_RANKS  ADC group regular - Sequencer ranks
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_REG_RANK_1                  (ADC_REG_RANK_1_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 1 */
 #define LL_ADC_REG_RANK_2                  (ADC_REG_RANK_2_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 2 */
 #define LL_ADC_REG_RANK_3                  (ADC_REG_RANK_3_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 3 */
@@ -1107,7 +1106,7 @@ typedef struct
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /** @defgroup ADC_LL_EC_INJ_TRIGGER_SOURCE  ADC group injected - Trigger source
@@ -1188,7 +1187,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_CHANNEL_SAMPLINGTIME  Channel - Sampling time
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_SAMPLINGTIME_1CYCLE_5       (0x00000000UL)                                        /*!< Sampling time 1.5 ADC clock cycle */
 #define LL_ADC_SAMPLINGTIME_3CYCLES_5      (ADC_SMPR_SMP1_0)                                     /*!< Sampling time 3.5 ADC clock cycles */
 #define LL_ADC_SAMPLINGTIME_7CYCLES_5      (ADC_SMPR_SMP1_1)                                     /*!< Sampling time 7.5 ADC clock cycles */
@@ -1206,7 +1205,7 @@ typedef struct
 #define LL_ADC_SAMPLINGTIME_92CYCLES_5     (ADC_SMPR2_SMP10_2                     | ADC_SMPR2_SMP10_0) /*!< Sampling time 92.5 ADC clock cycles */
 #define LL_ADC_SAMPLINGTIME_247CYCLES_5    (ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1                    ) /*!< Sampling time 247.5 ADC clock cycles */
 #define LL_ADC_SAMPLINGTIME_640CYCLES_5    (ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0) /*!< Sampling time 640.5 ADC clock cycles */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -1214,13 +1213,13 @@ typedef struct
 /** @defgroup ADC_LL_EC_CHANNEL_SINGLE_DIFF_ENDING  Channel - Single or differential ending
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_SINGLE_ENDED                (0x00000000UL)                                    /*!< ADC channel ending set to single ended (literal also used to set calibration mode) */
 #else
 #define LL_ADC_SINGLE_ENDED                (                  ADC_CALFACT_CALFACT_S)         /*!< ADC channel ending set to single ended (literal also used to set calibration mode) */
 #define LL_ADC_DIFFERENTIAL_ENDED          (ADC_CR_ADCALDIF | ADC_CALFACT_CALFACT_D)         /*!< ADC channel ending set to differential (literal also used to set calibration mode) */
 #define LL_ADC_BOTH_SINGLE_DIFF_ENDED      (LL_ADC_SINGLE_ENDED | LL_ADC_DIFFERENTIAL_ENDED) /*!< ADC channel ending set to both single ended and differential (literal used only to set calibration factors) */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -1229,12 +1228,12 @@ typedef struct
   * @{
   */
 #define LL_ADC_AWD1                        (ADC_AWD_CR1_CHANNEL_MASK  | ADC_AWD_CR1_REGOFFSET) /*!< ADC analog watchdog number 1 */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC analog watchdog 2 and 3" not available on ADC peripheral of this STM32WB device */
 #else
 #define LL_ADC_AWD2                        (ADC_AWD_CR23_CHANNEL_MASK | ADC_AWD_CR2_REGOFFSET) /*!< ADC analog watchdog number 2 */
 #define LL_ADC_AWD3                        (ADC_AWD_CR23_CHANNEL_MASK | ADC_AWD_CR3_REGOFFSET) /*!< ADC analog watchdog number 3 */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -1242,7 +1241,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_AWD_CHANNELS  Analog watchdog - Monitored channels
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_AWD_DISABLE                 (0x00000000UL)                                                                             /*!< ADC analog watchdog monitoring disabled */
 #define LL_ADC_AWD_ALL_CHANNELS_REG        (                                                    ADC_CFGR1_AWD1EN                    ) /*!< ADC analog watchdog monitoring of all channels, converted by group regular only */
 #define LL_ADC_AWD_CHANNEL_0_REG           ((LL_ADC_CHANNEL_0  & ADC_CHANNEL_ID_MASK)         | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN0, converted by group regular only */
@@ -1346,9 +1345,15 @@ typedef struct
 /** @defgroup ADC_LL_EC_AWD_THRESHOLDS  Analog watchdog - Thresholds
   * @{
   */
+#if defined (ADC_SUPPORT_2_5_MSPS)
+#define LL_ADC_AWD_THRESHOLD_HIGH          (ADC_TR_HT            )   /*!< ADC analog watchdog threshold high */
+#define LL_ADC_AWD_THRESHOLD_LOW           (            ADC_TR_LT)   /*!< ADC analog watchdog threshold low */
+#define LL_ADC_AWD_THRESHOLDS_HIGH_LOW     (ADC_TR_HT | ADC_TR_LT)   /*!< ADC analog watchdog both thresholds high and low concatenated into the same data */
+#else
 #define LL_ADC_AWD_THRESHOLD_HIGH          (ADC_TR1_HT1              ) /*!< ADC analog watchdog threshold high */
 #define LL_ADC_AWD_THRESHOLD_LOW           (              ADC_TR1_LT1) /*!< ADC analog watchdog threshold low */
 #define LL_ADC_AWD_THRESHOLDS_HIGH_LOW     (ADC_TR1_HT1 | ADC_TR1_LT1) /*!< ADC analog watchdog both thresholds high and low concatenated into the same data */
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -1356,7 +1361,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_OVS_SCOPE  Oversampling - Oversampling scope
   * @{
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_OVS_DISABLE                 (0x00000000UL)                                        /*!< ADC oversampling disabled. */
 #define LL_ADC_OVS_GRP_REGULAR_CONTINUED   (                                    ADC_CFGR2_OVSE)  /*!< ADC oversampling on conversions of ADC group regular. Literal suffix "continued" is kept for compatibility with other STM32 devices featuring ADC group injected, in this case other oversampling scope parameters are available. */
 #else
@@ -1365,7 +1370,7 @@ typedef struct
 #define LL_ADC_OVS_GRP_REGULAR_RESUMED     (ADC_CFGR2_ROVSM |                   ADC_CFGR2_ROVSE) /*!< ADC oversampling on conversions of ADC group regular. If group injected interrupts group regular: when ADC group injected is triggered, the oversampling on ADC group regular is resumed from start (oversampler buffer reset). */
 #define LL_ADC_OVS_GRP_INJECTED            (                  ADC_CFGR2_JOVSE                  ) /*!< ADC oversampling on conversions of ADC group injected. */
 #define LL_ADC_OVS_GRP_INJ_REG_RESUMED     (                  ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSE) /*!< ADC oversampling on conversions of both ADC groups regular and injected. If group injected interrupting group regular: when ADC group injected is triggered, the oversampling on ADC group regular is resumed from start (oversampler buffer reset). */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -1374,11 +1379,11 @@ typedef struct
   * @{
   */
 #define LL_ADC_OVS_REG_CONT                (0x00000000UL)         /*!< ADC oversampling discontinuous mode: continuous mode (all conversions of oversampling ratio are done from 1 trigger) */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_ADC_OVS_REG_DISCONT             (ADC_CFGR2_TOVS)       /*!< ADC oversampling discontinuous mode: discontinuous mode (each conversion of oversampling ratio needs a trigger) */
 #else
 #define LL_ADC_OVS_REG_DISCONT             (ADC_CFGR2_TROVS)      /*!< ADC oversampling discontinuous mode: discontinuous mode (each conversion of oversampling ratio needs a trigger) */
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -1429,7 +1434,7 @@ typedef struct
 /*       configuration (system clock versus ADC clock),                       */
 /*       and therefore must be defined in user application.                   */
 /*       Indications for estimation of ADC timeout delays, for this           */
-/*       STM32 serie:                                                         */
+/*       STM32 series:                                                         */
 /*       - ADC calibration time: maximum delay is 112/fADC.                   */
 /*         (refer to device datasheet, parameter "tCAL")                      */
 /*       - ADC enable time: maximum delay is 1 conversion cycle.              */
@@ -1445,7 +1450,7 @@ typedef struct
 /* Delay set to maximum value (refer to device datasheet,                     */
 /* parameter "tADCVREG_STUP").                                                */
 /* Unit: us                                                                   */
-#define LL_ADC_DELAY_INTERNAL_REGUL_STAB_US ( 10UL)  /*!< Delay for ADC stabilization time (ADC voltage regulator start-up time) */
+#define LL_ADC_DELAY_INTERNAL_REGUL_STAB_US ( 20UL)  /*!< Delay for ADC stabilization time (ADC voltage regulator start-up time) */
 
 /* Delay for internal voltage reference stabilization time.                   */
 /* Delay set to maximum value (refer to device datasheet,                     */
@@ -1461,7 +1466,7 @@ typedef struct
 #define LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US ( 15UL)  /*!< Delay for temperature sensor buffer stabilization time (starting from ADC enable, refer to @ref LL_ADC_Enable()) */
 
 /* Delay required between ADC end of calibration and ADC enable.              */
-/* Note: On this STM32 serie, a minimum number of ADC clock cycles            */
+/* Note: On this STM32 series, a minimum number of ADC clock cycles            */
 /*       are required between ADC end of calibration and ADC enable.          */
 /*       Wait time can be computed in user application by waiting for the     */
 /*       equivalent number of CPU cycles, by taking into account              */
@@ -1544,7 +1549,7 @@ typedef struct
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval Value between Min_Data=0 and Max_Data=18
   */
@@ -1590,13 +1595,13 @@ typedef struct
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (4)
   *         @arg @ref LL_ADC_CHANNEL_VBAT         (4)
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).\n
   *         (4) For ADC channel read back from ADC register,
   *             comparison with internal channel parameter to be done
   *             using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
   */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define __LL_ADC_DECIMAL_NB_TO_CHANNEL(__DECIMAL_NB__)                         \
   (                                                                            \
    ((__DECIMAL_NB__) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) |                 \
@@ -1660,7 +1665,7 @@ typedef struct
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval Value "0" if the channel corresponds to a parameter definition of a ADC external channel (channel connected to a GPIO pin).
   *         Value "1" if the channel corresponds to a parameter definition of a ADC internal channel.
@@ -1705,7 +1710,7 @@ typedef struct
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_ADC_CHANNEL_0
@@ -1759,7 +1764,7 @@ typedef struct
     ((__CHANNEL__) == LL_ADC_CHANNEL_VBAT)                                     \
   )
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Helper macro to define ADC analog watchdog parameter:
   *         define a single channel to monitor with analog watchdog
@@ -1793,7 +1798,7 @@ typedef struct
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (4)
   *         @arg @ref LL_ADC_CHANNEL_VBAT         (4)
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).\n
   *         (4) For ADC channel read back from ADC register,
   *             comparison with internal channel parameter to be done
@@ -1864,7 +1869,7 @@ typedef struct
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (4)
   *         @arg @ref LL_ADC_CHANNEL_VBAT         (4)
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).\n
   *         (4) For ADC channel read back from ADC register,
   *             comparison with internal channel parameter to be done
@@ -1946,7 +1951,7 @@ typedef struct
   *         @arg @ref LL_ADC_AWD_CH_VBAT_REG_INJ            (1)
   *
   *         (0) On STM32WB, parameter available only on analog watchdog number: AWD1.
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
 #define __LL_ADC_ANALOGWD_CHANNEL_GROUP(__CHANNEL__, __GROUP__)                                           \
   (((__GROUP__) == LL_ADC_GROUP_REGULAR)                                                                  \
@@ -1957,7 +1962,7 @@ typedef struct
    :                                                                                                      \
    (((__CHANNEL__) & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL)        \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @brief  Helper macro to set the value of ADC analog watchdog threshold high
@@ -2162,7 +2167,7 @@ typedef struct
   *         connected to pin Vref+.
   *         On devices with small package, the pin Vref+ is not present
   *         and internally bonded to pin Vdda.
-  * @note   On this STM32 serie, calibration data of internal voltage reference
+  * @note   On this STM32 series, calibration data of internal voltage reference
   *         VrefInt corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         internal voltage reference VrefInt.
@@ -2211,7 +2216,7 @@ typedef struct
   * @note   Analog reference voltage (Vref+) must be either known from
   *         user board environment or can be calculated using ADC measurement
   *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
-  * @note   On this STM32 serie, calibration data of temperature sensor
+  * @note   On this STM32 series, calibration data of temperature sensor
   *         corresponds to a resolution of 12 bits,
   *         this is the recommended ADC resolution to convert voltage of
   *         temperature sensor.
@@ -2351,7 +2356,7 @@ typedef struct
   *         @arg @ref LL_ADC_DMA_REG_REGULAR_DATA
   * @retval ADC register address
   */
-__STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(ADC_TypeDef *ADCx, uint32_t Register)
+__STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(const ADC_TypeDef *ADCx, uint32_t Register)
 {
   /* Prevent unused argument(s) compilation warning */
   (void)(Register);
@@ -2374,11 +2379,11 @@ __STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(ADC_TypeDef *ADCx, uint32_t Regis
   *         Example: STM32WB55xx ADC maximum frequency is 64MHz (corresponding to 4.27Msmp/s maximum)
   *         Example: STM32WB50xx ADC maximum frequency is 32MHz (corresponding to 2.13Msmp/s maximum)
   *         For ADC maximum frequency, refer to datasheet of the selected device.
-  * @note   On this STM32 serie, if ADC group injected is used, some
+  * @note   On this STM32 series, if ADC group injected is used, some
   *         clock ratio constraints between ADC clock and AHB clock
   *         must be respected.
   *         Refer to reference manual.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         All ADC instances of the ADC common group must be disabled.
   *         This check can be done with function @ref LL_ADC_IsEnabled() for each
@@ -2410,11 +2415,11 @@ __STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(ADC_TypeDef *ADCx, uint32_t Regis
   */
 __STATIC_INLINE void LL_ADC_SetCommonClock(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t CommonClock)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_PRESC, CommonClock);
 #else
   MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_CKMODE | ADC_CCR_PRESC, CommonClock);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -2442,13 +2447,13 @@ __STATIC_INLINE void LL_ADC_SetCommonClock(ADC_Common_TypeDef *ADCxy_COMMON, uin
   *
   *         (*) Value available on all STM32 devices except: STM32W10xxx, STM32W15xxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_GetCommonClock(ADC_Common_TypeDef *ADCxy_COMMON)
+__STATIC_INLINE uint32_t LL_ADC_GetCommonClock(const ADC_Common_TypeDef *ADCxy_COMMON)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_PRESC));
 #else
   return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_CKMODE | ADC_CCR_PRESC));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -2470,7 +2475,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetCommonClock(ADC_Common_TypeDef *ADCxy_COMMON)
   *         For ADC conversion of internal channels,
   *         a sampling time minimum value is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         All ADC instances of the ADC common group must be disabled.
   *         This check can be done with function @ref LL_ADC_IsEnabled() for each
@@ -2511,7 +2516,7 @@ __STATIC_INLINE void LL_ADC_SetCommonPathInternalCh(ADC_Common_TypeDef *ADCxy_CO
   *         For ADC conversion of internal channels,
   *         a sampling time minimum value is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         All ADC instances of the ADC common group must be disabled.
   *         This check can be done with function @ref LL_ADC_IsEnabled() for each
@@ -2541,7 +2546,7 @@ __STATIC_INLINE void LL_ADC_SetCommonPathInternalChAdd(ADC_Common_TypeDef *ADCxy
   * @note   One or several values can be selected.
   *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
   *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         All ADC instances of the ADC common group must be disabled.
   *         This check can be done with function @ref LL_ADC_IsEnabled() for each
@@ -2581,7 +2586,7 @@ __STATIC_INLINE void LL_ADC_SetCommonPathInternalChRem(ADC_Common_TypeDef *ADCxy
   *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
   *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
   */
-__STATIC_INLINE uint32_t LL_ADC_GetCommonPathInternalCh(ADC_Common_TypeDef *ADCxy_COMMON)
+__STATIC_INLINE uint32_t LL_ADC_GetCommonPathInternalCh(const ADC_Common_TypeDef *ADCxy_COMMON)
 {
   return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_VREFEN | ADC_CCR_TSEN | ADC_CCR_VBATEN));
 }
@@ -2594,10 +2599,10 @@ __STATIC_INLINE uint32_t LL_ADC_GetCommonPathInternalCh(ADC_Common_TypeDef *ADCx
   * @{
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set ADC instance clock source and prescaler.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled.
   * @rmtoll CFGR2    CKMODE         LL_ADC_SetClock
@@ -2646,9 +2651,9 @@ __STATIC_INLINE uint32_t LL_ADC_GetClock(ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_CKMODE));
 }
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set ADC calibration factor in the mode single-ended
   *         or differential (for devices with differential mode available).
@@ -2666,7 +2671,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetClock(ADC_TypeDef *ADCx)
   *         both calibration factors must be concatenated.
   *         To perform this processing, use helper macro
   *         @ref __LL_ADC_CALIB_FACTOR_SINGLE_DIFF().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled, without calibration on going, without conversion
   *         on going on group regular.
@@ -2700,7 +2705,7 @@ __STATIC_INLINE void LL_ADC_SetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t Cal
   *         both calibration factors must be concatenated.
   *         To perform this processing, use helper macro
   *         @ref __LL_ADC_CALIB_FACTOR_SINGLE_DIFF().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled, without calibration on going, without conversion
   *         on going on group regular.
@@ -2712,7 +2717,7 @@ __STATIC_INLINE void LL_ADC_SetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t Cal
   *         @arg @ref LL_ADC_DIFFERENTIAL_ENDED     (1)
   *         @arg @ref LL_ADC_BOTH_SINGLE_DIFF_ENDED (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @param  CalibrationFactor Value between Min_Data=0x00 and Max_Data=0x7F
   * @retval None
   */
@@ -2724,7 +2729,7 @@ __STATIC_INLINE void LL_ADC_SetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t Sin
 }
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Get ADC calibration factor in the mode single-ended
   *         or differential (for devices with differential mode available).
@@ -2738,7 +2743,7 @@ __STATIC_INLINE void LL_ADC_SetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t Sin
   * @param  ADCx ADC instance
   * @retval Value between Min_Data=0x00 and Max_Data=0x7F
   */
-__STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CALFACT, ADC_CALFACT_CALFACT));
 }
@@ -2759,7 +2764,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_DIFFERENTIAL_ENDED
   * @retval Value between Min_Data=0x00 and Max_Data=0x7F
   */
-__STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t SingleDiff)
+__STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(const ADC_TypeDef *ADCx, uint32_t SingleDiff)
 {
   /* Retrieve bits with position in register depending on parameter           */
   /* "SingleDiff".                                                            */
@@ -2772,7 +2777,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t
   * @brief  Set ADC resolution.
   *         Refer to reference manual for alignments formats
   *         dependencies to ADC resolutions.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -2787,11 +2792,11 @@ __STATIC_INLINE uint32_t LL_ADC_GetCalibrationFactor(ADC_TypeDef *ADCx, uint32_t
   */
 __STATIC_INLINE void LL_ADC_SetResolution(ADC_TypeDef *ADCx, uint32_t Resolution)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_RES, Resolution);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -2806,20 +2811,20 @@ __STATIC_INLINE void LL_ADC_SetResolution(ADC_TypeDef *ADCx, uint32_t Resolution
   *         @arg @ref LL_ADC_RESOLUTION_8B
   *         @arg @ref LL_ADC_RESOLUTION_6B
   */
-__STATIC_INLINE uint32_t LL_ADC_GetResolution(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetResolution(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_RES));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
   * @brief  Set ADC conversion data alignment.
   * @note   Refer to reference manual for alignments formats
   *         dependencies to ADC resolutions.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -2832,11 +2837,11 @@ __STATIC_INLINE uint32_t LL_ADC_GetResolution(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_SetDataAlignment(ADC_TypeDef *ADCx, uint32_t DataAlignment)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_ALIGN, DataAlignment);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_ALIGN, DataAlignment);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -2849,13 +2854,13 @@ __STATIC_INLINE void LL_ADC_SetDataAlignment(ADC_TypeDef *ADCx, uint32_t DataAli
   *         @arg @ref LL_ADC_DATA_ALIGN_RIGHT
   *         @arg @ref LL_ADC_DATA_ALIGN_LEFT
   */
-__STATIC_INLINE uint32_t LL_ADC_GetDataAlignment(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetDataAlignment(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_ALIGN));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_ALIGN));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -2898,7 +2903,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetDataAlignment(ADC_TypeDef *ADCx)
   *         Therefore, the ADC conversion data may be outdated: does not
   *         correspond to the current voltage level on the selected
   *         ADC channel.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -2910,16 +2915,16 @@ __STATIC_INLINE uint32_t LL_ADC_GetDataAlignment(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_LP_AUTOPOWEROFF          (1)
   *         @arg @ref LL_ADC_LP_AUTOWAIT_AUTOPOWEROFF (1)
   *
-  *         (1) On STM32WB serie, parameter available only on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter available only on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_SetLowPowerMode(ADC_TypeDef *ADCx, uint32_t LowPowerMode)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, (ADC_CFGR1_WAIT | ADC_CFGR1_AUTOFF), LowPowerMode);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_AUTDLY, LowPowerMode);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -2970,18 +2975,18 @@ __STATIC_INLINE void LL_ADC_SetLowPowerMode(ADC_TypeDef *ADCx, uint32_t LowPower
   *         @arg @ref LL_ADC_LP_AUTOPOWEROFF          (1)
   *         @arg @ref LL_ADC_LP_AUTOWAIT_AUTOPOWEROFF (1)
   *
-  *         (1) On STM32WB serie, parameter available only on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter available only on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_GetLowPowerMode(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetLowPowerMode(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, (ADC_CFGR1_WAIT | ADC_CFGR1_AUTOFF)));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_AUTDLY));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set ADC trigger frequency mode.
   * @note   ADC trigger frequency mode must be set to low frequency when
@@ -2995,7 +3000,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetLowPowerMode(ADC_TypeDef *ADCx)
   * @note   Usage of ADC trigger frequency mode with ADC low power mode:
   *         - Low power mode auto wait: Only the first ADC conversion
   *           start trigger inserts the rearm delay.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3024,12 +3029,12 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_LFTRIG));
 }
 
-#endif
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#endif /* ADC_SUPPORT_2_5_MSPS */
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set sampling time common to a group of channels.
   * @note   Unit: ADC clock cycles.
-  * @note   On this STM32 serie, sampling time scope is on ADC instance:
+  * @note   On this STM32 series, sampling time scope is on ADC instance:
   *         Sampling time common to all channels, independently
   *         of channels mapped on ADC group regular or injected.
   *         (on some other STM32 families, sampling time is channel wise)
@@ -3041,7 +3046,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
   *         Refer to device datasheet for timings values (parameters TS_vrefint,
   *         TS_temp, ...).
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -3050,7 +3055,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetTriggerFrequencyMode(ADC_TypeDef *ADCx)
   *         temperature sensor, ...), a sampling time minimum value
   *         is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -3081,12 +3086,12 @@ __STATIC_INLINE void LL_ADC_SetSamplingTimeCommonChannels(ADC_TypeDef *ADCx, uin
 /**
   * @brief  Get sampling time common to a group of channels.
   * @note   Unit: ADC clock cycles.
-  * @note   On this STM32 serie, sampling time scope is on ADC instance:
+  * @note   On this STM32 series, sampling time scope is on ADC instance:
   *         Sampling time common to all channels, independently
   *         of channels mapped on ADC group regular or injected.
   *         (on some other STM32 families, sampling time is channel wise)
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -3113,9 +3118,9 @@ __STATIC_INLINE uint32_t LL_ADC_GetSamplingTimeCommonChannels(ADC_TypeDef *ADCx,
                     >> (SamplingTimeY & ADC_SAMPLING_TIME_SMP_SHIFT_MASK));
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC offset" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -3133,11 +3138,11 @@ __STATIC_INLINE uint32_t LL_ADC_GetSamplingTimeCommonChannels(ADC_TypeDef *ADCx,
   *         to disable state using function LL_ADC_SetOffsetState().
   * @note   If a channel is mapped on several offsets numbers, only the offset
   *         with the lowest value is considered for the subtraction.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
   * @rmtoll OFR1     OFFSET1_CH     LL_ADC_SetOffset\n
   *         OFR1     OFFSET1        LL_ADC_SetOffset\n
@@ -3181,7 +3186,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetSamplingTimeCommonChannels(ADC_TypeDef *ADCx,
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @param  OffsetLevel Value between Min_Data=0x000 and Max_Data=0xFFF
   * @retval None
@@ -3211,7 +3216,7 @@ __STATIC_INLINE void LL_ADC_SetOffset(ADC_TypeDef *ADCx, uint32_t Offsety, uint3
   *         - To get the channel number in decimal format:
   *           process the returned value with the helper macro
   *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
   * @rmtoll OFR1     OFFSET1_CH     LL_ADC_GetOffsetChannel\n
   *         OFR2     OFFSET2_CH     LL_ADC_GetOffsetChannel\n
@@ -3247,13 +3252,13 @@ __STATIC_INLINE void LL_ADC_SetOffset(ADC_TypeDef *ADCx, uint32_t Offsety, uint3
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (4)
   *         @arg @ref LL_ADC_CHANNEL_VBAT         (4)
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).\n
   *         (4) For ADC channel read back from ADC register,
   *             comparison with internal channel parameter to be done
   *             using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOffsetChannel(ADC_TypeDef *ADCx, uint32_t Offsety)
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetChannel(const ADC_TypeDef *ADCx, uint32_t Offsety)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
 
@@ -3279,7 +3284,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOffsetChannel(ADC_TypeDef *ADCx, uint32_t Off
   *         @arg @ref LL_ADC_OFFSET_4
   * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOffsetLevel(ADC_TypeDef *ADCx, uint32_t Offsety)
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetLevel(const ADC_TypeDef *ADCx, uint32_t Offsety)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
 
@@ -3293,7 +3298,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOffsetLevel(ADC_TypeDef *ADCx, uint32_t Offse
   * @note   This function should be needed only in case of offset to be
   *         enabled-disabled dynamically, and should not be needed in other cases:
   *         function LL_ADC_SetOffset() automatically enables the offset.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -3338,14 +3343,14 @@ __STATIC_INLINE void LL_ADC_SetOffsetState(ADC_TypeDef *ADCx, uint32_t Offsety, 
   *         @arg @ref LL_ADC_OFFSET_DISABLE
   *         @arg @ref LL_ADC_OFFSET_ENABLE
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOffsetState(ADC_TypeDef *ADCx, uint32_t Offsety)
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetState(const ADC_TypeDef *ADCx, uint32_t Offsety)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
 
   return (uint32_t) READ_BIT(*preg, ADC_OFR1_OFFSET1_EN);
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @}
@@ -3359,19 +3364,19 @@ __STATIC_INLINE uint32_t LL_ADC_GetOffsetState(ADC_TypeDef *ADCx, uint32_t Offse
   * @brief  Set ADC group regular conversion trigger source:
   *         internal (SW start) or from external peripheral (timer event,
   *         external interrupt line).
-  * @note   On this STM32 serie, setting trigger source to external trigger
+  * @note   On this STM32 series, setting trigger source to external trigger
   *         also set trigger polarity to rising edge
   *         (default setting for compatibility with some ADC on other
   *         STM32 families having this setting set by HW default value).
   *         In case of need to modify trigger edge, use
   *         function @ref LL_ADC_REG_SetTriggerEdge().
-  * @note   On devices STM32WB10xx, STM32WB15xx: ADC trigger frequency mode must be set
+  * @note   On devices STM32WB10xx, STM32WB15xx, STM32WB1Mxx: ADC trigger frequency mode must be set
   *         in function of frequency of ADC group regular conversion trigger.
   *         Refer to description of function
   *         "LL_ADC_SetTriggerFrequencyMode()".
   * @note   Availability of parameters of trigger sources from timer
   *         depends on timers availability on the selected device.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3392,17 +3397,17 @@ __STATIC_INLINE uint32_t LL_ADC_GetOffsetState(ADC_TypeDef *ADCx, uint32_t Offse
   *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM2_CH4   (2)
   *         @arg @ref LL_ADC_REG_TRIG_EXT_EXTI_LINE11
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
-  *         (2) On STM32WB serie, parameter available only devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
+  *         (2) On STM32WB series, parameter available only devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_REG_SetTriggerSource(ADC_TypeDef *ADCx, uint32_t TriggerSource)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_EXTEN | ADC_CFGR1_EXTSEL, TriggerSource);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_EXTEN | ADC_CFGR_EXTSEL, TriggerSource);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -3434,12 +3439,12 @@ __STATIC_INLINE void LL_ADC_REG_SetTriggerSource(ADC_TypeDef *ADCx, uint32_t Tri
   *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM2_CH4   (2)
   *         @arg @ref LL_ADC_REG_TRIG_EXT_EXTI_LINE11
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
-  *         (2) On STM32WB serie, parameter available only devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
+  *         (2) On STM32WB series, parameter available only devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerSource(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerSource(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   __IO uint32_t TriggerSource = READ_BIT(ADCx->CFGR1, ADC_CFGR1_EXTSEL | ADC_CFGR1_EXTEN);
 
   /* Value for shift of {0; 4; 8; 12} depending on value of bitfield          */
@@ -3465,7 +3470,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerSource(ADC_TypeDef *ADCx)
            & (ADC_REG_TRIG_SOURCE_MASK >> ShiftExten) & ADC_CFGR_EXTSEL)
           | ((ADC_REG_TRIG_EDGE_MASK >> ShiftExten) & ADC_CFGR_EXTEN)
          );
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -3479,19 +3484,19 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerSource(ADC_TypeDef *ADCx)
   * @retval Value "0" if trigger source external trigger
   *         Value "1" if trigger source SW start.
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_IsTriggerSourceSWStart(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_IsTriggerSourceSWStart(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return ((READ_BIT(ADCx->CFGR1, ADC_CFGR1_EXTEN) == (LL_ADC_REG_TRIG_SOFTWARE & ADC_CFGR1_EXTEN)) ? 1UL : 0UL);
 #else
   return ((READ_BIT(ADCx->CFGR, ADC_CFGR_EXTEN) == (LL_ADC_REG_TRIG_SOFTWARE & ADC_CFGR_EXTEN)) ? 1UL : 0UL);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
   * @brief  Set ADC group regular conversion trigger polarity.
   * @note   Applicable only for trigger source set to external trigger.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3505,11 +3510,11 @@ __STATIC_INLINE uint32_t LL_ADC_REG_IsTriggerSourceSWStart(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_REG_SetTriggerEdge(ADC_TypeDef *ADCx, uint32_t ExternalTriggerEdge)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_EXTEN, ExternalTriggerEdge);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_EXTEN, ExternalTriggerEdge);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -3522,19 +3527,19 @@ __STATIC_INLINE void LL_ADC_REG_SetTriggerEdge(ADC_TypeDef *ADCx, uint32_t Exter
   *         @arg @ref LL_ADC_REG_TRIG_EXT_FALLING
   *         @arg @ref LL_ADC_REG_TRIG_EXT_RISINGFALLING
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerEdge(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerEdge(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_EXTEN));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_EXTEN));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set ADC group regular sequencer configuration flexibility.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable" are
   *         available:
   *         - sequencer configured to fully configurable:
@@ -3547,7 +3552,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerEdge(ADC_TypeDef *ADCx)
   *           are fixed by channel HW number.
   *           Refer to description of function
   *           @ref LL_ADC_REG_SetSequencerChannels().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3565,7 +3570,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerConfigurable(ADC_TypeDef *ADCx, uint
 
 /**
   * @brief  Get ADC group regular sequencer configuration flexibility.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable" are
   *         available:
   *         - sequencer configured to fully configurable:
@@ -3589,7 +3594,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerConfigurable(ADC_TypeDef *ADCx)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_CHSELRMOD));
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief  Set ADC group regular sequencer length and scan direction.
   * @note   Description of ADC group regular sequencer features:
@@ -3619,7 +3624,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerConfigurable(ADC_TypeDef *ADCx)
   *           function "LL_ADC_REG_SetSequencerChannels()".
   *           To set scan direction differently, refer to function
   *           "LL_ADC_REG_SetSequencerScanDirection()".
-  * @note   On devices STM32WB10xx, STM32WB15xx: after calling functions
+  * @note   On devices STM32WB10xx, STM32WB15xx, STM32WB1Mxx: after calling functions
   *         @ref LL_ADC_REG_SetSequencerLength()
   *         or @ref LL_ADC_REG_SetSequencerRanks(),
   *         it is mandatory to wait for the assertion of CCRDY flag
@@ -3629,7 +3634,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerConfigurable(ADC_TypeDef *ADCx)
   *         Refer to reference manual for more details.
   * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
   *         ADC conversion on only 1 channel.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3660,16 +3665,16 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerConfigurable(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS (1)
   *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t SequencerNbRanks)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   SET_BIT(ADCx->CHSELR, SequencerNbRanks);
 #else
   MODIFY_REG(ADCx->SQR1, ADC_SQR1_L, SequencerNbRanks);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -3730,11 +3735,11 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS (1)
   *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerLength(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerLength(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   __IO uint32_t ChannelsRanks = READ_BIT(ADCx->CHSELR, ADC_CHSELR_SQ_ALL);
   uint32_t SequencerLength = LL_ADC_REG_SEQ_SCAN_ENABLE_8RANKS;
   uint32_t RankIndex;
@@ -3752,18 +3757,18 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerLength(ADC_TypeDef *ADCx)
   return SequencerLength;
 #else
   return (uint32_t)(READ_BIT(ADCx->SQR1, ADC_SQR1_L));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set ADC group regular sequencer scan direction.
-  * @note   On this STM32 serie, parameter relevant only is sequencer is set
+  * @note   On this STM32 series, parameter relevant only is sequencer is set
   *         to mode not fully configurable,
   *         refer to function @ref LL_ADC_REG_SetSequencerConfigurable().
   * @note   On some other STM32 families, this setting is not available and
   *         the default scan direction is forward.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3794,7 +3799,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerScanDirection(ADC_TypeDef *ADCx)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_SCANDIR));
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief  Set ADC group regular sequencer discontinuous mode:
   *         sequence subdivided and scan conversions interrupted every selected
@@ -3803,7 +3808,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerScanDirection(ADC_TypeDef *ADCx)
   *         continuous mode and sequencer discontinuous mode.
   * @note   It is not possible to enable both ADC auto-injected mode
   *         and ADC group regular sequencer discontinuous mode.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3821,16 +3826,16 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerScanDirection(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_REG_SEQ_DISCONT_7RANKS (1)
   *         @arg @ref LL_ADC_REG_SEQ_DISCONT_8RANKS (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_REG_SetSequencerDiscont(ADC_TypeDef *ADCx, uint32_t SeqDiscont)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_DISCEN, SeqDiscont);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM, SeqDiscont);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -3851,15 +3856,15 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerDiscont(ADC_TypeDef *ADCx, uint32_t 
   *         @arg @ref LL_ADC_REG_SEQ_DISCONT_7RANKS (1)
   *         @arg @ref LL_ADC_REG_SEQ_DISCONT_8RANKS (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_DISCEN));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -3868,17 +3873,17 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(ADC_TypeDef *ADCx)
   * @note   This function performs configuration of:
   *         - Channels ordering into each rank of scan sequence:
   *           whatever channel can be placed into whatever rank.
-  * @note   On this STM32 serie, ADC group regular sequencer is
+  * @note   On this STM32 series, ADC group regular sequencer is
   *         fully configurable: sequencer length and each rank
   *         affectation to a channel are configurable.
   *         Refer to description of function @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On devices STM32WB10xx, STM32WB15xx: after calling functions
+  * @note   On devices STM32WB10xx, STM32WB15xx, STM32WB1Mxx: after calling functions
   *         @ref LL_ADC_REG_SetSequencerLength()
   *         or @ref LL_ADC_REG_SetSequencerRanks(),
   *         it is mandatory to wait for the assertion of CCRDY flag
@@ -3886,7 +3891,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(ADC_TypeDef *ADCx)
   *         Otherwise, performing some actions (configuration update,
   *         ADC conversion start, ... ) will be ignored.
   *         Refer to reference manual for more details.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -3925,7 +3930,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_REG_RANK_15 (1)
   *         @arg @ref LL_ADC_REG_RANK_16 (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @param  Channel This parameter can be one of the following values:
   *         @arg @ref LL_ADC_CHANNEL_0
   *         @arg @ref LL_ADC_CHANNEL_1            (7)
@@ -3950,13 +3955,13 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank, uint32_t Channel)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* Set bits with content of parameter "Channel" with bits position          */
   /* in register depending on parameter "Rank".                               */
   /* Parameters "Rank" and "Channel" are used with masks because containing   */
@@ -3974,13 +3979,13 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   MODIFY_REG(*preg,
              ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 << (Rank & ADC_REG_RANK_ID_SQRX_MASK),
              ((Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (Rank & ADC_REG_RANK_ID_SQRX_MASK));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
   * @brief  Get ADC group regular sequence: channel on the selected
   *         scan sequence rank.
-  * @note   On this STM32 serie, ADC group regular sequencer is
+  * @note   On this STM32 series, ADC group regular sequencer is
   *         fully configurable: sequencer length and each rank
   *         affectation to a channel are configurable.
   *         Refer to description of function @ref LL_ADC_REG_SetSequencerLength().
@@ -4032,7 +4037,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   *         @arg @ref LL_ADC_REG_RANK_15 (1)
   *         @arg @ref LL_ADC_REG_RANK_16 (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_ADC_CHANNEL_0
   *         @arg @ref LL_ADC_CHANNEL_1            (7)
@@ -4057,15 +4062,15 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (4)
   *         @arg @ref LL_ADC_CHANNEL_VBAT         (4)
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).\n
   *         (4) For ADC channel read back from ADC register,
   *             comparison with internal channel parameter to be done
   *             using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t) ((READ_BIT(ADCx->CHSELR,
                                ADC_CHSELR_SQ1 << (Rank & ADC_REG_RANK_ID_SQRX_MASK))
                       >> (Rank & ADC_REG_RANK_ID_SQRX_MASK)
@@ -4078,10 +4083,10 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_
                               ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 << (Rank & ADC_REG_RANK_ID_SQRX_MASK))
                      >> (Rank & ADC_REG_RANK_ID_SQRX_MASK)) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS
                    );
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set ADC group regular sequence: channel on rank corresponding to
   *         channel number.
@@ -4091,7 +4096,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
   *         - Set channels selected by overwriting the current sequencer
   *           configuration.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
@@ -4100,13 +4105,13 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_
   *         and @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4156,7 +4161,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval None
   */
@@ -4176,7 +4181,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChannels(ADC_TypeDef *ADCx, uint32_t
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
   *         - Set channels selected by adding them to the current sequencer
   *           configuration.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
@@ -4185,13 +4190,13 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChannels(ADC_TypeDef *ADCx, uint32_t
   *         and @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4241,7 +4246,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChannels(ADC_TypeDef *ADCx, uint32_t
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval None
   */
@@ -4261,7 +4266,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChAdd(ADC_TypeDef *ADCx, uint32_t Ch
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
   *         - Set channels selected by removing them to the current sequencer
   *           configuration.
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
@@ -4270,13 +4275,13 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChAdd(ADC_TypeDef *ADCx, uint32_t Ch
   *         and @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4326,7 +4331,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChAdd(ADC_TypeDef *ADCx, uint32_t Ch
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval None
   */
@@ -4344,7 +4349,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChRem(ADC_TypeDef *ADCx, uint32_t Ch
   *         - Channels order reading into each rank of scan sequence:
   *           rank of each channel is fixed by channel HW number
   *           (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
-  * @note   On this STM32 serie, ADC group regular sequencer both modes
+  * @note   On this STM32 series, ADC group regular sequencer both modes
   *         "fully configurable" or "not fully configurable"
   *         are available, they can be chosen using
   *         function @ref LL_ADC_REG_SetSequencerConfigurable().
@@ -4353,16 +4358,13 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChRem(ADC_TypeDef *ADCx, uint32_t Ch
   *         and @ref LL_ADC_REG_SetSequencerLength().
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
-*/
-//TBC
-/*
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4412,7 +4414,7 @@ __STATIC_INLINE void LL_ADC_REG_SetSequencerChRem(ADC_TypeDef *ADCx, uint32_t Ch
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   */
 __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerChannels(ADC_TypeDef *ADCx)
@@ -4440,7 +4442,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerChannels(ADC_TypeDef *ADCx)
            | (((ChannelsBitfield & ADC_CHSELR_CHSEL18) >> ADC_CHSELR_CHSEL18_BITOFFSET_POS) * LL_ADC_CHANNEL_18)
          );
 }
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief  Set ADC continuous conversion mode on ADC group regular.
   * @note   Description of ADC continuous conversion mode:
@@ -4449,7 +4451,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerChannels(ADC_TypeDef *ADCx)
   *           conversions launched successively automatically.
   * @note   It is not possible to enable both ADC group regular
   *         continuous mode and sequencer discontinuous mode.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4462,11 +4464,11 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerChannels(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_REG_SetContinuousMode(ADC_TypeDef *ADCx, uint32_t Continuous)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_CONT, Continuous);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_CONT, Continuous);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -4481,13 +4483,13 @@ __STATIC_INLINE void LL_ADC_REG_SetContinuousMode(ADC_TypeDef *ADCx, uint32_t Co
   *         @arg @ref LL_ADC_REG_CONV_SINGLE
   *         @arg @ref LL_ADC_REG_CONV_CONTINUOUS
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetContinuousMode(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetContinuousMode(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_CONT));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_CONT));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -4510,7 +4512,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetContinuousMode(ADC_TypeDef *ADCx)
   *        (overrun flag and interruption if enabled).
   * @note   To configure DMA source address (peripheral address),
   *         use function @ref LL_ADC_DMA_GetRegAddr().
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -4525,11 +4527,11 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetContinuousMode(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_REG_SetDMATransfer(ADC_TypeDef *ADCx, uint32_t DMATransfer)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_DMAEN | ADC_CFGR1_DMACFG, DMATransfer);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_DMAEN | ADC_CFGR_DMACFG, DMATransfer);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -4560,13 +4562,13 @@ __STATIC_INLINE void LL_ADC_REG_SetDMATransfer(ADC_TypeDef *ADCx, uint32_t DMATr
   *         @arg @ref LL_ADC_REG_DMA_TRANSFER_LIMITED
   *         @arg @ref LL_ADC_REG_DMA_TRANSFER_UNLIMITED
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetDMATransfer(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetDMATransfer(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_DMAEN | ADC_CFGR1_DMACFG));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_DMAEN | ADC_CFGR_DMACFG));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 
@@ -4579,7 +4581,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetDMATransfer(ADC_TypeDef *ADCx)
   *         The default setting of overrun is data preserved.
   *         Therefore, for compatibility with all devices, parameter
   *         overrun should be set to data overwritten.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
@@ -4592,11 +4594,11 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetDMATransfer(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_REG_SetOverrun(ADC_TypeDef *ADCx, uint32_t Overrun)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR1, ADC_CFGR1_OVRMOD, Overrun);
 #else
   MODIFY_REG(ADCx->CFGR, ADC_CFGR_OVRMOD, Overrun);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -4608,20 +4610,20 @@ __STATIC_INLINE void LL_ADC_REG_SetOverrun(ADC_TypeDef *ADCx, uint32_t Overrun)
   *         @arg @ref LL_ADC_REG_OVR_DATA_PRESERVED
   *         @arg @ref LL_ADC_REG_OVR_DATA_OVERWRITTEN
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_GetOverrun(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_GetOverrun(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR1, ADC_CFGR1_OVRMOD));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_OVRMOD));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /** @defgroup ADC_LL_EF_Configuration_ADC_Group_Injected Configuration of ADC hierarchical scope: group injected
@@ -4632,7 +4634,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetOverrun(ADC_TypeDef *ADCx)
   * @brief  Set ADC group injected conversion trigger source:
   *         internal (SW start) or from external peripheral (timer event,
   *         external interrupt line).
-  * @note   On this STM32 serie, setting trigger source to external trigger
+  * @note   On this STM32 series, setting trigger source to external trigger
   *         also set trigger polarity to rising edge
   *         (default setting for compatibility with some ADC on other
   *         STM32 families having this setting set by HW default value).
@@ -4640,7 +4642,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_GetOverrun(ADC_TypeDef *ADCx)
   *         function @ref LL_ADC_INJ_SetTriggerEdge().
   * @note   Availability of parameters of trigger sources from timer
   *         depends on timers availability on the selected device.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must not be disabled. Can be enabled with or without conversion
   *         on going on either groups regular or injected.
@@ -4686,7 +4688,7 @@ __STATIC_INLINE void LL_ADC_INJ_SetTriggerSource(ADC_TypeDef *ADCx, uint32_t Tri
   *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_CH1
   *         @arg @ref LL_ADC_INJ_TRIG_EXT_EXTI_LINE15
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerSource(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerSource(const ADC_TypeDef *ADCx)
 {
   __IO uint32_t TriggerSource = READ_BIT(ADCx->JSQR, ADC_JSQR_JEXTSEL | ADC_JSQR_JEXTEN);
 
@@ -4713,7 +4715,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerSource(ADC_TypeDef *ADCx)
   * @retval Value "0" if trigger source external trigger
   *         Value "1" if trigger source SW start.
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_IsTriggerSourceSWStart(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_IsTriggerSourceSWStart(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->JSQR, ADC_JSQR_JEXTEN) == (LL_ADC_INJ_TRIG_SOFTWARE & ADC_JSQR_JEXTEN)) ? 1UL : 0UL);
 }
@@ -4721,7 +4723,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_IsTriggerSourceSWStart(ADC_TypeDef *ADCx)
 /**
   * @brief  Set ADC group injected conversion trigger polarity.
   *         Applicable only for trigger source set to external trigger.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must not be disabled. Can be enabled with or without conversion
   *         on going on either groups regular or injected.
@@ -4748,7 +4750,7 @@ __STATIC_INLINE void LL_ADC_INJ_SetTriggerEdge(ADC_TypeDef *ADCx, uint32_t Exter
   *         @arg @ref LL_ADC_INJ_TRIG_EXT_FALLING
   *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISINGFALLING
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerEdge(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerEdge(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->JSQR, ADC_JSQR_JEXTEN));
 }
@@ -4761,7 +4763,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerEdge(ADC_TypeDef *ADCx)
   *           scan direction is forward (from rank 1 to rank n).
   * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
   *         ADC conversion on only 1 channel.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must not be disabled. Can be enabled with or without conversion
   *         on going on either groups regular or injected.
@@ -4795,7 +4797,7 @@ __STATIC_INLINE void LL_ADC_INJ_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t S
   *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_3RANKS
   *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_4RANKS
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerLength(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerLength(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->JSQR, ADC_JSQR_JL));
 }
@@ -4828,7 +4830,7 @@ __STATIC_INLINE void LL_ADC_INJ_SetSequencerDiscont(ADC_TypeDef *ADCx, uint32_t 
   *         @arg @ref LL_ADC_INJ_SEQ_DISCONT_DISABLE
   *         @arg @ref LL_ADC_INJ_SEQ_DISCONT_1RANK
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerDiscont(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerDiscont(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_JDISCEN));
 }
@@ -4838,13 +4840,13 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerDiscont(ADC_TypeDef *ADCx)
   *         sequence rank.
   * @note   Depending on devices and packages, some channels may not be available.
   *         Refer to device datasheet for channels availability.
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must not be disabled. Can be enabled with or without conversion
   *         on going on either groups regular or injected.
@@ -4882,7 +4884,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerDiscont(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval None
   */
@@ -4947,13 +4949,13 @@ __STATIC_INLINE void LL_ADC_INJ_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Ra
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (4)
   *         @arg @ref LL_ADC_CHANNEL_VBAT         (4)
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).\n
   *         (4) For ADC channel read back from ADC register,
   *             comparison with internal channel parameter to be done
   *             using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerRanks(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
   return (uint32_t)((READ_BIT(ADCx->JSQR,
                               (ADC_CHANNEL_ID_NUMBER_MASK >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (Rank & ADC_INJ_RANK_ID_JSQR_MASK))
@@ -4980,7 +4982,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerRanks(ADC_TypeDef *ADCx, uint32_
   *         from ADC group regular.
   * @note   It is not possible to enable both ADC group injected
   *         auto-injected mode and sequencer discontinuous mode.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -5005,7 +5007,7 @@ __STATIC_INLINE void LL_ADC_INJ_SetTrigAuto(ADC_TypeDef *ADCx, uint32_t TrigAuto
   *         @arg @ref LL_ADC_INJ_TRIG_INDEPENDENT
   *         @arg @ref LL_ADC_INJ_TRIG_FROM_GRP_REGULAR
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetTrigAuto(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetTrigAuto(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_JAUTO));
 }
@@ -5038,7 +5040,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetTrigAuto(ADC_TypeDef *ADCx)
   *         on either groups regular or injected.
   * @note   A modification of the context mode (bit JQDIS) causes the contexts
   *         queue to be flushed and the register JSQR is cleared.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -5066,7 +5068,7 @@ __STATIC_INLINE void LL_ADC_INJ_SetQueueMode(ADC_TypeDef *ADCx, uint32_t QueueMo
   *         @arg @ref LL_ADC_INJ_QUEUE_2CONTEXTS_LAST_ACTIVE
   *         @arg @ref LL_ADC_INJ_QUEUE_2CONTEXTS_END_EMPTY
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_JQM | ADC_CFGR_JQDIS));
 }
@@ -5088,13 +5090,13 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_INJ_GetTriggerSource()
   *         @arg @ref LL_ADC_INJ_GetTriggerEdge()
   *         @arg @ref LL_ADC_INJ_GetSequencerRanks()
-  * @note   On this STM32 serie, to measure internal channels (VrefInt,
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
   *         TempSensor, ...), measurement paths to internal channels must be
   *         enabled separately.
   *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
-  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx), some fast channels are available: fast analog inputs
+  * @note   On STM32WB (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx), some fast channels are available: fast analog inputs
   *         coming from GPIO pads (ADC_IN1..5).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must not be disabled. Can be enabled with or without conversion
   *         on going on either groups regular or injected.
@@ -5150,7 +5152,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @param  Rank2_Channel This parameter can be one of the following values:
   *         @arg @ref LL_ADC_CHANNEL_0
@@ -5176,7 +5178,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @param  Rank3_Channel This parameter can be one of the following values:
   *         @arg @ref LL_ADC_CHANNEL_0
@@ -5202,7 +5204,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @param  Rank4_Channel This parameter can be one of the following values:
   *         @arg @ref LL_ADC_CHANNEL_0
@@ -5228,7 +5230,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval None
   */
@@ -5275,7 +5277,7 @@ __STATIC_INLINE void LL_ADC_INJ_ConfigQueueContext(ADC_TypeDef *ADCx,
   * @{
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Set sampling time of the selected ADC channel
   *         Unit: ADC clock cycles.
@@ -5289,7 +5291,7 @@ __STATIC_INLINE void LL_ADC_INJ_ConfigQueueContext(ADC_TypeDef *ADCx,
   *         Refer to device datasheet for timings values (parameters TS_vrefint,
   *         TS_temp, ...).
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -5298,7 +5300,7 @@ __STATIC_INLINE void LL_ADC_INJ_ConfigQueueContext(ADC_TypeDef *ADCx,
   *         temperature sensor, ...), a sampling time minimum value
   *         is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -5346,7 +5348,7 @@ __STATIC_INLINE void LL_ADC_INJ_ConfigQueueContext(ADC_TypeDef *ADCx,
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @param  SamplingTimeY This parameter can be one of the following values:
   *         @arg @ref LL_ADC_SAMPLINGTIME_COMMON_1
@@ -5376,7 +5378,7 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   *         Refer to device datasheet for timings values (parameters TS_vrefint,
   *         TS_temp, ...).
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -5385,7 +5387,7 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   *         temperature sensor, ...), a sampling time minimum value
   *         is required.
   *         Refer to device datasheet.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -5433,7 +5435,7 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @param  SamplingTime This parameter can be one of the following values:
   *         @arg @ref LL_ADC_SAMPLINGTIME_2CYCLES_5
@@ -5448,7 +5450,7 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   */
 __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t Channel, uint32_t SamplingTime)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* Parameter "Channel" is used with masks because containing                */
   /* other bits reserved for other purpose.                                   */
   MODIFY_REG(ADCx->SMPR,
@@ -5465,18 +5467,18 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   MODIFY_REG(*preg,
              ADC_SMPR1_SMP0 << ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS),
              SamplingTime   << ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Get sampling time of the selected ADC channel
   *         Unit: ADC clock cycles.
   * @note   On this device, sampling time is on channel scope: independently
   *         of channel mapped on ADC group regular or injected.
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -5525,13 +5527,13 @@ __STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t C
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_ADC_SAMPLINGTIME_COMMON_1
   *         @arg @ref LL_ADC_SAMPLINGTIME_COMMON_2
   */
-__STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(const ADC_TypeDef *ADCx, uint32_t Channel)
 {
   __IO uint32_t smpr = READ_REG(ADCx->SMPR);
 
@@ -5551,7 +5553,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
   * @note   On this device, sampling time is on channel scope: independently
   *         of channel mapped on ADC group regular or injected.
   * @note   Conversion time is the addition of sampling time and processing time.
-  *         On this STM32 serie, ADC processing time is:
+  *         On this STM32 series, ADC processing time is:
   *         - 12.5 ADC clock cycles at ADC resolution 12 bits
   *         - 10.5 ADC clock cycles at ADC resolution 10 bits
   *         - 8.5 ADC clock cycles at ADC resolution 8 bits
@@ -5600,7 +5602,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
   *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR
   *         @arg @ref LL_ADC_CHANNEL_VBAT
   *
-  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
+  *         (7) On STM32WB devices (except devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx) fast channel (0.188 us for 12-bit resolution (ADC conversion rate up to 5.33 Ms/s)).
   *             Other channels are slow channels (0.238 us for 12-bit resolution (ADC conversion rate up to 4.21 Ms/s)).
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_ADC_SAMPLINGTIME_2CYCLES_5
@@ -5612,9 +5614,9 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
   *         @arg @ref LL_ADC_SAMPLINGTIME_247CYCLES_5
   *         @arg @ref LL_ADC_SAMPLINGTIME_640CYCLES_5
   */
-__STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(const ADC_TypeDef *ADCx, uint32_t Channel)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   __IO uint32_t smpr = READ_REG(ADCx->SMPR);
 
   /* Retrieve sampling time bit corresponding to the selected channel            */
@@ -5632,11 +5634,11 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
                              ADC_SMPR1_SMP0 << ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS))
                     >> ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS)
                    );
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC channel differential mode" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -5659,7 +5661,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(ADC_TypeDef *ADCx, uint32
   * @note   For ADC channels configured in differential mode, both inputs
   *         should be biased at (Vref+)/2 +/-200mV.
   *         (Vref+ is the analog voltage reference)
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @note   One or several values can be selected.
@@ -5737,7 +5739,7 @@ __STATIC_INLINE void LL_ADC_SetChannelSingleDiff(ADC_TypeDef *ADCx, uint32_t Cha
   *         @arg @ref LL_ADC_CHANNEL_15
   * @retval 0: channel in single-ended mode, else: channel in differential mode
   */
-__STATIC_INLINE uint32_t LL_ADC_GetChannelSingleDiff(ADC_TypeDef *ADCx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_ADC_GetChannelSingleDiff(const ADC_TypeDef *ADCx, uint32_t Channel)
 {
   return (uint32_t)(READ_BIT(ADCx->DIFSEL, (Channel & ADC_SINGLEDIFF_CHANNEL_MASK)));
 }
@@ -5760,7 +5762,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSingleDiff(ADC_TypeDef *ADCx, uint32_t
   * @note   In case of need to define a single channel to monitor
   *         with analog watchdog from sequencer channel definition,
   *         use helper macro @ref __LL_ADC_ANALOGWD_CHANNEL_GROUP().
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -5781,7 +5783,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSingleDiff(ADC_TypeDef *ADCx, uint32_t
   *           - resolution: resolution is limited to 8 bits: if ADC resolution is
   *             12 bits the 4 LSB are ignored, if ADC resolution is 10 bits
   *             the 2 LSB are ignored.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -5869,12 +5871,12 @@ __STATIC_INLINE uint32_t LL_ADC_GetChannelSingleDiff(ADC_TypeDef *ADCx, uint32_t
   *         @arg @ref LL_ADC_AWD_CH_VBAT_REG_INJ            (1)
   *
   *         (0) On STM32WB, parameter available only on analog watchdog number: AWD1.
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDChannelGroup)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* Prevent unused argument(s) compilation warning */
   (void)(AWDy);
 
@@ -5892,7 +5894,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   MODIFY_REG(*preg,
              (AWDy & ADC_AWD_CR_ALL_CHANNEL_MASK),
              AWDChannelGroup & AWDy);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -5910,7 +5912,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
   *           Applicable only when the analog watchdog is set to monitor
   *           one channel.
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -5931,7 +5933,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   *           - resolution: resolution is limited to 8 bits: if ADC resolution is
   *             12 bits the 4 LSB are ignored, if ADC resolution is 10 bits
   *             the 2 LSB are ignored.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -5952,7 +5954,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   *             This function cannot retrieve monitored channel if
   *             multiple channels are programmed simultaneously
   *             by bitfield.
-  *         (2) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (2) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_ADC_AWD_DISABLE
   *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG        (0)
@@ -6017,11 +6019,11 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t
   *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG_INJ         (1)
   *
   *         (0) On STM32WB, parameter available only on analog watchdog number: AWD1.
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t AWDy)
+__STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(const ADC_TypeDef *ADCx, uint32_t AWDy)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* Prevent unused argument(s) compilation warning */
   (void)(AWDy);
 
@@ -6103,7 +6105,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   }
 
   return AnalogWDMonitChannels;
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6114,7 +6116,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   * @note   In case of ADC resolution different of 12 bits,
   *         analog watchdog thresholds data require a specific shift.
   *         Use helper macro @ref __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION().
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -6139,7 +6141,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   *         impacted: the comparison of analog watchdog thresholds is done on
   *         oversampling final computation (after ratio and shift application):
   *         ADC data register bitfield [15:4] (12 most significant bits).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -6149,13 +6151,14 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint
   *         TR1      LT1            LL_ADC_ConfigAnalogWDThresholds\n
   *         TR2      LT2            LL_ADC_ConfigAnalogWDThresholds\n
   *         TR3      LT3            LL_ADC_ConfigAnalogWDThresholds
+  * @note For devices STM32WB15xx and STM32WB10xx, register ADC_TR is equivalent to ADC_TR1 (generic naming)
   * @param  ADCx ADC instance
   * @param  AWDy This parameter can be one of the following values:
   *         @arg @ref LL_ADC_AWD1
   *         @arg @ref LL_ADC_AWD2 (1)
   *         @arg @ref LL_ADC_AWD3 (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @param  AWDThresholdHighValue Value between Min_Data=0x000 and Max_Data=0xFFF
   * @param  AWDThresholdLowValue Value between Min_Data=0x000 and Max_Data=0xFFF
   * @retval None
@@ -6168,20 +6171,20 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   /* "AWDy".                                                                  */
   /* Parameters "AWDy" and "AWDThresholdxxxValue" are used with masks because */
   /* containing other bits reserved for other purpose.                        */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   /* Prevent unused argument(s) compilation warning */
   (void)(AWDy);
 
-  MODIFY_REG(ADCx->TR1,
-             ADC_TR1_HT1 | ADC_TR1_LT1,
-             (AWDThresholdHighValue << ADC_TR1_HT1_BITOFFSET_POS) | AWDThresholdLowValue);
+  MODIFY_REG(ADCx->TR,
+             ADC_TR_HT | ADC_TR_LT,
+             (AWDThresholdHighValue << ADC_TR_HT_BITOFFSET_POS) | AWDThresholdLowValue);
 #else
   __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1, ((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS));
 
   MODIFY_REG(*preg,
              ADC_TR1_HT1 | ADC_TR1_LT1,
              (AWDThresholdHighValue << ADC_TR1_HT1_BITOFFSET_POS) | AWDThresholdLowValue);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6192,7 +6195,7 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   * @note   In case of ADC resolution different of 12 bits,
   *         analog watchdog thresholds data require a specific shift.
   *         Use helper macro @ref __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION().
-  * @note   On this STM32 serie, there are 2 kinds of analog watchdog
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
   *         instance:
   *         - AWD standard (instance AWD1):
   *           - channels monitored: can monitor 1 channel or all channels.
@@ -6217,7 +6220,7 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   *         impacted: the comparison of analog watchdog thresholds is done on
   *         oversampling final computation (after ratio and shift application):
   *         ADC data register bitfield [15:4] (12 most significant bits).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either ADC groups regular or injected.
@@ -6227,13 +6230,14 @@ __STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t
   *         TR1      LT1            LL_ADC_SetAnalogWDThresholds\n
   *         TR2      LT2            LL_ADC_SetAnalogWDThresholds\n
   *         TR3      LT3            LL_ADC_SetAnalogWDThresholds
+  * @note For devices STM32WB15xx and STM32WB10xx, register ADC_TR is equivalent to ADC_TR1 (generic naming)
   * @param  ADCx ADC instance
   * @param  AWDy This parameter can be one of the following values:
   *         @arg @ref LL_ADC_AWD1
   *         @arg @ref LL_ADC_AWD2 (1)
   *         @arg @ref LL_ADC_AWD3 (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32, STM32WB1Mxx.
   * @param  AWDThresholdsHighLow This parameter can be one of the following values:
   *         @arg @ref LL_ADC_AWD_THRESHOLD_HIGH
   *         @arg @ref LL_ADC_AWD_THRESHOLD_LOW
@@ -6248,11 +6252,11 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AW
   /* "AWDThresholdsHighLow" and "AWDy".                                       */
   /* Parameters "AWDy" and "AWDThresholdValue" are used with masks because    */
   /* containing other bits reserved for other purpose.                        */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   /* Prevent unused argument(s) compilation warning */
   (void)(AWDy);
 
-  MODIFY_REG(ADCx->TR1,
+  MODIFY_REG(ADCx->TR,
              AWDThresholdsHighLow,
              AWDThresholdValue << ((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4));
 #else
@@ -6261,7 +6265,7 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AW
   MODIFY_REG(*preg,
              AWDThresholdsHighLow,
              AWDThresholdValue << ((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6281,28 +6285,29 @@ __STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AW
   *         TR1      LT1            LL_ADC_GetAnalogWDThresholds\n
   *         TR2      LT2            LL_ADC_GetAnalogWDThresholds\n
   *         TR3      LT3            LL_ADC_GetAnalogWDThresholds
+  * @note For devices STM32WB15xx and STM32WB10xx, register ADC_TR is equivalent to ADC_TR1 (generic naming)
   * @param  ADCx ADC instance
   * @param  AWDy This parameter can be one of the following values:
   *         @arg @ref LL_ADC_AWD1
   *         @arg @ref LL_ADC_AWD2 (1)
   *         @arg @ref LL_ADC_AWD3 (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @param  AWDThresholdsHighLow This parameter can be one of the following values:
   *         @arg @ref LL_ADC_AWD_THRESHOLD_HIGH
   *         @arg @ref LL_ADC_AWD_THRESHOLD_LOW
   *         @arg @ref LL_ADC_AWD_THRESHOLDS_HIGH_LOW
   * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
   */
-__STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow)
+__STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(const ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   /* Prevent unused argument(s) compilation warning */
   (void)(AWDy);
 
-  return (uint32_t)(READ_BIT(ADCx->TR1,
-                             (AWDThresholdsHighLow | ADC_TR1_LT1))
-                    >> (((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4) & ~(AWDThresholdsHighLow & ADC_TR1_LT1))
+  return (uint32_t)(READ_BIT(ADCx->TR,
+                             (AWDThresholdsHighLow | ADC_TR_LT))
+                    >> (((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4) & ~(AWDThresholdsHighLow & ADC_TR_LT))
                    );
 #else
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->TR1, ((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS));
@@ -6311,14 +6316,14 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_
                              (AWDThresholdsHighLow | ADC_TR1_LT1))
                     >> (((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4) & ~(AWDThresholdsHighLow & ADC_TR1_LT1))
                    );
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC oversampling" not available on ADC peripheral of this STM32WB device */
 #else
 /** @defgroup ADC_LL_EF_Configuration_ADC_oversampling Configuration of ADC transversal scope: oversampling
@@ -6334,7 +6339,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_
   *         the oversampling on ADC group regular is either
   *         temporary stopped and continued, or resumed from start
   *         (oversampler buffer reset).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -6349,16 +6354,16 @@ __STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_
   *         @arg @ref LL_ADC_OVS_GRP_INJECTED        (1)
   *         @arg @ref LL_ADC_OVS_GRP_INJ_REG_RESUMED (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval None
   */
 __STATIC_INLINE void LL_ADC_SetOverSamplingScope(ADC_TypeDef *ADCx, uint32_t OvsScope)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR2, ADC_CFGR2_OVSE, OvsScope);
 #else
   MODIFY_REG(ADCx->CFGR2, ADC_CFGR2_ROVSE | ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSM, OvsScope);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6381,15 +6386,15 @@ __STATIC_INLINE void LL_ADC_SetOverSamplingScope(ADC_TypeDef *ADCx, uint32_t Ovs
   *         @arg @ref LL_ADC_OVS_GRP_INJECTED        (1)
   *         @arg @ref LL_ADC_OVS_GRP_INJ_REG_RESUMED (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingScope(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingScope(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSE));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_ROVSE | ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSM));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6400,11 +6405,11 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingScope(ADC_TypeDef *ADCx)
   *           are done from 1 trigger)
   *         - discontinuous mode (each conversion of oversampling ratio
   *           needs a trigger)
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on group regular.
-  * @note   On this STM32 serie, oversampling discontinuous mode
+  * @note   On this STM32 series, oversampling discontinuous mode
   *         (triggered mode) can be used only when oversampling is
   *         set on group regular only and in resumed mode.
   * @rmtoll CFGR2    TROVS          LL_ADC_SetOverSamplingDiscont
@@ -6416,11 +6421,11 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingScope(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE void LL_ADC_SetOverSamplingDiscont(ADC_TypeDef *ADCx, uint32_t OverSamplingDiscont)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   MODIFY_REG(ADCx->CFGR2, ADC_CFGR2_TOVS, OverSamplingDiscont);
 #else
   MODIFY_REG(ADCx->CFGR2, ADC_CFGR2_TROVS, OverSamplingDiscont);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6437,13 +6442,13 @@ __STATIC_INLINE void LL_ADC_SetOverSamplingDiscont(ADC_TypeDef *ADCx, uint32_t O
   *         @arg @ref LL_ADC_OVS_REG_CONT
   *         @arg @ref LL_ADC_OVS_REG_DISCONT
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(const ADC_TypeDef *ADCx)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_TOVS));
 #else
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_TROVS));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -6452,7 +6457,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(ADC_TypeDef *ADCx)
   * @note   This function set the 2 items of oversampling configuration:
   *         - ratio
   *         - shift
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be disabled or enabled without conversion on going
   *         on either groups regular or injected.
@@ -6500,7 +6505,7 @@ __STATIC_INLINE void LL_ADC_ConfigOverSamplingRatioShift(ADC_TypeDef *ADCx, uint
   *         @arg @ref LL_ADC_OVS_RATIO_128
   *         @arg @ref LL_ADC_OVS_RATIO_256
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSR));
 }
@@ -6521,7 +6526,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_7
   *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_8
   */
-__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSS));
 }
@@ -6544,7 +6549,7 @@ __STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(ADC_TypeDef *ADCx)
   *         state, the internal analog calibration is lost. After exiting from
   *         deep power down, calibration must be relaunched or calibration factor
   *         (preliminarily saved) must be set back into calibration register.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       DEEPPWD        LL_ADC_EnableDeepPowerDown
@@ -6567,7 +6572,7 @@ __STATIC_INLINE void LL_ADC_EnableDeepPowerDown(ADC_TypeDef *ADCx)
   *         state, the internal analog calibration is lost. After exiting from
   *         deep power down, calibration must be relaunched or calibration factor
   *         (preliminarily saved) must be set back into calibration register.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       DEEPPWD        LL_ADC_DisableDeepPowerDown
@@ -6588,7 +6593,7 @@ __STATIC_INLINE void LL_ADC_DisableDeepPowerDown(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: deep power down is disabled, 1: deep power down is enabled.
   */
-__STATIC_INLINE uint32_t LL_ADC_IsDeepPowerDownEnabled(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsDeepPowerDownEnabled(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_DEEPPWD) == (ADC_CR_DEEPPWD)) ? 1UL : 0UL);
 }
@@ -6596,12 +6601,12 @@ __STATIC_INLINE uint32_t LL_ADC_IsDeepPowerDownEnabled(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Enable ADC instance internal voltage regulator.
-  * @note   On this STM32 serie, after ADC internal voltage regulator enable,
+  * @note   On this STM32 series, after ADC internal voltage regulator enable,
   *         a delay for ADC internal voltage regulator stabilization
   *         is required before performing a ADC calibration or ADC enable.
   *         Refer to device datasheet, parameter tADCVREG_STUP.
   *         Refer to literal @ref LL_ADC_DELAY_INTERNAL_REGUL_STAB_US.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       ADVREGEN       LL_ADC_EnableInternalRegulator
@@ -6620,7 +6625,7 @@ __STATIC_INLINE void LL_ADC_EnableInternalRegulator(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Disable ADC internal voltage regulator.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       ADVREGEN       LL_ADC_DisableInternalRegulator
@@ -6638,21 +6643,21 @@ __STATIC_INLINE void LL_ADC_DisableInternalRegulator(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: internal regulator is disabled, 1: internal regulator is enabled.
   */
-__STATIC_INLINE uint32_t LL_ADC_IsInternalRegulatorEnabled(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsInternalRegulatorEnabled(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_ADVREGEN) == (ADC_CR_ADVREGEN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable the selected ADC instance.
-  * @note   On this STM32 serie, after ADC enable, a delay for
+  * @note   On this STM32 series, after ADC enable, a delay for
   *         ADC internal analog stabilization is required before performing a
   *         ADC conversion start.
   *         Refer to device datasheet, parameter tSTAB.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled and ADC internal voltage regulator enabled.
   * @rmtoll CR       ADEN           LL_ADC_Enable
@@ -6671,7 +6676,7 @@ __STATIC_INLINE void LL_ADC_Enable(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Disable the selected ADC instance.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be not disabled. Must be enabled without conversion on going
   *         on either groups regular or injected.
@@ -6691,14 +6696,14 @@ __STATIC_INLINE void LL_ADC_Disable(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Get the selected ADC instance enable state.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
   * @rmtoll CR       ADEN           LL_ADC_IsEnabled
   * @param  ADCx ADC instance
   * @retval 0: ADC is disabled, 1: ADC is enabled.
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabled(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabled(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_ADEN) == (ADC_CR_ADEN)) ? 1UL : 0UL);
 }
@@ -6709,16 +6714,16 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabled(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: no ADC disable command on going.
   */
-__STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_ADDIS) == (ADC_CR_ADDIS)) ? 1UL : 0UL);
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Start ADC calibration in the mode single-ended
   *         or differential (for devices with differential mode available).
-  * @note   On this STM32 serie, a minimum number of ADC clock cycles
+  * @note   On this STM32 series, a minimum number of ADC clock cycles
   *         are required between ADC end of calibration and ADC enable.
   *         Refer to literal @ref LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES.
   * @note   For devices with differential mode available:
@@ -6727,9 +6732,12 @@ __STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(ADC_TypeDef *ADCx)
   *         (calibration run must be performed for each of these
   *         differential modes, if used afterwards and if the application
   *         requires their calibration).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
+  * @note   In case of usage of feature auto power-off:
+  *         This mode must be disabled during calibration
+  *         Refer to function @ref LL_ADC_SetLowPowerMode().
   * @rmtoll CR       ADCAL          LL_ADC_StartCalibration\n
   *         CR       ADCALDIF       LL_ADC_StartCalibration
   * @param  ADCx ADC instance
@@ -6748,7 +6756,7 @@ __STATIC_INLINE void LL_ADC_StartCalibration(ADC_TypeDef *ADCx)
 /**
   * @brief  Start ADC calibration in the mode single-ended
   *         or differential (for devices with differential mode available).
-  * @note   On this STM32 serie, a minimum number of ADC clock cycles
+  * @note   On this STM32 series, a minimum number of ADC clock cycles
   *         are required between ADC end of calibration and ADC enable.
   *         Refer to literal @ref LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES.
   * @note   For devices with differential mode available:
@@ -6757,7 +6765,7 @@ __STATIC_INLINE void LL_ADC_StartCalibration(ADC_TypeDef *ADCx)
   *         (calibration run must be performed for each of these
   *         differential modes, if used afterwards and if the application
   *         requires their calibration).
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be ADC disabled.
   * @rmtoll CR       ADCAL          LL_ADC_StartCalibration\n
@@ -6785,7 +6793,7 @@ __STATIC_INLINE void LL_ADC_StartCalibration(ADC_TypeDef *ADCx, uint32_t SingleD
   * @param  ADCx ADC instance
   * @retval 0: calibration complete, 1: calibration in progress.
   */
-__STATIC_INLINE uint32_t LL_ADC_IsCalibrationOnGoing(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsCalibrationOnGoing(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_ADCAL) == (ADC_CR_ADCAL)) ? 1UL : 0UL);
 }
@@ -6800,14 +6808,14 @@ __STATIC_INLINE uint32_t LL_ADC_IsCalibrationOnGoing(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Start ADC group regular conversion.
-  * @note   On this STM32 serie, this function is relevant for both
+  * @note   On this STM32 series, this function is relevant for both
   *         internal trigger (SW start) and external trigger:
   *         - If ADC trigger has been set to software start, ADC conversion
   *           starts immediately.
   *         - If ADC trigger has been set to external trigger, ADC conversion
   *           will start at next trigger event (on the selected trigger edge)
   *           following the ADC start conversion command.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled without conversion on going on group regular,
   *         without conversion stop command on going on group regular,
@@ -6828,7 +6836,7 @@ __STATIC_INLINE void LL_ADC_REG_StartConversion(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Stop ADC group regular conversion.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled with conversion on going on group regular,
   *         without ADC disable command on going.
@@ -6852,7 +6860,7 @@ __STATIC_INLINE void LL_ADC_REG_StopConversion(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: no conversion is on going on ADC group regular.
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_IsConversionOngoing(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_IsConversionOngoing(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_ADSTART) == (ADC_CR_ADSTART)) ? 1UL : 0UL);
 }
@@ -6863,7 +6871,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_IsConversionOngoing(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: no command of conversion stop is on going on ADC group regular.
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_IsStopConversionOngoing(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_IsStopConversionOngoing(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_ADSTP) == (ADC_CR_ADSTP)) ? 1UL : 0UL);
 }
@@ -6877,7 +6885,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_IsStopConversionOngoing(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval Value between Min_Data=0x00000000 and Max_Data=0xFFFFFFFF
   */
-__STATIC_INLINE uint32_t LL_ADC_REG_ReadConversionData32(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_REG_ReadConversionData32(const ADC_TypeDef *ADCx)
 {
   return (uint32_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
 }
@@ -6892,7 +6900,7 @@ __STATIC_INLINE uint32_t LL_ADC_REG_ReadConversionData32(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
   */
-__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData12(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData12(const ADC_TypeDef *ADCx)
 {
   return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
 }
@@ -6907,7 +6915,7 @@ __STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData12(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval Value between Min_Data=0x000 and Max_Data=0x3FF
   */
-__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData10(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData10(const ADC_TypeDef *ADCx)
 {
   return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
 }
@@ -6922,7 +6930,7 @@ __STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData10(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData8(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData8(const ADC_TypeDef *ADCx)
 {
   return (uint8_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
 }
@@ -6937,7 +6945,7 @@ __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData8(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval Value between Min_Data=0x00 and Max_Data=0x3F
   */
-__STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData6(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData6(const ADC_TypeDef *ADCx)
 {
   return (uint8_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
 }
@@ -6946,7 +6954,7 @@ __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData6(ADC_TypeDef *ADCx)
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /** @defgroup ADC_LL_EF_Operation_ADC_Group_Injected Operation on ADC hierarchical scope: group injected
@@ -6955,14 +6963,14 @@ __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData6(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Start ADC group injected conversion.
-  * @note   On this STM32 serie, this function is relevant for both
+  * @note   On this STM32 series, this function is relevant for both
   *         internal trigger (SW start) and external trigger:
   *         - If ADC trigger has been set to software start, ADC conversion
   *           starts immediately.
   *         - If ADC trigger has been set to external trigger, ADC conversion
   *           will start at next trigger event (on the selected trigger edge)
   *           following the ADC start conversion command.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled without conversion on going on group injected,
   *         without conversion stop command on going on group injected,
@@ -6983,7 +6991,7 @@ __STATIC_INLINE void LL_ADC_INJ_StartConversion(ADC_TypeDef *ADCx)
 
 /**
   * @brief  Stop ADC group injected conversion.
-  * @note   On this STM32 serie, setting of this feature is conditioned to
+  * @note   On this STM32 series, setting of this feature is conditioned to
   *         ADC state:
   *         ADC must be enabled with conversion on going on group injected,
   *         without ADC disable command on going.
@@ -7007,7 +7015,7 @@ __STATIC_INLINE void LL_ADC_INJ_StopConversion(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: no conversion is on going on ADC group injected.
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_IsConversionOngoing(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_IsConversionOngoing(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_JADSTART) == (ADC_CR_JADSTART)) ? 1UL : 0UL);
 }
@@ -7018,7 +7026,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_IsConversionOngoing(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval 0: no command of conversion stop is on going on ADC group injected.
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_IsStopConversionOngoing(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_INJ_IsStopConversionOngoing(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->CR, ADC_CR_JADSTP) == (ADC_CR_JADSTP)) ? 1UL : 0UL);
 }
@@ -7040,7 +7048,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_IsStopConversionOngoing(ADC_TypeDef *ADCx)
   *         @arg @ref LL_ADC_INJ_RANK_4
   * @retval Value between Min_Data=0x00000000 and Max_Data=0xFFFFFFFF
   */
-__STATIC_INLINE uint32_t LL_ADC_INJ_ReadConversionData32(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint32_t LL_ADC_INJ_ReadConversionData32(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
 
@@ -7067,7 +7075,7 @@ __STATIC_INLINE uint32_t LL_ADC_INJ_ReadConversionData32(ADC_TypeDef *ADCx, uint
   *         @arg @ref LL_ADC_INJ_RANK_4
   * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
   */
-__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData12(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData12(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
 
@@ -7094,7 +7102,7 @@ __STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData12(ADC_TypeDef *ADCx, uint
   *         @arg @ref LL_ADC_INJ_RANK_4
   * @retval Value between Min_Data=0x000 and Max_Data=0x3FF
   */
-__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData10(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData10(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
 
@@ -7121,7 +7129,7 @@ __STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData10(ADC_TypeDef *ADCx, uint
   *         @arg @ref LL_ADC_INJ_RANK_4
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData8(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData8(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
 
@@ -7148,7 +7156,7 @@ __STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData8(ADC_TypeDef *ADCx, uint32
   *         @arg @ref LL_ADC_INJ_RANK_4
   * @retval Value between Min_Data=0x00 and Max_Data=0x3F
   */
-__STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData6(ADC_TypeDef *ADCx, uint32_t Rank)
+__STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData6(const ADC_TypeDef *ADCx, uint32_t Rank)
 {
   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
 
@@ -7168,19 +7176,19 @@ __STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData6(ADC_TypeDef *ADCx, uint32
 
 /**
   * @brief  Get flag ADC ready.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
   * @rmtoll ISR      ADRDY          LL_ADC_IsActiveFlag_ADRDY
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_ADRDY(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_ADRDY(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_ADRDY) == (LL_ADC_FLAG_ADRDY)) ? 1UL : 0UL);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Get flag ADC channel configuration ready.
   * @note   Duration of ADC channel configuration ready: CCRDY handshake
@@ -7190,7 +7198,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_ADRDY(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_CCRDY(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_CCRDY(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_CCRDY) == (LL_ADC_FLAG_CCRDY)) ? 1UL : 0UL);
 }
@@ -7203,7 +7211,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_CCRDY(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOC(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOC(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, ADC_ISR_EOC) == (ADC_ISR_EOC)) ? 1UL : 0UL);
 }
@@ -7214,7 +7222,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOC(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOS(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOS(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_EOS) == (LL_ADC_FLAG_EOS)) ? 1UL : 0UL);
 }
@@ -7225,7 +7233,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOS(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_OVR(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_OVR(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_OVR) == (LL_ADC_FLAG_OVR)) ? 1UL : 0UL);
 }
@@ -7236,12 +7244,12 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_OVR(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOSMP(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOSMP(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_EOSMP) == (LL_ADC_FLAG_EOSMP)) ? 1UL : 0UL);
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -7250,7 +7258,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOSMP(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOC(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOC(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_JEOC) == (LL_ADC_FLAG_JEOC)) ? 1UL : 0UL);
 }
@@ -7261,7 +7269,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOC(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOS(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOS(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_JEOS) == (LL_ADC_FLAG_JEOS)) ? 1UL : 0UL);
 }
@@ -7272,7 +7280,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOS(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JQOVF(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JQOVF(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_JQOVF) == (LL_ADC_FLAG_JQOVF)) ? 1UL : 0UL);
 }
@@ -7284,7 +7292,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JQOVF(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD1(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD1(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_AWD1) == (LL_ADC_FLAG_AWD1)) ? 1UL : 0UL);
 }
@@ -7295,7 +7303,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD1(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD2(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD2(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_AWD2) == (LL_ADC_FLAG_AWD2)) ? 1UL : 0UL);
 }
@@ -7306,27 +7314,27 @@ __STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD2(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD3(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD3(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_AWD3) == (LL_ADC_FLAG_AWD3)) ? 1UL : 0UL);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Get flag ADC end of calibration.
   * @rmtoll ISR      EOCAL          LL_ADC_IsActiveFlag_EOCAL
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOCAL(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOCAL(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_EOCAL) == (LL_ADC_FLAG_EOCAL)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief  Clear flag ADC ready.
-  * @note   On this STM32 serie, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
   *         is enabled and when conversion clock is active.
   *         (not only core clock: this ADC has a dual clock domain)
   * @rmtoll ISR      ADRDY          LL_ADC_ClearFlag_ADRDY
@@ -7338,7 +7346,7 @@ __STATIC_INLINE void LL_ADC_ClearFlag_ADRDY(ADC_TypeDef *ADCx)
   WRITE_REG(ADCx->ISR, LL_ADC_FLAG_ADRDY);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Clear flag ADC channel configuration ready.
   * @rmtoll ISR      CCRDY          LL_ADC_ClearFlag_CCRDY
@@ -7396,7 +7404,7 @@ __STATIC_INLINE void LL_ADC_ClearFlag_EOSMP(ADC_TypeDef *ADCx)
   WRITE_REG(ADCx->ISR, LL_ADC_FLAG_EOSMP);
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -7466,7 +7474,7 @@ __STATIC_INLINE void LL_ADC_ClearFlag_AWD3(ADC_TypeDef *ADCx)
   WRITE_REG(ADCx->ISR, LL_ADC_FLAG_AWD3);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Clear flag ADC end of calibration.
   * @rmtoll ISR      EOCAL          LL_ADC_ClearFlag_EOCAL
@@ -7478,7 +7486,7 @@ __STATIC_INLINE void LL_ADC_ClearFlag_EOCAL(ADC_TypeDef *ADCx)
   WRITE_REG(ADCx->ISR, LL_ADC_FLAG_EOCAL);
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -7498,7 +7506,7 @@ __STATIC_INLINE void LL_ADC_EnableIT_ADRDY(ADC_TypeDef *ADCx)
   SET_BIT(ADCx->IER, LL_ADC_IT_ADRDY);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Enable interruption ADC channel configuration ready.
   * @rmtoll IER      ADRDYIE        LL_ADC_EnableIT_CCRDY
@@ -7556,7 +7564,7 @@ __STATIC_INLINE void LL_ADC_EnableIT_EOSMP(ADC_TypeDef *ADCx)
   SET_BIT(ADCx->IER, LL_ADC_IT_EOSMP);
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -7626,7 +7634,7 @@ __STATIC_INLINE void LL_ADC_EnableIT_AWD3(ADC_TypeDef *ADCx)
   SET_BIT(ADCx->IER, LL_ADC_IT_AWD3);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Enable interruption ADC end of calibration.
   * @rmtoll IER      EOCALIE        LL_ADC_EnableIT_EOCAL
@@ -7638,7 +7646,7 @@ __STATIC_INLINE void LL_ADC_EnableIT_EOCAL(ADC_TypeDef *ADCx)
   SET_BIT(ADCx->IER, LL_ADC_IT_EOCAL);
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief  Disable interruption ADC ready.
   * @rmtoll IER      ADRDYIE        LL_ADC_DisableIT_ADRDY
@@ -7650,7 +7658,7 @@ __STATIC_INLINE void LL_ADC_DisableIT_ADRDY(ADC_TypeDef *ADCx)
   CLEAR_BIT(ADCx->IER, LL_ADC_IT_ADRDY);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Disable interruption ADC channel configuration ready.
   * @rmtoll IER      ADRDYIE        LL_ADC_DisableIT_CCRDY
@@ -7708,7 +7716,7 @@ __STATIC_INLINE void LL_ADC_DisableIT_EOSMP(ADC_TypeDef *ADCx)
   CLEAR_BIT(ADCx->IER, LL_ADC_IT_EOSMP);
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -7778,7 +7786,7 @@ __STATIC_INLINE void LL_ADC_DisableIT_AWD3(ADC_TypeDef *ADCx)
   CLEAR_BIT(ADCx->IER, LL_ADC_IT_AWD3);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Disable interruption ADC end of calibration.
   * @rmtoll IER      EOCALIE        LL_ADC_DisableIT_EOCAL
@@ -7790,7 +7798,7 @@ __STATIC_INLINE void LL_ADC_DisableIT_EOCAL(ADC_TypeDef *ADCx)
   CLEAR_BIT(ADCx->IER, LL_ADC_IT_EOCAL);
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @brief  Get state of interruption ADC ready
   *         (0: interrupt disabled, 1: interrupt enabled).
@@ -7798,19 +7806,19 @@ __STATIC_INLINE void LL_ADC_DisableIT_EOCAL(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_ADRDY(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_ADRDY(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_ADRDY) == (LL_ADC_IT_ADRDY)) ? 1UL : 0UL);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Get state of interruption ADC channel configuration ready.
   * @rmtoll IER      ADRDYIE        LL_ADC_IsEnabledIT_CCRDY
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_CCRDY(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_CCRDY(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_FLAG_CCRDY) == (LL_ADC_FLAG_CCRDY)) ? 1UL : 0UL);
 }
@@ -7824,7 +7832,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_CCRDY(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOC(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOC(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOC) == (LL_ADC_IT_EOC)) ? 1UL : 0UL);
 }
@@ -7836,7 +7844,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOC(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOS(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOS(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOS) == (LL_ADC_IT_EOS)) ? 1UL : 0UL);
 }
@@ -7848,7 +7856,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOS(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_OVR(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_OVR(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_OVR) == (LL_ADC_IT_OVR)) ? 1UL : 0UL);
 }
@@ -7860,12 +7868,12 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_OVR(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOSMP(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOSMP(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOSMP) == (LL_ADC_IT_EOSMP)) ? 1UL : 0UL);
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -7875,7 +7883,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOSMP(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOC(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOC(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_JEOC) == (LL_ADC_IT_JEOC)) ? 1UL : 0UL);
 }
@@ -7887,7 +7895,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOC(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOS(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOS(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_JEOS) == (LL_ADC_IT_JEOS)) ? 1UL : 0UL);
 }
@@ -7899,7 +7907,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOS(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JQOVF(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JQOVF(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_JQOVF) == (LL_ADC_IT_JQOVF)) ? 1UL : 0UL);
 }
@@ -7912,7 +7920,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JQOVF(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD1(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD1(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_AWD1) == (LL_ADC_IT_AWD1)) ? 1UL : 0UL);
 }
@@ -7924,7 +7932,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD1(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD2(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD2(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_AWD2) == (LL_ADC_IT_AWD2)) ? 1UL : 0UL);
 }
@@ -7936,12 +7944,12 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD2(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD3(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD3(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_AWD3) == (LL_ADC_IT_AWD3)) ? 1UL : 0UL);
 }
 
-#if defined(ADC_SUPPORT_2_5_MSPS)
+#if   defined(ADC_SUPPORT_2_5_MSPS)
 /**
   * @brief  Get state of interruption ADC end of calibration
   *         (0: interrupt disabled, 1: interrupt enabled).
@@ -7949,12 +7957,12 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD3(ADC_TypeDef *ADCx)
   * @param  ADCx ADC instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOCAL(ADC_TypeDef *ADCx)
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOCAL(const ADC_TypeDef *ADCx)
 {
   return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOCAL) == (LL_ADC_IT_EOCAL)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -7966,7 +7974,7 @@ __STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOCAL(ADC_TypeDef *ADCx)
 
 /* Initialization of some features of ADC common parameters and multimode */
 ErrorStatus LL_ADC_CommonDeInit(ADC_Common_TypeDef *ADCxy_COMMON);
-ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct);
+ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, const LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct);
 void        LL_ADC_CommonStructInit(LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct);
 
 /* De-initialization of ADC instance, ADC group regular and ADC group injected */
@@ -7974,21 +7982,21 @@ void        LL_ADC_CommonStructInit(LL_ADC_CommonInitTypeDef *ADC_CommonInitStru
 ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx);
 
 /* Initialization of some features of ADC instance */
-ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct);
+ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, const LL_ADC_InitTypeDef *ADC_InitStruct);
 void        LL_ADC_StructInit(LL_ADC_InitTypeDef *ADC_InitStruct);
 
 /* Initialization of some features of ADC instance and ADC group regular */
-ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct);
+ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, const LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct);
 void        LL_ADC_REG_StructInit(LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /* Initialization of some features of ADC instance and ADC group injected */
-ErrorStatus LL_ADC_INJ_Init(ADC_TypeDef *ADCx, LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct);
+ErrorStatus LL_ADC_INJ_Init(ADC_TypeDef *ADCx, const LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct);
 void        LL_ADC_INJ_StructInit(LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct);
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /**
   * @}
   */
@@ -8013,5 +8021,3 @@ void        LL_ADC_INJ_StructInit(LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_ADC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_bus.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_bus.h
@@ -3,7 +3,17 @@
   * @file    stm32wbxx_ll_bus.h
   * @author  MCD Application Team
   * @brief   Header file of BUS LL module.
-
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
                       ##### RCC Limitations #####
   ==============================================================================
@@ -20,17 +30,6 @@
           inserted in each LL_{BUS}_GRP{x}_EnableClock() function.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -77,13 +76,13 @@ extern "C" {
 #define LL_AHB1_GRP1_PERIPH_DMA1           RCC_AHB1ENR_DMA1EN
 #if defined(DMA2)
 #define LL_AHB1_GRP1_PERIPH_DMA2           RCC_AHB1ENR_DMA2EN
-#endif
+#endif /* DMA2 */
 #define LL_AHB1_GRP1_PERIPH_DMAMUX1        RCC_AHB1ENR_DMAMUX1EN
 #define LL_AHB1_GRP1_PERIPH_SRAM1          RCC_AHB1SMENR_SRAM1SMEN
 #define LL_AHB1_GRP1_PERIPH_CRC            RCC_AHB1ENR_CRCEN
 #if defined(TSC)
 #define LL_AHB1_GRP1_PERIPH_TSC            RCC_AHB1ENR_TSCEN
-#endif
+#endif /* TSC */
 /**
   * @}
   */
@@ -98,15 +97,15 @@ extern "C" {
 #define LL_AHB2_GRP1_PERIPH_GPIOC          RCC_AHB2ENR_GPIOCEN
 #if defined(GPIOD)
 #define LL_AHB2_GRP1_PERIPH_GPIOD          RCC_AHB2ENR_GPIODEN
-#endif
+#endif /* GPIOD */
 #define LL_AHB2_GRP1_PERIPH_GPIOE          RCC_AHB2ENR_GPIOEEN
 #define LL_AHB2_GRP1_PERIPH_GPIOH          RCC_AHB2ENR_GPIOHEN
 #if defined(ADC_SUPPORT_5_MSPS)
 #define LL_AHB2_GRP1_PERIPH_ADC            RCC_AHB2ENR_ADCEN
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define LL_AHB2_GRP1_PERIPH_AES1           RCC_AHB2ENR_AES1EN
-#endif
+#endif /* AES1 */
 /**
   * @}
   */
@@ -117,7 +116,7 @@ extern "C" {
 #define LL_AHB3_GRP1_PERIPH_ALL            (0xFFFFFFFFU)
 #if defined(QUADSPI)
 #define LL_AHB3_GRP1_PERIPH_QUADSPI        RCC_AHB3ENR_QUADSPIEN
-#endif
+#endif /* QUADSPI */
 #define LL_AHB3_GRP1_PERIPH_PKA            RCC_AHB3ENR_PKAEN
 #define LL_AHB3_GRP1_PERIPH_AES2           RCC_AHB3ENR_AES2EN
 #define LL_AHB3_GRP1_PERIPH_RNG            RCC_AHB3ENR_RNGEN
@@ -136,22 +135,22 @@ extern "C" {
 #define LL_APB1_GRP1_PERIPH_TIM2           RCC_APB1ENR1_TIM2EN
 #if defined(LCD)
 #define LL_APB1_GRP1_PERIPH_LCD            RCC_APB1ENR1_LCDEN
-#endif
+#endif /* LCD */
 #define LL_APB1_GRP1_PERIPH_RTCAPB         RCC_APB1ENR1_RTCAPBEN
 #define LL_APB1_GRP1_PERIPH_WWDG           RCC_APB1ENR1_WWDGEN
 #if defined(SPI2)
 #define LL_APB1_GRP1_PERIPH_SPI2           RCC_APB1ENR1_SPI2EN
-#endif
+#endif /* SPI2 */
 #define LL_APB1_GRP1_PERIPH_I2C1           RCC_APB1ENR1_I2C1EN
 #if defined(I2C3)
 #define LL_APB1_GRP1_PERIPH_I2C3           RCC_APB1ENR1_I2C3EN
-#endif
+#endif /* I2C3 */
 #if defined(CRS)
 #define LL_APB1_GRP1_PERIPH_CRS            RCC_APB1ENR1_CRSEN
-#endif
+#endif /* CRS */
 #if defined(USB)
 #define LL_APB1_GRP1_PERIPH_USB            RCC_APB1ENR1_USBEN
-#endif
+#endif /* USB */
 #define LL_APB1_GRP1_PERIPH_LPTIM1         RCC_APB1ENR1_LPTIM1EN
 /**
   * @}
@@ -165,7 +164,7 @@ extern "C" {
 
 #if defined(LPUART1)
 #define LL_APB1_GRP2_PERIPH_LPUART1        RCC_APB1ENR2_LPUART1EN
-#endif
+#endif /* LPUART1 */
 #define LL_APB1_GRP2_PERIPH_LPTIM2         RCC_APB1ENR2_LPTIM2EN
 /**
   * @}
@@ -178,19 +177,19 @@ extern "C" {
 
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_APB2_GRP1_PERIPH_ADC            RCC_APB2ENR_ADCEN
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define LL_APB2_GRP1_PERIPH_TIM1           RCC_APB2ENR_TIM1EN
 #define LL_APB2_GRP1_PERIPH_SPI1           RCC_APB2ENR_SPI1EN
 #define LL_APB2_GRP1_PERIPH_USART1         RCC_APB2ENR_USART1EN
 #if defined(TIM16)
 #define LL_APB2_GRP1_PERIPH_TIM16          RCC_APB2ENR_TIM16EN
-#endif
+#endif /* TIM16 */
 #if defined(TIM17)
 #define LL_APB2_GRP1_PERIPH_TIM17          RCC_APB2ENR_TIM17EN
-#endif
+#endif /* TIM17 */
 #if defined(SAI1)
 #define LL_APB2_GRP1_PERIPH_SAI1           RCC_APB2ENR_SAI1EN
-#endif
+#endif /* SAI1 */
 /**
   * @}
   */
@@ -211,13 +210,13 @@ extern "C" {
 #define LL_C2_AHB1_GRP1_PERIPH_DMA1         RCC_C2AHB1ENR_DMA1EN
 #if defined(DMA2)
 #define LL_C2_AHB1_GRP1_PERIPH_DMA2         RCC_C2AHB1ENR_DMA2EN
-#endif
+#endif /* DMA2 */
 #define LL_C2_AHB1_GRP1_PERIPH_DMAMUX1      RCC_C2AHB1ENR_DMAMUX1EN
 #define LL_C2_AHB1_GRP1_PERIPH_SRAM1        RCC_C2AHB1ENR_SRAM1EN
 #define LL_C2_AHB1_GRP1_PERIPH_CRC          RCC_C2AHB1ENR_CRCEN
 #if defined(TSC)
 #define LL_C2_AHB1_GRP1_PERIPH_TSC          RCC_C2AHB1ENR_TSCEN
-#endif
+#endif /* TSC */
 /**
   * @}
   */
@@ -231,15 +230,15 @@ extern "C" {
 #define LL_C2_AHB2_GRP1_PERIPH_GPIOC        RCC_C2AHB2ENR_GPIOCEN
 #if defined(GPIOD)
 #define LL_C2_AHB2_GRP1_PERIPH_GPIOD        RCC_C2AHB2ENR_GPIODEN
-#endif
+#endif /* GPIOD */
 #define LL_C2_AHB2_GRP1_PERIPH_GPIOE        RCC_C2AHB2ENR_GPIOEEN
 #define LL_C2_AHB2_GRP1_PERIPH_GPIOH        RCC_C2AHB2ENR_GPIOHEN
 #if defined(ADC_SUPPORT_5_MSPS)
 #define LL_C2_AHB2_GRP1_PERIPH_ADC          RCC_C2AHB2ENR_ADCEN
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #if defined(AES1)
 #define LL_C2_AHB2_GRP1_PERIPH_AES1         RCC_C2AHB2ENR_AES1EN
-#endif
+#endif /* AES1 */
 /**
   * @}
   */
@@ -266,17 +265,17 @@ extern "C" {
 #define LL_C2_APB1_GRP1_PERIPH_TIM2         RCC_C2APB1ENR1_TIM2EN
 #if defined(LCD)
 #define LL_C2_APB1_GRP1_PERIPH_LCD          RCC_C2APB1ENR1_LCDEN
-#endif
+#endif /* LCD */
 #define LL_C2_APB1_GRP1_PERIPH_RTCAPB       RCC_C2APB1ENR1_RTCAPBEN
 #if defined(SPI2)
 #define LL_C2_APB1_GRP1_PERIPH_SPI2         RCC_C2APB1ENR1_SPI2EN
-#endif
+#endif /* SPI2 */
 #define LL_C2_APB1_GRP1_PERIPH_I2C1         RCC_C2APB1ENR1_I2C1EN
 #if defined(I2C3)
 #define LL_C2_APB1_GRP1_PERIPH_I2C3         RCC_C2APB1ENR1_I2C3EN
 #define LL_C2_APB1_GRP1_PERIPH_CRS          RCC_C2APB1ENR1_CRSEN
 #define LL_C2_APB1_GRP1_PERIPH_USB          RCC_C2APB1ENR1_USBEN
-#endif
+#endif /* I2C3 */
 #define LL_C2_APB1_GRP1_PERIPH_LPTIM1       RCC_C2APB1ENR1_LPTIM1EN
 /**
   * @}
@@ -288,7 +287,7 @@ extern "C" {
   */
 #if defined(LPUART1)
 #define LL_C2_APB1_GRP2_PERIPH_LPUART1      RCC_C2APB1ENR2_LPUART1EN
-#endif
+#endif /* LPUART1 */
 #define LL_C2_APB1_GRP2_PERIPH_LPTIM2       RCC_C2APB1ENR2_LPTIM2EN
 /**
   * @}
@@ -300,19 +299,19 @@ extern "C" {
   */
 #if defined(ADC_SUPPORT_2_5_MSPS)
 #define LL_C2_APB2_GRP1_PERIPH_ADC          RCC_C2APB2ENR_ADCEN
-#endif
+#endif /* ADC_SUPPORT_5_MSPS */
 #define LL_C2_APB2_GRP1_PERIPH_TIM1         RCC_C2APB2ENR_TIM1EN
 #define LL_C2_APB2_GRP1_PERIPH_SPI1         RCC_C2APB2ENR_SPI1EN
 #define LL_C2_APB2_GRP1_PERIPH_USART1       RCC_C2APB2ENR_USART1EN
 #if defined(TIM16)
 #define LL_C2_APB2_GRP1_PERIPH_TIM16        RCC_C2APB2ENR_TIM16EN
-#endif
+#endif /* TIM16 */
 #if defined(TIM17)
 #define LL_C2_APB2_GRP1_PERIPH_TIM17        RCC_C2APB2ENR_TIM17EN
-#endif
+#endif /* TIM17 */
 #if defined(SAI1)
 #define LL_C2_APB2_GRP1_PERIPH_SAI1         RCC_C2APB2ENR_SAI1EN
-#endif
+#endif /* SAI1 */
 /**
   * @}
   */
@@ -324,7 +323,7 @@ extern "C" {
 #define LL_C2_APB3_GRP1_PERIPH_BLE          RCC_C2APB3ENR_BLEEN
 #if defined(RCC_802_SUPPORT)
 #define LL_C2_APB3_GRP1_PERIPH_802          RCC_C2APB3ENR_802EN
-#endif
+#endif /* RCC_802_SUPPORT */
 /**
   * @}
   */
@@ -2376,5 +2375,3 @@ __STATIC_INLINE void LL_C2_APB3_GRP1_DisableClockSleep(uint32_t Periphs)
 #endif
 
 #endif /* STM32WBxx_LL_BUS_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_comp.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_comp.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -74,33 +73,33 @@ typedef struct
 {
   uint32_t PowerMode;                   /*!< Set comparator operating mode to adjust power and speed.
                                              This parameter can be a value of @ref COMP_LL_EC_POWERMODE
-
-                                             This feature can be modified afterwards using unitary function @ref LL_COMP_SetPowerMode(). */
+                                             This feature can be modified afterwards using unitary
+                                             function @ref LL_COMP_SetPowerMode(). */
 
   uint32_t InputPlus;                   /*!< Set comparator input plus (non-inverting input).
                                              This parameter can be a value of @ref COMP_LL_EC_INPUT_PLUS
-
-                                             This feature can be modified afterwards using unitary function @ref LL_COMP_SetInputPlus(). */
+                                             This feature can be modified afterwards using unitary function
+                                             @ref LL_COMP_SetInputPlus(). */
 
   uint32_t InputMinus;                  /*!< Set comparator input minus (inverting input).
                                              This parameter can be a value of @ref COMP_LL_EC_INPUT_MINUS
-
-                                             This feature can be modified afterwards using unitary function @ref LL_COMP_SetInputMinus(). */
+                                             This feature can be modified afterwards using unitary function
+                                              @ref LL_COMP_SetInputMinus(). */
 
   uint32_t InputHysteresis;             /*!< Set comparator hysteresis mode of the input minus.
                                              This parameter can be a value of @ref COMP_LL_EC_INPUT_HYSTERESIS
-
-                                             This feature can be modified afterwards using unitary function @ref LL_COMP_SetInputHysteresis(). */
+                                             This feature can be modified afterwards using unitary function
+                                             @ref LL_COMP_SetInputHysteresis(). */
 
   uint32_t OutputPolarity;              /*!< Set comparator output polarity.
                                              This parameter can be a value of @ref COMP_LL_EC_OUTPUT_POLARITY
-
-                                             This feature can be modified afterwards using unitary function @ref LL_COMP_SetOutputPolarity(). */
+                                             This feature can be modified afterwards using unitary function
+                                             @ref LL_COMP_SetOutputPolarity(). */
 
   uint32_t OutputBlankingSource;        /*!< Set comparator blanking source.
                                              This parameter can be a value of @ref COMP_LL_EC_OUTPUT_BLANKING_SOURCE
-
-                                             This feature can be modified afterwards using unitary function @ref LL_COMP_SetOutputBlankingSource(). */
+                                             This feature can be modified afterwards using unitary function
+                                             @ref LL_COMP_SetOutputBlankingSource(). */
 
 } LL_COMP_InitTypeDef;
 
@@ -114,6 +113,7 @@ typedef struct
   * @{
   */
 
+
 /** @defgroup COMP_LL_EC_COMMON_WINDOWMODE Comparator common modes - Window mode
   * @{
   */
@@ -124,6 +124,8 @@ typedef struct
 /**
   * @}
   */
+
+
 
 /** @defgroup COMP_LL_EC_POWERMODE Comparator modes - Power mode
   * @{
@@ -138,7 +140,11 @@ typedef struct
 /** @defgroup COMP_LL_EC_INPUT_PLUS Comparator inputs - Input plus (input non-inverting) selection
   * @{
   */
-#define LL_COMP_INPUT_PLUS_IO1          (0x00000000UL)                          /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1 (except device STM32WB35xx), pin PB4 for COMP2). Note: On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx. */
+#if defined(STM32WB15xx) || defined(STM32WB10xx) || defined(STM32WB1Mxx)
+/* LL_COMP_INPUT_PLUS_IO1 not available on this device */
+#else
+#define LL_COMP_INPUT_PLUS_IO1          (0x00000000UL)                          /*!< Comparator input plus connected to IO1 (pin PC5 for COMP1 (except device STM32WB35xx), pin PB4 for COMP2). Note: On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx. */
+#endif /* STM32WB15xx || STM32WB10xx || STM32WB1Mxx */
 #define LL_COMP_INPUT_PLUS_IO2          (COMP_CSR_INPSEL_0)                     /*!< Comparator input plus connected to IO2 (pin PB2 for COMP1, pin PB6 for COMP2) */
 #define LL_COMP_INPUT_PLUS_IO3          (COMP_CSR_INPSEL_1)                     /*!< Comparator input plus connected to IO3 (pin PA1 for COMP1, pin PA3 for COMP2) */
 /**
@@ -153,7 +159,11 @@ typedef struct
 #define LL_COMP_INPUT_MINUS_3_4VREFINT  (                    COMP_CSR_INMSEL_1                     | COMP_CSR_SCALEN | COMP_CSR_BRGEN)        /*!< Comparator input minus connected to 3/4 VrefInt  */
 #define LL_COMP_INPUT_MINUS_VREFINT     (                    COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0 | COMP_CSR_SCALEN                 )        /*!< Comparator input minus connected to VrefInt */
 #define LL_COMP_INPUT_MINUS_IO1         (COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1                    )                                           /*!< Comparator input minus connected to IO1 (pin PA9 for COMP1, pin PB3 for COMP2) */
-#define LL_COMP_INPUT_MINUS_IO2         (COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0)                                           /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1 (except device STM32WB35xx), pin PB7 for COMP2). Note: On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx. */
+#if defined(STM32WB15xx) || defined(STM32WB10xx) || defined(STM32WB1Mxx)
+/* LL_COMP_INPUT_MINUS_IO2 not available on this device */
+#else
+#define LL_COMP_INPUT_MINUS_IO2         (COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0)                                           /*!< Comparator input minus connected to IO2 (pin PC4 for COMP1 (except device STM32WB35xx), pin PB7 for COMP2). Note: On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx. */
+#endif /* STM32WB15xx || STM32WB10xx || STM32WB1Mxx */
 #define LL_COMP_INPUT_MINUS_IO3         (                     COMP_CSR_INMESEL_0 | COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO3 (pin PA0 for COMP1, pin PA2 for COMP2) */
 #define LL_COMP_INPUT_MINUS_IO4         (COMP_CSR_INMESEL_1                      | COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO4 (pin PA4 for COMP1, pin PA4 for COMP2) */
 #define LL_COMP_INPUT_MINUS_IO5         (COMP_CSR_INMESEL_1 | COMP_CSR_INMESEL_0 | COMP_CSR_INMSEL_2 | COMP_CSR_INMSEL_1 | COMP_CSR_INMSEL_0) /*!< Comparator input minus connected to IO5 (pin PA5 for COMP1, pin PA5 for COMP2) */
@@ -273,8 +283,7 @@ typedef struct
   * @param  __COMPx__ COMP instance
   * @retval COMP common instance or value "0" if there is no COMP common instance.
   */
-#define __LL_COMP_COMMON_INSTANCE(__COMPx__)                                   \
-  (COMP12_COMMON)
+#define __LL_COMP_COMMON_INSTANCE(__COMPx__)          (COMP12_COMMON)
 
 /**
   * @}
@@ -290,7 +299,8 @@ typedef struct
   */
 
 #if defined(COMP2)
-/** @defgroup COMP_LL_EF_Configuration_comparator_common Configuration of COMP hierarchical scope: common to several COMP instances
+/** @defgroup COMP_LL_EF_Configuration_comparator_common Configuration of COMP hierarchical scope:
+  *           common to several COMP instances
   * @{
   */
 
@@ -322,7 +332,7 @@ __STATIC_INLINE void LL_COMP_SetCommonWindowMode(COMP_Common_TypeDef *COMPxy_COM
   *         @arg @ref LL_COMP_WINDOWMODE_DISABLE
   *         @arg @ref LL_COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON
   */
-__STATIC_INLINE uint32_t LL_COMP_GetCommonWindowMode(COMP_Common_TypeDef *COMPxy_COMMON)
+__STATIC_INLINE uint32_t LL_COMP_GetCommonWindowMode(const COMP_Common_TypeDef *COMPxy_COMMON)
 {
   return (uint32_t)(READ_BIT(COMPxy_COMMON->CSR, COMP_CSR_WINMODE));
 }
@@ -360,7 +370,7 @@ __STATIC_INLINE void LL_COMP_SetPowerMode(COMP_TypeDef *COMPx, uint32_t PowerMod
   *         @arg @ref LL_COMP_POWERMODE_MEDIUMSPEED
   *         @arg @ref LL_COMP_POWERMODE_ULTRALOWPOWER
   */
-__STATIC_INLINE uint32_t LL_COMP_GetPowerMode(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_GetPowerMode(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_PWRMODE));
 }
@@ -454,7 +464,7 @@ __STATIC_INLINE void LL_COMP_SetInputPlus(COMP_TypeDef *COMPx, uint32_t InputPlu
   *
   *         (*) Parameter not available on all devices.
   */
-__STATIC_INLINE uint32_t LL_COMP_GetInputPlus(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_GetInputPlus(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_INPSEL));
 }
@@ -517,7 +527,7 @@ __STATIC_INLINE void LL_COMP_SetInputMinus(COMP_TypeDef *COMPx, uint32_t InputMi
   *         @arg @ref LL_COMP_INPUT_MINUS_IO4
   *         @arg @ref LL_COMP_INPUT_MINUS_IO5
   */
-__STATIC_INLINE uint32_t LL_COMP_GetInputMinus(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_GetInputMinus(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_INMESEL | COMP_CSR_INMSEL | COMP_CSR_SCALEN | COMP_CSR_BRGEN));
 }
@@ -548,7 +558,7 @@ __STATIC_INLINE void LL_COMP_SetInputHysteresis(COMP_TypeDef *COMPx, uint32_t In
   *         @arg @ref LL_COMP_HYSTERESIS_MEDIUM
   *         @arg @ref LL_COMP_HYSTERESIS_HIGH
   */
-__STATIC_INLINE uint32_t LL_COMP_GetInputHysteresis(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_GetInputHysteresis(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_HYST));
 }
@@ -583,7 +593,7 @@ __STATIC_INLINE void LL_COMP_SetOutputPolarity(COMP_TypeDef *COMPx, uint32_t Out
   *         @arg @ref LL_COMP_OUTPUTPOL_NONINVERTED
   *         @arg @ref LL_COMP_OUTPUTPOL_INVERTED
   */
-__STATIC_INLINE uint32_t LL_COMP_GetOutputPolarity(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_GetOutputPolarity(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_POLARITY));
 }
@@ -626,7 +636,7 @@ __STATIC_INLINE void LL_COMP_SetOutputBlankingSource(COMP_TypeDef *COMPx, uint32
   *         (1) Parameter availability depending on timer availability
   *             on the selected device.
   */
-__STATIC_INLINE uint32_t LL_COMP_GetOutputBlankingSource(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_GetOutputBlankingSource(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_BLANKING));
 }
@@ -671,7 +681,7 @@ __STATIC_INLINE void LL_COMP_Disable(COMP_TypeDef *COMPx)
   * @param  COMPx Comparator instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_COMP_IsEnabled(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_IsEnabled(const COMP_TypeDef *COMPx)
 {
   return ((READ_BIT(COMPx->CSR, COMP_CSR_EN) == (COMP_CSR_EN)) ? 1UL : 0UL);
 }
@@ -698,7 +708,7 @@ __STATIC_INLINE void LL_COMP_Lock(COMP_TypeDef *COMPx)
   * @param  COMPx Comparator instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_COMP_IsLocked(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_IsLocked(const COMP_TypeDef *COMPx)
 {
   return ((READ_BIT(COMPx->CSR, COMP_CSR_LOCK) == (COMP_CSR_LOCK)) ? 1UL : 0UL);
 }
@@ -723,7 +733,7 @@ __STATIC_INLINE uint32_t LL_COMP_IsLocked(COMP_TypeDef *COMPx)
   *         @arg @ref LL_COMP_OUTPUT_LEVEL_LOW
   *         @arg @ref LL_COMP_OUTPUT_LEVEL_HIGH
   */
-__STATIC_INLINE uint32_t LL_COMP_ReadOutputLevel(COMP_TypeDef *COMPx)
+__STATIC_INLINE uint32_t LL_COMP_ReadOutputLevel(const COMP_TypeDef *COMPx)
 {
   return (uint32_t)(READ_BIT(COMPx->CSR, COMP_CSR_VALUE)
                     >> LL_COMP_OUTPUT_LEVEL_BITOFFSET_POS);
@@ -739,7 +749,7 @@ __STATIC_INLINE uint32_t LL_COMP_ReadOutputLevel(COMP_TypeDef *COMPx)
   */
 
 ErrorStatus LL_COMP_DeInit(COMP_TypeDef *COMPx);
-ErrorStatus LL_COMP_Init(COMP_TypeDef *COMPx, LL_COMP_InitTypeDef *COMP_InitStruct);
+ErrorStatus LL_COMP_Init(COMP_TypeDef *COMPx, const LL_COMP_InitTypeDef *COMP_InitStruct);
 void        LL_COMP_StructInit(LL_COMP_InitTypeDef *COMP_InitStruct);
 
 /**
@@ -770,5 +780,3 @@ void        LL_COMP_StructInit(LL_COMP_InitTypeDef *COMP_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_COMP_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_cortex.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_cortex.h
@@ -3,6 +3,17 @@
   * @file    stm32wbxx_ll_cortex.h
   * @author  MCD Application Team
   * @brief   Header file of CORTEX LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -10,7 +21,7 @@
     [..]
     The LL CORTEX driver contains a set of generic APIs that can be
     used by user:
-      (+) SYSTICK configuration used by @ref LL_mDelay and @ref LL_Init1msTick
+      (+) SYSTICK configuration used by LL_mDelay and LL_Init1msTick
           functions
       (+) Low power mode configuration (SCB register of Cortex-MCU)
       (+) MPU API to configure and enable regions
@@ -18,17 +29,6 @@
       (+) API to enable fault handler (SHCSR accesses)
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -82,6 +82,7 @@ extern "C" {
 /**
   * @}
   */
+
 
 #if __MPU_PRESENT
 
@@ -565,22 +566,28 @@ __STATIC_INLINE void LL_MPU_EnableRegion(uint32_t Region)
   * @param  Address Value of region base address
   * @param  SubRegionDisable Sub-region disable value between Min_Data = 0x00 and Max_Data = 0xFF
   * @param  Attributes This parameter can be a combination of the following values:
-  *         @arg @ref LL_MPU_REGION_SIZE_32B or @ref LL_MPU_REGION_SIZE_64B or @ref LL_MPU_REGION_SIZE_128B or @ref LL_MPU_REGION_SIZE_256B or @ref LL_MPU_REGION_SIZE_512B
-  *           or @ref LL_MPU_REGION_SIZE_1KB or @ref LL_MPU_REGION_SIZE_2KB or @ref LL_MPU_REGION_SIZE_4KB or @ref LL_MPU_REGION_SIZE_8KB or @ref LL_MPU_REGION_SIZE_16KB
-  *           or @ref LL_MPU_REGION_SIZE_32KB or @ref LL_MPU_REGION_SIZE_64KB or @ref LL_MPU_REGION_SIZE_128KB or @ref LL_MPU_REGION_SIZE_256KB or @ref LL_MPU_REGION_SIZE_512KB
-  *           or @ref LL_MPU_REGION_SIZE_1MB or @ref LL_MPU_REGION_SIZE_2MB or @ref LL_MPU_REGION_SIZE_4MB or @ref LL_MPU_REGION_SIZE_8MB or @ref LL_MPU_REGION_SIZE_16MB
-  *           or @ref LL_MPU_REGION_SIZE_32MB or @ref LL_MPU_REGION_SIZE_64MB or @ref LL_MPU_REGION_SIZE_128MB or @ref LL_MPU_REGION_SIZE_256MB or @ref LL_MPU_REGION_SIZE_512MB
-  *           or @ref LL_MPU_REGION_SIZE_1GB or @ref LL_MPU_REGION_SIZE_2GB or @ref LL_MPU_REGION_SIZE_4GB
-  *         @arg @ref LL_MPU_REGION_NO_ACCESS or @ref LL_MPU_REGION_PRIV_RW or @ref LL_MPU_REGION_PRIV_RW_URO or @ref LL_MPU_REGION_FULL_ACCESS
-  *           or @ref LL_MPU_REGION_PRIV_RO or @ref LL_MPU_REGION_PRIV_RO_URO
+  *         @arg @ref LL_MPU_REGION_SIZE_32B (*) or @ref LL_MPU_REGION_SIZE_64B (*) or @ref LL_MPU_REGION_SIZE_128B (*)
+  *           or @ref LL_MPU_REGION_SIZE_256B or @ref LL_MPU_REGION_SIZE_512B or @ref LL_MPU_REGION_SIZE_1KB
+  *           or @ref LL_MPU_REGION_SIZE_2KB or @ref LL_MPU_REGION_SIZE_4KB or @ref LL_MPU_REGION_SIZE_8KB
+  *           or @ref LL_MPU_REGION_SIZE_16KB or @ref LL_MPU_REGION_SIZE_32KB or @ref LL_MPU_REGION_SIZE_64KB
+  *           or @ref LL_MPU_REGION_SIZE_128KB or @ref LL_MPU_REGION_SIZE_256KB or @ref LL_MPU_REGION_SIZE_512KB
+  *           or @ref LL_MPU_REGION_SIZE_1MB or @ref LL_MPU_REGION_SIZE_2MB or @ref LL_MPU_REGION_SIZE_4MB
+  *           or @ref LL_MPU_REGION_SIZE_8MB or @ref LL_MPU_REGION_SIZE_16MB or @ref LL_MPU_REGION_SIZE_32MB
+  *           or @ref LL_MPU_REGION_SIZE_64MB or @ref LL_MPU_REGION_SIZE_128MB or @ref LL_MPU_REGION_SIZE_256MB
+  *           or @ref LL_MPU_REGION_SIZE_512MB or @ref LL_MPU_REGION_SIZE_1GB or @ref LL_MPU_REGION_SIZE_2GB
+  *           or @ref LL_MPU_REGION_SIZE_4GB
+  *         @arg @ref LL_MPU_REGION_NO_ACCESS or @ref LL_MPU_REGION_PRIV_RW or @ref LL_MPU_REGION_PRIV_RW_URO
+  *           or @ref LL_MPU_REGION_FULL_ACCESS or @ref LL_MPU_REGION_PRIV_RO or @ref LL_MPU_REGION_PRIV_RO_URO
   *         @arg @ref LL_MPU_TEX_LEVEL0 or @ref LL_MPU_TEX_LEVEL1 or @ref LL_MPU_TEX_LEVEL2 or @ref LL_MPU_TEX_LEVEL4
   *         @arg @ref LL_MPU_INSTRUCTION_ACCESS_ENABLE or  @ref LL_MPU_INSTRUCTION_ACCESS_DISABLE
   *         @arg @ref LL_MPU_ACCESS_SHAREABLE or @ref LL_MPU_ACCESS_NOT_SHAREABLE
   *         @arg @ref LL_MPU_ACCESS_CACHEABLE or @ref LL_MPU_ACCESS_NOT_CACHEABLE
   *         @arg @ref LL_MPU_ACCESS_BUFFERABLE or @ref LL_MPU_ACCESS_NOT_BUFFERABLE
+  *         (*) value not defined for CM0+ core.
   * @retval None
   */
-__STATIC_INLINE void LL_MPU_ConfigRegion(uint32_t Region, uint32_t SubRegionDisable, uint32_t Address, uint32_t Attributes)
+__STATIC_INLINE void LL_MPU_ConfigRegion(uint32_t Region, uint32_t SubRegionDisable, uint32_t Address,
+                                         uint32_t Attributes)
 {
   /* Set Region number */
   WRITE_REG(MPU->RNR, Region);
@@ -635,5 +642,3 @@ __STATIC_INLINE void LL_MPU_DisableRegion(uint32_t Region)
 #endif
 
 #endif /* STM32WBxx_LL_CORTEX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_crc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_crc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -185,7 +184,7 @@ __STATIC_INLINE void LL_CRC_SetPolynomialSize(CRC_TypeDef *CRCx, uint32_t PolySi
   *         @arg @ref LL_CRC_POLYLENGTH_8B
   *         @arg @ref LL_CRC_POLYLENGTH_7B
   */
-__STATIC_INLINE uint32_t LL_CRC_GetPolynomialSize(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_GetPolynomialSize(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_BIT(CRCx->CR, CRC_CR_POLYSIZE));
 }
@@ -216,7 +215,7 @@ __STATIC_INLINE void LL_CRC_SetInputDataReverseMode(CRC_TypeDef *CRCx, uint32_t 
   *         @arg @ref LL_CRC_INDATA_REVERSE_HALFWORD
   *         @arg @ref LL_CRC_INDATA_REVERSE_WORD
   */
-__STATIC_INLINE uint32_t LL_CRC_GetInputDataReverseMode(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_GetInputDataReverseMode(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_BIT(CRCx->CR, CRC_CR_REV_IN));
 }
@@ -236,14 +235,14 @@ __STATIC_INLINE void LL_CRC_SetOutputDataReverseMode(CRC_TypeDef *CRCx, uint32_t
 }
 
 /**
-  * @brief  Configure the reversal of the bit order of the Output data
+  * @brief  Return type of reversal of the bit order of the Output data
   * @rmtoll CR           REV_OUT       LL_CRC_GetOutputDataReverseMode
   * @param  CRCx CRC Instance
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_CRC_OUTDATA_REVERSE_NONE
   *         @arg @ref LL_CRC_OUTDATA_REVERSE_BIT
   */
-__STATIC_INLINE uint32_t LL_CRC_GetOutputDataReverseMode(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_GetOutputDataReverseMode(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_BIT(CRCx->CR, CRC_CR_REV_OUT));
 }
@@ -271,7 +270,7 @@ __STATIC_INLINE void LL_CRC_SetInitialData(CRC_TypeDef *CRCx, uint32_t InitCrc)
   * @param  CRCx CRC Instance
   * @retval Value programmed in Programmable initial CRC value register
   */
-__STATIC_INLINE uint32_t LL_CRC_GetInitialData(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_GetInitialData(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_REG(CRCx->INIT));
 }
@@ -302,7 +301,7 @@ __STATIC_INLINE void LL_CRC_SetPolynomialCoef(CRC_TypeDef *CRCx, uint32_t Polyno
   * @param  CRCx CRC Instance
   * @retval Value programmed in Programmable Polynomial value register
   */
-__STATIC_INLINE uint32_t LL_CRC_GetPolynomialCoef(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_GetPolynomialCoef(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_REG(CRCx->POL));
 }
@@ -360,7 +359,7 @@ __STATIC_INLINE void LL_CRC_FeedData8(CRC_TypeDef *CRCx, uint8_t InData)
   * @param  CRCx CRC Instance
   * @retval Current CRC calculation result as stored in CRC_DR register (32 bits).
   */
-__STATIC_INLINE uint32_t LL_CRC_ReadData32(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_ReadData32(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_REG(CRCx->DR));
 }
@@ -372,7 +371,7 @@ __STATIC_INLINE uint32_t LL_CRC_ReadData32(CRC_TypeDef *CRCx)
   * @param  CRCx CRC Instance
   * @retval Current CRC calculation result as stored in CRC_DR register (16 bits).
   */
-__STATIC_INLINE uint16_t LL_CRC_ReadData16(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint16_t LL_CRC_ReadData16(const CRC_TypeDef *CRCx)
 {
   return (uint16_t)READ_REG(CRCx->DR);
 }
@@ -384,7 +383,7 @@ __STATIC_INLINE uint16_t LL_CRC_ReadData16(CRC_TypeDef *CRCx)
   * @param  CRCx CRC Instance
   * @retval Current CRC calculation result as stored in CRC_DR register (8 bits).
   */
-__STATIC_INLINE uint8_t LL_CRC_ReadData8(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint8_t LL_CRC_ReadData8(const CRC_TypeDef *CRCx)
 {
   return (uint8_t)READ_REG(CRCx->DR);
 }
@@ -396,7 +395,7 @@ __STATIC_INLINE uint8_t LL_CRC_ReadData8(CRC_TypeDef *CRCx)
   * @param  CRCx CRC Instance
   * @retval Current CRC calculation result as stored in CRC_DR register (7 bits).
   */
-__STATIC_INLINE uint8_t LL_CRC_ReadData7(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint8_t LL_CRC_ReadData7(const CRC_TypeDef *CRCx)
 {
   return (uint8_t)(READ_REG(CRCx->DR) & 0x7FU);
 }
@@ -408,7 +407,7 @@ __STATIC_INLINE uint8_t LL_CRC_ReadData7(CRC_TypeDef *CRCx)
   * @param  CRCx CRC Instance
   * @retval Value stored in CRC_IDR register (General-purpose 32-bit data register).
   */
-__STATIC_INLINE uint32_t LL_CRC_Read_IDR(CRC_TypeDef *CRCx)
+__STATIC_INLINE uint32_t LL_CRC_Read_IDR(const CRC_TypeDef *CRCx)
 {
   return (uint32_t)(READ_REG(CRCx->IDR));
 }
@@ -434,7 +433,7 @@ __STATIC_INLINE void LL_CRC_Write_IDR(CRC_TypeDef *CRCx, uint32_t InData)
   * @{
   */
 
-ErrorStatus LL_CRC_DeInit(CRC_TypeDef *CRCx);
+ErrorStatus LL_CRC_DeInit(const CRC_TypeDef *CRCx);
 
 /**
   * @}
@@ -460,5 +459,3 @@ ErrorStatus LL_CRC_DeInit(CRC_TypeDef *CRCx);
 #endif
 
 #endif /* STM32WBxx_LL_CRC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_crs.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_crs.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -109,7 +108,7 @@ extern "C" {
 /** @defgroup CRS_LL_EC_SYNC_SOURCE Synchronization Signal Source
   * @{
   */
-#define LL_CRS_SYNC_SOURCE_GPIO            0x00000000U             /*!< Synchro Signal soucre GPIO */
+#define LL_CRS_SYNC_SOURCE_GPIO            0x00000000U             /*!< Synchro Signal source GPIO */
 #define LL_CRS_SYNC_SOURCE_LSE             CRS_CFGR_SYNCSRC_0      /*!< Synchro Signal source LSE */
 #define LL_CRS_SYNC_SOURCE_USB             CRS_CFGR_SYNCSRC_1      /*!< Synchro Signal source USB SOF (default)*/
 /**
@@ -794,5 +793,3 @@ ErrorStatus LL_CRS_DeInit(void);
 #endif
 
 #endif /* STM32WBxx_LL_CRS_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_dma.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_dma.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -55,11 +54,11 @@ extern "C" {
   */
 #if defined (DMA2)
 #define __LL_DMA_INSTANCE_TO_CHANNEL(__DMA_INSTANCE__, __CHANNEL_INDEX__)   \
-(((__DMA_INSTANCE__) == DMA1) ? (DMA1_Channel1 + (__CHANNEL_INDEX__)) : (DMA2_Channel1 + (__CHANNEL_INDEX__)))
+  (((__DMA_INSTANCE__) == DMA1) ? (DMA1_Channel1 + (__CHANNEL_INDEX__)) : (DMA2_Channel1 + (__CHANNEL_INDEX__)))
 #else
 #define __LL_DMA_INSTANCE_TO_CHANNEL(__DMA_INSTANCE__, __CHANNEL_INDEX__)   \
-(DMA1_Channel1 + (__CHANNEL_INDEX__))
-#endif
+  (DMA1_Channel1 + (__CHANNEL_INDEX__))
+#endif /* DMA2 */
 
 /**
   * @brief  Helper macro to convert DMA Instance and index into DMAMUX channel
@@ -71,11 +70,11 @@ extern "C" {
   */
 #if defined (DMA2)
 #define __LL_DMA_INSTANCE_TO_DMAMUX_CCR(__DMA_INSTANCE__, __CHANNEL_INDEX__)\
-(((__DMA_INSTANCE__) == DMA1) ? (DMAMUX1_Channel0 + (__CHANNEL_INDEX__)) : (DMAMUX1_Channel7 + (__CHANNEL_INDEX__)))
+  (((__DMA_INSTANCE__) == DMA1) ? (DMAMUX1_Channel0 + (__CHANNEL_INDEX__)) : (DMAMUX1_Channel7 + (__CHANNEL_INDEX__)))
 #else
 #define __LL_DMA_INSTANCE_TO_DMAMUX_CCR(__DMA_INSTANCE__, __CHANNEL_INDEX__)\
-(DMAMUX1_Channel0 + (__CHANNEL_INDEX__))
-#endif
+  (DMAMUX1_Channel0 + (__CHANNEL_INDEX__))
+#endif /* DMA2 */
 /**
   * @}
   */
@@ -256,7 +255,7 @@ typedef struct
 #define LL_DMA_CHANNEL_7                  0x00000007U /*!< DMA Channel 7 */
 #if defined(USE_FULL_LL_DRIVER)
 #define LL_DMA_CHANNEL_ALL                0xFFFF0000U /*!< DMA Channel all (used only for function @ref LL_DMA_DeInit(). */
-#endif /*USE_FULL_LL_DRIVER*/
+#endif /* USE_FULL_LL_DRIVER */
 /**
   * @}
   */
@@ -371,10 +370,10 @@ typedef struct
   */
 #if defined(DMA2)
 #define __LL_DMA_GET_INSTANCE(__CHANNEL_INSTANCE__)   \
-(((uint32_t)(__CHANNEL_INSTANCE__) > ((uint32_t)DMA1_Channel7)) ?  DMA2 : DMA1)
+  (((uint32_t)(__CHANNEL_INSTANCE__) > ((uint32_t)DMA1_Channel7)) ?  DMA2 : DMA1)
 #else
 #define __LL_DMA_GET_INSTANCE(__CHANNEL_INSTANCE__)  (DMA1)
-#endif
+#endif /* DMA2 */
 
 /**
   * @brief  Convert DMAx_Channely into LL_DMA_CHANNEL_y
@@ -384,44 +383,44 @@ typedef struct
 #if defined (DMA2)
 #if defined (DMA2_Channel6) && defined (DMA2_Channel7)
 #define __LL_DMA_GET_CHANNEL(__CHANNEL_INSTANCE__)   \
-(((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel1)) ? LL_DMA_CHANNEL_1 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel2)) ? LL_DMA_CHANNEL_2 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel3)) ? LL_DMA_CHANNEL_3 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel4)) ? LL_DMA_CHANNEL_4 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel5)) ? LL_DMA_CHANNEL_5 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel6)) ? LL_DMA_CHANNEL_6 : \
- LL_DMA_CHANNEL_7)
+  (((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel1)) ? LL_DMA_CHANNEL_1 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel2)) ? LL_DMA_CHANNEL_2 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel3)) ? LL_DMA_CHANNEL_3 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel4)) ? LL_DMA_CHANNEL_4 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel5)) ? LL_DMA_CHANNEL_5 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel6)) ? LL_DMA_CHANNEL_6 : \
+   LL_DMA_CHANNEL_7)
 #else
 #define __LL_DMA_GET_CHANNEL(__CHANNEL_INSTANCE__)   \
-(((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel1)) ? LL_DMA_CHANNEL_1 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel2)) ? LL_DMA_CHANNEL_2 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel3)) ? LL_DMA_CHANNEL_3 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel4)) ? LL_DMA_CHANNEL_4 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel5)) ? LL_DMA_CHANNEL_5 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
- LL_DMA_CHANNEL_7)
-#endif
+  (((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel1)) ? LL_DMA_CHANNEL_1 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel2)) ? LL_DMA_CHANNEL_2 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel3)) ? LL_DMA_CHANNEL_3 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel4)) ? LL_DMA_CHANNEL_4 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA2_Channel5)) ? LL_DMA_CHANNEL_5 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
+   LL_DMA_CHANNEL_7)
+#endif /* DMA2_Channel6 && DMA2_Channel7 */
 #else
 #define __LL_DMA_GET_CHANNEL(__CHANNEL_INSTANCE__)   \
-(((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
- ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
- LL_DMA_CHANNEL_7)
-#endif
+  (((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel1)) ? LL_DMA_CHANNEL_1 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel2)) ? LL_DMA_CHANNEL_2 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel3)) ? LL_DMA_CHANNEL_3 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel4)) ? LL_DMA_CHANNEL_4 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel5)) ? LL_DMA_CHANNEL_5 : \
+   ((uint32_t)(__CHANNEL_INSTANCE__) == ((uint32_t)DMA1_Channel6)) ? LL_DMA_CHANNEL_6 : \
+   LL_DMA_CHANNEL_7)
+#endif /* DMA2 */
 
 /**
   * @brief  Convert DMA Instance DMAx and LL_DMA_CHANNEL_y into DMAx_Channely
@@ -432,45 +431,45 @@ typedef struct
 #if defined (DMA2)
 #if defined (DMA2_Channel6) && defined (DMA2_Channel7)
 #define __LL_DMA_GET_CHANNEL_INSTANCE(__DMA_INSTANCE__, __CHANNEL__)   \
-((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA2_Channel1 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA2_Channel2 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA2_Channel3 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA2_Channel4 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA2_Channel5 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA2_Channel6 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_7))) ? DMA1_Channel7 : \
- DMA2_Channel7)
+  ((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA2_Channel1 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA2_Channel2 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA2_Channel3 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA2_Channel4 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA2_Channel5 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA2_Channel6 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_7))) ? DMA1_Channel7 : \
+   DMA2_Channel7)
 #else
 #define __LL_DMA_GET_CHANNEL_INSTANCE(__DMA_INSTANCE__, __CHANNEL__)   \
-((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA2_Channel1 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA2_Channel2 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA2_Channel3 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA2_Channel4 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA2_Channel5 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
- DMA1_Channel7)
-#endif
+  ((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA2_Channel1 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA2_Channel2 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA2_Channel3 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA2_Channel4 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA2)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA2_Channel5 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
+   DMA1_Channel7)
+#endif /* DMA2_Channel6 && DMA2_Channel7 */
 #else
 #define __LL_DMA_GET_CHANNEL_INSTANCE(__DMA_INSTANCE__, __CHANNEL__)   \
-((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
- (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
- DMA1_Channel7)
-#endif
+  ((((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_1))) ? DMA1_Channel1 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_2))) ? DMA1_Channel2 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_3))) ? DMA1_Channel3 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_4))) ? DMA1_Channel4 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_5))) ? DMA1_Channel5 : \
+   (((uint32_t)(__DMA_INSTANCE__) == ((uint32_t)DMA1)) && ((uint32_t)(__CHANNEL__) == ((uint32_t)LL_DMA_CHANNEL_6))) ? DMA1_Channel6 : \
+   DMA1_Channel7)
+#endif /* DMA2 */
 
 /**
   * @}
@@ -482,8 +481,8 @@ typedef struct
 
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup DMA_LL_Exported_Functions DMA Exported Functions
- * @{
- */
+  * @{
+  */
 
 /** @defgroup DMA_LL_EF_Configuration Configuration
   * @{
@@ -543,7 +542,7 @@ __STATIC_INLINE void LL_DMA_DisableChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledChannel(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   return ((READ_BIT(__LL_DMA_INSTANCE_TO_CHANNEL(DMAx, Channel - 1U)->CCR,
-                   DMA_CCR_EN) == (DMA_CCR_EN)) ? 1UL : 0UL);
+                    DMA_CCR_EN) == (DMA_CCR_EN)) ? 1UL : 0UL);
 }
 
 /**
@@ -959,7 +958,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetDataLength(DMA_TypeDef *DMAx, uint32_t Channe
 /**
   * @brief  Configure the Source and Destination addresses.
   * @note   This API must not be called when the DMA channel is enabled.
-  * @note   Each peripheral using DMA provides an API to get directly the register adress (LL_PPP_DMA_GetRegAddr).
+  * @note   Each peripheral using DMA provides an API to get directly the register address (LL_PPP_DMA_GetRegAddr).
   * @rmtoll CPAR         PA            LL_DMA_ConfigAddresses\n
   *         CMAR         MA            LL_DMA_ConfigAddresses
   * @param  DMAx DMAx Instance
@@ -1607,6 +1606,10 @@ __STATIC_INLINE uint32_t LL_DMA_IsActiveFlag_TE7(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 1 global interrupt flag.
+  * @note Do not Clear Channel 1 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC1, LL_DMA_ClearFlag_HT1,
+    LL_DMA_ClearFlag_TE1. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF1         LL_DMA_ClearFlag_GI1
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1618,6 +1621,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI1(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 2 global interrupt flag.
+  * @note Do not Clear Channel 2 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC2, LL_DMA_ClearFlag_HT2,
+    LL_DMA_ClearFlag_TE2. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF2         LL_DMA_ClearFlag_GI2
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1629,6 +1636,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI2(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 3 global interrupt flag.
+  * @note Do not Clear Channel 3 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC3, LL_DMA_ClearFlag_HT3,
+    LL_DMA_ClearFlag_TE3. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF3         LL_DMA_ClearFlag_GI3
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1640,6 +1651,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI3(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 4 global interrupt flag.
+  * @note Do not Clear Channel 4 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC4, LL_DMA_ClearFlag_HT4,
+    LL_DMA_ClearFlag_TE4. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF4         LL_DMA_ClearFlag_GI4
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1651,6 +1666,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI4(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 5 global interrupt flag.
+  * @note Do not Clear Channel 5 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC5, LL_DMA_ClearFlag_HT5,
+    LL_DMA_ClearFlag_TE5. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF5         LL_DMA_ClearFlag_GI5
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1662,6 +1681,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI5(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 6 global interrupt flag.
+  * @note Do not Clear Channel 6 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC6, LL_DMA_ClearFlag_HT6,
+    LL_DMA_ClearFlag_TE6. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF6         LL_DMA_ClearFlag_GI6
   * @param  DMAx DMAx Instance
   * @retval None
@@ -1673,6 +1696,10 @@ __STATIC_INLINE void LL_DMA_ClearFlag_GI6(DMA_TypeDef *DMAx)
 
 /**
   * @brief  Clear Channel 7 global interrupt flag.
+  * @note Do not Clear Channel 7 global interrupt flag when the channel in ON.
+    Instead clear specific flags transfer complete, half transfer & transfer
+    error flag with LL_DMA_ClearFlag_TC7, LL_DMA_ClearFlag_HT7,
+    LL_DMA_ClearFlag_TE7. bug id 2.4.1 in Product Errata Sheet.
   * @rmtoll IFCR         CGIF7         LL_DMA_ClearFlag_GI7
   * @param  DMAx DMAx Instance
   * @retval None
@@ -2051,7 +2078,7 @@ __STATIC_INLINE void LL_DMA_DisableIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TC(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   return ((READ_BIT(__LL_DMA_INSTANCE_TO_CHANNEL(DMAx, Channel - 1U)->CCR,
-                   DMA_CCR_TCIE) == (DMA_CCR_TCIE)) ? 1UL : 0UL);
+                    DMA_CCR_TCIE) == (DMA_CCR_TCIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2071,7 +2098,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TC(DMA_TypeDef *DMAx, uint32_t Chann
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_HT(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   return ((READ_BIT(__LL_DMA_INSTANCE_TO_CHANNEL(DMAx, Channel - 1U)->CCR,
-                   DMA_CCR_HTIE) == (DMA_CCR_HTIE)) ? 1UL : 0UL);
+                    DMA_CCR_HTIE) == (DMA_CCR_HTIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2091,7 +2118,7 @@ __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_HT(DMA_TypeDef *DMAx, uint32_t Chann
 __STATIC_INLINE uint32_t LL_DMA_IsEnabledIT_TE(DMA_TypeDef *DMAx, uint32_t Channel)
 {
   return ((READ_BIT(__LL_DMA_INSTANCE_TO_CHANNEL(DMAx, Channel - 1U)->CCR,
-                   DMA_CCR_TEIE) == (DMA_CCR_TEIE)) ? 1UL : 0UL);
+                    DMA_CCR_TEIE) == (DMA_CCR_TEIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2130,5 +2157,3 @@ void LL_DMA_StructInit(LL_DMA_InitTypeDef *DMA_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_DMA_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_dmamux.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_dmamux.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -139,26 +138,26 @@ extern "C" {
 #if defined(SPI2)
 #define LL_DMAMUX_REQ_SPI2_RX             0x00000008U  /*!< DMAMUX SPI2 RX request     */
 #define LL_DMAMUX_REQ_SPI2_TX             0x00000009U  /*!< DMAMUX SPI2 TX request     */
-#endif
+#endif /* SPI2 */
 #define LL_DMAMUX_REQ_I2C1_RX             0x0000000AU  /*!< DMAMUX I2C1 RX request     */
 #define LL_DMAMUX_REQ_I2C1_TX             0x0000000BU  /*!< DMAMUX I2C1 TX request     */
 #if defined(I2C3)
 #define LL_DMAMUX_REQ_I2C3_RX             0x0000000CU  /*!< DMAMUX I2C3 RX request     */
 #define LL_DMAMUX_REQ_I2C3_TX             0x0000000DU  /*!< DMAMUX I2C3 TX request     */
-#endif
+#endif /* I2C3 */
 #define LL_DMAMUX_REQ_USART1_RX           0x0000000EU  /*!< DMAMUX USART1 RX request   */
 #define LL_DMAMUX_REQ_USART1_TX           0x0000000FU  /*!< DMAMUX USART1 TX request   */
 #if defined(LPUART1)
 #define LL_DMAMUX_REQ_LPUART1_RX          0x00000010U  /*!< DMAMUX LPUART1 RX request  */
 #define LL_DMAMUX_REQ_LPUART1_TX          0x00000011U  /*!< DMAMUX LPUART1 TX request  */
-#endif
+#endif /* LPUART1 */
 #if defined(SAI1)
 #define LL_DMAMUX_REQ_SAI1_A              0x00000012U  /*!< DMAMUX SAI1 A request      */
 #define LL_DMAMUX_REQ_SAI1_B              0x00000013U  /*!< DMAMUX SAI1 B request      */
-#endif
+#endif /* SAI1 */
 #if defined(QUADSPI)
 #define LL_DMAMUX_REQ_QUADSPI             0x00000014U  /*!< DMAMUX QUADSPI request     */
-#endif
+#endif /* QUADSPI */
 #define LL_DMAMUX_REQ_TIM1_CH1            0x00000015U  /*!< DMAMUX TIM1 CH1 request    */
 #define LL_DMAMUX_REQ_TIM1_CH2            0x00000016U  /*!< DMAMUX TIM1 CH2 request    */
 #define LL_DMAMUX_REQ_TIM1_CH3            0x00000017U  /*!< DMAMUX TIM1 CH3 request    */
@@ -178,7 +177,7 @@ extern "C" {
 #if defined(AES1)
 #define LL_DMAMUX_REQ_AES1_IN             0x00000025U  /*!< DMAMUX AES1_IN request     */
 #define LL_DMAMUX_REQ_AES1_OUT            0x00000026U  /*!< DMAMUX AES1_OUT request    */
-#endif
+#endif /* AES1 */
 #define LL_DMAMUX_REQ_AES2_IN             0x00000027U  /*!< DMAMUX AES2_IN request     */
 #define LL_DMAMUX_REQ_AES2_OUT            0x00000028U  /*!< DMAMUX AES2_OUT request    */
 /**
@@ -203,7 +202,7 @@ extern "C" {
 #define LL_DMAMUX_CHANNEL_11              0x0000000BU               /*!< DMAMUX Channel 11 connected to DMA2 Channel 5 */
 #define LL_DMAMUX_CHANNEL_12              0x0000000CU               /*!< DMAMUX Channel 12 connected to DMA2 Channel 6 */
 #define LL_DMAMUX_CHANNEL_13              0x0000000DU               /*!< DMAMUX Channel 13 connected to DMA2 Channel 7 */
-#endif
+#endif /* DMA2 */
 /**
   * @}
   */
@@ -240,8 +239,8 @@ extern "C" {
 #define LL_DMAMUX_SYNC_EXTI_LINE15        (DMAMUX_CxCR_SYNC_ID_3 | DMAMUX_CxCR_SYNC_ID_2 | DMAMUX_CxCR_SYNC_ID_1 | DMAMUX_CxCR_SYNC_ID_0) /*!< Synchronization signal from EXTI Line15 */
 #define LL_DMAMUX_SYNC_DMAMUX_CH0         DMAMUX_CxCR_SYNC_ID_4                                                                           /*!< Synchronization signal from DMAMUX channel0 Event */
 #define LL_DMAMUX_SYNC_DMAMUX_CH1         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_0)                                                 /*!< Synchronization signal from DMAMUX channel1 Event */
-#define LL_DMAMUX_SYNC_LPTIM1_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_1)                                                 /*!< Synchronization signal from LPTIM1 Ouput */
-#define LL_DMAMUX_SYNC_LPTIM2_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_1 | DMAMUX_CxCR_SYNC_ID_0)                         /*!< Synchronization signal from LPTIM2 Ouput */
+#define LL_DMAMUX_SYNC_LPTIM1_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_1)                                                 /*!< Synchronization signal from LPTIM1 Output */
+#define LL_DMAMUX_SYNC_LPTIM2_OUT         (DMAMUX_CxCR_SYNC_ID_4 | DMAMUX_CxCR_SYNC_ID_1 | DMAMUX_CxCR_SYNC_ID_0)                         /*!< Synchronization signal from LPTIM2 Output */
 /**
   * @}
   */
@@ -289,8 +288,8 @@ extern "C" {
 #define LL_DMAMUX_REQ_GEN_EXTI_LINE15     (DMAMUX_RGxCR_SIG_ID_3 | DMAMUX_RGxCR_SIG_ID_2 | DMAMUX_RGxCR_SIG_ID_1 | DMAMUX_RGxCR_SIG_ID_0) /*!< Request signal generation from EXTI Line15 */
 #define LL_DMAMUX_REQ_GEN_DMAMUX_CH0      DMAMUX_RGxCR_SIG_ID_4                                                                           /*!< Request signal generation from DMAMUX channel0 Event */
 #define LL_DMAMUX_REQ_GEN_DMAMUX_CH1      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_0)                                                 /*!< Request signal generation from DMAMUX channel1 Event */
-#define LL_DMAMUX_REQ_GEN_LPTIM1_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_1)                                                 /*!< Request signal generation from LPTIM1 Ouput */
-#define LL_DMAMUX_REQ_GEN_LPTIM2_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_1 | DMAMUX_RGxCR_SIG_ID_0)                         /*!< Request signal generation from LPTIM2 Ouput */
+#define LL_DMAMUX_REQ_GEN_LPTIM1_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_1)                                                 /*!< Request signal generation from LPTIM1 Output */
+#define LL_DMAMUX_REQ_GEN_LPTIM2_OUT      (DMAMUX_RGxCR_SIG_ID_4 | DMAMUX_RGxCR_SIG_ID_1 | DMAMUX_RGxCR_SIG_ID_0)                         /*!< Request signal generation from LPTIM2 Output */
 /**
   * @}
   */
@@ -333,8 +332,8 @@ extern "C" {
 
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup DMAMUX_LL_Exported_Functions DMAMUX Exported Functions
- * @{
- */
+  * @{
+  */
 
 /** @defgroup DMAMUX_LL_EF_Configuration Configuration
   * @{
@@ -921,7 +920,8 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetSyncID(DMAMUX_Channel_TypeDef *DMAMUXx, ui
 __STATIC_INLINE void LL_DMAMUX_EnableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  SET_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
+  SET_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE *
+                                                    (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
 }
 
 /**
@@ -938,7 +938,8 @@ __STATIC_INLINE void LL_DMAMUX_EnableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx,
 __STATIC_INLINE void LL_DMAMUX_DisableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  CLEAR_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
+  CLEAR_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE *
+                                                      (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE);
 }
 
 /**
@@ -955,7 +956,8 @@ __STATIC_INLINE void LL_DMAMUX_DisableRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx
 __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledRequestGen(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return ((READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE) == (DMAMUX_RGxCR_GE)) ? 1UL : 0UL);
+  return ((READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE *
+                                                              (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GE) == (DMAMUX_RGxCR_GE)) ? 1UL : 0UL);
 }
 
 /**
@@ -974,10 +976,12 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledRequestGen(DMAMUX_Channel_TypeDef *D
   *         @arg @ref LL_DMAMUX_REQ_GEN_POL_RISING_FALLING
   * @retval None
   */
-__STATIC_INLINE void LL_DMAMUX_SetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel, uint32_t Polarity)
+__STATIC_INLINE void LL_DMAMUX_SetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel,
+                                                     uint32_t Polarity)
 {
   (void)(DMAMUXx);
-  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL, Polarity);
+  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE *
+                                                       (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL, Polarity);
 }
 
 /**
@@ -998,7 +1002,8 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMA
 __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestGenPolarity(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL));
+  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 +
+                                                                       (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GPOL));
 }
 
 /**
@@ -1014,10 +1019,12 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestGenPolarity(DMAMUX_Channel_TypeDef 
   * @param  RequestNb This parameter must be a value between Min_Data = 1 and Max_Data = 32.
   * @retval None
   */
-__STATIC_INLINE void LL_DMAMUX_SetGenRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel, uint32_t RequestNb)
+__STATIC_INLINE void LL_DMAMUX_SetGenRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel,
+                                               uint32_t RequestNb)
 {
   (void)(DMAMUXx);
-  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GNBREQ, (RequestNb - 1U) << DMAMUX_RGxCR_GNBREQ_Pos);
+  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE *
+                                                       (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GNBREQ, (RequestNb - 1U) << DMAMUX_RGxCR_GNBREQ_Pos);
 }
 
 /**
@@ -1034,7 +1041,8 @@ __STATIC_INLINE void LL_DMAMUX_SetGenRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx, 
 __STATIC_INLINE uint32_t LL_DMAMUX_GetGenRequestNb(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return (uint32_t)((READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GNBREQ) >> DMAMUX_RGxCR_GNBREQ_Pos) + 1U);
+  return (uint32_t)((READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 +
+                                                                        (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_GNBREQ) >> DMAMUX_RGxCR_GNBREQ_Pos) + 1U);
 }
 
 /**
@@ -1069,10 +1077,12 @@ __STATIC_INLINE uint32_t LL_DMAMUX_GetGenRequestNb(DMAMUX_Channel_TypeDef *DMAMU
   *         @arg @ref LL_DMAMUX_REQ_GEN_LPTIM2_OUT
   * @retval None
   */
-__STATIC_INLINE void LL_DMAMUX_SetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel, uint32_t RequestSignalID)
+__STATIC_INLINE void LL_DMAMUX_SetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel,
+                                                  uint32_t RequestSignalID)
 {
   (void)(DMAMUXx);
-  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID, RequestSignalID);
+  MODIFY_REG(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE *
+                                                       (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID, RequestSignalID);
 }
 
 /**
@@ -1109,7 +1119,8 @@ __STATIC_INLINE void LL_DMAMUX_SetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUX
 __STATIC_INLINE uint32_t LL_DMAMUX_GetRequestSignalID(DMAMUX_Channel_TypeDef *DMAMUXx, uint32_t RequestGenChannel)
 {
   (void)(DMAMUXx);
-  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 + (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID));
+  return (uint32_t)(READ_BIT(((DMAMUX_RequestGen_TypeDef *)((uint32_t)((uint32_t)DMAMUX1_RequestGenerator0 +
+                                                                       (DMAMUX_RGCR_SIZE * (RequestGenChannel)))))->RGCR, DMAMUX_RGxCR_SIG_ID));
 }
 
 /**
@@ -1217,7 +1228,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO7(DMAMUX_Channel_TypeDef *DMAM
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF7) == (DMAMUX_CSR_SOF7)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel7 */
 #if defined(DMAMUX1_Channel8)
 /**
   * @brief  Get Synchronization Event Overrun Flag Channel 8.
@@ -1231,7 +1242,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO8(DMAMUX_Channel_TypeDef *DMAM
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF8) == (DMAMUX_CSR_SOF8)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel8 */
 #if defined(DMAMUX1_Channel9)
 /**
   * @brief  Get Synchronization Event Overrun Flag Channel 9.
@@ -1245,7 +1256,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO9(DMAMUX_Channel_TypeDef *DMAM
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF9) == (DMAMUX_CSR_SOF9)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel9 */
 #if defined(DMAMUX1_Channel10)
 /**
   * @brief  Get Synchronization Event Overrun Flag Channel 10.
@@ -1259,7 +1270,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO10(DMAMUX_Channel_TypeDef *DMA
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF10) == (DMAMUX_CSR_SOF10)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel10 */
 #if defined(DMAMUX1_Channel11)
 /**
   * @brief  Get Synchronization Event Overrun Flag Channel 11.
@@ -1273,7 +1284,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO11(DMAMUX_Channel_TypeDef *DMA
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF11) == (DMAMUX_CSR_SOF11)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel11 */
 #if defined(DMAMUX1_Channel12)
 /**
   * @brief  Get Synchronization Event Overrun Flag Channel 12.
@@ -1287,7 +1298,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO12(DMAMUX_Channel_TypeDef *DMA
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF12) == (DMAMUX_CSR_SOF12)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel12 */
 #if defined(DMAMUX1_Channel13)
 /**
   * @brief  Get Synchronization Event Overrun Flag Channel 13.
@@ -1301,7 +1312,7 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsActiveFlag_SO13(DMAMUX_Channel_TypeDef *DMA
   return ((READ_BIT(DMAMUX1_ChannelStatus->CSR, DMAMUX_CSR_SOF13) == (DMAMUX_CSR_SOF13)) ? 1UL : 0UL);
 }
 
-#endif
+#endif /* DMAMUX1_Channel13 */
 /**
   * @brief  Get Request Generator 0 Trigger Event Overrun Flag.
   * @rmtoll RGSR         OF0           LL_DMAMUX_IsActiveFlag_RGO0
@@ -1447,7 +1458,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO7(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF7);
 }
 
-#endif
+#endif /* DMAMUX1_Channel7 */
 #if defined(DMAMUX1_Channel8)
 /**
   * @brief  Clear Synchronization Event Overrun Flag Channel 8.
@@ -1461,7 +1472,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO8(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF8);
 }
 
-#endif
+#endif /* DMAMUX1_Channel8 */
 #if defined(DMAMUX1_Channel9)
 /**
   * @brief  Clear Synchronization Event Overrun Flag Channel 9.
@@ -1475,7 +1486,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO9(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF9);
 }
 
-#endif
+#endif /* DMAMUX1_Channel9 */
 #if defined(DMAMUX1_Channel10)
 /**
   * @brief  Clear Synchronization Event Overrun Flag Channel 10.
@@ -1489,7 +1500,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO10(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF10);
 }
 
-#endif
+#endif /* DMAMUX1_Channel10 */
 #if defined(DMAMUX1_Channel11)
 /**
   * @brief  Clear Synchronization Event Overrun Flag Channel 11.
@@ -1503,7 +1514,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO11(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF11);
 }
 
-#endif
+#endif /* DMAMUX1_Channel11 */
 #if defined(DMAMUX1_Channel12)
 /**
   * @brief  Clear Synchronization Event Overrun Flag Channel 12.
@@ -1517,7 +1528,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO12(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF12);
 }
 
-#endif
+#endif /* DMAMUX1_Channel12 */
 #if defined(DMAMUX1_Channel13)
 /**
   * @brief  Clear Synchronization Event Overrun Flag Channel 13.
@@ -1531,7 +1542,7 @@ __STATIC_INLINE void LL_DMAMUX_ClearFlag_SO13(DMAMUX_Channel_TypeDef *DMAMUXx)
   SET_BIT(DMAMUX1_ChannelStatus->CFR, DMAMUX_CFR_CSOF13);
 }
 
-#endif
+#endif /* DMAMUX1_Channel13 */
 /**
   * @brief  Clear Request Generator 0 Trigger Event Overrun Flag.
   * @rmtoll RGCFR        COF0          LL_DMAMUX_ClearFlag_RGO0
@@ -1755,5 +1766,3 @@ __STATIC_INLINE uint32_t LL_DMAMUX_IsEnabledIT_RGO(DMAMUX_Channel_TypeDef *DMAMU
 #endif
 
 #endif /* STM32WBxx_LL_DMAMUX_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_exti.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_exti.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -107,28 +106,28 @@ typedef struct
 #define LL_EXTI_LINE_17                EXTI_IMR1_IM17          /*!< Extended line 17 */
 #define LL_EXTI_LINE_18                EXTI_IMR1_IM18          /*!< Extended line 18 */
 #define LL_EXTI_LINE_19                EXTI_IMR1_IM19          /*!< Extended line 19 */
-#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined STM32WB35xx
+#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx) || defined (STM32WB15xx) || defined(STM32WB1Mxx)
 #define LL_EXTI_LINE_20                EXTI_IMR1_IM20          /*!< Extended line 20 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define LL_EXTI_LINE_21                EXTI_IMR1_IM21          /*!< Extended line 21 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define LL_EXTI_LINE_22                EXTI_IMR1_IM22          /*!< Extended line 22 */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define LL_EXTI_LINE_23                EXTI_IMR1_IM23          /*!< Extended line 23 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define LL_EXTI_LINE_24                EXTI_IMR1_IM24          /*!< Extended line 24 */
-#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined STM32WB35xx
+#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx) || defined (STM32WB15xx) || defined(STM32WB1Mxx)
 #define LL_EXTI_LINE_25                EXTI_IMR1_IM25          /*!< Extended line 25 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define LL_EXTI_LINE_28                EXTI_IMR1_IM28          /*!< Extended line 28 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define LL_EXTI_LINE_29                EXTI_IMR1_IM29          /*!< Extended line 29 */
 #define LL_EXTI_LINE_30                EXTI_IMR1_IM30          /*!< Extended line 30 */
-#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined STM32WB35xx
+#if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx) || defined (STM32WB15xx) || defined(STM32WB1Mxx)
 #define LL_EXTI_LINE_31                EXTI_IMR1_IM31          /*!< Extended line 31 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define LL_EXTI_LINE_ALL_0_31          (LL_EXTI_LINE_0 | LL_EXTI_LINE_1 | LL_EXTI_LINE_2 | \
@@ -141,6 +140,16 @@ typedef struct
                                         LL_EXTI_LINE_21 | LL_EXTI_LINE_22 | LL_EXTI_LINE_23 | \
                                         LL_EXTI_LINE_24 | LL_EXTI_LINE_25 | LL_EXTI_LINE_28 | \
                                         LL_EXTI_LINE_29 | LL_EXTI_LINE_30 | LL_EXTI_LINE_31) /*!< All Extended line not reserved*/
+#elif defined (STM32WB15xx) || defined(STM32WB1Mxx)
+#define LL_EXTI_LINE_ALL_0_31          (LL_EXTI_LINE_0 | LL_EXTI_LINE_1 | LL_EXTI_LINE_2 | \
+                                        LL_EXTI_LINE_3 | LL_EXTI_LINE_4 | LL_EXTI_LINE_5 | \
+                                        LL_EXTI_LINE_6 | LL_EXTI_LINE_7 | LL_EXTI_LINE_8 | \
+                                        LL_EXTI_LINE_9 | LL_EXTI_LINE_10 | LL_EXTI_LINE_11 | \
+                                        LL_EXTI_LINE_12 | LL_EXTI_LINE_13 | LL_EXTI_LINE_14 | \
+                                        LL_EXTI_LINE_15 | LL_EXTI_LINE_16 | LL_EXTI_LINE_17 | \
+                                        LL_EXTI_LINE_18 | LL_EXTI_LINE_19 | LL_EXTI_LINE_20 | \
+                                        LL_EXTI_LINE_22 | LL_EXTI_LINE_24 | LL_EXTI_LINE_25 | \
+                                        LL_EXTI_LINE_29 | LL_EXTI_LINE_30 | LL_EXTI_LINE_31) /*!< All Extended line not reserved*/
 #else
 #define LL_EXTI_LINE_ALL_0_31          (LL_EXTI_LINE_0 | LL_EXTI_LINE_1 | LL_EXTI_LINE_2 | \
                                         LL_EXTI_LINE_3 | LL_EXTI_LINE_4 | LL_EXTI_LINE_5 | \
@@ -150,7 +159,7 @@ typedef struct
                                         LL_EXTI_LINE_15 | LL_EXTI_LINE_16 | LL_EXTI_LINE_17 | \
                                         LL_EXTI_LINE_18 | LL_EXTI_LINE_19 | LL_EXTI_LINE_22 | \
                                         LL_EXTI_LINE_24 | LL_EXTI_LINE_29 | LL_EXTI_LINE_30) /*!< All Extended line not reserved*/
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 
 #define LL_EXTI_LINE_33                EXTI_IMR2_IM33          /*!< Extended line 33 */
 #define LL_EXTI_LINE_36                EXTI_IMR2_IM36          /*!< Extended line 36 */
@@ -162,12 +171,12 @@ typedef struct
 #define LL_EXTI_LINE_42                EXTI_IMR2_IM42          /*!< Extended line 42 */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx)
 #define LL_EXTI_LINE_43                EXTI_IMR2_IM43          /*!< Extended line 43 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 #define LL_EXTI_LINE_44                EXTI_IMR2_IM44          /*!< Extended line 44 */
 #define LL_EXTI_LINE_45                EXTI_IMR2_IM45          /*!< Extended line 45 */
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB50xx) || defined (STM32WB35xx) || defined (STM32WB30xx)
 #define LL_EXTI_LINE_46                EXTI_IMR2_IM46          /*!< Extended line 46 */
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx || ... */
 #define LL_EXTI_LINE_48                EXTI_IMR2_IM48          /*!< Extended line 48 */
 
 #if defined (STM32WB55xx) || defined (STM32WB5Mxx)
@@ -186,7 +195,7 @@ typedef struct
                                         LL_EXTI_LINE_38 | LL_EXTI_LINE_39 | LL_EXTI_LINE_40 | \
                                         LL_EXTI_LINE_41 | LL_EXTI_LINE_42 | LL_EXTI_LINE_44 | \
                                         LL_EXTI_LINE_45 | LL_EXTI_LINE_48)  /*!< All Extended line not reserved*/
-#endif
+#endif /* STM32WB55xx || STM32WB5Mxx */
 
 
 #define LL_EXTI_LINE_ALL               (0xFFFFFFFFU)  /*!< All Extended line */
@@ -266,8 +275,8 @@ typedef struct
 
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup EXTI_LL_Exported_Functions EXTI Exported Functions
- * @{
- */
+  * @{
+  */
 /** @defgroup EXTI_LL_EF_IT_Management IT_Management
   * @{
   */
@@ -1396,7 +1405,7 @@ __STATIC_INLINE void LL_EXTI_GenerateSWI_0_31(uint32_t ExtiLine)
 
 /**
   * @brief  Generate a software Interrupt Event for Lines in range 32 to 63
-  * @note If the interrupt is enabled on this line inthe EXTI_IMR2, writing a 1 to
+  * @note If the interrupt is enabled on this line in the EXTI_IMR2, writing a 1 to
   *       this bit when it is at '0' sets the corresponding pending bit in EXTI_PR2
   *       resulting in an interrupt request generation.
   *       This bit is cleared by clearing the corresponding bit in the EXTI_PR2
@@ -1622,5 +1631,3 @@ void LL_EXTI_StructInit(LL_EXTI_InitTypeDef *EXTI_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_EXTI_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_gpio.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_gpio.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -58,7 +57,7 @@ extern "C" {
 /**
   * @}
   */
-#endif /*USE_FULL_LL_DRIVER*/
+#endif /* USE_FULL_LL_DRIVER */
 
 /* Exported types ------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
@@ -130,11 +129,11 @@ typedef struct
 #define LL_GPIO_PIN_14                     GPIO_BSRR_BS14 /*!< Select pin 14 */
 #define LL_GPIO_PIN_15                     GPIO_BSRR_BS15 /*!< Select pin 15 */
 #define LL_GPIO_PIN_ALL                    (GPIO_BSRR_BS0 | GPIO_BSRR_BS1  | GPIO_BSRR_BS2  | \
-                                           GPIO_BSRR_BS3  | GPIO_BSRR_BS4  | GPIO_BSRR_BS5  | \
-                                           GPIO_BSRR_BS6  | GPIO_BSRR_BS7  | GPIO_BSRR_BS8  | \
-                                           GPIO_BSRR_BS9  | GPIO_BSRR_BS10 | GPIO_BSRR_BS11 | \
-                                           GPIO_BSRR_BS12 | GPIO_BSRR_BS13 | GPIO_BSRR_BS14 | \
-                                           GPIO_BSRR_BS15) /*!< Select all pins */
+                                            GPIO_BSRR_BS3  | GPIO_BSRR_BS4  | GPIO_BSRR_BS5  | \
+                                            GPIO_BSRR_BS6  | GPIO_BSRR_BS7  | GPIO_BSRR_BS8  | \
+                                            GPIO_BSRR_BS9  | GPIO_BSRR_BS10 | GPIO_BSRR_BS11 | \
+                                            GPIO_BSRR_BS12 | GPIO_BSRR_BS13 | GPIO_BSRR_BS14 | \
+                                            GPIO_BSRR_BS15) /*!< Select all pins */
 /**
   * @}
   */
@@ -988,5 +987,3 @@ void        LL_GPIO_StructInit(LL_GPIO_InitTypeDef *GPIO_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_GPIO_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_hsem.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_hsem.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -60,6 +59,7 @@ extern "C" {
 /**
   * @}
   */
+
 
 /** @defgroup HSEM_LL_EC_GET_FLAG Get Flags Defines
   * @brief    Flags defines which can be used with LL_HSEM_ReadReg function
@@ -157,7 +157,7 @@ extern "C" {
   * @param  Semaphore Semaphore number. Value between Min_Data=0 and Max_Data=31
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsSemaphoreLocked(HSEM_TypeDef *HSEMx, uint32_t Semaphore)
+__STATIC_INLINE uint32_t LL_HSEM_IsSemaphoreLocked(const HSEM_TypeDef *HSEMx, uint32_t Semaphore)
 {
   return ((READ_BIT(HSEMx->R[Semaphore], HSEM_R_LOCK) == (HSEM_R_LOCK_Msk)) ? 1UL : 0UL);
 }
@@ -172,7 +172,7 @@ __STATIC_INLINE uint32_t LL_HSEM_IsSemaphoreLocked(HSEM_TypeDef *HSEMx, uint32_t
   *         @arg @ref LL_HSEM_COREID_CPU1
   *         @arg @ref LL_HSEM_COREID_CPU2
   */
-__STATIC_INLINE uint32_t LL_HSEM_GetCoreId(HSEM_TypeDef *HSEMx, uint32_t Semaphore)
+__STATIC_INLINE uint32_t LL_HSEM_GetCoreId(const HSEM_TypeDef *HSEMx, uint32_t Semaphore)
 {
   return (uint32_t)(READ_BIT(HSEMx->R[Semaphore], HSEM_R_COREID_Msk));
 }
@@ -184,7 +184,7 @@ __STATIC_INLINE uint32_t LL_HSEM_GetCoreId(HSEM_TypeDef *HSEMx, uint32_t Semapho
   * @param  Semaphore Semaphore number. Value between Min_Data=0 and Max_Data=31
   * @retval Process number. Value between Min_Data=0 and Max_Data=255
   */
-__STATIC_INLINE uint32_t LL_HSEM_GetProcessId(HSEM_TypeDef *HSEMx, uint32_t Semaphore)
+__STATIC_INLINE uint32_t LL_HSEM_GetProcessId(const HSEM_TypeDef *HSEMx, uint32_t Semaphore)
 {
   return (uint32_t)(READ_BIT(HSEMx->R[Semaphore], HSEM_R_PROCID_Msk));
 }
@@ -230,9 +230,9 @@ __STATIC_INLINE uint32_t LL_HSEM_2StepLock(HSEM_TypeDef *HSEMx, uint32_t Semapho
   * @param  Semaphore Semaphore number. Value between Min_Data=0 and Max_Data=31
   * @retval 1 lock fail, 0 lock successful or already locked by same core
   */
-__STATIC_INLINE uint32_t LL_HSEM_1StepLock(HSEM_TypeDef *HSEMx, uint32_t Semaphore)
+__STATIC_INLINE uint32_t LL_HSEM_1StepLock(const HSEM_TypeDef *HSEMx, uint32_t Semaphore)
 {
-  return ((HSEMx->RLR[Semaphore] != (HSEM_R_LOCK | LL_HSEM_COREID)) ? 1UL : 0UL);
+  return ((HSEMx->RLR[Semaphore] != (HSEM_RLR_LOCK | LL_HSEM_COREID)) ? 1UL : 0UL);
 }
 
 /**
@@ -255,7 +255,7 @@ __STATIC_INLINE void LL_HSEM_ReleaseLock(HSEM_TypeDef *HSEMx, uint32_t Semaphore
   * @param  HSEMx HSEM Instance.
   * @param  Semaphore Semaphore number. Value between Min_Data=0 and Max_Data=31
   * @retval 0 semaphore is free, 1 semaphore is locked  */
-__STATIC_INLINE uint32_t LL_HSEM_GetStatus(HSEM_TypeDef *HSEMx, uint32_t Semaphore)
+__STATIC_INLINE uint32_t LL_HSEM_GetStatus(const HSEM_TypeDef *HSEMx, uint32_t Semaphore)
 {
   return ((HSEMx->R[Semaphore] != 0U) ? 1UL : 0UL);
 }
@@ -278,7 +278,7 @@ __STATIC_INLINE void LL_HSEM_SetKey(HSEM_TypeDef *HSEMx, uint32_t key)
   * @param  HSEMx HSEM Instance.
   * @retval key to unlock all semaphore from the same core
   */
-__STATIC_INLINE uint32_t LL_HSEM_GetKey(HSEM_TypeDef *HSEMx)
+__STATIC_INLINE uint32_t LL_HSEM_GetKey(const HSEM_TypeDef *HSEMx)
 {
   return (uint32_t)(READ_BIT(HSEMx->KEYR, HSEM_KEYR_KEY) >> HSEM_KEYR_KEY_Pos);
 }
@@ -286,6 +286,8 @@ __STATIC_INLINE uint32_t LL_HSEM_GetKey(HSEM_TypeDef *HSEMx)
 /**
   * @brief  Release all semaphore with the same core id.
   * @rmtoll CR           KEY           LL_HSEM_ResetAllLock
+  * @rmtoll CR           SEC           LL_HSEM_ResetAllLock
+  * @rmtoll CR           PRIV          LL_HSEM_ResetAllLock
   * @param  HSEMx HSEM Instance.
   * @param  key Key value.
   * @param  core This parameter can be one of the following values:
@@ -436,7 +438,7 @@ __STATIC_INLINE void LL_HSEM_DisableIT_C1IER(HSEM_TypeDef *HSEMx, uint32_t Semap
   *         @arg @ref LL_HSEM_SEMAPHORE_ALL
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsEnabledIT_C1IER(HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
+__STATIC_INLINE uint32_t LL_HSEM_IsEnabledIT_C1IER(const HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
 {
   return ((READ_BIT(HSEMx->C1IER, SemaphoreMask) == (SemaphoreMask)) ? 1UL : 0UL);
 }
@@ -571,7 +573,7 @@ __STATIC_INLINE void LL_HSEM_DisableIT_C2IER(HSEM_TypeDef *HSEMx, uint32_t Semap
   *         @arg @ref LL_HSEM_SEMAPHORE_ALL
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsEnabledIT_C2IER(HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
+__STATIC_INLINE uint32_t LL_HSEM_IsEnabledIT_C2IER(const HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
 {
   return ((READ_BIT(HSEMx->C2IER, SemaphoreMask) == (SemaphoreMask)) ? 1UL : 0UL);
 }
@@ -669,7 +671,7 @@ __STATIC_INLINE void LL_HSEM_ClearFlag_C1ICR(HSEM_TypeDef *HSEMx, uint32_t Semap
   *         @arg @ref LL_HSEM_SEMAPHORE_ALL
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C1ISR(HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
+__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C1ISR(const HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
 {
   return ((READ_BIT(HSEMx->C1ISR, SemaphoreMask) == (SemaphoreMask)) ? 1UL : 0UL);
 }
@@ -714,7 +716,7 @@ __STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C1ISR(HSEM_TypeDef *HSEMx, uint32_
   *         @arg @ref LL_HSEM_SEMAPHORE_ALL
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C1MISR(HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
+__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C1MISR(const HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
 {
   return ((READ_BIT(HSEMx->C1MISR, SemaphoreMask) == (SemaphoreMask)) ? 1UL : 0UL);
 }
@@ -804,7 +806,7 @@ __STATIC_INLINE void LL_HSEM_ClearFlag_C2ICR(HSEM_TypeDef *HSEMx, uint32_t Semap
   *         @arg @ref LL_HSEM_SEMAPHORE_ALL
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C2ISR(HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
+__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C2ISR(const HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
 {
   return ((READ_BIT(HSEMx->C2ISR, SemaphoreMask) == (SemaphoreMask)) ? 1UL : 0UL);
 }
@@ -849,7 +851,7 @@ __STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C2ISR(HSEM_TypeDef *HSEMx, uint32_
   *         @arg @ref LL_HSEM_SEMAPHORE_ALL
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C2MISR(HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
+__STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C2MISR(const HSEM_TypeDef *HSEMx, uint32_t SemaphoreMask)
 {
   return ((READ_BIT(HSEMx->C2MISR, SemaphoreMask) == (SemaphoreMask)) ? 1UL : 0UL);
 }
@@ -876,5 +878,3 @@ __STATIC_INLINE uint32_t LL_HSEM_IsActiveFlag_C2MISR(HSEM_TypeDef *HSEMx, uint32
 #endif
 
 #endif /* __STM32WBxx_LL_HSEM_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_i2c.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_i2c.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -69,38 +68,46 @@ typedef struct
   uint32_t PeripheralMode;      /*!< Specifies the peripheral mode.
                                      This parameter can be a value of @ref I2C_LL_EC_PERIPHERAL_MODE.
 
-                                     This feature can be modified afterwards using unitary function @ref LL_I2C_SetMode(). */
+                                     This feature can be modified afterwards using unitary function
+                                     @ref LL_I2C_SetMode(). */
 
   uint32_t Timing;              /*!< Specifies the SDA setup, hold time and the SCL high, low period values.
                                      This parameter must be set by referring to the STM32CubeMX Tool and
                                      the helper macro @ref __LL_I2C_CONVERT_TIMINGS().
 
-                                     This feature can be modified afterwards using unitary function @ref LL_I2C_SetTiming(). */
+                                     This feature can be modified afterwards using unitary function
+                                     @ref LL_I2C_SetTiming(). */
 
   uint32_t AnalogFilter;        /*!< Enables or disables analog noise filter.
                                      This parameter can be a value of @ref I2C_LL_EC_ANALOGFILTER_SELECTION.
 
-                                     This feature can be modified afterwards using unitary functions @ref LL_I2C_EnableAnalogFilter() or LL_I2C_DisableAnalogFilter(). */
+                                     This feature can be modified afterwards using unitary functions
+                                     @ref LL_I2C_EnableAnalogFilter() or LL_I2C_DisableAnalogFilter(). */
 
   uint32_t DigitalFilter;       /*!< Configures the digital noise filter.
                                      This parameter can be a number between Min_Data = 0x00 and Max_Data = 0x0F.
 
-                                     This feature can be modified afterwards using unitary function @ref LL_I2C_SetDigitalFilter(). */
+                                     This feature can be modified afterwards using unitary function
+                                     @ref LL_I2C_SetDigitalFilter(). */
 
   uint32_t OwnAddress1;         /*!< Specifies the device own address 1.
                                      This parameter must be a value between Min_Data = 0x00 and Max_Data = 0x3FF.
 
-                                     This feature can be modified afterwards using unitary function @ref LL_I2C_SetOwnAddress1(). */
+                                     This feature can be modified afterwards using unitary function
+                                     @ref LL_I2C_SetOwnAddress1(). */
 
-  uint32_t TypeAcknowledge;     /*!< Specifies the ACKnowledge or Non ACKnowledge condition after the address receive match code or next received byte.
+  uint32_t TypeAcknowledge;     /*!< Specifies the ACKnowledge or Non ACKnowledge condition after the address receive
+                                     match code or next received byte.
                                      This parameter can be a value of @ref I2C_LL_EC_I2C_ACKNOWLEDGE.
 
-                                     This feature can be modified afterwards using unitary function @ref LL_I2C_AcknowledgeNextData(). */
+                                     This feature can be modified afterwards using unitary function
+                                     @ref LL_I2C_AcknowledgeNextData(). */
 
   uint32_t OwnAddrSize;         /*!< Specifies the device own address 1 size (7-bit or 10-bit).
                                      This parameter can be a value of @ref I2C_LL_EC_OWNADDRESS1.
 
-                                     This feature can be modified afterwards using unitary function @ref LL_I2C_SetOwnAddress1(). */
+                                     This feature can be modified afterwards using unitary function
+                                     @ref LL_I2C_SetOwnAddress1(). */
 } LL_I2C_InitTypeDef;
 /**
   * @}
@@ -170,10 +177,11 @@ typedef struct
 /** @defgroup I2C_LL_EC_PERIPHERAL_MODE Peripheral Mode
   * @{
   */
-#define LL_I2C_MODE_I2C                    0x00000000U              /*!< I2C Master or Slave mode                                    */
-#define LL_I2C_MODE_SMBUS_HOST             I2C_CR1_SMBHEN           /*!< SMBus Host address acknowledge                              */
-#define LL_I2C_MODE_SMBUS_DEVICE           0x00000000U              /*!< SMBus Device default mode (Default address not acknowledge) */
-#define LL_I2C_MODE_SMBUS_DEVICE_ARP       I2C_CR1_SMBDEN           /*!< SMBus Device Default address acknowledge                    */
+#define LL_I2C_MODE_I2C                    0x00000000U              /*!< I2C Master or Slave mode                 */
+#define LL_I2C_MODE_SMBUS_HOST             I2C_CR1_SMBHEN           /*!< SMBus Host address acknowledge           */
+#define LL_I2C_MODE_SMBUS_DEVICE           0x00000000U              /*!< SMBus Device default mode
+                                                                         (Default address not acknowledge)        */
+#define LL_I2C_MODE_SMBUS_DEVICE_ARP       I2C_CR1_SMBDEN           /*!< SMBus Device Default address acknowledge */
 /**
   * @}
   */
@@ -208,14 +216,15 @@ typedef struct
 /** @defgroup I2C_LL_EC_OWNADDRESS2 Own Address 2 Masks
   * @{
   */
-#define LL_I2C_OWNADDRESS2_NOMASK           I2C_OAR2_OA2NOMASK      /*!< Own Address2 No mask.                                */
-#define LL_I2C_OWNADDRESS2_MASK01           I2C_OAR2_OA2MASK01      /*!< Only Address2 bits[7:2] are compared.                */
-#define LL_I2C_OWNADDRESS2_MASK02           I2C_OAR2_OA2MASK02      /*!< Only Address2 bits[7:3] are compared.                */
-#define LL_I2C_OWNADDRESS2_MASK03           I2C_OAR2_OA2MASK03      /*!< Only Address2 bits[7:4] are compared.                */
-#define LL_I2C_OWNADDRESS2_MASK04           I2C_OAR2_OA2MASK04      /*!< Only Address2 bits[7:5] are compared.                */
-#define LL_I2C_OWNADDRESS2_MASK05           I2C_OAR2_OA2MASK05      /*!< Only Address2 bits[7:6] are compared.                */
-#define LL_I2C_OWNADDRESS2_MASK06           I2C_OAR2_OA2MASK06      /*!< Only Address2 bits[7] are compared.                  */
-#define LL_I2C_OWNADDRESS2_MASK07           I2C_OAR2_OA2MASK07      /*!< No comparison is done. All Address2 are acknowledged.*/
+#define LL_I2C_OWNADDRESS2_NOMASK           I2C_OAR2_OA2NOMASK      /*!< Own Address2 No mask.                 */
+#define LL_I2C_OWNADDRESS2_MASK01           I2C_OAR2_OA2MASK01      /*!< Only Address2 bits[7:2] are compared. */
+#define LL_I2C_OWNADDRESS2_MASK02           I2C_OAR2_OA2MASK02      /*!< Only Address2 bits[7:3] are compared. */
+#define LL_I2C_OWNADDRESS2_MASK03           I2C_OAR2_OA2MASK03      /*!< Only Address2 bits[7:4] are compared. */
+#define LL_I2C_OWNADDRESS2_MASK04           I2C_OAR2_OA2MASK04      /*!< Only Address2 bits[7:5] are compared. */
+#define LL_I2C_OWNADDRESS2_MASK05           I2C_OAR2_OA2MASK05      /*!< Only Address2 bits[7:6] are compared. */
+#define LL_I2C_OWNADDRESS2_MASK06           I2C_OAR2_OA2MASK06      /*!< Only Address2 bits[7] are compared.   */
+#define LL_I2C_OWNADDRESS2_MASK07           I2C_OAR2_OA2MASK07      /*!< No comparison is done.
+                                                                         All Address2 are acknowledged.        */
 /**
   * @}
   */
@@ -250,14 +259,21 @@ typedef struct
 /** @defgroup I2C_LL_EC_MODE Transfer End Mode
   * @{
   */
-#define LL_I2C_MODE_RELOAD                  I2C_CR2_RELOAD                                      /*!< Enable I2C Reload mode.                                   */
-#define LL_I2C_MODE_AUTOEND                 I2C_CR2_AUTOEND                                     /*!< Enable I2C Automatic end mode with no HW PEC comparison.  */
-#define LL_I2C_MODE_SOFTEND                 0x00000000U                                         /*!< Enable I2C Software end mode with no HW PEC comparison.   */
-#define LL_I2C_MODE_SMBUS_RELOAD            LL_I2C_MODE_RELOAD                                  /*!< Enable SMBUS Automatic end mode with HW PEC comparison.   */
-#define LL_I2C_MODE_SMBUS_AUTOEND_NO_PEC    LL_I2C_MODE_AUTOEND                                 /*!< Enable SMBUS Automatic end mode with HW PEC comparison.   */
-#define LL_I2C_MODE_SMBUS_SOFTEND_NO_PEC    LL_I2C_MODE_SOFTEND                                 /*!< Enable SMBUS Software end mode with HW PEC comparison.    */
-#define LL_I2C_MODE_SMBUS_AUTOEND_WITH_PEC  (uint32_t)(LL_I2C_MODE_AUTOEND | I2C_CR2_PECBYTE)   /*!< Enable SMBUS Automatic end mode with HW PEC comparison.   */
-#define LL_I2C_MODE_SMBUS_SOFTEND_WITH_PEC  (uint32_t)(LL_I2C_MODE_SOFTEND | I2C_CR2_PECBYTE)   /*!< Enable SMBUS Software end mode with HW PEC comparison.    */
+#define LL_I2C_MODE_RELOAD                  I2C_CR2_RELOAD           /*!< Enable I2C Reload mode.     */
+#define LL_I2C_MODE_AUTOEND                 I2C_CR2_AUTOEND          /*!< Enable I2C Automatic end mode
+                                                                          with no HW PEC comparison.  */
+#define LL_I2C_MODE_SOFTEND                 0x00000000U              /*!< Enable I2C Software end mode
+                                                                          with no HW PEC comparison.  */
+#define LL_I2C_MODE_SMBUS_RELOAD            LL_I2C_MODE_RELOAD       /*!< Enable SMBUS Automatic end mode
+                                                                          with HW PEC comparison.     */
+#define LL_I2C_MODE_SMBUS_AUTOEND_NO_PEC    LL_I2C_MODE_AUTOEND      /*!< Enable SMBUS Automatic end mode
+                                                                          with HW PEC comparison.     */
+#define LL_I2C_MODE_SMBUS_SOFTEND_NO_PEC    LL_I2C_MODE_SOFTEND      /*!< Enable SMBUS Software end mode
+                                                                          with HW PEC comparison.     */
+#define LL_I2C_MODE_SMBUS_AUTOEND_WITH_PEC  (uint32_t)(LL_I2C_MODE_AUTOEND | I2C_CR2_PECBYTE)
+/*!< Enable SMBUS Automatic end mode with HW PEC comparison.   */
+#define LL_I2C_MODE_SMBUS_SOFTEND_WITH_PEC  (uint32_t)(LL_I2C_MODE_SOFTEND | I2C_CR2_PECBYTE)
+/*!< Enable SMBUS Software end mode with HW PEC comparison.    */
 /**
   * @}
   */
@@ -265,14 +281,23 @@ typedef struct
 /** @defgroup I2C_LL_EC_GENERATE Start And Stop Generation
   * @{
   */
-#define LL_I2C_GENERATE_NOSTARTSTOP         0x00000000U                                                                /*!< Don't Generate Stop and Start condition.                */
-#define LL_I2C_GENERATE_STOP                (uint32_t)(0x80000000U | I2C_CR2_STOP)                                     /*!< Generate Stop condition (Size should be set to 0).      */
-#define LL_I2C_GENERATE_START_READ          (uint32_t)(0x80000000U | I2C_CR2_START | I2C_CR2_RD_WRN)                   /*!< Generate Start for read request.                        */
-#define LL_I2C_GENERATE_START_WRITE         (uint32_t)(0x80000000U | I2C_CR2_START)                                    /*!< Generate Start for write request.                       */
-#define LL_I2C_GENERATE_RESTART_7BIT_READ   (uint32_t)(0x80000000U | I2C_CR2_START | I2C_CR2_RD_WRN)                   /*!< Generate Restart for read request, slave 7Bit address.  */
-#define LL_I2C_GENERATE_RESTART_7BIT_WRITE  (uint32_t)(0x80000000U | I2C_CR2_START)                                    /*!< Generate Restart for write request, slave 7Bit address. */
-#define LL_I2C_GENERATE_RESTART_10BIT_READ  (uint32_t)(0x80000000U | I2C_CR2_START | I2C_CR2_RD_WRN | I2C_CR2_HEAD10R) /*!< Generate Restart for read request, slave 10Bit address. */
-#define LL_I2C_GENERATE_RESTART_10BIT_WRITE (uint32_t)(0x80000000U | I2C_CR2_START)                                    /*!< Generate Restart for write request, slave 10Bit address.*/
+#define LL_I2C_GENERATE_NOSTARTSTOP         0x00000000U
+/*!< Don't Generate Stop and Start condition. */
+#define LL_I2C_GENERATE_STOP                (uint32_t)(0x80000000U | I2C_CR2_STOP)
+/*!< Generate Stop condition (Size should be set to 0).      */
+#define LL_I2C_GENERATE_START_READ          (uint32_t)(0x80000000U | I2C_CR2_START | I2C_CR2_RD_WRN)
+/*!< Generate Start for read request. */
+#define LL_I2C_GENERATE_START_WRITE         (uint32_t)(0x80000000U | I2C_CR2_START)
+/*!< Generate Start for write request. */
+#define LL_I2C_GENERATE_RESTART_7BIT_READ   (uint32_t)(0x80000000U | I2C_CR2_START | I2C_CR2_RD_WRN)
+/*!< Generate Restart for read request, slave 7Bit address.  */
+#define LL_I2C_GENERATE_RESTART_7BIT_WRITE  (uint32_t)(0x80000000U | I2C_CR2_START)
+/*!< Generate Restart for write request, slave 7Bit address. */
+#define LL_I2C_GENERATE_RESTART_10BIT_READ  (uint32_t)(0x80000000U | I2C_CR2_START | \
+                                                       I2C_CR2_RD_WRN | I2C_CR2_HEAD10R)
+/*!< Generate Restart for read request, slave 10Bit address. */
+#define LL_I2C_GENERATE_RESTART_10BIT_WRITE (uint32_t)(0x80000000U | I2C_CR2_START)
+/*!< Generate Restart for write request, slave 10Bit address.*/
 /**
   * @}
   */
@@ -280,8 +305,10 @@ typedef struct
 /** @defgroup I2C_LL_EC_DIRECTION Read Write Direction
   * @{
   */
-#define LL_I2C_DIRECTION_WRITE              0x00000000U              /*!< Write transfer request by master, slave enters receiver mode.  */
-#define LL_I2C_DIRECTION_READ               I2C_ISR_DIR              /*!< Read transfer request by master, slave enters transmitter mode.*/
+#define LL_I2C_DIRECTION_WRITE              0x00000000U              /*!< Write transfer request by master,
+                                                                          slave enters receiver mode.  */
+#define LL_I2C_DIRECTION_READ               I2C_ISR_DIR              /*!< Read transfer request by master,
+                                                                          slave enters transmitter mode.*/
 /**
   * @}
   */
@@ -289,8 +316,10 @@ typedef struct
 /** @defgroup I2C_LL_EC_DMA_REG_DATA DMA Register Data
   * @{
   */
-#define LL_I2C_DMA_REG_DATA_TRANSMIT        0x00000000U              /*!< Get address of data register used for transmission */
-#define LL_I2C_DMA_REG_DATA_RECEIVE         0x00000001U              /*!< Get address of data register used for reception */
+#define LL_I2C_DMA_REG_DATA_TRANSMIT        0x00000000U              /*!< Get address of data register used for
+                                                                          transmission */
+#define LL_I2C_DMA_REG_DATA_RECEIVE         0x00000001U              /*!< Get address of data register used for
+                                                                          reception */
 /**
   * @}
   */
@@ -298,8 +327,10 @@ typedef struct
 /** @defgroup I2C_LL_EC_SMBUS_TIMEOUTA_MODE SMBus TimeoutA Mode SCL SDA Timeout
   * @{
   */
-#define LL_I2C_SMBUS_TIMEOUTA_MODE_SCL_LOW      0x00000000U          /*!< TimeoutA is used to detect SCL low level timeout.              */
-#define LL_I2C_SMBUS_TIMEOUTA_MODE_SDA_SCL_HIGH I2C_TIMEOUTR_TIDLE   /*!< TimeoutA is used to detect both SCL and SDA high level timeout.*/
+#define LL_I2C_SMBUS_TIMEOUTA_MODE_SCL_LOW      0x00000000U          /*!< TimeoutA is used to detect
+                                                                          SCL low level timeout.              */
+#define LL_I2C_SMBUS_TIMEOUTA_MODE_SDA_SCL_HIGH I2C_TIMEOUTR_TIDLE   /*!< TimeoutA is used to detect
+                                                                          both SCL and SDA high level timeout.*/
 /**
   * @}
   */
@@ -307,9 +338,12 @@ typedef struct
 /** @defgroup I2C_LL_EC_SMBUS_TIMEOUT_SELECTION SMBus Timeout Selection
   * @{
   */
-#define LL_I2C_SMBUS_TIMEOUTA               I2C_TIMEOUTR_TIMOUTEN                                   /*!< TimeoutA enable bit                                */
-#define LL_I2C_SMBUS_TIMEOUTB               I2C_TIMEOUTR_TEXTEN                                     /*!< TimeoutB (extended clock) enable bit               */
-#define LL_I2C_SMBUS_ALL_TIMEOUT            (uint32_t)(I2C_TIMEOUTR_TIMOUTEN | I2C_TIMEOUTR_TEXTEN) /*!< TimeoutA and TimeoutB (extended clock) enable bits */
+#define LL_I2C_SMBUS_TIMEOUTA               I2C_TIMEOUTR_TIMOUTEN                 /*!< TimeoutA enable bit          */
+#define LL_I2C_SMBUS_TIMEOUTB               I2C_TIMEOUTR_TEXTEN                   /*!< TimeoutB (extended clock)
+                                                                                       enable bit                   */
+#define LL_I2C_SMBUS_ALL_TIMEOUT            (uint32_t)(I2C_TIMEOUTR_TIMOUTEN | \
+                                                       I2C_TIMEOUTR_TEXTEN)       /*!< TimeoutA and TimeoutB
+(extended clock) enable bits */
 /**
   * @}
   */
@@ -353,18 +387,22 @@ typedef struct
 /**
   * @brief  Configure the SDA setup, hold time and the SCL high, low period.
   * @param  __PRESCALER__ This parameter must be a value between  Min_Data=0 and Max_Data=0xF.
-  * @param  __DATA_SETUP_TIME__ This parameter must be a value between Min_Data=0 and Max_Data=0xF. (tscldel = (SCLDEL+1)xtpresc)
-  * @param  __DATA_HOLD_TIME__ This parameter must be a value between Min_Data=0 and Max_Data=0xF. (tsdadel = SDADELxtpresc)
-  * @param  __CLOCK_HIGH_PERIOD__ This parameter must be a value between Min_Data=0 and Max_Data=0xFF. (tsclh = (SCLH+1)xtpresc)
-  * @param  __CLOCK_LOW_PERIOD__ This parameter must be a value between  Min_Data=0 and Max_Data=0xFF. (tscll = (SCLL+1)xtpresc)
+  * @param  __SETUP_TIME__ This parameter must be a value between Min_Data=0 and Max_Data=0xF.
+                           (tscldel = (SCLDEL+1)xtpresc)
+  * @param  __HOLD_TIME__  This parameter must be a value between Min_Data=0 and Max_Data=0xF.
+                           (tsdadel = SDADELxtpresc)
+  * @param  __SCLH_PERIOD__ This parameter must be a value between Min_Data=0 and Max_Data=0xFF.
+                            (tsclh = (SCLH+1)xtpresc)
+  * @param  __SCLL_PERIOD__ This parameter must be a value between  Min_Data=0 and Max_Data=0xFF.
+                            (tscll = (SCLL+1)xtpresc)
   * @retval Value between Min_Data=0 and Max_Data=0xFFFFFFFF
   */
-#define __LL_I2C_CONVERT_TIMINGS(__PRESCALER__, __DATA_SETUP_TIME__, __DATA_HOLD_TIME__, __CLOCK_HIGH_PERIOD__, __CLOCK_LOW_PERIOD__)   \
-        ((((uint32_t)(__PRESCALER__)         << I2C_TIMINGR_PRESC_Pos)  & I2C_TIMINGR_PRESC)   | \
-         (((uint32_t)(__DATA_SETUP_TIME__)   << I2C_TIMINGR_SCLDEL_Pos) & I2C_TIMINGR_SCLDEL)  | \
-         (((uint32_t)(__DATA_HOLD_TIME__)    << I2C_TIMINGR_SDADEL_Pos) & I2C_TIMINGR_SDADEL)  | \
-         (((uint32_t)(__CLOCK_HIGH_PERIOD__) << I2C_TIMINGR_SCLH_Pos)   & I2C_TIMINGR_SCLH)    | \
-         (((uint32_t)(__CLOCK_LOW_PERIOD__)  << I2C_TIMINGR_SCLL_Pos)   & I2C_TIMINGR_SCLL))
+#define __LL_I2C_CONVERT_TIMINGS(__PRESCALER__, __SETUP_TIME__, __HOLD_TIME__, __SCLH_PERIOD__, __SCLL_PERIOD__) \
+  ((((uint32_t)(__PRESCALER__)    << I2C_TIMINGR_PRESC_Pos)  & I2C_TIMINGR_PRESC)   | \
+   (((uint32_t)(__SETUP_TIME__)   << I2C_TIMINGR_SCLDEL_Pos) & I2C_TIMINGR_SCLDEL)  | \
+   (((uint32_t)(__HOLD_TIME__)    << I2C_TIMINGR_SDADEL_Pos) & I2C_TIMINGR_SDADEL)  | \
+   (((uint32_t)(__SCLH_PERIOD__)  << I2C_TIMINGR_SCLH_Pos)   & I2C_TIMINGR_SCLH)    | \
+   (((uint32_t)(__SCLL_PERIOD__)  << I2C_TIMINGR_SCLL_Pos)   & I2C_TIMINGR_SCLL))
 /**
   * @}
   */
@@ -413,7 +451,7 @@ __STATIC_INLINE void LL_I2C_Disable(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabled(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabled(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_PE) == (I2C_CR1_PE)) ? 1UL : 0UL);
 }
@@ -428,7 +466,8 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabled(I2C_TypeDef *I2Cx)
   * @param  AnalogFilter This parameter can be one of the following values:
   *         @arg @ref LL_I2C_ANALOGFILTER_ENABLE
   *         @arg @ref LL_I2C_ANALOGFILTER_DISABLE
-  * @param  DigitalFilter This parameter must be a value between Min_Data=0x00 (Digital filter disabled) and Max_Data=0x0F (Digital filter enabled and filtering capability up to 15*ti2cclk).
+  * @param  DigitalFilter This parameter must be a value between Min_Data=0x00 (Digital filter disabled)
+                          and Max_Data=0x0F (Digital filter enabled and filtering capability up to 15*ti2cclk).
   *         This parameter is used to configure the digital noise filter on SDA and SCL input.
   *         The digital filter will filter spikes with a length of up to DNF[3:0]*ti2cclk.
   * @retval None
@@ -444,7 +483,8 @@ __STATIC_INLINE void LL_I2C_ConfigFilters(I2C_TypeDef *I2Cx, uint32_t AnalogFilt
   *         This filter can only be programmed when the I2C is disabled (PE = 0).
   * @rmtoll CR1          DNF           LL_I2C_SetDigitalFilter
   * @param  I2Cx I2C Instance.
-  * @param  DigitalFilter This parameter must be a value between Min_Data=0x00 (Digital filter disabled) and Max_Data=0x0F (Digital filter enabled and filtering capability up to 15*ti2cclk).
+  * @param  DigitalFilter This parameter must be a value between Min_Data=0x00 (Digital filter disabled)
+                          and Max_Data=0x0F (Digital filter enabled and filtering capability up to 15*ti2cclk).
   *         This parameter is used to configure the digital noise filter on SDA and SCL input.
   *         The digital filter will filter spikes with a length of up to DNF[3:0]*ti2cclk.
   * @retval None
@@ -460,7 +500,7 @@ __STATIC_INLINE void LL_I2C_SetDigitalFilter(I2C_TypeDef *I2Cx, uint32_t Digital
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x0 and Max_Data=0xF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetDigitalFilter(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetDigitalFilter(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->CR1, I2C_CR1_DNF) >> I2C_CR1_DNF_Pos);
 }
@@ -495,7 +535,7 @@ __STATIC_INLINE void LL_I2C_DisableAnalogFilter(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledAnalogFilter(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledAnalogFilter(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_ANFOFF) != (I2C_CR1_ANFOFF)) ? 1UL : 0UL);
 }
@@ -528,7 +568,7 @@ __STATIC_INLINE void LL_I2C_DisableDMAReq_TX(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledDMAReq_TX(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledDMAReq_TX(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_TXDMAEN) == (I2C_CR1_TXDMAEN)) ? 1UL : 0UL);
 }
@@ -561,7 +601,7 @@ __STATIC_INLINE void LL_I2C_DisableDMAReq_RX(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledDMAReq_RX(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledDMAReq_RX(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_RXDMAEN) == (I2C_CR1_RXDMAEN)) ? 1UL : 0UL);
 }
@@ -576,19 +616,19 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledDMAReq_RX(I2C_TypeDef *I2Cx)
   *         @arg @ref LL_I2C_DMA_REG_DATA_RECEIVE
   * @retval Address of data register
   */
-__STATIC_INLINE uint32_t LL_I2C_DMA_GetRegAddr(I2C_TypeDef *I2Cx, uint32_t Direction)
+__STATIC_INLINE uint32_t LL_I2C_DMA_GetRegAddr(const I2C_TypeDef *I2Cx, uint32_t Direction)
 {
   uint32_t data_reg_addr;
 
   if (Direction == LL_I2C_DMA_REG_DATA_TRANSMIT)
   {
     /* return address of TXDR register */
-    data_reg_addr = (uint32_t) & (I2Cx->TXDR);
+    data_reg_addr = (uint32_t) &(I2Cx->TXDR);
   }
   else
   {
     /* return address of RXDR register */
-    data_reg_addr = (uint32_t) & (I2Cx->RXDR);
+    data_reg_addr = (uint32_t) &(I2Cx->RXDR);
   }
 
   return data_reg_addr;
@@ -624,7 +664,7 @@ __STATIC_INLINE void LL_I2C_DisableClockStretching(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledClockStretching(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledClockStretching(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_NOSTRETCH) != (I2C_CR1_NOSTRETCH)) ? 1UL : 0UL);
 }
@@ -657,14 +697,14 @@ __STATIC_INLINE void LL_I2C_DisableSlaveByteControl(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledSlaveByteControl(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledSlaveByteControl(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_SBC) == (I2C_CR1_SBC)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable Wakeup from STOP.
-  * @note   Macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
   *         WakeUpFromStop feature is supported by the I2Cx Instance.
   * @note   This bit can only be programmed when Digital Filter is disabled.
   * @rmtoll CR1          WUPEN         LL_I2C_EnableWakeUpFromStop
@@ -678,7 +718,7 @@ __STATIC_INLINE void LL_I2C_EnableWakeUpFromStop(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable Wakeup from STOP.
-  * @note   Macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
   *         WakeUpFromStop feature is supported by the I2Cx Instance.
   * @rmtoll CR1          WUPEN         LL_I2C_DisableWakeUpFromStop
   * @param  I2Cx I2C Instance.
@@ -691,13 +731,13 @@ __STATIC_INLINE void LL_I2C_DisableWakeUpFromStop(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if Wakeup from STOP is enabled or disabled.
-  * @note   Macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_I2C_WAKEUP_FROMSTOP_INSTANCE(I2Cx) can be used to check whether or not
   *         WakeUpFromStop feature is supported by the I2Cx Instance.
   * @rmtoll CR1          WUPEN         LL_I2C_IsEnabledWakeUpFromStop
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledWakeUpFromStop(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledWakeUpFromStop(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_WUPEN) == (I2C_CR1_WUPEN)) ? 1UL : 0UL);
 }
@@ -732,7 +772,7 @@ __STATIC_INLINE void LL_I2C_DisableGeneralCall(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledGeneralCall(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledGeneralCall(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_GCEN) == (I2C_CR1_GCEN)) ? 1UL : 0UL);
 }
@@ -760,7 +800,7 @@ __STATIC_INLINE void LL_I2C_SetMasterAddressingMode(I2C_TypeDef *I2Cx, uint32_t 
   *         @arg @ref LL_I2C_ADDRESSING_MODE_7BIT
   *         @arg @ref LL_I2C_ADDRESSING_MODE_10BIT
   */
-__STATIC_INLINE uint32_t LL_I2C_GetMasterAddressingMode(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetMasterAddressingMode(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->CR2, I2C_CR2_ADD10));
 }
@@ -809,7 +849,7 @@ __STATIC_INLINE void LL_I2C_DisableOwnAddress1(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledOwnAddress1(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledOwnAddress1(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->OAR1, I2C_OAR1_OA1EN) == (I2C_OAR1_OA1EN)) ? 1UL : 0UL);
 }
@@ -865,7 +905,7 @@ __STATIC_INLINE void LL_I2C_DisableOwnAddress2(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledOwnAddress2(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledOwnAddress2(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->OAR2, I2C_OAR2_OA2EN) == (I2C_OAR2_OA2EN)) ? 1UL : 0UL);
 }
@@ -890,7 +930,7 @@ __STATIC_INLINE void LL_I2C_SetTiming(I2C_TypeDef *I2Cx, uint32_t Timing)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x0 and Max_Data=0xF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetTimingPrescaler(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetTimingPrescaler(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMINGR, I2C_TIMINGR_PRESC) >> I2C_TIMINGR_PRESC_Pos);
 }
@@ -901,7 +941,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetTimingPrescaler(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetClockLowPeriod(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetClockLowPeriod(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMINGR, I2C_TIMINGR_SCLL) >> I2C_TIMINGR_SCLL_Pos);
 }
@@ -912,7 +952,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetClockLowPeriod(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetClockHighPeriod(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetClockHighPeriod(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMINGR, I2C_TIMINGR_SCLH) >> I2C_TIMINGR_SCLH_Pos);
 }
@@ -923,7 +963,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetClockHighPeriod(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x0 and Max_Data=0xF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetDataHoldTime(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetDataHoldTime(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMINGR, I2C_TIMINGR_SDADEL) >> I2C_TIMINGR_SDADEL_Pos);
 }
@@ -934,14 +974,14 @@ __STATIC_INLINE uint32_t LL_I2C_GetDataHoldTime(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x0 and Max_Data=0xF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetDataSetupTime(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetDataSetupTime(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMINGR, I2C_TIMINGR_SCLDEL) >> I2C_TIMINGR_SCLDEL_Pos);
 }
 
 /**
   * @brief  Configure peripheral mode.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          SMBHEN        LL_I2C_SetMode\n
   *         CR1          SMBDEN        LL_I2C_SetMode
@@ -960,7 +1000,7 @@ __STATIC_INLINE void LL_I2C_SetMode(I2C_TypeDef *I2Cx, uint32_t PeripheralMode)
 
 /**
   * @brief  Get peripheral mode.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          SMBHEN        LL_I2C_GetMode\n
   *         CR1          SMBDEN        LL_I2C_GetMode
@@ -971,14 +1011,14 @@ __STATIC_INLINE void LL_I2C_SetMode(I2C_TypeDef *I2Cx, uint32_t PeripheralMode)
   *         @arg @ref LL_I2C_MODE_SMBUS_DEVICE
   *         @arg @ref LL_I2C_MODE_SMBUS_DEVICE_ARP
   */
-__STATIC_INLINE uint32_t LL_I2C_GetMode(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetMode(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->CR1, I2C_CR1_SMBHEN | I2C_CR1_SMBDEN));
 }
 
 /**
   * @brief  Enable SMBus alert (Host or Device mode)
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   SMBus Device mode:
   *         - SMBus Alert pin is drived low and
@@ -996,7 +1036,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusAlert(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable SMBus alert (Host or Device mode)
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   SMBus Device mode:
   *         - SMBus Alert pin is not drived (can be used as a standard GPIO) and
@@ -1014,20 +1054,20 @@ __STATIC_INLINE void LL_I2C_DisableSMBusAlert(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if SMBus alert (Host or Device mode) is enabled or disabled.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          ALERTEN       LL_I2C_IsEnabledSMBusAlert
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusAlert(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusAlert(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_ALERTEN) == (I2C_CR1_ALERTEN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable SMBus Packet Error Calculation (PEC).
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          PECEN         LL_I2C_EnableSMBusPEC
   * @param  I2Cx I2C Instance.
@@ -1040,7 +1080,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusPEC(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable SMBus Packet Error Calculation (PEC).
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          PECEN         LL_I2C_DisableSMBusPEC
   * @param  I2Cx I2C Instance.
@@ -1053,20 +1093,20 @@ __STATIC_INLINE void LL_I2C_DisableSMBusPEC(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if SMBus Packet Error Calculation (PEC) is enabled or disabled.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR1          PECEN         LL_I2C_IsEnabledSMBusPEC
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPEC(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPEC(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_PECEN) == (I2C_CR1_PECEN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Configure the SMBus Clock Timeout.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   This configuration can only be programmed when associated Timeout is disabled (TimeoutA and/orTimeoutB).
   * @rmtoll TIMEOUTR     TIMEOUTA      LL_I2C_ConfigSMBusTimeout\n
@@ -1089,7 +1129,7 @@ __STATIC_INLINE void LL_I2C_ConfigSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Timeo
 
 /**
   * @brief  Configure the SMBus Clock TimeoutA (SCL low timeout or SCL and SDA high timeout depends on TimeoutA mode).
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   These bits can only be programmed when TimeoutA is disabled.
   * @rmtoll TIMEOUTR     TIMEOUTA      LL_I2C_SetSMBusTimeoutA
@@ -1104,20 +1144,20 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutA(I2C_TypeDef *I2Cx, uint32_t Timeout
 
 /**
   * @brief  Get the SMBus Clock TimeoutA setting.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMEOUTA      LL_I2C_GetSMBusTimeoutA
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0 and Max_Data=0xFFF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutA(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutA(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMEOUTR, I2C_TIMEOUTR_TIMEOUTA));
 }
 
 /**
   * @brief  Set the SMBus Clock TimeoutA mode.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   This bit can only be programmed when TimeoutA is disabled.
   * @rmtoll TIMEOUTR     TIDLE         LL_I2C_SetSMBusTimeoutAMode
@@ -1134,7 +1174,7 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutAMode(I2C_TypeDef *I2Cx, uint32_t Tim
 
 /**
   * @brief  Get the SMBus Clock TimeoutA mode.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIDLE         LL_I2C_GetSMBusTimeoutAMode
   * @param  I2Cx I2C Instance.
@@ -1142,14 +1182,14 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutAMode(I2C_TypeDef *I2Cx, uint32_t Tim
   *         @arg @ref LL_I2C_SMBUS_TIMEOUTA_MODE_SCL_LOW
   *         @arg @ref LL_I2C_SMBUS_TIMEOUTA_MODE_SDA_SCL_HIGH
   */
-__STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutAMode(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutAMode(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMEOUTR, I2C_TIMEOUTR_TIDLE));
 }
 
 /**
   * @brief  Configure the SMBus Extended Cumulative Clock TimeoutB (Master or Slave mode).
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   These bits can only be programmed when TimeoutB is disabled.
   * @rmtoll TIMEOUTR     TIMEOUTB      LL_I2C_SetSMBusTimeoutB
@@ -1164,20 +1204,20 @@ __STATIC_INLINE void LL_I2C_SetSMBusTimeoutB(I2C_TypeDef *I2Cx, uint32_t Timeout
 
 /**
   * @brief  Get the SMBus Extended Cumulative Clock TimeoutB setting.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMEOUTB      LL_I2C_GetSMBusTimeoutB
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0 and Max_Data=0xFFF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutB(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetSMBusTimeoutB(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->TIMEOUTR, I2C_TIMEOUTR_TIMEOUTB) >> I2C_TIMEOUTR_TIMEOUTB_Pos);
 }
 
 /**
   * @brief  Enable the SMBus Clock Timeout.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMOUTEN      LL_I2C_EnableSMBusTimeout\n
   *         TIMEOUTR     TEXTEN        LL_I2C_EnableSMBusTimeout
@@ -1195,7 +1235,7 @@ __STATIC_INLINE void LL_I2C_EnableSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Clock
 
 /**
   * @brief  Disable the SMBus Clock Timeout.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMOUTEN      LL_I2C_DisableSMBusTimeout\n
   *         TIMEOUTR     TEXTEN        LL_I2C_DisableSMBusTimeout
@@ -1213,7 +1253,7 @@ __STATIC_INLINE void LL_I2C_DisableSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Cloc
 
 /**
   * @brief  Check if the SMBus Clock Timeout is enabled or disabled.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll TIMEOUTR     TIMOUTEN      LL_I2C_IsEnabledSMBusTimeout\n
   *         TIMEOUTR     TEXTEN        LL_I2C_IsEnabledSMBusTimeout
@@ -1224,9 +1264,10 @@ __STATIC_INLINE void LL_I2C_DisableSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t Cloc
   *         @arg @ref LL_I2C_SMBUS_ALL_TIMEOUT
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusTimeout(I2C_TypeDef *I2Cx, uint32_t ClockTimeout)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusTimeout(const I2C_TypeDef *I2Cx, uint32_t ClockTimeout)
 {
-  return ((READ_BIT(I2Cx->TIMEOUTR, (I2C_TIMEOUTR_TIMOUTEN | I2C_TIMEOUTR_TEXTEN)) == (ClockTimeout)) ? 1UL : 0UL);
+  return ((READ_BIT(I2Cx->TIMEOUTR, (I2C_TIMEOUTR_TIMOUTEN | I2C_TIMEOUTR_TEXTEN)) == \
+           (ClockTimeout)) ? 1UL : 0UL);
 }
 
 /**
@@ -1265,7 +1306,7 @@ __STATIC_INLINE void LL_I2C_DisableIT_TX(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_TX(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_TX(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_TXIE) == (I2C_CR1_TXIE)) ? 1UL : 0UL);
 }
@@ -1298,7 +1339,7 @@ __STATIC_INLINE void LL_I2C_DisableIT_RX(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_RX(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_RX(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_RXIE) == (I2C_CR1_RXIE)) ? 1UL : 0UL);
 }
@@ -1331,7 +1372,7 @@ __STATIC_INLINE void LL_I2C_DisableIT_ADDR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_ADDR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_ADDR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_ADDRIE) == (I2C_CR1_ADDRIE)) ? 1UL : 0UL);
 }
@@ -1364,7 +1405,7 @@ __STATIC_INLINE void LL_I2C_DisableIT_NACK(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_NACK(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_NACK(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_NACKIE) == (I2C_CR1_NACKIE)) ? 1UL : 0UL);
 }
@@ -1397,7 +1438,7 @@ __STATIC_INLINE void LL_I2C_DisableIT_STOP(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_STOP(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_STOP(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_STOPIE) == (I2C_CR1_STOPIE)) ? 1UL : 0UL);
 }
@@ -1436,14 +1477,14 @@ __STATIC_INLINE void LL_I2C_DisableIT_TC(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_TC(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_TC(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_TCIE) == (I2C_CR1_TCIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable Error interrupts.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   Any of these errors will generate interrupt :
   *         Arbitration Loss (ARLO)
@@ -1463,7 +1504,7 @@ __STATIC_INLINE void LL_I2C_EnableIT_ERR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Disable Error interrupts.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   Any of these errors will generate interrupt :
   *         Arbitration Loss (ARLO)
@@ -1487,7 +1528,7 @@ __STATIC_INLINE void LL_I2C_DisableIT_ERR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_ERR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_ERR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR1, I2C_CR1_ERRIE) == (I2C_CR1_ERRIE)) ? 1UL : 0UL);
 }
@@ -1508,7 +1549,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledIT_ERR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TXE(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TXE(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_TXE) == (I2C_ISR_TXE)) ? 1UL : 0UL);
 }
@@ -1521,7 +1562,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TXE(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TXIS(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TXIS(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_TXIS) == (I2C_ISR_TXIS)) ? 1UL : 0UL);
 }
@@ -1534,7 +1575,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TXIS(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_RXNE(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_RXNE(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_RXNE) == (I2C_ISR_RXNE)) ? 1UL : 0UL);
 }
@@ -1547,7 +1588,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_RXNE(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_ADDR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_ADDR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_ADDR) == (I2C_ISR_ADDR)) ? 1UL : 0UL);
 }
@@ -1560,7 +1601,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_ADDR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_NACK(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_NACK(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_NACKF) == (I2C_ISR_NACKF)) ? 1UL : 0UL);
 }
@@ -1573,7 +1614,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_NACK(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_STOP(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_STOP(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_STOPF) == (I2C_ISR_STOPF)) ? 1UL : 0UL);
 }
@@ -1586,7 +1627,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_STOP(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TC(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TC(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_TC) == (I2C_ISR_TC)) ? 1UL : 0UL);
 }
@@ -1599,7 +1640,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TC(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TCR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TCR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_TCR) == (I2C_ISR_TCR)) ? 1UL : 0UL);
 }
@@ -1612,7 +1653,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_TCR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_BERR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_BERR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_BERR) == (I2C_ISR_BERR)) ? 1UL : 0UL);
 }
@@ -1625,7 +1666,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_BERR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_ARLO(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_ARLO(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_ARLO) == (I2C_ISR_ARLO)) ? 1UL : 0UL);
 }
@@ -1638,14 +1679,14 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_ARLO(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_OVR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_OVR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_OVR) == (I2C_ISR_OVR)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Indicate the status of SMBus PEC error flag in reception.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   RESET: Clear default value.
   *         SET: When the received PEC does not match with the PEC register content.
@@ -1653,14 +1694,14 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_OVR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_PECERR(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_PECERR(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_PECERR) == (I2C_ISR_PECERR)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Indicate the status of SMBus Timeout detection flag.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   RESET: Clear default value.
   *         SET: When a timeout or extended clock timeout occurs.
@@ -1668,14 +1709,14 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_PECERR(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_TIMEOUT(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_TIMEOUT(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_TIMEOUT) == (I2C_ISR_TIMEOUT)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Indicate the status of SMBus alert flag.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @note   RESET: Clear default value.
   *         SET: When SMBus host configuration, SMBus alert enabled and
@@ -1684,7 +1725,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_TIMEOUT(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_ALERT(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_ALERT(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_ALERT) == (I2C_ISR_ALERT)) ? 1UL : 0UL);
 }
@@ -1697,7 +1738,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsActiveSMBusFlag_ALERT(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_BUSY(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsActiveFlag_BUSY(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->ISR, I2C_ISR_BUSY) == (I2C_ISR_BUSY)) ? 1UL : 0UL);
 }
@@ -1782,7 +1823,7 @@ __STATIC_INLINE void LL_I2C_ClearFlag_OVR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Clear SMBus PEC error flag.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll ICR          PECCF         LL_I2C_ClearSMBusFlag_PECERR
   * @param  I2Cx I2C Instance.
@@ -1795,7 +1836,7 @@ __STATIC_INLINE void LL_I2C_ClearSMBusFlag_PECERR(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Clear SMBus Timeout detection flag.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll ICR          TIMOUTCF      LL_I2C_ClearSMBusFlag_TIMEOUT
   * @param  I2Cx I2C Instance.
@@ -1808,7 +1849,7 @@ __STATIC_INLINE void LL_I2C_ClearSMBusFlag_TIMEOUT(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Clear SMBus Alert flag.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll ICR          ALERTCF       LL_I2C_ClearSMBusFlag_ALERT
   * @param  I2Cx I2C Instance.
@@ -1858,7 +1899,7 @@ __STATIC_INLINE void LL_I2C_DisableAutoEndMode(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledAutoEndMode(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledAutoEndMode(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR2, I2C_CR2_AUTOEND) == (I2C_CR2_AUTOEND)) ? 1UL : 0UL);
 }
@@ -1893,7 +1934,7 @@ __STATIC_INLINE void LL_I2C_DisableReloadMode(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledReloadMode(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledReloadMode(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR2, I2C_CR2_RELOAD) == (I2C_CR2_RELOAD)) ? 1UL : 0UL);
 }
@@ -1917,13 +1958,14 @@ __STATIC_INLINE void LL_I2C_SetTransferSize(I2C_TypeDef *I2Cx, uint32_t Transfer
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x0 and Max_Data=0xFF
   */
-__STATIC_INLINE uint32_t LL_I2C_GetTransferSize(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetTransferSize(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->CR2, I2C_CR2_NBYTES) >> I2C_CR2_NBYTES_Pos);
 }
 
 /**
-  * @brief  Prepare the generation of a ACKnowledge or Non ACKnowledge condition after the address receive match code or next received byte.
+  * @brief  Prepare the generation of a ACKnowledge or Non ACKnowledge condition after the address receive match code
+            or next received byte.
   * @note   Usage in Slave mode only.
   * @rmtoll CR2          NACK          LL_I2C_AcknowledgeNextData
   * @param  I2Cx I2C Instance.
@@ -1964,7 +2006,8 @@ __STATIC_INLINE void LL_I2C_GenerateStopCondition(I2C_TypeDef *I2Cx)
 /**
   * @brief  Enable automatic RESTART Read request condition for 10bit address header (master mode).
   * @note   The master sends the complete 10bit slave address read sequence :
-  *         Start + 2 bytes 10bit address in Write direction + Restart + first 7 bits of 10bit address in Read direction.
+  *         Start + 2 bytes 10bit address in Write direction + Restart + first 7 bits of 10bit address
+            in Read direction.
   * @rmtoll CR2          HEAD10R       LL_I2C_EnableAuto10BitRead
   * @param  I2Cx I2C Instance.
   * @retval None
@@ -1992,7 +2035,7 @@ __STATIC_INLINE void LL_I2C_DisableAuto10BitRead(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledAuto10BitRead(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledAuto10BitRead(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR2, I2C_CR2_HEAD10R) != (I2C_CR2_HEAD10R)) ? 1UL : 0UL);
 }
@@ -2020,7 +2063,7 @@ __STATIC_INLINE void LL_I2C_SetTransferRequest(I2C_TypeDef *I2Cx, uint32_t Trans
   *         @arg @ref LL_I2C_REQUEST_WRITE
   *         @arg @ref LL_I2C_REQUEST_READ
   */
-__STATIC_INLINE uint32_t LL_I2C_GetTransferRequest(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetTransferRequest(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->CR2, I2C_CR2_RD_WRN));
 }
@@ -2044,7 +2087,7 @@ __STATIC_INLINE void LL_I2C_SetSlaveAddr(I2C_TypeDef *I2Cx, uint32_t SlaveAddr)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x0 and Max_Data=0x3F
   */
-__STATIC_INLINE uint32_t LL_I2C_GetSlaveAddr(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetSlaveAddr(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->CR2, I2C_CR2_SADD));
 }
@@ -2090,9 +2133,18 @@ __STATIC_INLINE uint32_t LL_I2C_GetSlaveAddr(I2C_TypeDef *I2Cx)
 __STATIC_INLINE void LL_I2C_HandleTransfer(I2C_TypeDef *I2Cx, uint32_t SlaveAddr, uint32_t SlaveAddrSize,
                                            uint32_t TransferSize, uint32_t EndMode, uint32_t Request)
 {
-  MODIFY_REG(I2Cx->CR2, I2C_CR2_SADD | I2C_CR2_ADD10 | (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31U - I2C_CR2_RD_WRN_Pos))) | I2C_CR2_START | I2C_CR2_STOP | I2C_CR2_RELOAD |
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  uint32_t tmp = ((uint32_t)(((uint32_t)SlaveAddr & I2C_CR2_SADD) | \
+                             ((uint32_t)SlaveAddrSize & I2C_CR2_ADD10) | \
+                             (((uint32_t)TransferSize << I2C_CR2_NBYTES_Pos) & I2C_CR2_NBYTES) | \
+                             (uint32_t)EndMode | (uint32_t)Request) & (~0x80000000U));
+
+  /* update CR2 register */
+  MODIFY_REG(I2Cx->CR2, I2C_CR2_SADD | I2C_CR2_ADD10 |
+             (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31U - I2C_CR2_RD_WRN_Pos))) |
+             I2C_CR2_START | I2C_CR2_STOP | I2C_CR2_RELOAD |
              I2C_CR2_NBYTES | I2C_CR2_AUTOEND | I2C_CR2_HEAD10R,
-             SlaveAddr | SlaveAddrSize | (TransferSize << I2C_CR2_NBYTES_Pos) | EndMode | Request);
+             tmp);
 }
 
 /**
@@ -2105,7 +2157,7 @@ __STATIC_INLINE void LL_I2C_HandleTransfer(I2C_TypeDef *I2Cx, uint32_t SlaveAddr
   *         @arg @ref LL_I2C_DIRECTION_WRITE
   *         @arg @ref LL_I2C_DIRECTION_READ
   */
-__STATIC_INLINE uint32_t LL_I2C_GetTransferDirection(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetTransferDirection(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->ISR, I2C_ISR_DIR));
 }
@@ -2116,16 +2168,17 @@ __STATIC_INLINE uint32_t LL_I2C_GetTransferDirection(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x00 and Max_Data=0x3F
   */
-__STATIC_INLINE uint32_t LL_I2C_GetAddressMatchCode(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_GetAddressMatchCode(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->ISR, I2C_ISR_ADDCODE) >> I2C_ISR_ADDCODE_Pos << 1);
 }
 
 /**
   * @brief  Enable internal comparison of the SMBus Packet Error byte (transmission or reception mode).
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
-  * @note   This feature is cleared by hardware when the PEC byte is transferred, or when a STOP condition or an Address Matched is received.
+  * @note   This feature is cleared by hardware when the PEC byte is transferred, or when a STOP condition
+            or an Address Matched is received.
   *         This bit has no effect when RELOAD bit is set.
   *         This bit has no effect in device mode when SBC bit is not set.
   * @rmtoll CR2          PECBYTE       LL_I2C_EnableSMBusPECCompare
@@ -2139,26 +2192,26 @@ __STATIC_INLINE void LL_I2C_EnableSMBusPECCompare(I2C_TypeDef *I2Cx)
 
 /**
   * @brief  Check if the SMBus Packet Error byte internal comparison is requested or not.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll CR2          PECBYTE       LL_I2C_IsEnabledSMBusPECCompare
   * @param  I2Cx I2C Instance.
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPECCompare(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPECCompare(const I2C_TypeDef *I2Cx)
 {
   return ((READ_BIT(I2Cx->CR2, I2C_CR2_PECBYTE) == (I2C_CR2_PECBYTE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Get the SMBus Packet Error byte calculated.
-  * @note   Macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
+  * @note   The macro IS_SMBUS_ALL_INSTANCE(I2Cx) can be used to check whether or not
   *         SMBus feature is supported by the I2Cx Instance.
   * @rmtoll PECR         PEC           LL_I2C_GetSMBusPEC
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
-*/
-__STATIC_INLINE uint32_t LL_I2C_GetSMBusPEC(I2C_TypeDef *I2Cx)
+  */
+__STATIC_INLINE uint32_t LL_I2C_GetSMBusPEC(const I2C_TypeDef *I2Cx)
 {
   return (uint32_t)(READ_BIT(I2Cx->PECR, I2C_PECR_PEC));
 }
@@ -2169,7 +2222,7 @@ __STATIC_INLINE uint32_t LL_I2C_GetSMBusPEC(I2C_TypeDef *I2Cx)
   * @param  I2Cx I2C Instance.
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint8_t LL_I2C_ReceiveData8(I2C_TypeDef *I2Cx)
+__STATIC_INLINE uint8_t LL_I2C_ReceiveData8(const I2C_TypeDef *I2Cx)
 {
   return (uint8_t)(READ_BIT(I2Cx->RXDR, I2C_RXDR_RXDATA));
 }
@@ -2195,8 +2248,8 @@ __STATIC_INLINE void LL_I2C_TransmitData8(I2C_TypeDef *I2Cx, uint8_t Data)
   * @{
   */
 
-ErrorStatus LL_I2C_Init(I2C_TypeDef *I2Cx, LL_I2C_InitTypeDef *I2C_InitStruct);
-ErrorStatus LL_I2C_DeInit(I2C_TypeDef *I2Cx);
+ErrorStatus LL_I2C_Init(I2C_TypeDef *I2Cx, const LL_I2C_InitTypeDef *I2C_InitStruct);
+ErrorStatus LL_I2C_DeInit(const I2C_TypeDef *I2Cx);
 void LL_I2C_StructInit(LL_I2C_InitTypeDef *I2C_InitStruct);
 
 
@@ -2224,5 +2277,3 @@ void LL_I2C_StructInit(LL_I2C_InitTypeDef *I2C_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_I2C_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_ipcc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_ipcc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -711,7 +710,6 @@ __STATIC_INLINE uint32_t LL_IPCC_GetChannelNumber(IPCC_TypeDef *IPCCx)
   * @}
   */
 
-
 /**
   * @}
   */
@@ -720,7 +718,7 @@ __STATIC_INLINE uint32_t LL_IPCC_GetChannelNumber(IPCC_TypeDef *IPCCx)
   * @}
   */
 
-#endif /* defined(IPCC) */
+#endif /* IPCC */
 
 /**
   * @}
@@ -732,4 +730,3 @@ __STATIC_INLINE uint32_t LL_IPCC_GetChannelNumber(IPCC_TypeDef *IPCCx)
 
 #endif /* STM32WBxx_LL_IPCC_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_iwdg.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_iwdg.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -209,7 +208,7 @@ __STATIC_INLINE void LL_IWDG_SetPrescaler(IWDG_TypeDef *IWDGx, uint32_t Prescale
   *         @arg @ref LL_IWDG_PRESCALER_128
   *         @arg @ref LL_IWDG_PRESCALER_256
   */
-__STATIC_INLINE uint32_t LL_IWDG_GetPrescaler(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_GetPrescaler(const IWDG_TypeDef *IWDGx)
 {
   return (READ_REG(IWDGx->PR));
 }
@@ -232,7 +231,7 @@ __STATIC_INLINE void LL_IWDG_SetReloadCounter(IWDG_TypeDef *IWDGx, uint32_t Coun
   * @param  IWDGx IWDG Instance
   * @retval Value between Min_Data=0 and Max_Data=0x0FFF
   */
-__STATIC_INLINE uint32_t LL_IWDG_GetReloadCounter(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_GetReloadCounter(const IWDG_TypeDef *IWDGx)
 {
   return (READ_REG(IWDGx->RLR));
 }
@@ -255,7 +254,7 @@ __STATIC_INLINE void LL_IWDG_SetWindow(IWDG_TypeDef *IWDGx, uint32_t Window)
   * @param  IWDGx IWDG Instance
   * @retval Value between Min_Data=0 and Max_Data=0x0FFF
   */
-__STATIC_INLINE uint32_t LL_IWDG_GetWindow(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_GetWindow(const IWDG_TypeDef *IWDGx)
 {
   return (READ_REG(IWDGx->WINR));
 }
@@ -274,7 +273,7 @@ __STATIC_INLINE uint32_t LL_IWDG_GetWindow(IWDG_TypeDef *IWDGx)
   * @param  IWDGx IWDG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_PVU(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_PVU(const IWDG_TypeDef *IWDGx)
 {
   return ((READ_BIT(IWDGx->SR, IWDG_SR_PVU) == (IWDG_SR_PVU)) ? 1UL : 0UL);
 }
@@ -285,7 +284,7 @@ __STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_PVU(IWDG_TypeDef *IWDGx)
   * @param  IWDGx IWDG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_RVU(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_RVU(const IWDG_TypeDef *IWDGx)
 {
   return ((READ_BIT(IWDGx->SR, IWDG_SR_RVU) == (IWDG_SR_RVU)) ? 1UL : 0UL);
 }
@@ -296,7 +295,7 @@ __STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_RVU(IWDG_TypeDef *IWDGx)
   * @param  IWDGx IWDG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_WVU(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_WVU(const IWDG_TypeDef *IWDGx)
 {
   return ((READ_BIT(IWDGx->SR, IWDG_SR_WVU) == (IWDG_SR_WVU)) ? 1UL : 0UL);
 }
@@ -304,12 +303,12 @@ __STATIC_INLINE uint32_t LL_IWDG_IsActiveFlag_WVU(IWDG_TypeDef *IWDGx)
 /**
   * @brief  Check if all flags Prescaler, Reload & Window Value Update are reset or not
   * @rmtoll SR           PVU           LL_IWDG_IsReady\n
-  *         SR           WVU           LL_IWDG_IsReady\n
-  *         SR           RVU           LL_IWDG_IsReady
+  *         SR           RVU           LL_IWDG_IsReady\n
+  *         SR           WVU           LL_IWDG_IsReady
   * @param  IWDGx IWDG Instance
   * @retval State of bits (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_IWDG_IsReady(IWDG_TypeDef *IWDGx)
+__STATIC_INLINE uint32_t LL_IWDG_IsReady(const IWDG_TypeDef *IWDGx)
 {
   return ((READ_BIT(IWDGx->SR, IWDG_SR_PVU | IWDG_SR_RVU | IWDG_SR_WVU) == 0U) ? 1UL : 0UL);
 }
@@ -317,7 +316,6 @@ __STATIC_INLINE uint32_t LL_IWDG_IsReady(IWDG_TypeDef *IWDGx)
 /**
   * @}
   */
-
 
 /**
   * @}
@@ -338,5 +336,3 @@ __STATIC_INLINE uint32_t LL_IWDG_IsReady(IWDG_TypeDef *IWDGx)
 #endif
 
 #endif /* STM32WBxx_LL_IWDG_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_lptim.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_lptim.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -67,22 +66,26 @@ typedef struct
   uint32_t ClockSource;    /*!< Specifies the source of the clock used by the LPTIM instance.
                                 This parameter can be a value of @ref LPTIM_LL_EC_CLK_SOURCE.
 
-                                This feature can be modified afterwards using unitary function @ref LL_LPTIM_SetClockSource().*/
+                                This feature can be modified afterwards using unitary
+                                function @ref LL_LPTIM_SetClockSource().*/
 
   uint32_t Prescaler;      /*!< Specifies the prescaler division ratio.
                                 This parameter can be a value of @ref LPTIM_LL_EC_PRESCALER.
 
-                                This feature can be modified afterwards using using unitary function @ref LL_LPTIM_SetPrescaler().*/
+                                This feature can be modified afterwards using using unitary
+                                function @ref LL_LPTIM_SetPrescaler().*/
 
   uint32_t Waveform;       /*!< Specifies the waveform shape.
                                 This parameter can be a value of @ref LPTIM_LL_EC_OUTPUT_WAVEFORM.
 
-                                This feature can be modified afterwards using unitary function @ref LL_LPTIM_ConfigOutput().*/
+                                This feature can be modified afterwards using unitary
+                                function @ref LL_LPTIM_ConfigOutput().*/
 
   uint32_t Polarity;       /*!< Specifies waveform polarity.
                                 This parameter can be a value of @ref LPTIM_LL_EC_OUTPUT_POLARITY.
 
-                                This feature can be modified afterwards using unitary function @ref LL_LPTIM_ConfigOutput().*/
+                                This feature can be modified afterwards using unitary
+                                function @ref LL_LPTIM_ConfigOutput().*/
 } LL_LPTIM_InitTypeDef;
 
 /**
@@ -100,9 +103,9 @@ typedef struct
   * @{
   */
 #define LL_LPTIM_ISR_CMPM                     LPTIM_ISR_CMPM     /*!< Compare match */
+#define LL_LPTIM_ISR_CMPOK                    LPTIM_ISR_CMPOK    /*!< Compare register update OK */
 #define LL_LPTIM_ISR_ARRM                     LPTIM_ISR_ARRM     /*!< Autoreload match */
 #define LL_LPTIM_ISR_EXTTRIG                  LPTIM_ISR_EXTTRIG  /*!< External trigger edge event */
-#define LL_LPTIM_ISR_CMPOK                    LPTIM_ISR_CMPOK    /*!< Compare register update OK */
 #define LL_LPTIM_ISR_ARROK                    LPTIM_ISR_ARROK    /*!< Autoreload register update OK */
 #define LL_LPTIM_ISR_UP                       LPTIM_ISR_UP       /*!< Counter direction change down to up */
 #define LL_LPTIM_ISR_DOWN                     LPTIM_ISR_DOWN     /*!< Counter direction change up to down */
@@ -114,13 +117,13 @@ typedef struct
   * @brief    IT defines which can be used with LL_LPTIM_ReadReg and  LL_LPTIM_WriteReg functions
   * @{
   */
-#define LL_LPTIM_IER_CMPMIE                   LPTIM_IER_CMPMIE       /*!< Compare match Interrupt Enable */
-#define LL_LPTIM_IER_ARRMIE                   LPTIM_IER_ARRMIE       /*!< Autoreload match Interrupt Enable */
-#define LL_LPTIM_IER_EXTTRIGIE                LPTIM_IER_EXTTRIGIE    /*!< External trigger valid edge Interrupt Enable */
-#define LL_LPTIM_IER_CMPOKIE                  LPTIM_IER_CMPOKIE      /*!< Compare register update OK Interrupt Enable */
-#define LL_LPTIM_IER_ARROKIE                  LPTIM_IER_ARROKIE      /*!< Autoreload register update OK Interrupt Enable */
-#define LL_LPTIM_IER_UPIE                     LPTIM_IER_UPIE         /*!< Direction change to UP Interrupt Enable */
-#define LL_LPTIM_IER_DOWNIE                   LPTIM_IER_DOWNIE       /*!< Direction change to down Interrupt Enable */
+#define LL_LPTIM_IER_CMPMIE                   LPTIM_IER_CMPMIE     /*!< Compare match */
+#define LL_LPTIM_IER_CMPOKIE                  LPTIM_IER_CMPOKIE    /*!< Compare register update OK */
+#define LL_LPTIM_IER_ARRMIE                   LPTIM_IER_ARRMIE     /*!< Autoreload match */
+#define LL_LPTIM_IER_EXTTRIGIE                LPTIM_IER_EXTTRIGIE  /*!< External trigger edge event */
+#define LL_LPTIM_IER_ARROKIE                  LPTIM_IER_ARROKIE    /*!< Autoreload register update OK */
+#define LL_LPTIM_IER_UPIE                     LPTIM_IER_UPIE       /*!< Counter direction change down to up */
+#define LL_LPTIM_IER_DOWNIE                   LPTIM_IER_DOWNIE     /*!< Counter direction change up to down */
 /**
   * @}
   */
@@ -155,7 +158,7 @@ typedef struct
 /** @defgroup LPTIM_LL_EC_OUTPUT_WAVEFORM Output Waveform Type
   * @{
   */
-#define LL_LPTIM_OUTPUT_WAVEFORM_PWM          0x00000000U     /*!<LPTIM  generates either a PWM waveform or a One pulse waveform depending on chosen operating mode CONTINOUS or SINGLE*/
+#define LL_LPTIM_OUTPUT_WAVEFORM_PWM          0x00000000U     /*!<LPTIM  generates either a PWM waveform or a One pulse waveform depending on chosen operating mode CONTINUOUS or SINGLE*/
 #define LL_LPTIM_OUTPUT_WAVEFORM_SETONCE      LPTIM_CFGR_WAVE /*!<LPTIM  generates a Set Once waveform*/
 /**
   * @}
@@ -276,11 +279,11 @@ typedef struct
 #define LL_LPTIM_INPUT1_SRC_GPIO         0x00000000U            /*!< For LPTIM1 and LPTIM2 */
 #if defined(COMP1)
 #define LL_LPTIM_INPUT1_SRC_COMP1        LPTIM_OR_OR_0          /*!< For LPTIM1 and LPTIM2 */
-#endif
+#endif /* COMP1 */
 #if defined(COMP2)
 #define LL_LPTIM_INPUT1_SRC_COMP2        LPTIM_OR_OR_1          /*!< For LPTIM2 */
 #define LL_LPTIM_INPUT1_SRC_COMP1_COMP2  LPTIM_OR_OR            /*!< For LPTIM2 */
-#endif
+#endif /* COMP2 */
 /**
   * @}
   */
@@ -293,7 +296,7 @@ typedef struct
 #define LL_LPTIM_INPUT2_SRC_GPIO         0x00000000U                   /*!< For LPTIM1 */
 #if defined(COMP2)
 #define LL_LPTIM_INPUT2_SRC_COMP2        LPTIM_OR_OR_1                 /*!< For LPTIM1 */
-#endif
+#endif /* COMP2 */
 /**
   * @}
   */
@@ -341,14 +344,27 @@ typedef struct
   * @{
   */
 
+/** Legacy definitions for compatibility purpose
+@cond 0
+  */
+#define LL_LPTIM_ClearFLAG_CMPM  LL_LPTIM_ClearFlag_CMPM
+#define LL_LPTIM_ClearFLAG_CC1   LL_LPTIM_ClearFlag_CC1
+#define LL_LPTIM_ClearFLAG_CC2   LL_LPTIM_ClearFlag_CC2
+#define LL_LPTIM_ClearFLAG_CC1O  LL_LPTIM_ClearFlag_CC1O
+#define LL_LPTIM_ClearFLAG_CC2O  LL_LPTIM_ClearFlag_CC2O
+#define LL_LPTIM_ClearFLAG_ARRM  LL_LPTIM_ClearFlag_ARRM
+/**
+@endcond
+  */
+
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup LPTIM_LL_EF_Init Initialisation and deinitialisation functions
   * @{
   */
 
-ErrorStatus LL_LPTIM_DeInit(LPTIM_TypeDef *LPTIMx);
+ErrorStatus LL_LPTIM_DeInit(const LPTIM_TypeDef *LPTIMx);
 void LL_LPTIM_StructInit(LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
-ErrorStatus LL_LPTIM_Init(LPTIM_TypeDef *LPTIMx, LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
+ErrorStatus LL_LPTIM_Init(LPTIM_TypeDef *LPTIMx, const LL_LPTIM_InitTypeDef *LPTIM_InitStruct);
 void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx);
 /**
   * @}
@@ -378,7 +394,7 @@ __STATIC_INLINE void LL_LPTIM_Enable(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabled(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabled(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->CR, LPTIM_CR_ENABLE) == LPTIM_CR_ENABLE) ? 1UL : 0UL));
 }
@@ -431,7 +447,7 @@ __STATIC_INLINE void LL_LPTIM_DisableResetAfterRead(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledResetAfterRead(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledResetAfterRead(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->CR, LPTIM_CR_RSTARE) == LPTIM_CR_RSTARE) ? 1UL : 0UL));
 }
@@ -474,7 +490,7 @@ __STATIC_INLINE void LL_LPTIM_SetUpdateMode(LPTIM_TypeDef *LPTIMx, uint32_t Upda
   *         @arg @ref LL_LPTIM_UPDATE_MODE_IMMEDIATE
   *         @arg @ref LL_LPTIM_UPDATE_MODE_ENDOFPERIOD
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetUpdateMode(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetUpdateMode(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_PRELOAD));
 }
@@ -489,7 +505,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetUpdateMode(LPTIM_TypeDef *LPTIMx)
   * @note autoreload value be strictly greater than the compare value.
   * @rmtoll ARR          ARR           LL_LPTIM_SetAutoReload
   * @param  LPTIMx Low-Power Timer instance
-  * @param  AutoReload Value between Min_Data=0x00 and Max_Data=0xFFFF
+  * @param  AutoReload Value between Min_Data=0x0001 and Max_Data=0xFFFF
   * @retval None
   */
 __STATIC_INLINE void LL_LPTIM_SetAutoReload(LPTIM_TypeDef *LPTIMx, uint32_t AutoReload)
@@ -501,9 +517,9 @@ __STATIC_INLINE void LL_LPTIM_SetAutoReload(LPTIM_TypeDef *LPTIMx, uint32_t Auto
   * @brief  Get actual auto reload value
   * @rmtoll ARR          ARR           LL_LPTIM_GetAutoReload
   * @param  LPTIMx Low-Power Timer instance
-  * @retval AutoReload Value between Min_Data=0x00 and Max_Data=0xFFFF
+  * @retval AutoReload Value between Min_Data=0x0001 and Max_Data=0xFFFF
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetAutoReload(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetAutoReload(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->ARR, LPTIM_ARR_ARR));
 }
@@ -530,7 +546,7 @@ __STATIC_INLINE void LL_LPTIM_SetCompare(LPTIM_TypeDef *LPTIMx, uint32_t Compare
   * @param  LPTIMx Low-Power Timer instance
   * @retval CompareValue Value between Min_Data=0x00 and Max_Data=0xFFFF
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetCompare(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetCompare(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CMP, LPTIM_CMP_CMP));
 }
@@ -545,7 +561,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetCompare(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval Counter value
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetCounter(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetCounter(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CNT, LPTIM_CNT_CNT));
 }
@@ -573,7 +589,7 @@ __STATIC_INLINE void LL_LPTIM_SetCounterMode(LPTIM_TypeDef *LPTIMx, uint32_t Cou
   *         @arg @ref LL_LPTIM_COUNTER_MODE_INTERNAL
   *         @arg @ref LL_LPTIM_COUNTER_MODE_EXTERNAL
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetCounterMode(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetCounterMode(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_COUNTMODE));
 }
@@ -622,7 +638,7 @@ __STATIC_INLINE void LL_LPTIM_SetWaveform(LPTIM_TypeDef *LPTIMx, uint32_t Wavefo
   *         @arg @ref LL_LPTIM_OUTPUT_WAVEFORM_PWM
   *         @arg @ref LL_LPTIM_OUTPUT_WAVEFORM_SETONCE
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetWaveform(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetWaveform(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_WAVE));
 }
@@ -649,7 +665,7 @@ __STATIC_INLINE void LL_LPTIM_SetPolarity(LPTIM_TypeDef *LPTIMx, uint32_t Polari
   *         @arg @ref LL_LPTIM_OUTPUT_POLARITY_REGULAR
   *         @arg @ref LL_LPTIM_OUTPUT_POLARITY_INVERSE
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetPolarity(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetPolarity(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_WAVPOL));
 }
@@ -693,7 +709,7 @@ __STATIC_INLINE void LL_LPTIM_SetPrescaler(LPTIM_TypeDef *LPTIMx, uint32_t Presc
   *         @arg @ref LL_LPTIM_PRESCALER_DIV64
   *         @arg @ref LL_LPTIM_PRESCALER_DIV128
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetPrescaler(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetPrescaler(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_PRESC));
 }
@@ -778,7 +794,7 @@ __STATIC_INLINE void LL_LPTIM_DisableTimeout(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledTimeout(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledTimeout(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_TIMOUT) == LPTIM_CFGR_TIMOUT) ? 1UL : 0UL));
 }
@@ -849,7 +865,7 @@ __STATIC_INLINE void LL_LPTIM_ConfigTrigger(LPTIM_TypeDef *LPTIMx, uint32_t Sour
   *         (*)  Value not defined in all devices. \n
   *
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetTriggerSource(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetTriggerSource(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_TRIGSEL));
 }
@@ -864,7 +880,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetTriggerSource(LPTIM_TypeDef *LPTIMx)
   *         @arg @ref LL_LPTIM_TRIG_FILTER_4
   *         @arg @ref LL_LPTIM_TRIG_FILTER_8
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetTriggerFilter(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetTriggerFilter(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_TRGFLT));
 }
@@ -878,7 +894,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetTriggerFilter(LPTIM_TypeDef *LPTIMx)
   *         @arg @ref LL_LPTIM_TRIG_POLARITY_FALLING
   *         @arg @ref LL_LPTIM_TRIG_POLARITY_RISING_FALLING
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetTriggerPolarity(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetTriggerPolarity(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_TRIGEN));
 }
@@ -914,13 +930,14 @@ __STATIC_INLINE void LL_LPTIM_SetClockSource(LPTIM_TypeDef *LPTIMx, uint32_t Clo
   *         @arg @ref LL_LPTIM_CLK_SOURCE_INTERNAL
   *         @arg @ref LL_LPTIM_CLK_SOURCE_EXTERNAL
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetClockSource(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetClockSource(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_CKSEL));
 }
 
 /**
-  * @brief  Configure the active edge or edges used by the counter when the LPTIM is clocked by an external clock source.
+  * @brief  Configure the active edge or edges used by the counter when
+            the LPTIM is clocked by an external clock source.
   * @note This function must be called when the LPTIM instance is disabled.
   * @note When both external clock signal edges are considered active ones,
   *       the LPTIM must also be clocked by an internal clock source with a
@@ -955,7 +972,7 @@ __STATIC_INLINE void LL_LPTIM_ConfigClock(LPTIM_TypeDef *LPTIMx, uint32_t ClockF
   *         @arg @ref LL_LPTIM_CLK_POLARITY_FALLING
   *         @arg @ref LL_LPTIM_CLK_POLARITY_RISING_FALLING
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetClockPolarity(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetClockPolarity(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_CKPOL));
 }
@@ -970,7 +987,7 @@ __STATIC_INLINE uint32_t LL_LPTIM_GetClockPolarity(LPTIM_TypeDef *LPTIMx)
   *         @arg @ref LL_LPTIM_CLK_FILTER_4
   *         @arg @ref LL_LPTIM_CLK_FILTER_8
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetClockFilter(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetClockFilter(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_CKFLT));
 }
@@ -1008,7 +1025,7 @@ __STATIC_INLINE void LL_LPTIM_SetEncoderMode(LPTIM_TypeDef *LPTIMx, uint32_t Enc
   *         @arg @ref LL_LPTIM_ENCODER_MODE_FALLING
   *         @arg @ref LL_LPTIM_ENCODER_MODE_RISING_FALLING
   */
-__STATIC_INLINE uint32_t LL_LPTIM_GetEncoderMode(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_GetEncoderMode(const LPTIM_TypeDef *LPTIMx)
 {
   return (uint32_t)(READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_CKPOL));
 }
@@ -1047,7 +1064,7 @@ __STATIC_INLINE void LL_LPTIM_DisableEncoderMode(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledEncoderMode(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledEncoderMode(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->CFGR, LPTIM_CFGR_ENC) == LPTIM_CFGR_ENC) ? 1UL : 0UL));
 }
@@ -1060,13 +1077,14 @@ __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledEncoderMode(LPTIM_TypeDef *LPTIMx)
   * @{
   */
 
+
 /**
   * @brief  Clear the compare match flag (CMPMCF)
-  * @rmtoll ICR          CMPMCF        LL_LPTIM_ClearFLAG_CMPM
+  * @rmtoll ICR          CMPMCF        LL_LPTIM_ClearFlag_CMPM
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
-__STATIC_INLINE void LL_LPTIM_ClearFLAG_CMPM(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE void LL_LPTIM_ClearFlag_CMPM(LPTIM_TypeDef *LPTIMx)
 {
   SET_BIT(LPTIMx->ICR, LPTIM_ICR_CMPMCF);
 }
@@ -1077,18 +1095,18 @@ __STATIC_INLINE void LL_LPTIM_ClearFLAG_CMPM(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_CMPM(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_CMPM(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_CMPM) == LPTIM_ISR_CMPM) ? 1UL : 0UL));
 }
 
 /**
   * @brief  Clear the autoreload match flag (ARRMCF)
-  * @rmtoll ICR          ARRMCF        LL_LPTIM_ClearFLAG_ARRM
+  * @rmtoll ICR          ARRMCF        LL_LPTIM_ClearFlag_ARRM
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
-__STATIC_INLINE void LL_LPTIM_ClearFLAG_ARRM(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE void LL_LPTIM_ClearFlag_ARRM(LPTIM_TypeDef *LPTIMx)
 {
   SET_BIT(LPTIMx->ICR, LPTIM_ICR_ARRMCF);
 }
@@ -1099,7 +1117,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFLAG_ARRM(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_ARRM(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_ARRM(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_ARRM) == LPTIM_ISR_ARRM) ? 1UL : 0UL));
 }
@@ -1121,7 +1139,7 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_EXTTRIG(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_EXTTRIG(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_EXTTRIG(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_EXTTRIG) == LPTIM_ISR_EXTTRIG) ? 1UL : 0UL));
 }
@@ -1138,12 +1156,13 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_CMPOK(LPTIM_TypeDef *LPTIMx)
 }
 
 /**
-  * @brief  Informs application whether the APB bus write operation to the LPTIMx_CMP register has been successfully completed. If so, a new one can be initiated.
+  * @brief  Informs application whether the APB bus write operation to the LPTIMx_CMP register has been successfully
+            completed. If so, a new one can be initiated.
   * @rmtoll ISR          CMPOK         LL_LPTIM_IsActiveFlag_CMPOK
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_CMPOK(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_CMPOK(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_CMPOK) == LPTIM_ISR_CMPOK) ? 1UL : 0UL));
 }
@@ -1160,12 +1179,13 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_ARROK(LPTIM_TypeDef *LPTIMx)
 }
 
 /**
-  * @brief  Informs application whether the APB bus write operation to the LPTIMx_ARR register has been successfully completed. If so, a new one can be initiated.
+  * @brief  Informs application whether the APB bus write operation to the LPTIMx_ARR register has been successfully
+            completed. If so, a new one can be initiated.
   * @rmtoll ISR          ARROK         LL_LPTIM_IsActiveFlag_ARROK
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_ARROK(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_ARROK(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_ARROK) == LPTIM_ISR_ARROK) ? 1UL : 0UL));
 }
@@ -1182,12 +1202,13 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_UP(LPTIM_TypeDef *LPTIMx)
 }
 
 /**
-  * @brief  Informs the application whether the counter direction has changed from down to up (when the LPTIM instance operates in encoder mode).
+  * @brief  Informs the application whether the counter direction has changed from down to up (when the LPTIM instance
+            operates in encoder mode).
   * @rmtoll ISR          UP            LL_LPTIM_IsActiveFlag_UP
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_UP(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_UP(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_UP) == LPTIM_ISR_UP) ? 1UL : 0UL));
 }
@@ -1204,12 +1225,13 @@ __STATIC_INLINE void LL_LPTIM_ClearFlag_DOWN(LPTIM_TypeDef *LPTIMx)
 }
 
 /**
-  * @brief  Informs the application whether the counter direction has changed from up to down (when the LPTIM instance operates in encoder mode).
+  * @brief  Informs the application whether the counter direction has changed from up to down (when the LPTIM instance
+            operates in encoder mode).
   * @rmtoll ISR          DOWN          LL_LPTIM_IsActiveFlag_DOWN
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_DOWN(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsActiveFlag_DOWN(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->ISR, LPTIM_ISR_DOWN) == LPTIM_ISR_DOWN) ? 1UL : 0UL));
 }
@@ -1250,7 +1272,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_CMPM(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_CMPM(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_CMPM(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->IER, LPTIM_IER_CMPMIE) == LPTIM_IER_CMPMIE) ? 1UL : 0UL));
 }
@@ -1283,7 +1305,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_ARRM(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_ARRM(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_ARRM(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->IER, LPTIM_IER_ARRMIE) == LPTIM_IER_ARRMIE) ? 1UL : 0UL));
 }
@@ -1316,7 +1338,7 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_EXTTRIG(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_EXTTRIG(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_EXTTRIG(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->IER, LPTIM_IER_EXTTRIGIE) == LPTIM_IER_EXTTRIGIE) ? 1UL : 0UL));
 }
@@ -1349,14 +1371,14 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_CMPOK(LPTIM_TypeDef *LPTIMx)
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_CMPOK(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_CMPOK(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->IER, LPTIM_IER_CMPOKIE) == LPTIM_IER_CMPOKIE) ? 1UL : 0UL));
 }
 
 /**
   * @brief  Enable autoreload register write completed interrupt (ARROKIE).
-  * @rmtoll IER          ARROKIE       LL_LPTIM_EnableIT_ARROK
+  * @rmtoll IER         ARROKIE       LL_LPTIM_EnableIT_ARROK
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
@@ -1367,7 +1389,7 @@ __STATIC_INLINE void LL_LPTIM_EnableIT_ARROK(LPTIM_TypeDef *LPTIMx)
 
 /**
   * @brief  Disable autoreload register write completed interrupt (ARROKIE).
-  * @rmtoll IER          ARROKIE       LL_LPTIM_DisableIT_ARROK
+  * @rmtoll IER         ARROKIE       LL_LPTIM_DisableIT_ARROK
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
@@ -1378,18 +1400,18 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_ARROK(LPTIM_TypeDef *LPTIMx)
 
 /**
   * @brief  Indicates whether the autoreload register write completed interrupt (ARROKIE) is enabled.
-  * @rmtoll IER          ARROKIE       LL_LPTIM_IsEnabledIT_ARROK
+  * @rmtoll IER         ARROKIE       LL_LPTIM_IsEnabledIT_ARROK
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit(1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_ARROK(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_ARROK(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->IER, LPTIM_IER_ARROKIE) == LPTIM_IER_ARROKIE) ? 1UL : 0UL));
 }
 
 /**
   * @brief  Enable direction change to up interrupt (UPIE).
-  * @rmtoll IER          UPIE          LL_LPTIM_EnableIT_UP
+  * @rmtoll IER         UPIE          LL_LPTIM_EnableIT_UP
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
@@ -1400,7 +1422,7 @@ __STATIC_INLINE void LL_LPTIM_EnableIT_UP(LPTIM_TypeDef *LPTIMx)
 
 /**
   * @brief  Disable direction change to up interrupt (UPIE).
-  * @rmtoll IER          UPIE          LL_LPTIM_DisableIT_UP
+  * @rmtoll IER         UPIE          LL_LPTIM_DisableIT_UP
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
@@ -1411,18 +1433,18 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_UP(LPTIM_TypeDef *LPTIMx)
 
 /**
   * @brief  Indicates whether the direction change to up interrupt (UPIE) is enabled.
-  * @rmtoll IER          UPIE          LL_LPTIM_IsEnabledIT_UP
+  * @rmtoll IER         UPIE          LL_LPTIM_IsEnabledIT_UP
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit(1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_UP(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_UP(const LPTIM_TypeDef *LPTIMx)
 {
   return (((READ_BIT(LPTIMx->IER, LPTIM_IER_UPIE) == LPTIM_IER_UPIE) ? 1UL : 0UL));
 }
 
 /**
   * @brief  Enable direction change to down interrupt (DOWNIE).
-  * @rmtoll IER          DOWNIE        LL_LPTIM_EnableIT_DOWN
+  * @rmtoll IER         DOWNIE        LL_LPTIM_EnableIT_DOWN
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
@@ -1433,7 +1455,7 @@ __STATIC_INLINE void LL_LPTIM_EnableIT_DOWN(LPTIM_TypeDef *LPTIMx)
 
 /**
   * @brief  Disable direction change to down interrupt (DOWNIE).
-  * @rmtoll IER          DOWNIE        LL_LPTIM_DisableIT_DOWN
+  * @rmtoll IER         DOWNIE        LL_LPTIM_DisableIT_DOWN
   * @param  LPTIMx Low-Power Timer instance
   * @retval None
   */
@@ -1444,11 +1466,11 @@ __STATIC_INLINE void LL_LPTIM_DisableIT_DOWN(LPTIM_TypeDef *LPTIMx)
 
 /**
   * @brief  Indicates whether the direction change to down interrupt (DOWNIE) is enabled.
-  * @rmtoll IER          DOWNIE        LL_LPTIM_IsEnabledIT_DOWN
+  * @rmtoll IER         DOWNIE        LL_LPTIM_IsEnabledIT_DOWN
   * @param  LPTIMx Low-Power Timer instance
   * @retval State of bit(1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_DOWN(LPTIM_TypeDef *LPTIMx)
+__STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_DOWN(const LPTIM_TypeDef *LPTIMx)
 {
   return ((READ_BIT(LPTIMx->IER, LPTIM_IER_DOWNIE) == LPTIM_IER_DOWNIE) ? 1UL : 0UL);
 }
@@ -1476,5 +1498,3 @@ __STATIC_INLINE uint32_t LL_LPTIM_IsEnabledIT_DOWN(LPTIM_TypeDef *LPTIMx)
 #endif
 
 #endif /* STM32WBxx_LL_LPTIM_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_lpuart.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_lpuart.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -57,6 +56,10 @@ static const uint16_t LPUART_PRESCALER_TAB[] =
   (uint16_t)32,
   (uint16_t)64,
   (uint16_t)128,
+  (uint16_t)256,
+  (uint16_t)256,
+  (uint16_t)256,
+  (uint16_t)256,
   (uint16_t)256
 };
 /**
@@ -100,36 +103,43 @@ typedef struct
   uint32_t PrescalerValue;            /*!< Specifies the Prescaler to compute the communication baud rate.
                                            This parameter can be a value of @ref LPUART_LL_EC_PRESCALER.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetPrescaler().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetPrescaler().*/
 
   uint32_t BaudRate;                  /*!< This field defines expected LPUART communication baud rate.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetBaudRate().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetBaudRate().*/
 
   uint32_t DataWidth;                 /*!< Specifies the number of data bits transmitted or received in a frame.
                                            This parameter can be a value of @ref LPUART_LL_EC_DATAWIDTH.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetDataWidth().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetDataWidth().*/
 
   uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
                                            This parameter can be a value of @ref LPUART_LL_EC_STOPBITS.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetStopBitsLength().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetStopBitsLength().*/
 
   uint32_t Parity;                    /*!< Specifies the parity mode.
                                            This parameter can be a value of @ref LPUART_LL_EC_PARITY.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetParity().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetParity().*/
 
   uint32_t TransferDirection;         /*!< Specifies whether the Receive and/or Transmit mode is enabled or disabled.
                                            This parameter can be a value of @ref LPUART_LL_EC_DIRECTION.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetTransferDirection().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetTransferDirection().*/
 
   uint32_t HardwareFlowControl;       /*!< Specifies whether the hardware flow control mode is enabled or disabled.
                                            This parameter can be a value of @ref LPUART_LL_EC_HWCONTROL.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_LPUART_SetHWFlowCtrl().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_LPUART_SetHWFlowCtrl().*/
 
 } LL_LPUART_InitTypeDef;
 
@@ -147,16 +157,15 @@ typedef struct
   * @brief    Flags defines which can be used with LL_LPUART_WriteReg function
   * @{
   */
-#define LL_LPUART_ICR_PECF                 USART_ICR_PECF                /*!< Parity error flag */
-#define LL_LPUART_ICR_FECF                 USART_ICR_FECF                /*!< Framing error flag */
-#define LL_LPUART_ICR_NCF                  USART_ICR_NECF                /*!< Noise error detected flag */
-#define LL_LPUART_ICR_ORECF                USART_ICR_ORECF               /*!< Overrun error flag */
-#define LL_LPUART_ICR_IDLECF               USART_ICR_IDLECF              /*!< Idle line detected flag */
-#define LL_LPUART_ICR_TXFECF               USART_ICR_TXFECF              /*!< TX FIFO Empty Clear flag */
-#define LL_LPUART_ICR_TCCF                 USART_ICR_TCCF                /*!< Transmission complete flag */
-#define LL_LPUART_ICR_CTSCF                USART_ICR_CTSCF               /*!< CTS flag */
-#define LL_LPUART_ICR_CMCF                 USART_ICR_CMCF                /*!< Character match flag */
-#define LL_LPUART_ICR_WUCF                 USART_ICR_WUCF                /*!< Wakeup from Stop mode flag */
+#define LL_LPUART_ICR_PECF                 USART_ICR_PECF                /*!< Parity error clear flag */
+#define LL_LPUART_ICR_FECF                 USART_ICR_FECF                /*!< Framing error clear flag */
+#define LL_LPUART_ICR_NCF                  USART_ICR_NECF                /*!< Noise error detected clear flag */
+#define LL_LPUART_ICR_ORECF                USART_ICR_ORECF               /*!< Overrun error clear flag */
+#define LL_LPUART_ICR_IDLECF               USART_ICR_IDLECF              /*!< Idle line detected clear flag */
+#define LL_LPUART_ICR_TCCF                 USART_ICR_TCCF                /*!< Transmission complete clear flag */
+#define LL_LPUART_ICR_CTSCF                USART_ICR_CTSCF               /*!< CTS clear flag */
+#define LL_LPUART_ICR_CMCF                 USART_ICR_CMCF                /*!< Character match clear flag */
+#define LL_LPUART_ICR_WUCF                 USART_ICR_WUCF                /*!< Wakeup from Stop mode clear flag */
 /**
   * @}
   */
@@ -165,27 +174,27 @@ typedef struct
   * @brief    Flags defines which can be used with LL_LPUART_ReadReg function
   * @{
   */
-#define LL_LPUART_ISR_PE                   USART_ISR_PE                  /*!< Parity error flag */
-#define LL_LPUART_ISR_FE                   USART_ISR_FE                  /*!< Framing error flag */
-#define LL_LPUART_ISR_NE                   USART_ISR_NE                  /*!< Noise detected flag */
-#define LL_LPUART_ISR_ORE                  USART_ISR_ORE                 /*!< Overrun error flag */
-#define LL_LPUART_ISR_IDLE                 USART_ISR_IDLE                /*!< Idle line detected flag */
-#define LL_LPUART_ISR_RXNE_RXFNE           USART_ISR_RXNE_RXFNE          /*!< Read data register or RX FIFO not empty flag */
-#define LL_LPUART_ISR_TC                   USART_ISR_TC                  /*!< Transmission complete flag */
-#define LL_LPUART_ISR_TXE_TXFNF            USART_ISR_TXE_TXFNF           /*!< Transmit data register empty or TX FIFO Not Full flag*/
-#define LL_LPUART_ISR_CTSIF                USART_ISR_CTSIF               /*!< CTS interrupt flag */
-#define LL_LPUART_ISR_CTS                  USART_ISR_CTS                 /*!< CTS flag */
-#define LL_LPUART_ISR_BUSY                 USART_ISR_BUSY                /*!< Busy flag */
-#define LL_LPUART_ISR_CMF                  USART_ISR_CMF                 /*!< Character match flag */
-#define LL_LPUART_ISR_SBKF                 USART_ISR_SBKF                /*!< Send break flag */
-#define LL_LPUART_ISR_RWU                  USART_ISR_RWU                 /*!< Receiver wakeup from Mute mode flag */
-#define LL_LPUART_ISR_WUF                  USART_ISR_WUF                 /*!< Wakeup from Stop mode flag */
-#define LL_LPUART_ISR_TEACK                USART_ISR_TEACK               /*!< Transmit enable acknowledge flag */
-#define LL_LPUART_ISR_REACK                USART_ISR_REACK               /*!< Receive enable acknowledge flag */
-#define LL_LPUART_ISR_TXFE                 USART_ISR_TXFE                /*!< TX FIFO empty flag */
-#define LL_LPUART_ISR_RXFF                 USART_ISR_RXFF                /*!< RX FIFO full flag */
-#define LL_LPUART_ISR_RXFT                 USART_ISR_RXFT                /*!< RX FIFO threshold flag */
-#define LL_LPUART_ISR_TXFT                 USART_ISR_TXFT                /*!< TX FIFO threshold flag */
+#define LL_LPUART_ISR_PE               USART_ISR_PE         /*!< Parity error flag */
+#define LL_LPUART_ISR_FE               USART_ISR_FE         /*!< Framing error flag */
+#define LL_LPUART_ISR_NE               USART_ISR_NE         /*!< Noise detected flag */
+#define LL_LPUART_ISR_ORE              USART_ISR_ORE        /*!< Overrun error flag */
+#define LL_LPUART_ISR_IDLE             USART_ISR_IDLE       /*!< Idle line detected flag */
+#define LL_LPUART_ISR_RXNE_RXFNE       USART_ISR_RXNE_RXFNE /*!< Read data register or RX FIFO not empty flag */
+#define LL_LPUART_ISR_TC               USART_ISR_TC         /*!< Transmission complete flag */
+#define LL_LPUART_ISR_TXE_TXFNF        USART_ISR_TXE_TXFNF  /*!< Transmit data register empty or TX FIFO Not Full flag*/
+#define LL_LPUART_ISR_CTSIF            USART_ISR_CTSIF      /*!< CTS interrupt flag */
+#define LL_LPUART_ISR_CTS              USART_ISR_CTS        /*!< CTS flag */
+#define LL_LPUART_ISR_BUSY             USART_ISR_BUSY       /*!< Busy flag */
+#define LL_LPUART_ISR_CMF              USART_ISR_CMF        /*!< Character match flag */
+#define LL_LPUART_ISR_SBKF             USART_ISR_SBKF       /*!< Send break flag */
+#define LL_LPUART_ISR_RWU              USART_ISR_RWU        /*!< Receiver wakeup from Mute mode flag */
+#define LL_LPUART_ISR_WUF              USART_ISR_WUF        /*!< Wakeup from Stop mode flag */
+#define LL_LPUART_ISR_TEACK            USART_ISR_TEACK      /*!< Transmit enable acknowledge flag */
+#define LL_LPUART_ISR_REACK            USART_ISR_REACK      /*!< Receive enable acknowledge flag */
+#define LL_LPUART_ISR_TXFE             USART_ISR_TXFE       /*!< TX FIFO empty flag */
+#define LL_LPUART_ISR_RXFF             USART_ISR_RXFF       /*!< RX FIFO full flag */
+#define LL_LPUART_ISR_RXFT             USART_ISR_RXFT       /*!< RX FIFO threshold flag */
+#define LL_LPUART_ISR_TXFT             USART_ISR_TXFT       /*!< TX FIFO threshold flag */
 /**
   * @}
   */
@@ -194,19 +203,21 @@ typedef struct
   * @brief    IT defines which can be used with LL_LPUART_ReadReg and  LL_LPUART_WriteReg functions
   * @{
   */
-#define LL_LPUART_CR1_IDLEIE               USART_CR1_IDLEIE              /*!< IDLE interrupt enable */
-#define LL_LPUART_CR1_RXNEIE_RXFNEIE       USART_CR1_RXNEIE_RXFNEIE      /*!< Read data register and RXFIFO not empty interrupt enable */
-#define LL_LPUART_CR1_TCIE                 USART_CR1_TCIE                /*!< Transmission complete interrupt enable */
-#define LL_LPUART_CR1_TXEIE_TXFNFIE        USART_CR1_TXEIE_TXFNFIE       /*!< Transmit data register empty and TX FIFO not full interrupt enable */
-#define LL_LPUART_CR1_PEIE                 USART_CR1_PEIE                /*!< Parity error */
-#define LL_LPUART_CR1_CMIE                 USART_CR1_CMIE                /*!< Character match interrupt enable */
-#define LL_LPUART_CR1_TXFEIE               USART_CR1_TXFEIE              /*!< TX FIFO empty interrupt enable */
-#define LL_LPUART_CR1_RXFFIE               USART_CR1_RXFFIE              /*!< RX FIFO full interrupt enable */
-#define LL_LPUART_CR3_EIE                  USART_CR3_EIE                 /*!< Error interrupt enable */
-#define LL_LPUART_CR3_CTSIE                USART_CR3_CTSIE               /*!< CTS interrupt enable */
-#define LL_LPUART_CR3_WUFIE                USART_CR3_WUFIE               /*!< Wakeup from Stop mode interrupt enable */
-#define LL_LPUART_CR3_TXFTIE               USART_CR3_TXFTIE              /*!< TX FIFO threshold interrupt enable */
-#define LL_LPUART_CR3_RXFTIE               USART_CR3_RXFTIE              /*!< RX FIFO threshold interrupt enable */
+#define LL_LPUART_CR1_IDLEIE         USART_CR1_IDLEIE         /*!< IDLE interrupt enable */
+#define LL_LPUART_CR1_RXNEIE_RXFNEIE USART_CR1_RXNEIE_RXFNEIE /*!< Read data register and RXFIFO not empty
+                                                                   interrupt enable */
+#define LL_LPUART_CR1_TCIE           USART_CR1_TCIE           /*!< Transmission complete interrupt enable */
+#define LL_LPUART_CR1_TXEIE_TXFNFIE  USART_CR1_TXEIE_TXFNFIE  /*!< Transmit data register empty and TX FIFO
+                                                                   not full interrupt enable */
+#define LL_LPUART_CR1_PEIE           USART_CR1_PEIE           /*!< Parity error */
+#define LL_LPUART_CR1_CMIE           USART_CR1_CMIE           /*!< Character match interrupt enable */
+#define LL_LPUART_CR1_TXFEIE         USART_CR1_TXFEIE         /*!< TX FIFO empty interrupt enable */
+#define LL_LPUART_CR1_RXFFIE         USART_CR1_RXFFIE         /*!< RX FIFO full interrupt enable */
+#define LL_LPUART_CR3_EIE            USART_CR3_EIE            /*!< Error interrupt enable */
+#define LL_LPUART_CR3_CTSIE          USART_CR3_CTSIE          /*!< CTS interrupt enable */
+#define LL_LPUART_CR3_WUFIE          USART_CR3_WUFIE          /*!< Wakeup from Stop mode interrupt enable */
+#define LL_LPUART_CR3_TXFTIE         USART_CR3_TXFTIE         /*!< TX FIFO threshold interrupt enable */
+#define LL_LPUART_CR3_RXFTIE         USART_CR3_RXFTIE         /*!< RX FIFO threshold interrupt enable */
 /**
   * @}
   */
@@ -227,10 +238,10 @@ typedef struct
 /** @defgroup LPUART_LL_EC_DIRECTION Direction
   * @{
   */
-#define LL_LPUART_DIRECTION_NONE           0x00000000U                        /*!< Transmitter and Receiver are disabled */
-#define LL_LPUART_DIRECTION_RX             USART_CR1_RE                       /*!< Transmitter is disabled and Receiver is enabled */
-#define LL_LPUART_DIRECTION_TX             USART_CR1_TE                       /*!< Transmitter is enabled and Receiver is disabled */
-#define LL_LPUART_DIRECTION_TX_RX          (USART_CR1_TE |USART_CR1_RE)       /*!< Transmitter and Receiver are enabled */
+#define LL_LPUART_DIRECTION_NONE  0x00000000U                  /*!< Transmitter and Receiver are disabled           */
+#define LL_LPUART_DIRECTION_RX    USART_CR1_RE                 /*!< Transmitter is disabled and Receiver is enabled */
+#define LL_LPUART_DIRECTION_TX    USART_CR1_TE                 /*!< Transmitter is enabled and Receiver is disabled */
+#define LL_LPUART_DIRECTION_TX_RX (USART_CR1_TE |USART_CR1_RE) /*!< Transmitter and Receiver are enabled            */
 /**
   * @}
   */
@@ -238,9 +249,9 @@ typedef struct
 /** @defgroup LPUART_LL_EC_PARITY Parity Control
   * @{
   */
-#define LL_LPUART_PARITY_NONE              0x00000000U                        /*!< Parity control disabled */
-#define LL_LPUART_PARITY_EVEN              USART_CR1_PCE                      /*!< Parity control enabled and Even Parity is selected */
-#define LL_LPUART_PARITY_ODD               (USART_CR1_PCE | USART_CR1_PS)     /*!< Parity control enabled and Odd Parity is selected */
+#define LL_LPUART_PARITY_NONE 0x00000000U                    /*!< Parity control disabled                            */
+#define LL_LPUART_PARITY_EVEN USART_CR1_PCE                  /*!< Parity control enabled and Even Parity is selected */
+#define LL_LPUART_PARITY_ODD  (USART_CR1_PCE | USART_CR1_PS) /*!< Parity control enabled and Odd Parity is selected  */
 /**
   * @}
   */
@@ -248,8 +259,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_WAKEUP Wakeup
   * @{
   */
-#define LL_LPUART_WAKEUP_IDLELINE          0x00000000U                        /*!<  LPUART wake up from Mute mode on Idle Line */
-#define LL_LPUART_WAKEUP_ADDRESSMARK       USART_CR1_WAKE                     /*!<  LPUART wake up from Mute mode on Address Mark */
+#define LL_LPUART_WAKEUP_IDLELINE    0x00000000U    /*!<  LPUART wake up from Mute mode on Idle Line    */
+#define LL_LPUART_WAKEUP_ADDRESSMARK USART_CR1_WAKE /*!<  LPUART wake up from Mute mode on Address Mark */
 /**
   * @}
   */
@@ -257,9 +268,9 @@ typedef struct
 /** @defgroup LPUART_LL_EC_DATAWIDTH Datawidth
   * @{
   */
-#define LL_LPUART_DATAWIDTH_7B             USART_CR1_M1                       /*!< 7 bits word length : Start bit, 7 data bits, n stop bits */
-#define LL_LPUART_DATAWIDTH_8B             0x00000000U                        /*!< 8 bits word length : Start bit, 8 data bits, n stop bits */
-#define LL_LPUART_DATAWIDTH_9B             USART_CR1_M0                       /*!< 9 bits word length : Start bit, 9 data bits, n stop bits */
+#define LL_LPUART_DATAWIDTH_7B USART_CR1_M1 /*!< 7 bits word length : Start bit, 7 data bits, n stop bits */
+#define LL_LPUART_DATAWIDTH_8B 0x00000000U  /*!< 8 bits word length : Start bit, 8 data bits, n stop bits */
+#define LL_LPUART_DATAWIDTH_9B USART_CR1_M0 /*!< 9 bits word length : Start bit, 9 data bits, n stop bits */
 /**
   * @}
   */
@@ -267,18 +278,27 @@ typedef struct
 /** @defgroup LPUART_LL_EC_PRESCALER Clock Source Prescaler
   * @{
   */
-#define LL_LPUART_PRESCALER_DIV1           0x00000000U                                                                   /*!< Input clock not devided   */
-#define LL_LPUART_PRESCALER_DIV2           (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock devided by 2  */
-#define LL_LPUART_PRESCALER_DIV4           (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock devided by 4  */
-#define LL_LPUART_PRESCALER_DIV6           (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 6  */
-#define LL_LPUART_PRESCALER_DIV8           (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock devided by 8  */
-#define LL_LPUART_PRESCALER_DIV10          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 10 */
-#define LL_LPUART_PRESCALER_DIV12          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 12 */
-#define LL_LPUART_PRESCALER_DIV16          (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 16 */
-#define LL_LPUART_PRESCALER_DIV32          (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock devided by 32 */
-#define LL_LPUART_PRESCALER_DIV64          (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 64 */
-#define LL_LPUART_PRESCALER_DIV128         (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 128 */
-#define LL_LPUART_PRESCALER_DIV256         (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 256 */
+#define LL_LPUART_PRESCALER_DIV1   0x00000000U                    /*!< Input clock not divided   */
+#define LL_LPUART_PRESCALER_DIV2   (USART_PRESC_PRESCALER_0)      /*!< Input clock divided by 2  */
+#define LL_LPUART_PRESCALER_DIV4   (USART_PRESC_PRESCALER_1)      /*!< Input clock divided by 4  */
+#define LL_LPUART_PRESCALER_DIV6   (USART_PRESC_PRESCALER_1 |\
+                                    USART_PRESC_PRESCALER_0)      /*!< Input clock divided by 6  */
+#define LL_LPUART_PRESCALER_DIV8   (USART_PRESC_PRESCALER_2)      /*!< Input clock divided by 8  */
+#define LL_LPUART_PRESCALER_DIV10  (USART_PRESC_PRESCALER_2 |\
+                                    USART_PRESC_PRESCALER_0)      /*!< Input clock divided by 10 */
+#define LL_LPUART_PRESCALER_DIV12  (USART_PRESC_PRESCALER_2 |\
+                                    USART_PRESC_PRESCALER_1)      /*!< Input clock divided by 12 */
+#define LL_LPUART_PRESCALER_DIV16  (USART_PRESC_PRESCALER_2 |\
+                                    USART_PRESC_PRESCALER_1 |\
+                                    USART_PRESC_PRESCALER_0)      /*!< Input clock divided by 16 */
+#define LL_LPUART_PRESCALER_DIV32  (USART_PRESC_PRESCALER_3)      /*!< Input clock divided by 32 */
+#define LL_LPUART_PRESCALER_DIV64  (USART_PRESC_PRESCALER_3 |\
+                                    USART_PRESC_PRESCALER_0)      /*!< Input clock divided by 64 */
+#define LL_LPUART_PRESCALER_DIV128 (USART_PRESC_PRESCALER_3 |\
+                                    USART_PRESC_PRESCALER_1)      /*!< Input clock divided by 128 */
+#define LL_LPUART_PRESCALER_DIV256 (USART_PRESC_PRESCALER_3 |\
+                                    USART_PRESC_PRESCALER_1 |\
+                                    USART_PRESC_PRESCALER_0)      /*!< Input clock divided by 256 */
 /**
   * @}
   */
@@ -286,8 +306,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_STOPBITS Stop Bits
   * @{
   */
-#define LL_LPUART_STOPBITS_1               0x00000000U                        /*!< 1 stop bit */
-#define LL_LPUART_STOPBITS_2               USART_CR2_STOP_1                   /*!< 2 stop bits */
+#define LL_LPUART_STOPBITS_1         0x00000000U             /*!< 1 stop bit */
+#define LL_LPUART_STOPBITS_2         USART_CR2_STOP_1        /*!< 2 stop bits */
 /**
   * @}
   */
@@ -295,8 +315,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_TXRX TX RX Pins Swap
   * @{
   */
-#define LL_LPUART_TXRX_STANDARD            0x00000000U                        /*!< TX/RX pins are used as defined in standard pinout */
-#define LL_LPUART_TXRX_SWAPPED             (USART_CR2_SWAP)                   /*!< TX and RX pins functions are swapped.             */
+#define LL_LPUART_TXRX_STANDARD      0x00000000U        /*!< TX/RX pins are used as defined in standard pinout */
+#define LL_LPUART_TXRX_SWAPPED       (USART_CR2_SWAP)   /*!< TX and RX pins functions are swapped.             */
 /**
   * @}
   */
@@ -304,8 +324,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_RXPIN_LEVEL RX Pin Active Level Inversion
   * @{
   */
-#define LL_LPUART_RXPIN_LEVEL_STANDARD     0x00000000U                        /*!< RX pin signal works using the standard logic levels */
-#define LL_LPUART_RXPIN_LEVEL_INVERTED     (USART_CR2_RXINV)                  /*!< RX pin signal values are inverted.                  */
+#define LL_LPUART_RXPIN_LEVEL_STANDARD   0x00000000U       /*!< RX pin signal works using the standard logic levels */
+#define LL_LPUART_RXPIN_LEVEL_INVERTED   (USART_CR2_RXINV) /*!< RX pin signal values are inverted.                  */
 /**
   * @}
   */
@@ -313,8 +333,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_TXPIN_LEVEL TX Pin Active Level Inversion
   * @{
   */
-#define LL_LPUART_TXPIN_LEVEL_STANDARD     0x00000000U                        /*!< TX pin signal works using the standard logic levels */
-#define LL_LPUART_TXPIN_LEVEL_INVERTED     (USART_CR2_TXINV)                  /*!< TX pin signal values are inverted.                  */
+#define LL_LPUART_TXPIN_LEVEL_STANDARD  0x00000000U       /*!< TX pin signal works using the standard logic levels */
+#define LL_LPUART_TXPIN_LEVEL_INVERTED  (USART_CR2_TXINV) /*!< TX pin signal values are inverted.                  */
 /**
   * @}
   */
@@ -322,8 +342,11 @@ typedef struct
 /** @defgroup LPUART_LL_EC_BINARY_LOGIC Binary Data Inversion
   * @{
   */
-#define LL_LPUART_BINARY_LOGIC_POSITIVE    0x00000000U                        /*!< Logical data from the data register are send/received in positive/direct logic. (1=H, 0=L) */
-#define LL_LPUART_BINARY_LOGIC_NEGATIVE    USART_CR2_DATAINV                  /*!< Logical data from the data register are send/received in negative/inverse logic. (1=L, 0=H). The parity bit is also inverted. */
+#define LL_LPUART_BINARY_LOGIC_POSITIVE 0x00000000U       /*!< Logical data from the data register are send/received
+                                                               in positive/direct logic. (1=H, 0=L)                  */
+#define LL_LPUART_BINARY_LOGIC_NEGATIVE USART_CR2_DATAINV /*!< Logical data from the data register are send/received
+                                                               in negative/inverse logic. (1=L, 0=H).
+                                                               The parity bit is also inverted.                      */
 /**
   * @}
   */
@@ -331,8 +354,10 @@ typedef struct
 /** @defgroup LPUART_LL_EC_BITORDER Bit Order
   * @{
   */
-#define LL_LPUART_BITORDER_LSBFIRST        0x00000000U                        /*!< data is transmitted/received with data bit 0 first, following the start bit */
-#define LL_LPUART_BITORDER_MSBFIRST        USART_CR2_MSBFIRST                 /*!< data is transmitted/received with the MSB first, following the start bit */
+#define LL_LPUART_BITORDER_LSBFIRST 0x00000000U        /*!< data is transmitted/received with data bit 0 first,
+                                                            following the start bit */
+#define LL_LPUART_BITORDER_MSBFIRST USART_CR2_MSBFIRST /*!< data is transmitted/received with the MSB first,
+                                                            following the start bit */
 /**
   * @}
   */
@@ -340,8 +365,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_ADDRESS_DETECT Address Length Detection
   * @{
   */
-#define LL_LPUART_ADDRESS_DETECT_4B        0x00000000U                        /*!< 4-bit address detection method selected */
-#define LL_LPUART_ADDRESS_DETECT_7B        USART_CR2_ADDM7                    /*!< 7-bit address detection (in 8-bit data mode) method selected */
+#define LL_LPUART_ADDRESS_DETECT_4B 0x00000000U     /*!< 4-bit address detection method selected */
+#define LL_LPUART_ADDRESS_DETECT_7B USART_CR2_ADDM7 /*!< 7-bit address detection (in 8-bit data mode) method selected */
 /**
   * @}
   */
@@ -349,10 +374,12 @@ typedef struct
 /** @defgroup LPUART_LL_EC_HWCONTROL Hardware Control
   * @{
   */
-#define LL_LPUART_HWCONTROL_NONE           0x00000000U                        /*!< CTS and RTS hardware flow control disabled */
-#define LL_LPUART_HWCONTROL_RTS            USART_CR3_RTSE                     /*!< RTS output enabled, data is only requested when there is space in the receive buffer */
-#define LL_LPUART_HWCONTROL_CTS            USART_CR3_CTSE                     /*!< CTS mode enabled, data is only transmitted when the nCTS input is asserted (tied to 0) */
-#define LL_LPUART_HWCONTROL_RTS_CTS        (USART_CR3_RTSE | USART_CR3_CTSE)  /*!< CTS and RTS hardware flow control enabled */
+#define LL_LPUART_HWCONTROL_NONE    0x00000000U                       /*!< CTS and RTS hardware flow control disabled */
+#define LL_LPUART_HWCONTROL_RTS     USART_CR3_RTSE                    /*!< RTS output enabled, data is only requested
+                                                                           when there is space in the receive buffer  */
+#define LL_LPUART_HWCONTROL_CTS     USART_CR3_CTSE                    /*!< CTS mode enabled, data is only transmitted
+                                                                           when the nCTS input is asserted (tied to 0)*/
+#define LL_LPUART_HWCONTROL_RTS_CTS (USART_CR3_RTSE | USART_CR3_CTSE) /*!< CTS and RTS hardware flow control enabled  */
 /**
   * @}
   */
@@ -360,9 +387,9 @@ typedef struct
 /** @defgroup LPUART_LL_EC_WAKEUP_ON Wakeup Activation
   * @{
   */
-#define LL_LPUART_WAKEUP_ON_ADDRESS        0x00000000U                             /*!< Wake up active on address match */
-#define LL_LPUART_WAKEUP_ON_STARTBIT       USART_CR3_WUS_1                         /*!< Wake up active on Start bit detection */
-#define LL_LPUART_WAKEUP_ON_RXNE           (USART_CR3_WUS_0 | USART_CR3_WUS_1)     /*!< Wake up active on RXNE */
+#define LL_LPUART_WAKEUP_ON_ADDRESS   0x00000000U                          /*!< Wake up active on address match */
+#define LL_LPUART_WAKEUP_ON_STARTBIT  USART_CR3_WUS_1                      /*!< Wake up active on Start bit detection */
+#define LL_LPUART_WAKEUP_ON_RXNE      (USART_CR3_WUS_0 | USART_CR3_WUS_1)  /*!< Wake up active on RXNE */
 /**
   * @}
   */
@@ -370,8 +397,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_DE_POLARITY Driver Enable Polarity
   * @{
   */
-#define LL_LPUART_DE_POLARITY_HIGH         0x00000000U                        /*!< DE signal is active high */
-#define LL_LPUART_DE_POLARITY_LOW          USART_CR3_DEP                      /*!< DE signal is active low */
+#define LL_LPUART_DE_POLARITY_HIGH         0x00000000U    /*!< DE signal is active high */
+#define LL_LPUART_DE_POLARITY_LOW          USART_CR3_DEP  /*!< DE signal is active low */
 /**
   * @}
   */
@@ -379,8 +406,8 @@ typedef struct
 /** @defgroup LPUART_LL_EC_DMA_REG_DATA DMA Register Data
   * @{
   */
-#define LL_LPUART_DMA_REG_DATA_TRANSMIT    0x00000000U                       /*!< Get address of data register used for transmission */
-#define LL_LPUART_DMA_REG_DATA_RECEIVE     0x00000001U                       /*!< Get address of data register used for reception */
+#define LL_LPUART_DMA_REG_DATA_TRANSMIT    0x00000000U    /*!< Get address of data register used for transmission */
+#define LL_LPUART_DMA_REG_DATA_RECEIVE     0x00000001U    /*!< Get address of data register used for reception */
 /**
   * @}
   */
@@ -442,8 +469,9 @@ typedef struct
   * @param  __BAUDRATE__ Baud Rate value to achieve
   * @retval LPUARTDIV value to be used for BRR register filling
   */
-#define __LL_LPUART_DIV(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) (uint32_t)((((((uint64_t)(__PERIPHCLK__)/(uint64_t)(LPUART_PRESCALER_TAB[(uint16_t)(__PRESCALER__)])) * LPUART_LPUARTDIV_FREQ_MUL)\
-                                                                                + (uint32_t)((__BAUDRATE__)/2U))/(__BAUDRATE__)) & LPUART_BRR_MASK)
+#define __LL_LPUART_DIV(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) (uint32_t)\
+  ((((((uint64_t)(__PERIPHCLK__)/(uint64_t)(LPUART_PRESCALER_TAB[(uint16_t)(__PRESCALER__)]))\
+      * LPUART_LPUARTDIV_FREQ_MUL) + (uint32_t)((__BAUDRATE__)/2U))/(__BAUDRATE__)) & LPUART_BRR_MASK)
 
 /**
   * @}
@@ -498,7 +526,7 @@ __STATIC_INLINE void LL_LPUART_Disable(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabled(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabled(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_UE) == (USART_CR1_UE)) ? 1UL : 0UL);
 }
@@ -531,7 +559,7 @@ __STATIC_INLINE void LL_LPUART_DisableFIFO(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledFIFO(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledFIFO(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_FIFOEN) == (USART_CR1_FIFOEN)) ? 1UL : 0UL);
 }
@@ -551,7 +579,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledFIFO(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_SetTXFIFOThreshold(USART_TypeDef *LPUARTx, uint32_t Threshold)
 {
-  MODIFY_REG(LPUARTx->CR3, USART_CR3_TXFTCFG, Threshold << USART_CR3_TXFTCFG_Pos);
+  ATOMIC_MODIFY_REG(LPUARTx->CR3, USART_CR3_TXFTCFG, Threshold << USART_CR3_TXFTCFG_Pos);
 }
 
 /**
@@ -566,7 +594,7 @@ __STATIC_INLINE void LL_LPUART_SetTXFIFOThreshold(USART_TypeDef *LPUARTx, uint32
   *         @arg @ref LL_LPUART_FIFOTHRESHOLD_7_8
   *         @arg @ref LL_LPUART_FIFOTHRESHOLD_8_8
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetTXFIFOThreshold(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetTXFIFOThreshold(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR3, USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos);
 }
@@ -586,7 +614,7 @@ __STATIC_INLINE uint32_t LL_LPUART_GetTXFIFOThreshold(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_SetRXFIFOThreshold(USART_TypeDef *LPUARTx, uint32_t Threshold)
 {
-  MODIFY_REG(LPUARTx->CR3, USART_CR3_RXFTCFG, Threshold << USART_CR3_RXFTCFG_Pos);
+  ATOMIC_MODIFY_REG(LPUARTx->CR3, USART_CR3_RXFTCFG, Threshold << USART_CR3_RXFTCFG_Pos);
 }
 
 /**
@@ -601,7 +629,7 @@ __STATIC_INLINE void LL_LPUART_SetRXFIFOThreshold(USART_TypeDef *LPUARTx, uint32
   *         @arg @ref LL_LPUART_FIFOTHRESHOLD_7_8
   *         @arg @ref LL_LPUART_FIFOTHRESHOLD_8_8
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetRXFIFOThreshold(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetRXFIFOThreshold(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR3, USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos);
 }
@@ -629,7 +657,8 @@ __STATIC_INLINE uint32_t LL_LPUART_GetRXFIFOThreshold(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_ConfigFIFOsThreshold(USART_TypeDef *LPUARTx, uint32_t TXThreshold, uint32_t RXThreshold)
 {
-  MODIFY_REG(LPUARTx->CR3, USART_CR3_TXFTCFG | USART_CR3_RXFTCFG, (TXThreshold << USART_CR3_TXFTCFG_Pos) | (RXThreshold << USART_CR3_RXFTCFG_Pos));
+  ATOMIC_MODIFY_REG(LPUARTx->CR3, USART_CR3_TXFTCFG | USART_CR3_RXFTCFG, (TXThreshold << USART_CR3_TXFTCFG_Pos) | \
+                    (RXThreshold << USART_CR3_RXFTCFG_Pos));
 }
 
 /**
@@ -642,7 +671,7 @@ __STATIC_INLINE void LL_LPUART_ConfigFIFOsThreshold(USART_TypeDef *LPUARTx, uint
   */
 __STATIC_INLINE void LL_LPUART_EnableInStopMode(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_UESM);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_UESM);
 }
 
 /**
@@ -654,7 +683,7 @@ __STATIC_INLINE void LL_LPUART_EnableInStopMode(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableInStopMode(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_UESM);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_UESM);
 }
 
 /**
@@ -664,7 +693,7 @@ __STATIC_INLINE void LL_LPUART_DisableInStopMode(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledInStopMode(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledInStopMode(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_UESM) == (USART_CR1_UESM)) ? 1UL : 0UL);
 }
@@ -677,7 +706,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledInStopMode(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableDirectionRx(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_RE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_RE);
 }
 
 /**
@@ -688,7 +717,7 @@ __STATIC_INLINE void LL_LPUART_EnableDirectionRx(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableDirectionRx(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_RE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_RE);
 }
 
 /**
@@ -699,7 +728,7 @@ __STATIC_INLINE void LL_LPUART_DisableDirectionRx(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableDirectionTx(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_TE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_TE);
 }
 
 /**
@@ -710,7 +739,7 @@ __STATIC_INLINE void LL_LPUART_EnableDirectionTx(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableDirectionTx(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_TE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_TE);
 }
 
 /**
@@ -728,7 +757,7 @@ __STATIC_INLINE void LL_LPUART_DisableDirectionTx(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_SetTransferDirection(USART_TypeDef *LPUARTx, uint32_t TransferDirection)
 {
-  MODIFY_REG(LPUARTx->CR1, USART_CR1_RE | USART_CR1_TE, TransferDirection);
+  ATOMIC_MODIFY_REG(LPUARTx->CR1, USART_CR1_RE | USART_CR1_TE, TransferDirection);
 }
 
 /**
@@ -742,7 +771,7 @@ __STATIC_INLINE void LL_LPUART_SetTransferDirection(USART_TypeDef *LPUARTx, uint
   *         @arg @ref LL_LPUART_DIRECTION_TX
   *         @arg @ref LL_LPUART_DIRECTION_TX_RX
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetTransferDirection(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetTransferDirection(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR1, USART_CR1_RE | USART_CR1_TE));
 }
@@ -776,7 +805,7 @@ __STATIC_INLINE void LL_LPUART_SetParity(USART_TypeDef *LPUARTx, uint32_t Parity
   *         @arg @ref LL_LPUART_PARITY_EVEN
   *         @arg @ref LL_LPUART_PARITY_ODD
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetParity(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetParity(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR1, USART_CR1_PS | USART_CR1_PCE));
 }
@@ -803,7 +832,7 @@ __STATIC_INLINE void LL_LPUART_SetWakeUpMethod(USART_TypeDef *LPUARTx, uint32_t 
   *         @arg @ref LL_LPUART_WAKEUP_IDLELINE
   *         @arg @ref LL_LPUART_WAKEUP_ADDRESSMARK
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetWakeUpMethod(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetWakeUpMethod(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR1, USART_CR1_WAKE));
 }
@@ -832,7 +861,7 @@ __STATIC_INLINE void LL_LPUART_SetDataWidth(USART_TypeDef *LPUARTx, uint32_t Dat
   *         @arg @ref LL_LPUART_DATAWIDTH_8B
   *         @arg @ref LL_LPUART_DATAWIDTH_9B
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetDataWidth(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetDataWidth(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR1, USART_CR1_M));
 }
@@ -845,7 +874,7 @@ __STATIC_INLINE uint32_t LL_LPUART_GetDataWidth(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableMuteMode(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_MME);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_MME);
 }
 
 /**
@@ -856,7 +885,7 @@ __STATIC_INLINE void LL_LPUART_EnableMuteMode(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableMuteMode(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_MME);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_MME);
 }
 
 /**
@@ -865,7 +894,7 @@ __STATIC_INLINE void LL_LPUART_DisableMuteMode(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledMuteMode(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledMuteMode(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_MME) == (USART_CR1_MME)) ? 1UL : 0UL);
 }
@@ -912,7 +941,7 @@ __STATIC_INLINE void LL_LPUART_SetPrescaler(USART_TypeDef *LPUARTx, uint32_t Pre
   *         @arg @ref LL_LPUART_PRESCALER_DIV128
   *         @arg @ref LL_LPUART_PRESCALER_DIV256
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetPrescaler(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetPrescaler(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->PRESC, USART_PRESC_PRESCALER));
 }
@@ -939,7 +968,7 @@ __STATIC_INLINE void LL_LPUART_SetStopBitsLength(USART_TypeDef *LPUARTx, uint32_
   *         @arg @ref LL_LPUART_STOPBITS_1
   *         @arg @ref LL_LPUART_STOPBITS_2
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetStopBitsLength(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetStopBitsLength(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_STOP));
 }
@@ -997,7 +1026,7 @@ __STATIC_INLINE void LL_LPUART_SetTXRXSwap(USART_TypeDef *LPUARTx, uint32_t Swap
   *         @arg @ref LL_LPUART_TXRX_STANDARD
   *         @arg @ref LL_LPUART_TXRX_SWAPPED
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetTXRXSwap(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetTXRXSwap(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_SWAP));
 }
@@ -1024,7 +1053,7 @@ __STATIC_INLINE void LL_LPUART_SetRXPinLevel(USART_TypeDef *LPUARTx, uint32_t Pi
   *         @arg @ref LL_LPUART_RXPIN_LEVEL_STANDARD
   *         @arg @ref LL_LPUART_RXPIN_LEVEL_INVERTED
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetRXPinLevel(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetRXPinLevel(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_RXINV));
 }
@@ -1051,7 +1080,7 @@ __STATIC_INLINE void LL_LPUART_SetTXPinLevel(USART_TypeDef *LPUARTx, uint32_t Pi
   *         @arg @ref LL_LPUART_TXPIN_LEVEL_STANDARD
   *         @arg @ref LL_LPUART_TXPIN_LEVEL_INVERTED
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetTXPinLevel(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetTXPinLevel(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_TXINV));
 }
@@ -1081,7 +1110,7 @@ __STATIC_INLINE void LL_LPUART_SetBinaryDataLogic(USART_TypeDef *LPUARTx, uint32
   *         @arg @ref LL_LPUART_BINARY_LOGIC_POSITIVE
   *         @arg @ref LL_LPUART_BINARY_LOGIC_NEGATIVE
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetBinaryDataLogic(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetBinaryDataLogic(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_DATAINV));
 }
@@ -1112,7 +1141,7 @@ __STATIC_INLINE void LL_LPUART_SetTransferBitOrder(USART_TypeDef *LPUARTx, uint3
   *         @arg @ref LL_LPUART_BITORDER_LSBFIRST
   *         @arg @ref LL_LPUART_BITORDER_MSBFIRST
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetTransferBitOrder(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetTransferBitOrder(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_MSBFIRST));
 }
@@ -1156,7 +1185,7 @@ __STATIC_INLINE void LL_LPUART_ConfigNodeAddress(USART_TypeDef *LPUARTx, uint32_
   * @param  LPUARTx LPUART Instance
   * @retval Address of the LPUART node (Value between Min_Data=0 and Max_Data=255)
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetNodeAddress(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetNodeAddress(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_ADD) >> USART_CR2_ADD_Pos);
 }
@@ -1169,7 +1198,7 @@ __STATIC_INLINE uint32_t LL_LPUART_GetNodeAddress(USART_TypeDef *LPUARTx)
   *         @arg @ref LL_LPUART_ADDRESS_DETECT_4B
   *         @arg @ref LL_LPUART_ADDRESS_DETECT_7B
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetNodeAddressLen(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetNodeAddressLen(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR2, USART_CR2_ADDM7));
 }
@@ -1246,7 +1275,7 @@ __STATIC_INLINE void LL_LPUART_SetHWFlowCtrl(USART_TypeDef *LPUARTx, uint32_t Ha
   *         @arg @ref LL_LPUART_HWCONTROL_CTS
   *         @arg @ref LL_LPUART_HWCONTROL_RTS_CTS
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetHWFlowCtrl(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetHWFlowCtrl(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR3, USART_CR3_RTSE | USART_CR3_CTSE));
 }
@@ -1279,7 +1308,7 @@ __STATIC_INLINE void LL_LPUART_DisableOverrunDetect(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledOverrunDetect(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledOverrunDetect(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_OVRDIS) != USART_CR3_OVRDIS) ? 1UL : 0UL);
 }
@@ -1308,7 +1337,7 @@ __STATIC_INLINE void LL_LPUART_SetWKUPType(USART_TypeDef *LPUARTx, uint32_t Type
   *         @arg @ref LL_LPUART_WAKEUP_ON_STARTBIT
   *         @arg @ref LL_LPUART_WAKEUP_ON_RXNE
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetWKUPType(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetWKUPType(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR3, USART_CR3_WUS));
 }
@@ -1345,7 +1374,10 @@ __STATIC_INLINE uint32_t LL_LPUART_GetWKUPType(USART_TypeDef *LPUARTx)
 __STATIC_INLINE void LL_LPUART_SetBaudRate(USART_TypeDef *LPUARTx, uint32_t PeriphClk, uint32_t PrescalerValue,
                                            uint32_t BaudRate)
 {
-  LPUARTx->BRR = __LL_LPUART_DIV(PeriphClk, PrescalerValue, BaudRate);
+  if (BaudRate != 0U)
+  {
+    LPUARTx->BRR = __LL_LPUART_DIV(PeriphClk, PrescalerValue, BaudRate);
+  }
 }
 
 /**
@@ -1370,7 +1402,8 @@ __STATIC_INLINE void LL_LPUART_SetBaudRate(USART_TypeDef *LPUARTx, uint32_t Peri
   *         @arg @ref LL_LPUART_PRESCALER_DIV256
   * @retval Baud Rate
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetBaudRate(USART_TypeDef *LPUARTx, uint32_t PeriphClk, uint32_t PrescalerValue)
+__STATIC_INLINE uint32_t LL_LPUART_GetBaudRate(const USART_TypeDef *LPUARTx, uint32_t PeriphClk,
+                                               uint32_t PrescalerValue)
 {
   uint32_t lpuartdiv;
   uint32_t brrresult;
@@ -1426,7 +1459,7 @@ __STATIC_INLINE void LL_LPUART_DisableHalfDuplex(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledHalfDuplex(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledHalfDuplex(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_HDSEL) == (USART_CR3_HDSEL)) ? 1UL : 0UL);
 }
@@ -1457,7 +1490,7 @@ __STATIC_INLINE void LL_LPUART_SetDEDeassertionTime(USART_TypeDef *LPUARTx, uint
   * @param  LPUARTx LPUART Instance
   * @retval Time value expressed on 5 bits ([4:0] bits) : c
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetDEDeassertionTime(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetDEDeassertionTime(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR1, USART_CR1_DEDT) >> USART_CR1_DEDT_Pos);
 }
@@ -1480,7 +1513,7 @@ __STATIC_INLINE void LL_LPUART_SetDEAssertionTime(USART_TypeDef *LPUARTx, uint32
   * @param  LPUARTx LPUART Instance
   * @retval Time value expressed on 5 bits ([4:0] bits) : Time Value between Min_Data=0 and Max_Data=31
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetDEAssertionTime(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetDEAssertionTime(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR1, USART_CR1_DEAT) >> USART_CR1_DEAT_Pos);
 }
@@ -1513,7 +1546,7 @@ __STATIC_INLINE void LL_LPUART_DisableDEMode(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDEMode(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDEMode(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_DEM) == (USART_CR3_DEM)) ? 1UL : 0UL);
 }
@@ -1540,7 +1573,7 @@ __STATIC_INLINE void LL_LPUART_SetDESignalPolarity(USART_TypeDef *LPUARTx, uint3
   *         @arg @ref LL_LPUART_DE_POLARITY_HIGH
   *         @arg @ref LL_LPUART_DE_POLARITY_LOW
   */
-__STATIC_INLINE uint32_t LL_LPUART_GetDESignalPolarity(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_GetDESignalPolarity(const USART_TypeDef *LPUARTx)
 {
   return (uint32_t)(READ_BIT(LPUARTx->CR3, USART_CR3_DEP));
 }
@@ -1559,7 +1592,7 @@ __STATIC_INLINE uint32_t LL_LPUART_GetDESignalPolarity(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_PE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_PE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_PE) == (USART_ISR_PE)) ? 1UL : 0UL);
 }
@@ -1570,7 +1603,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_PE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_FE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_FE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_FE) == (USART_ISR_FE)) ? 1UL : 0UL);
 }
@@ -1581,7 +1614,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_FE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_NE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_NE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_NE) == (USART_ISR_NE)) ? 1UL : 0UL);
 }
@@ -1592,7 +1625,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_NE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_ORE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_ORE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_ORE) == (USART_ISR_ORE)) ? 1UL : 0UL);
 }
@@ -1603,13 +1636,12 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_ORE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_IDLE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_IDLE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_IDLE) == (USART_ISR_IDLE)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_LPUART_IsActiveFlag_RXNE  LL_LPUART_IsActiveFlag_RXNE_RXFNE
+#define LL_LPUART_IsActiveFlag_RXNE  LL_LPUART_IsActiveFlag_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the LPUART Read Data Register or LPUART RX FIFO Not Empty Flag is set or not
@@ -1617,7 +1649,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_IDLE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXNE_RXFNE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXNE_RXFNE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_RXNE_RXFNE) == (USART_ISR_RXNE_RXFNE)) ? 1UL : 0UL);
 }
@@ -1628,13 +1660,12 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXNE_RXFNE(USART_TypeDef *LPUART
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TC(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TC(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_TC) == (USART_ISR_TC)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_LPUART_IsActiveFlag_TXE  LL_LPUART_IsActiveFlag_TXE_TXFNF
+#define LL_LPUART_IsActiveFlag_TXE  LL_LPUART_IsActiveFlag_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the LPUART Transmit Data Register Empty or LPUART TX FIFO Not Full Flag is set or not
@@ -1642,7 +1673,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TC(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXE_TXFNF(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXE_TXFNF(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_TXE_TXFNF) == (USART_ISR_TXE_TXFNF)) ? 1UL : 0UL);
 }
@@ -1653,7 +1684,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXE_TXFNF(USART_TypeDef *LPUARTx
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_nCTS(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_nCTS(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_CTSIF) == (USART_ISR_CTSIF)) ? 1UL : 0UL);
 }
@@ -1664,7 +1695,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_nCTS(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_CTS(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_CTS(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_CTS) == (USART_ISR_CTS)) ? 1UL : 0UL);
 }
@@ -1675,7 +1706,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_CTS(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_BUSY(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_BUSY(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_BUSY) == (USART_ISR_BUSY)) ? 1UL : 0UL);
 }
@@ -1686,7 +1717,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_BUSY(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_CM(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_CM(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_CMF) == (USART_ISR_CMF)) ? 1UL : 0UL);
 }
@@ -1697,7 +1728,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_CM(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_SBK(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_SBK(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_SBKF) == (USART_ISR_SBKF)) ? 1UL : 0UL);
 }
@@ -1708,7 +1739,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_SBK(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RWU(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RWU(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_RWU) == (USART_ISR_RWU)) ? 1UL : 0UL);
 }
@@ -1719,7 +1750,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RWU(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_WKUP(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_WKUP(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_WUF) == (USART_ISR_WUF)) ? 1UL : 0UL);
 }
@@ -1730,7 +1761,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_WKUP(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TEACK(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TEACK(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_TEACK) == (USART_ISR_TEACK)) ? 1UL : 0UL);
 }
@@ -1741,7 +1772,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TEACK(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_REACK(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_REACK(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_REACK) == (USART_ISR_REACK)) ? 1UL : 0UL);
 }
@@ -1752,7 +1783,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_REACK(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXFE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXFE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_TXFE) == (USART_ISR_TXFE)) ? 1UL : 0UL);
 }
@@ -1763,7 +1794,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXFE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXFF(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXFF(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_RXFF) == (USART_ISR_RXFF)) ? 1UL : 0UL);
 }
@@ -1774,7 +1805,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXFF(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXFT(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXFT(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_TXFT) == (USART_ISR_TXFT)) ? 1UL : 0UL);
 }
@@ -1785,7 +1816,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_TXFT(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXFT(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsActiveFlag_RXFT(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->ISR, USART_ISR_RXFT) == (USART_ISR_RXFT)) ? 1UL : 0UL);
 }
@@ -1843,17 +1874,6 @@ __STATIC_INLINE void LL_LPUART_ClearFlag_ORE(USART_TypeDef *LPUARTx)
 __STATIC_INLINE void LL_LPUART_ClearFlag_IDLE(USART_TypeDef *LPUARTx)
 {
   WRITE_REG(LPUARTx->ICR, USART_ICR_IDLECF);
-}
-
-/**
-  * @brief  Clear TX FIFO Empty Flag
-  * @rmtoll ICR          TXFECF        LL_LPUART_ClearFlag_TXFE
-  * @param  LPUARTx LPUART Instance
-  * @retval None
-  */
-__STATIC_INLINE void LL_LPUART_ClearFlag_TXFE(USART_TypeDef *LPUARTx)
-{
-  WRITE_REG(LPUARTx->ICR, USART_ICR_TXFECF);
 }
 
 /**
@@ -1916,11 +1936,10 @@ __STATIC_INLINE void LL_LPUART_ClearFlag_WKUP(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_IDLE(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_IDLEIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_IDLEIE);
 }
 
-/* Legacy define */
-#define LL_LPUART_EnableIT_RXNE  LL_LPUART_EnableIT_RXNE_RXFNE
+#define LL_LPUART_EnableIT_RXNE  LL_LPUART_EnableIT_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Enable RX Not Empty and RX FIFO Not Empty Interrupt
@@ -1930,7 +1949,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_IDLE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_RXNE_RXFNE(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
 }
 
 /**
@@ -1941,11 +1960,10 @@ __STATIC_INLINE void LL_LPUART_EnableIT_RXNE_RXFNE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_TC(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_TCIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_TCIE);
 }
 
-/* Legacy define */
-#define LL_LPUART_EnableIT_TXE  LL_LPUART_EnableIT_TXE_TXFNF
+#define LL_LPUART_EnableIT_TXE  LL_LPUART_EnableIT_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Enable TX Empty and TX FIFO Not Full Interrupt
@@ -1955,7 +1973,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_TC(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_TXE_TXFNF(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
 }
 
 /**
@@ -1966,7 +1984,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_TXE_TXFNF(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_PE(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_PEIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_PEIE);
 }
 
 /**
@@ -1977,7 +1995,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_PE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_CM(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_CMIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_CMIE);
 }
 
 /**
@@ -1988,7 +2006,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_CM(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_TXFE(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_TXFEIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_TXFEIE);
 }
 
 /**
@@ -1999,7 +2017,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_TXFE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_RXFF(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR1, USART_CR1_RXFFIE);
+  ATOMIC_SET_BIT(LPUARTx->CR1, USART_CR1_RXFFIE);
 }
 
 /**
@@ -2014,7 +2032,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_RXFF(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_ERROR(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_EIE);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_EIE);
 }
 
 /**
@@ -2025,7 +2043,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_ERROR(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_CTS(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_CTSIE);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_CTSIE);
 }
 
 /**
@@ -2036,7 +2054,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_CTS(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_WKUP(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_WUFIE);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_WUFIE);
 }
 
 /**
@@ -2047,7 +2065,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_WKUP(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_TXFT(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_TXFTIE);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_TXFTIE);
 }
 
 /**
@@ -2058,7 +2076,7 @@ __STATIC_INLINE void LL_LPUART_EnableIT_TXFT(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableIT_RXFT(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_RXFTIE);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_RXFTIE);
 }
 
 /**
@@ -2069,11 +2087,10 @@ __STATIC_INLINE void LL_LPUART_EnableIT_RXFT(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_IDLE(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_IDLEIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_IDLEIE);
 }
 
-/* Legacy define */
-#define LL_LPUART_DisableIT_RXNE  LL_LPUART_DisableIT_RXNE_RXFNE
+#define LL_LPUART_DisableIT_RXNE  LL_LPUART_DisableIT_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Disable RX Not Empty and RX FIFO Not Empty Interrupt
@@ -2083,7 +2100,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_IDLE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_RXNE_RXFNE(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
 }
 
 /**
@@ -2094,11 +2111,10 @@ __STATIC_INLINE void LL_LPUART_DisableIT_RXNE_RXFNE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_TC(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_TCIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_TCIE);
 }
 
-/* Legacy define */
-#define LL_LPUART_DisableIT_TXE  LL_LPUART_DisableIT_TXE_TXFNF
+#define LL_LPUART_DisableIT_TXE  LL_LPUART_DisableIT_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Disable TX Empty and TX FIFO Not Full Interrupt
@@ -2108,7 +2124,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_TC(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_TXE_TXFNF(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
 }
 
 /**
@@ -2119,7 +2135,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_TXE_TXFNF(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_PE(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_PEIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_PEIE);
 }
 
 /**
@@ -2130,7 +2146,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_PE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_CM(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_CMIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_CMIE);
 }
 
 /**
@@ -2141,7 +2157,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_CM(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_TXFE(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_TXFEIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_TXFEIE);
 }
 
 /**
@@ -2152,7 +2168,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_TXFE(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_RXFF(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR1, USART_CR1_RXFFIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR1, USART_CR1_RXFFIE);
 }
 
 /**
@@ -2167,7 +2183,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_RXFF(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_ERROR(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_EIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_EIE);
 }
 
 /**
@@ -2178,7 +2194,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_ERROR(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_CTS(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_CTSIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_CTSIE);
 }
 
 /**
@@ -2189,7 +2205,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_CTS(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_WKUP(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_WUFIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_WUFIE);
 }
 
 /**
@@ -2200,7 +2216,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_WKUP(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_TXFT(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_TXFTIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_TXFTIE);
 }
 
 /**
@@ -2211,7 +2227,7 @@ __STATIC_INLINE void LL_LPUART_DisableIT_TXFT(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableIT_RXFT(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_RXFTIE);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_RXFTIE);
 }
 
 /**
@@ -2220,13 +2236,12 @@ __STATIC_INLINE void LL_LPUART_DisableIT_RXFT(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_IDLE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_IDLE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_IDLEIE) == (USART_CR1_IDLEIE)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_LPUART_IsEnabledIT_RXNE  LL_LPUART_IsEnabledIT_RXNE_RXFNE
+#define LL_LPUART_IsEnabledIT_RXNE  LL_LPUART_IsEnabledIT_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the LPUART RX Not Empty and LPUART RX FIFO Not Empty Interrupt is enabled or disabled.
@@ -2234,7 +2249,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_IDLE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXNE_RXFNE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXNE_RXFNE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_RXNEIE_RXFNEIE) == (USART_CR1_RXNEIE_RXFNEIE)) ? 1UL : 0UL);
 }
@@ -2245,13 +2260,12 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXNE_RXFNE(USART_TypeDef *LPUARTx
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TC(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TC(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_TCIE) == (USART_CR1_TCIE)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_LPUART_IsEnabledIT_TXE  LL_LPUART_IsEnabledIT_TXE_TXFNF
+#define LL_LPUART_IsEnabledIT_TXE  LL_LPUART_IsEnabledIT_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the LPUART TX Empty and LPUART TX FIFO Not Full Interrupt is enabled or disabled
@@ -2259,7 +2273,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TC(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXE_TXFNF(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXE_TXFNF(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_TXEIE_TXFNFIE) == (USART_CR1_TXEIE_TXFNFIE)) ? 1UL : 0UL);
 }
@@ -2270,7 +2284,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXE_TXFNF(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_PE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_PE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_PEIE) == (USART_CR1_PEIE)) ? 1UL : 0UL);
 }
@@ -2281,7 +2295,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_PE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_CM(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_CM(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_CMIE) == (USART_CR1_CMIE)) ? 1UL : 0UL);
 }
@@ -2292,7 +2306,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_CM(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXFE(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXFE(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_TXFEIE) == (USART_CR1_TXFEIE)) ? 1UL : 0UL);
 }
@@ -2303,7 +2317,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXFE(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXFF(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXFF(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR1, USART_CR1_RXFFIE) == (USART_CR1_RXFFIE)) ? 1UL : 0UL);
 }
@@ -2314,7 +2328,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXFF(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_ERROR(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_ERROR(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_EIE) == (USART_CR3_EIE)) ? 1UL : 0UL);
 }
@@ -2325,7 +2339,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_ERROR(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_CTS(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_CTS(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_CTSIE) == (USART_CR3_CTSIE)) ? 1UL : 0UL);
 }
@@ -2336,7 +2350,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_CTS(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_WKUP(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_WKUP(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_WUFIE) == (USART_CR3_WUFIE)) ? 1UL : 0UL);
 }
@@ -2347,7 +2361,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_WKUP(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXFT(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXFT(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_TXFTIE) == (USART_CR3_TXFTIE)) ? 1UL : 0UL);
 }
@@ -2358,7 +2372,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_TXFT(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXFT(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXFT(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_RXFTIE) == (USART_CR3_RXFTIE)) ? 1UL : 0UL);
 }
@@ -2379,7 +2393,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledIT_RXFT(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableDMAReq_RX(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_DMAR);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_DMAR);
 }
 
 /**
@@ -2390,7 +2404,7 @@ __STATIC_INLINE void LL_LPUART_EnableDMAReq_RX(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableDMAReq_RX(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_DMAR);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_DMAR);
 }
 
 /**
@@ -2399,7 +2413,7 @@ __STATIC_INLINE void LL_LPUART_DisableDMAReq_RX(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMAReq_RX(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMAReq_RX(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_DMAR) == (USART_CR3_DMAR)) ? 1UL : 0UL);
 }
@@ -2412,7 +2426,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMAReq_RX(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_EnableDMAReq_TX(USART_TypeDef *LPUARTx)
 {
-  SET_BIT(LPUARTx->CR3, USART_CR3_DMAT);
+  ATOMIC_SET_BIT(LPUARTx->CR3, USART_CR3_DMAT);
 }
 
 /**
@@ -2423,7 +2437,7 @@ __STATIC_INLINE void LL_LPUART_EnableDMAReq_TX(USART_TypeDef *LPUARTx)
   */
 __STATIC_INLINE void LL_LPUART_DisableDMAReq_TX(USART_TypeDef *LPUARTx)
 {
-  CLEAR_BIT(LPUARTx->CR3, USART_CR3_DMAT);
+  ATOMIC_CLEAR_BIT(LPUARTx->CR3, USART_CR3_DMAT);
 }
 
 /**
@@ -2432,7 +2446,7 @@ __STATIC_INLINE void LL_LPUART_DisableDMAReq_TX(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMAReq_TX(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMAReq_TX(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_DMAT) == (USART_CR3_DMAT)) ? 1UL : 0UL);
 }
@@ -2465,7 +2479,7 @@ __STATIC_INLINE void LL_LPUART_DisableDMADeactOnRxErr(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMADeactOnRxErr(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMADeactOnRxErr(const USART_TypeDef *LPUARTx)
 {
   return ((READ_BIT(LPUARTx->CR3, USART_CR3_DDRE) == (USART_CR3_DDRE)) ? 1UL : 0UL);
 }
@@ -2480,7 +2494,7 @@ __STATIC_INLINE uint32_t LL_LPUART_IsEnabledDMADeactOnRxErr(USART_TypeDef *LPUAR
   *         @arg @ref LL_LPUART_DMA_REG_DATA_RECEIVE
   * @retval Address of data register
   */
-__STATIC_INLINE uint32_t LL_LPUART_DMA_GetRegAddr(USART_TypeDef *LPUARTx, uint32_t Direction)
+__STATIC_INLINE uint32_t LL_LPUART_DMA_GetRegAddr(const USART_TypeDef *LPUARTx, uint32_t Direction)
 {
   uint32_t data_reg_addr;
 
@@ -2512,7 +2526,7 @@ __STATIC_INLINE uint32_t LL_LPUART_DMA_GetRegAddr(USART_TypeDef *LPUARTx, uint32
   * @param  LPUARTx LPUART Instance
   * @retval Time Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint8_t LL_LPUART_ReceiveData8(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint8_t LL_LPUART_ReceiveData8(const USART_TypeDef *LPUARTx)
 {
   return (uint8_t)(READ_BIT(LPUARTx->RDR, USART_RDR_RDR) & 0xFFU);
 }
@@ -2523,7 +2537,7 @@ __STATIC_INLINE uint8_t LL_LPUART_ReceiveData8(USART_TypeDef *LPUARTx)
   * @param  LPUARTx LPUART Instance
   * @retval Time Value between Min_Data=0x00 and Max_Data=0x1FF
   */
-__STATIC_INLINE uint16_t LL_LPUART_ReceiveData9(USART_TypeDef *LPUARTx)
+__STATIC_INLINE uint16_t LL_LPUART_ReceiveData9(const USART_TypeDef *LPUARTx)
 {
   return (uint16_t)(READ_BIT(LPUARTx->RDR, USART_RDR_RDR));
 }
@@ -2596,6 +2610,21 @@ __STATIC_INLINE void LL_LPUART_RequestRxDataFlush(USART_TypeDef *LPUARTx)
 }
 
 /**
+  * @brief  Request a Transmit data FIFO flush
+  * @note   TXFRQ bit is set to flush the whole FIFO when FIFO mode is enabled. This
+  *         also sets the flag TXFE (TXFIFO empty bit in the LPUART_ISR register).
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  *         FIFO mode feature is supported by the USARTx instance.
+  * @rmtoll RQR          TXFRQ         LL_LPUART_RequestTxDataFlush
+  * @param  LPUARTx LPUART Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_LPUART_RequestTxDataFlush(USART_TypeDef *LPUARTx)
+{
+  SET_BIT(LPUARTx->RQR, (uint16_t)USART_RQR_TXFRQ);
+}
+
+/**
   * @}
   */
 
@@ -2603,8 +2632,8 @@ __STATIC_INLINE void LL_LPUART_RequestRxDataFlush(USART_TypeDef *LPUARTx)
 /** @defgroup LPUART_LL_EF_Init Initialization and de-initialization functions
   * @{
   */
-ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx);
-ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, LL_LPUART_InitTypeDef *LPUART_InitStruct);
+ErrorStatus LL_LPUART_DeInit(const USART_TypeDef *LPUARTx);
+ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, const LL_LPUART_InitTypeDef *LPUART_InitStruct);
 void        LL_LPUART_StructInit(LL_LPUART_InitTypeDef *LPUART_InitStruct);
 /**
   * @}
@@ -2631,4 +2660,3 @@ void        LL_LPUART_StructInit(LL_LPUART_InitTypeDef *LPUART_InitStruct);
 
 #endif /* STM32WBxx_LL_LPUART_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_pka.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_pka.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -94,7 +93,7 @@ typedef struct
   */
 
 /** @defgroup PKA_LL_EC_MODE Operation Mode
-  * @brief    List of opearation mode.
+  * @brief    List of operation mode.
   * @{
   */
 #define LL_PKA_MODE_MONTGOMERY_PARAM_MOD_EXP ((uint32_t)0x00000000U) /*!< Compute Montgomery parameter and modular exponentiation */
@@ -173,9 +172,9 @@ typedef struct
   * @param  PKAx PKA Instance.
   * @param  Mode This parameter can be one of the following values:
   *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_MOD_EXP
+  *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_ECC
   *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM
   *         @arg @ref LL_PKA_MODE_MODULAR_EXP
-  *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_ECC
   *         @arg @ref LL_PKA_MODE_ECC_KP_PRIMITIVE
   *         @arg @ref LL_PKA_MODE_ECDSA_SIGNATURE
   *         @arg @ref LL_PKA_MODE_ECDSA_VERIFICATION
@@ -235,9 +234,9 @@ __STATIC_INLINE uint32_t LL_PKA_IsEnabled(PKA_TypeDef *PKAx)
   * @param  PKAx PKA Instance.
   * @param  Mode This parameter can be one of the following values:
   *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_MOD_EXP
+  *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_ECC
   *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM
   *         @arg @ref LL_PKA_MODE_MODULAR_EXP
-  *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_ECC
   *         @arg @ref LL_PKA_MODE_ECC_KP_PRIMITIVE
   *         @arg @ref LL_PKA_MODE_ECDSA_SIGNATURE
   *         @arg @ref LL_PKA_MODE_ECDSA_VERIFICATION
@@ -265,9 +264,9 @@ __STATIC_INLINE void LL_PKA_SetMode(PKA_TypeDef *PKAx, uint32_t Mode)
   * @param  PKAx PKA Instance.
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_MOD_EXP
+  *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_ECC
   *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM
   *         @arg @ref LL_PKA_MODE_MODULAR_EXP
-  *         @arg @ref LL_PKA_MODE_MONTGOMERY_PARAM_ECC
   *         @arg @ref LL_PKA_MODE_ECC_KP_PRIMITIVE
   *         @arg @ref LL_PKA_MODE_ECDSA_SIGNATURE
   *         @arg @ref LL_PKA_MODE_ECDSA_VERIFICATION
@@ -533,5 +532,3 @@ void LL_PKA_StructInit(LL_PKA_InitTypeDef *PKA_InitStruct);
 #endif
 
 #endif /* STM32WBxx_LL_PKA_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_pwr.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_pwr.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -59,7 +58,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /**
   * @}
@@ -80,14 +79,14 @@ extern "C" {
 #define LL_PWR_SCR_CWUF                    PWR_SCR_CWUF
 #if defined(PWR_CR3_EWUP2)
 #define LL_PWR_SCR_CWUF5                   PWR_SCR_CWUF5
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #define LL_PWR_SCR_CWUF4                   PWR_SCR_CWUF4
 #if defined(PWR_CR3_EWUP3)
 #define LL_PWR_SCR_CWUF3                   PWR_SCR_CWUF3
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #if defined(PWR_CR3_EWUP2)
 #define LL_PWR_SCR_CWUF2                   PWR_SCR_CWUF2
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #define LL_PWR_SCR_CWUF1                   PWR_SCR_CWUF1
 #define LL_PWR_SCR_CC2HF                   PWR_SCR_CC2HF
 #define LL_PWR_SCR_CBLEAF                  PWR_SCR_CBLEAF
@@ -95,12 +94,12 @@ extern "C" {
 #if defined(PWR_CR3_E802A)
 #define LL_PWR_SCR_C802AF                  PWR_SCR_C802AF
 #define LL_PWR_SCR_C802WUF                 PWR_SCR_C802WUF
-#endif
+#endif /* PWR_CR3_E802A */
 #define LL_PWR_SCR_CBLEWUF                 PWR_SCR_CBLEWUF
 #if defined(PWR_CR5_SMPSEN)
 #define LL_PWR_SCR_CBORHF                  PWR_SCR_CBORHF
 #define LL_PWR_SCR_CSMPSFBF                PWR_SCR_CSMPSFBF
-#endif
+#endif /* PWR_CR5_SMPSEN */
 #define LL_PWR_EXTSCR_CCRPF                PWR_EXTSCR_CCRPF
 #define LL_PWR_EXTSCR_C2CSSF               PWR_EXTSCR_C2CSSF
 #define LL_PWR_EXTSCR_C1CSSF               PWR_EXTSCR_C1CSSF
@@ -115,23 +114,23 @@ extern "C" {
 #define LL_PWR_SR1_WUFI                    PWR_SR1_WUFI
 #if defined(PWR_CR3_EWUP5)
 #define LL_PWR_SR1_WUF5                    PWR_SR1_WUF5
-#endif
+#endif /* PWR_CR3_EWUP5 */
 #define LL_PWR_SR1_WUF4                    PWR_SR1_WUF4
 #if defined(PWR_CR3_EWUP3)
 #define LL_PWR_SR1_WUF3                    PWR_SR1_WUF3
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #if defined(PWR_CR3_EWUP2)
 #define LL_PWR_SR1_WUF2                    PWR_SR1_WUF2
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #define LL_PWR_SR1_WUF1                    PWR_SR1_WUF1
 #define LL_PWR_SR2_PVMO3                   PWR_SR2_PVMO3
 #if defined(PWR_CR2_PVME1)
 #define LL_PWR_SR2_PVMO1                   PWR_SR2_PVMO1
-#endif
+#endif /* PWR_CR2_PVME1 */
 #define LL_PWR_SR2_PVDO                    PWR_SR2_PVDO
 #if defined(PWR_CR1_VOS)
 #define LL_PWR_SR2_VOSF                    PWR_SR2_VOSF
-#endif
+#endif /* PWR_CR1_VOS */
 #define LL_PWR_SR2_REGLPF                  PWR_SR2_REGLPF
 #define LL_PWR_SR2_REGLPS                  PWR_SR2_REGLPS
 
@@ -143,7 +142,7 @@ extern "C" {
 #define LL_PWR_FLAG_SMPS                   PWR_SR2_SMPSF  /* SMPS step down converter ready flag */
 #define LL_PWR_FLAG_SMPSB                  PWR_SR2_SMPSBF /* SMPS step down converter in bypass mode flag */
 #define LL_PWR_FLAG_SMPSFB                 PWR_SR1_SMPSFB /* SMPS step down converter forced in bypass mode interrupt flag */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /* Radio (BLE or 802.15.4) flags */
 #define LL_PWR_FLAG_BLEWU                  PWR_SR1_BLEWUF  /* BLE wakeup interrupt flag */
@@ -152,7 +151,7 @@ extern "C" {
 #if defined(PWR_CR3_E802A)
 #define LL_PWR_FLAG_802WU                  PWR_SR1_802WUF  /* 802.15.4 wakeup interrupt flag */
 #define LL_PWR_FLAG_802A                   PWR_SR1_802AF   /* 802.15.4 end of activity interrupt flag */
-#endif
+#endif /* PWR_CR3_E802A */
 #define LL_PWR_FLAG_CRPE                   PWR_SR1_CRPEF   /* Critical radio phase end of activity interrupt flag */
 #define LL_PWR_FLAG_CRP                    PWR_EXTSCR_CRPF /* Critical radio system phase */
 
@@ -177,7 +176,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR1_VOS */
 
 /** @defgroup PWR_LL_EC_MODE_PWR MODE PWR
   * @{
@@ -186,7 +185,7 @@ extern "C" {
 #define LL_PWR_MODE_STOP1                  (PWR_CR1_LPMS_0)
 #if defined(PWR_SUPPORT_STOP2)
 #define LL_PWR_MODE_STOP2                  (PWR_CR1_LPMS_1)
-#endif
+#endif /* PWR_SUPPORT_STOP2 */
 #define LL_PWR_MODE_STANDBY                (PWR_CR1_LPMS_1 | PWR_CR1_LPMS_0)
 #define LL_PWR_MODE_SHUTDOWN               (PWR_CR1_LPMS_2)
 /**
@@ -216,7 +215,7 @@ extern "C" {
   */
 #if defined(PWR_CR2_PVME1)
 #define LL_PWR_PVM_VDDUSB_1_2V             (PWR_CR2_PVME1)     /* Monitoring VDDUSB vs. 1.2V */
-#endif
+#endif /* PWR_CR2_PVME1 */
 #define LL_PWR_PVM_VDDA_1_62V              (PWR_CR2_PVME3)     /* Monitoring VDDA vs. 1.62V  */
 /**
   * @}
@@ -243,14 +242,14 @@ extern "C" {
 #define LL_PWR_WAKEUP_PIN1                 (PWR_CR3_EWUP1)
 #if defined(PWR_CR3_EWUP2)
 #define LL_PWR_WAKEUP_PIN2                 (PWR_CR3_EWUP2)
-#endif
+#endif /* PWR_CR3_EWUP2 */
 #if defined(PWR_CR3_EWUP3)
 #define LL_PWR_WAKEUP_PIN3                 (PWR_CR3_EWUP3)
-#endif
+#endif /* PWR_CR3_EWUP3 */
 #define LL_PWR_WAKEUP_PIN4                 (PWR_CR3_EWUP4)
 #if defined(PWR_CR3_EWUP5)
 #define LL_PWR_WAKEUP_PIN5                 (PWR_CR3_EWUP5)
-#endif
+#endif /* PWR_CR3_EWUP5 */
 /**
   * @}
   */
@@ -316,7 +315,7 @@ extern "C" {
 #define LL_PWR_GPIO_BIT_13                 (PWR_PUCRA_PA13)
 #define LL_PWR_GPIO_BIT_14                 (PWR_PUCRC_PC14)
 #define LL_PWR_GPIO_BIT_15                 (PWR_PUCRC_PC15)
-#endif
+#endif /* PWR_PUCRC_PC0 */
 /**
   * @}
   */
@@ -336,7 +335,7 @@ extern "C" {
   */
 /* Note: Literals values are defined from register SR2 bits SMPSF and SMPSBF  */
 /*       but they are also used as register CR5 bits SMPSEN and SMPSBEN,      */
-/*       as used by all SMPS operating mode functions targetting different    */
+/*       as used by all SMPS operating mode functions targeting different    */
 /*       registers:                                                           */
 /*       "LL_PWR_SMPS_SetMode()", "LL_PWR_SMPS_GetMode()"                     */
 /*       and "LL_PWR_SMPS_GetEffectiveMode()".                                */
@@ -384,7 +383,7 @@ extern "C" {
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /**
   * @}
@@ -490,7 +489,7 @@ __STATIC_INLINE uint32_t LL_PWR_GetRegulVoltageScaling(void)
 {
   return (uint32_t)(READ_BIT(PWR->CR1, PWR_CR1_VOS));
 }
-#endif
+#endif /* PWR_CR1_VOS */
 
 /**
   * @brief  Enable access to the backup domain
@@ -532,7 +531,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledBkUpAccess(void)
   *         @arg @ref LL_PWR_MODE_STANDBY
   *         @arg @ref LL_PWR_MODE_SHUTDOWN
   *
-  *         (*) Not available on devices STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_SetPowerMode(uint32_t LowPowerMode)
@@ -550,7 +549,7 @@ __STATIC_INLINE void LL_PWR_SetPowerMode(uint32_t LowPowerMode)
   *         @arg @ref LL_PWR_MODE_STANDBY
   *         @arg @ref LL_PWR_MODE_SHUTDOWN
   *
-  *         (*) Not available on devices STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   */
 __STATIC_INLINE uint32_t LL_PWR_GetPowerMode(void)
 {
@@ -651,7 +650,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledVddUSB(void)
   *         @arg @ref LL_PWR_PVM_VDDUSB_1_2V (*)
   *         @arg @ref LL_PWR_PVM_VDDA_1_62V
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_EnablePVM(uint32_t PeriphVoltage)
@@ -667,7 +666,7 @@ __STATIC_INLINE void LL_PWR_EnablePVM(uint32_t PeriphVoltage)
   *         @arg @ref LL_PWR_PVM_VDDUSB_1_2V (*)
   *         @arg @ref LL_PWR_PVM_VDDA_1_62V
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_DisablePVM(uint32_t PeriphVoltage)
@@ -683,7 +682,7 @@ __STATIC_INLINE void LL_PWR_DisablePVM(uint32_t PeriphVoltage)
   *         @arg @ref LL_PWR_PVM_VDDUSB_1_2V (*)
   *         @arg @ref LL_PWR_PVM_VDDA_1_62V
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_PWR_IsEnabledPVM(uint32_t PeriphVoltage)
@@ -820,7 +819,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledPUPDCfg(void)
 
 /**
   * @brief  Enable SRAM2a content retention in Standby mode
-  * @note   On devices STM32WB15xx, STM32WB10xx, retention is extended
+  * @note   On devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx, retention is extended
   *         to SRAM1, SRAM2a and SRAM2b.
   * @rmtoll CR3          RRS           LL_PWR_EnableSRAM2Retention
   * @retval None
@@ -832,7 +831,7 @@ __STATIC_INLINE void LL_PWR_EnableSRAM2Retention(void)
 
 /**
   * @brief  Disable SRAM2a content retention in Standby mode
-  * @note   On devices STM32WB15xx, STM32WB10xx, retention is extended
+  * @note   On devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx, retention is extended
   *         to SRAM1, SRAM2a and SRAM2b.
   * @rmtoll CR3          RRS           LL_PWR_DisableSRAM2Retention
   * @retval None
@@ -844,7 +843,7 @@ __STATIC_INLINE void LL_PWR_DisableSRAM2Retention(void)
 
 /**
   * @brief  Check if SRAM2 content retention in Standby mode  is enabled
-  * @note   On devices STM32WB15xx, STM32WB10xx, retention is extended
+  * @note   On devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx, retention is extended
   *         to SRAM1, SRAM2a and SRAM2b.
   * @rmtoll CR3          RRS           LL_PWR_IsEnabledSRAM2Retention
   * @retval State of bit (1 or 0).
@@ -868,7 +867,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledSRAM2Retention(void)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
@@ -890,7 +889,7 @@ __STATIC_INLINE void LL_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
@@ -912,7 +911,7 @@ __STATIC_INLINE void LL_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_PWR_IsEnabledWakeUpPin(uint32_t WakeUpPin)
@@ -989,7 +988,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledBatteryCharging(void)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityLow(uint32_t WakeUpPin)
@@ -1011,7 +1010,7 @@ __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityLow(uint32_t WakeUpPin)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityHigh(uint32_t WakeUpPin)
@@ -1033,7 +1032,7 @@ __STATIC_INLINE void LL_PWR_SetWakeUpPinPolarityHigh(uint32_t WakeUpPin)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_PWR_IsWakeUpPinPolarityLow(uint32_t WakeUpPin)
@@ -1307,7 +1306,7 @@ __STATIC_INLINE uint32_t LL_PWR_GetBORConfig(void)
 {
   return (uint32_t)(READ_BIT(PWR->CR5, PWR_CR5_BORHC));
 }
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /**
   * @}
@@ -1327,7 +1326,7 @@ __STATIC_INLINE uint32_t LL_PWR_GetBORConfig(void)
   *         switching on the fly is performed automaticcaly
   *         and interruption is generated.
   *         Refer to function @ref LL_PWR_SetBORConfig().
-  * @note   Occurence of SMPS step down converter forced in bypass mode
+  * @note   Occurrence of SMPS step down converter forced in bypass mode
   *         can be monitored by flag and interruption.
   *         Refer to functions
   *         @ref LL_PWR_IsActiveFlag_SMPSFB(), @ref LL_PWR_ClearFlag_SMPSFB(),
@@ -1504,10 +1503,10 @@ __STATIC_INLINE uint32_t LL_PWR_SMPS_GetStartupCurrent(void)
 __STATIC_INLINE void LL_PWR_SMPS_SetOutputVoltageLevel(uint32_t OutputVoltageLevel)
 {
   __IO const uint32_t OutputVoltageLevel_calibration = (((*SMPS_VOLTAGE_CAL_ADDR) & SMPS_VOLTAGE_CAL) >> SMPS_VOLTAGE_CAL_POS);  /* SMPS output voltage level calibrated in production */
-  int32_t TrimmingSteps;                               /* Trimming steps between theorical output voltage and calibrated output voltage */
+  int32_t TrimmingSteps;                               /* Trimming steps between theoretical output voltage and calibrated output voltage */
   int32_t OutputVoltageLevelTrimmed;                   /* SMPS output voltage level after calibration: trimming value added to required level */
 
-  if(OutputVoltageLevel_calibration == 0UL)
+  if (OutputVoltageLevel_calibration == 0UL)
   {
     /* Device with SMPS output voltage not calibrated in production: Apply output voltage value directly */
 
@@ -1522,13 +1521,13 @@ __STATIC_INLINE void LL_PWR_SMPS_SetOutputVoltageLevel(uint32_t OutputVoltageLev
     OutputVoltageLevelTrimmed = ((int32_t)((uint32_t)(OutputVoltageLevel >> PWR_CR5_SMPSVOS_Pos)) + (int32_t)TrimmingSteps);
 
     /* Clamp value to voltage trimming bitfield range */
-    if(OutputVoltageLevelTrimmed < 0)
+    if (OutputVoltageLevelTrimmed < 0)
     {
       OutputVoltageLevelTrimmed = 0;
     }
     else
     {
-      if(OutputVoltageLevelTrimmed > (int32_t)PWR_CR5_SMPSVOS)
+      if (OutputVoltageLevelTrimmed > (int32_t)PWR_CR5_SMPSVOS)
       {
         OutputVoltageLevelTrimmed = (int32_t)PWR_CR5_SMPSVOS;
       }
@@ -1565,10 +1564,10 @@ __STATIC_INLINE void LL_PWR_SMPS_SetOutputVoltageLevel(uint32_t OutputVoltageLev
 __STATIC_INLINE uint32_t LL_PWR_SMPS_GetOutputVoltageLevel(void)
 {
   __IO const uint32_t OutputVoltageLevel_calibration = (((*SMPS_VOLTAGE_CAL_ADDR) & SMPS_VOLTAGE_CAL) >> SMPS_VOLTAGE_CAL_POS);  /* SMPS output voltage level calibrated in production */
-  int32_t TrimmingSteps;                               /* Trimming steps between theorical output voltage and calibrated output voltage */
+  int32_t TrimmingSteps;                               /* Trimming steps between theoretical output voltage and calibrated output voltage */
   int32_t OutputVoltageLevelTrimmed;                   /* SMPS output voltage level after calibration: trimming value added to required level */
 
-  if(OutputVoltageLevel_calibration == 0UL)
+  if (OutputVoltageLevel_calibration == 0UL)
   {
     /* Device with SMPS output voltage not calibrated in production: Return output voltage value directly */
 
@@ -1578,18 +1577,18 @@ __STATIC_INLINE uint32_t LL_PWR_SMPS_GetOutputVoltageLevel(void)
   {
     /* Device with SMPS output voltage calibrated in production: Return output voltage value after correction by calibration value */
 
-    TrimmingSteps = ((int32_t)OutputVoltageLevel_calibration - (int32_t)(LL_PWR_SMPS_OUTPUT_VOLTAGE_1V50 >> PWR_CR5_SMPSVOS_Pos)); /* Trimming steps between theorical output voltage and calibrated output voltage */
+    TrimmingSteps = ((int32_t)OutputVoltageLevel_calibration - (int32_t)(LL_PWR_SMPS_OUTPUT_VOLTAGE_1V50 >> PWR_CR5_SMPSVOS_Pos)); /* Trimming steps between theoretical output voltage and calibrated output voltage */
 
     OutputVoltageLevelTrimmed = ((int32_t)((uint32_t)READ_BIT(PWR->CR5, PWR_CR5_SMPSVOS)) - TrimmingSteps);
 
     /* Clamp value to voltage range */
-    if(OutputVoltageLevelTrimmed < 0)
+    if (OutputVoltageLevelTrimmed < 0)
     {
       OutputVoltageLevelTrimmed = (int32_t)LL_PWR_SMPS_OUTPUT_VOLTAGE_1V20;
     }
     else
     {
-      if(OutputVoltageLevelTrimmed > (int32_t)PWR_CR5_SMPSVOS)
+      if (OutputVoltageLevelTrimmed > (int32_t)PWR_CR5_SMPSVOS)
       {
         OutputVoltageLevelTrimmed = (int32_t)LL_PWR_SMPS_OUTPUT_VOLTAGE_1V90;
       }
@@ -1602,7 +1601,7 @@ __STATIC_INLINE uint32_t LL_PWR_SMPS_GetOutputVoltageLevel(void)
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /** @defgroup PWR_LL_EF_Configuration_Multicore Configuration of multicore, intended to be executed by CPU1
   * @{
@@ -1658,7 +1657,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledBootC2(void)
   *         @arg @ref LL_PWR_MODE_STANDBY
   *         @arg @ref LL_PWR_MODE_SHUTDOWN
   *
-  *         (*) Not available on devices STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_C2_PWR_SetPowerMode(uint32_t LowPowerMode)
@@ -1676,7 +1675,7 @@ __STATIC_INLINE void LL_C2_PWR_SetPowerMode(uint32_t LowPowerMode)
   *         @arg @ref LL_PWR_MODE_STANDBY
   *         @arg @ref LL_PWR_MODE_SHUTDOWN
   *
-  *         (*) Not available on devices STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   */
 __STATIC_INLINE uint32_t LL_C2_PWR_GetPowerMode(void)
 {
@@ -1782,7 +1781,7 @@ __STATIC_INLINE uint32_t LL_C2_PWR_IsEnabledInternWU(void)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_C2_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
@@ -1804,7 +1803,7 @@ __STATIC_INLINE void LL_C2_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE void LL_C2_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
@@ -1826,7 +1825,7 @@ __STATIC_INLINE void LL_C2_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
   *         @arg @ref LL_PWR_WAKEUP_PIN4
   *         @arg @ref LL_PWR_WAKEUP_PIN5 (*)
   *
-  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx
+  *         (*) Not available on devices STM32WB50xx, STM32WB35xx, STM32WB30xx, STM32WB15xx, STM32WB10xx, STM32WB1Mxx
   * @retval None
   */
 __STATIC_INLINE uint32_t LL_C2_PWR_IsEnabledWakeUpPin(uint32_t WakeUpPin)
@@ -1918,7 +1917,7 @@ __STATIC_INLINE uint32_t LL_C2_PWR_IsWokenUp_802_15_4(void)
 {
   return ((READ_BIT(PWR->C2CR1, PWR_C2CR1_802EWKUP) == (PWR_C2CR1_802EWKUP)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @}
@@ -1948,7 +1947,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_WU5(void)
 {
   return ((READ_BIT(PWR->SR1, PWR_SR1_WUF5) == (PWR_SR1_WUF5)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_EWUP5 */
 
 /**
   * @brief  Get Wake-up Flag 4
@@ -1970,7 +1969,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_WU3(void)
 {
   return ((READ_BIT(PWR->SR1, PWR_SR1_WUF3) == (PWR_SR1_WUF3)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_EWUP3 */
 
 #if defined(PWR_CR3_EWUP2)
 /**
@@ -1982,7 +1981,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_WU2(void)
 {
   return ((READ_BIT(PWR->SR1, PWR_SR1_WUF2) == (PWR_SR1_WUF2)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_EWUP2 */
 
 /**
   * @brief  Get Wake-up Flag 1
@@ -2014,7 +2013,7 @@ __STATIC_INLINE void LL_PWR_ClearFlag_WU5(void)
 {
   WRITE_REG(PWR->SCR, PWR_SCR_CWUF5);
 }
-#endif
+#endif /* PWR_CR3_EWUP5 */
 
 /**
   * @brief  Clear Wake-up Flag 4
@@ -2036,7 +2035,7 @@ __STATIC_INLINE void LL_PWR_ClearFlag_WU3(void)
 {
   WRITE_REG(PWR->SCR, PWR_SCR_CWUF3);
 }
-#endif
+#endif /* PWR_CR3_EWUP3 */
 
 #if defined(PWR_CR3_EWUP2)
 /**
@@ -2048,7 +2047,7 @@ __STATIC_INLINE void LL_PWR_ClearFlag_WU2(void)
 {
   WRITE_REG(PWR->SCR, PWR_SCR_CWUF2);
 }
-#endif
+#endif /* PWR_CR3_EWUP2 */
 
 /**
   * @brief  Clear Wake-up Flag 1
@@ -2081,7 +2080,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_PVMO1(void)
 {
   return ((READ_BIT(PWR->SR2, PWR_SR2_PVMO1) == (PWR_SR2_PVMO1)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 /**
   * @brief  Indicate whether VDD voltage is below or above the selected PVD threshold
@@ -2103,7 +2102,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_VOS(void)
 {
   return ((READ_BIT(PWR->SR2, PWR_SR2_VOSF) == (PWR_SR2_VOSF)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR1_VOS */
 
 /**
   * @brief  Indicate whether the regulator is ready in main mode or is in low-power mode
@@ -2186,7 +2185,7 @@ __STATIC_INLINE void LL_PWR_ClearFlag_SMPSFB(void)
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /** @defgroup PWR_LL_EF_FLAG_Management_Radio FLAG management for radio (BLE or 802.15.4)
   * @{
@@ -2212,7 +2211,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_802WU(void)
 {
   return ((READ_BIT(PWR->SR1, PWR_SR1_802WUF) == (PWR_SR1_802WUF)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Get BLE end of activity interrupt flag
@@ -2234,7 +2233,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_802A(void)
 {
   return ((READ_BIT(PWR->SR1, PWR_SR1_802AF) == (PWR_SR1_802AF)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Get critical radio phase end of activity interrupt flag
@@ -2276,7 +2275,7 @@ __STATIC_INLINE void LL_PWR_ClearFlag_802WU(void)
 {
   WRITE_REG(PWR->SCR, PWR_SCR_C802WUF);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Clear BLE end of activity interrupt flag
@@ -2298,7 +2297,7 @@ __STATIC_INLINE void LL_PWR_ClearFlag_802A(void)
 {
   WRITE_REG(PWR->SCR, PWR_SCR_C802AF);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Clear critical radio phase end of activity interrupt flag
@@ -2476,7 +2475,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledIT_BORH_SMPSFB(void)
 /**
   * @}
   */
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /** @defgroup PWR_LL_EF_IT_Management_Radio PWR IT management for radio (BLE or 802.15.4)
   * @{
@@ -2502,7 +2501,7 @@ __STATIC_INLINE void LL_PWR_EnableIT_802A(void)
 {
   SET_BIT(PWR->CR3, PWR_CR3_E802A);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Disable BLE end of activity interrupt for CPU1
@@ -2524,7 +2523,7 @@ __STATIC_INLINE void LL_PWR_DisableIT_802A(void)
 {
   CLEAR_BIT(PWR->CR3, PWR_CR3_E802A);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Check if BLE end of activity interrupt is enabled for CPU1
@@ -2546,7 +2545,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledIT_802A(void)
 {
   return ((READ_BIT(PWR->CR3, PWR_CR3_E802A) == (PWR_CR3_E802A)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Enable critical radio phase end of activity interrupt for CPU1
@@ -2644,7 +2643,7 @@ __STATIC_INLINE void LL_C2_PWR_EnableIT_802WU(void)
 {
   SET_BIT(PWR->C2CR3, PWR_C2CR3_E802WUP);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Disable BLE host wakeup interrupt for CPU2
@@ -2666,7 +2665,7 @@ __STATIC_INLINE void LL_C2_PWR_DisableIT_802WU(void)
 {
   CLEAR_BIT(PWR->C2CR3, PWR_C2CR3_E802WUP);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief  Check if BLE host wakeup interrupt is enabled for CPU2
@@ -2688,7 +2687,7 @@ __STATIC_INLINE uint32_t LL_C2_PWR_IsEnabledIT_802WU(void)
 {
   return ((READ_BIT(PWR->C2CR3, PWR_C2CR3_E802WUP) == (PWR_C2CR3_E802WUP)) ? 1UL : 0UL);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @}
@@ -2712,7 +2711,7 @@ ErrorStatus LL_PWR_DeInit(void);
   * @}
   */
 
-#endif /* defined(PWR) */
+#endif /* PWR */
 
 /**
   * @}
@@ -2724,4 +2723,3 @@ ErrorStatus LL_PWR_DeInit(void);
 
 #endif /* STM32WBxx_LL_PWR_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_rcc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_rcc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -59,7 +58,7 @@ extern "C" {
 /**
   * @}
   */
-#endif /*USE_FULL_LL_DRIVER*/
+#endif /* USE_FULL_LL_DRIVER */
 
 /* Exported types ------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
@@ -107,25 +106,29 @@ typedef struct
   */
 #if !defined  (HSE_VALUE)
 #define HSE_VALUE    32000000U  /*!< Value of the HSE oscillator in Hz */
-#endif /* HSE_VALUE */
+#endif /* !HSE_VALUE */
 
 #if !defined  (HSI_VALUE)
 #define HSI_VALUE    16000000U  /*!< Value of the HSI oscillator in Hz */
-#endif /* HSI_VALUE */
+#endif /* !HSI_VALUE */
 
 #if !defined  (LSE_VALUE)
+#if defined(STM32WB5Mxx)
+#define LSE_VALUE    32774U     /*!< Value of the LSE oscillator in Hz */
+#else
 #define LSE_VALUE    32768U     /*!< Value of the LSE oscillator in Hz */
-#endif /* LSE_VALUE */
+#endif /* STM32WB5Mxx */
+#endif /* !LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
 #define LSI_VALUE    32000U     /*!< Value of the LSI oscillator in Hz */
-#endif /* LSI_VALUE */
+#endif /* !LSI_VALUE */
 
 #if defined(RCC_HSI48_SUPPORT)
 #if !defined  (HSI48_VALUE)
 #define HSI48_VALUE  48000000U  /*!< Value of the HSI48 oscillator in Hz */
-#endif /* HSI48_VALUE */
-#endif
+#endif /* !HSI48_VALUE */
+#endif /* RCC_HSI48_SUPPORT */
 
 /**
   * @}
@@ -144,10 +147,10 @@ typedef struct
 #define LL_RCC_CICR_PLLRDYC                RCC_CICR_PLLRDYC     /*!< PLL Ready Interrupt Clear                 */
 #if defined(RCC_HSI48_SUPPORT)
 #define LL_RCC_CICR_HSI48RDYC              RCC_CICR_HSI48RDYC   /*!< HSI48 Ready Interrupt Clear               */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #if defined(SAI1)
 #define LL_RCC_CICR_PLLSAI1RDYC            RCC_CICR_PLLSAI1RDYC /*!< PLLSAI1 Ready Interrupt Clear             */
-#endif
+#endif /* SAI1 */
 #define LL_RCC_CICR_LSECSSC                RCC_CICR_LSECSSC     /*!< LSE Clock Security System Interrupt Clear */
 #define LL_RCC_CICR_CSSC                   RCC_CICR_CSSC        /*!< Clock Security System Interrupt Clear     */
 /**
@@ -167,10 +170,10 @@ typedef struct
 #define LL_RCC_CIFR_PLLRDYF                RCC_CIFR_PLLRDYF     /*!< PLL Ready Interrupt flag                 */
 #if defined(RCC_HSI48_SUPPORT)
 #define LL_RCC_CIFR_HSI48RDYF              RCC_CIFR_HSI48RDYF   /*!< HSI48 Ready Interrupt flag               */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #if defined(SAI1)
 #define LL_RCC_CIFR_PLLSAI1RDYF            RCC_CIFR_PLLSAI1RDYF /*!< PLLSAI1 Ready Interrupt flag             */
-#endif
+#endif /* SAI1 */
 #define LL_RCC_CIFR_LSECSSF                RCC_CIFR_LSECSSF     /*!< LSE Clock Security System Interrupt flag */
 #define LL_RCC_CIFR_CSSF                   RCC_CIFR_CSSF        /*!< Clock Security System Interrupt flag     */
 #define LL_RCC_CSR_LPWRRSTF                RCC_CSR_LPWRRSTF     /*!< Low-Power reset flag                     */
@@ -197,10 +200,10 @@ typedef struct
 #define LL_RCC_CIER_PLLRDYIE               RCC_CIER_PLLRDYIE      /*!< PLL Ready Interrupt Enable     */
 #if defined(RCC_HSI48_SUPPORT)
 #define LL_RCC_CIER_HSI48RDYIE             RCC_CIER_HSI48RDYIE    /*!< HSI48 Ready Interrupt Enable   */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #if defined(SAI1)
 #define LL_RCC_CIER_PLLSAI1RDYIE           RCC_CIER_PLLSAI1RDYIE  /*!< PLLSAI1 Ready Interrupt Enable */
-#endif
+#endif /* SAI1 */
 #define LL_RCC_CIER_LSECSSIE               RCC_CIER_LSECSSIE      /*!< LSE CSS Interrupt Enable       */
 /**
   * @}
@@ -369,7 +372,7 @@ typedef struct
 #define LL_RCC_MCO1SOURCE_LSE              RCC_CFGR_MCOSEL_3                             /*!< LSE selection as MCO1 source                      */
 #if defined(RCC_HSI48_SUPPORT)
 #define LL_RCC_MCO1SOURCE_HSI48            (RCC_CFGR_MCOSEL_0|RCC_CFGR_MCOSEL_3)         /*!< HSI48 selection as MCO1 source                    */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #define LL_RCC_MCO1SOURCE_HSE_BEFORE_STAB  (RCC_CFGR_MCOSEL_2|RCC_CFGR_MCOSEL_3)         /*!< HSE before stabilization selection as MCO1 source */
 /**
   * @}
@@ -419,7 +422,7 @@ typedef struct
 /**
     * @}
     */
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup RCC_LL_EC_PERIPH_FREQUENCY Peripheral clock frequency
@@ -454,7 +457,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* LPUART1 */
 
 /** @defgroup RCC_LL_EC_I2Cx_CLKSOURCE I2Cx CLKSOURCE
   * @{
@@ -466,7 +469,7 @@ typedef struct
 #define LL_RCC_I2C3_CLKSOURCE_PCLK1        (uint32_t)((RCC_CCIPR_I2C3SEL << 4) | (0x00000000U >> 4))         /*!< PCLK1 selected as I2C3 clock  */
 #define LL_RCC_I2C3_CLKSOURCE_SYSCLK       (uint32_t)((RCC_CCIPR_I2C3SEL << 4) | (RCC_CCIPR_I2C3SEL_0 >> 4)) /*!< SYSCLK selected as I2C3 clock */
 #define LL_RCC_I2C3_CLKSOURCE_HSI          (uint32_t)((RCC_CCIPR_I2C3SEL << 4) | (RCC_CCIPR_I2C3SEL_1 >> 4)) /*!< HSI selected as I2C3 clock    */
-#endif
+#endif /* I2C3 */
 /**
   * @}
   */
@@ -497,17 +500,17 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* SAI1 */
 
 /** @defgroup RCC_LL_EC_CLK48_CLKSOURCE CLK48 CLKSOURCE
   * @{
   */
 #if defined(RCC_HSI48_SUPPORT)
 #define LL_RCC_CLK48_CLKSOURCE_HSI48       0x00000000U           /*!< HSI48 selected as CLK48 clock   */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #if defined(SAI1)
 #define LL_RCC_CLK48_CLKSOURCE_PLLSAI1     RCC_CCIPR_CLK48SEL_0  /*!< PLLSAI1 selected as CLK48 clock */
-#endif
+#endif /* SAI1 */
 #define LL_RCC_CLK48_CLKSOURCE_PLL         RCC_CCIPR_CLK48SEL_1  /*!< PLL selected as CLK48 clock     */
 #define LL_RCC_CLK48_CLKSOURCE_MSI         RCC_CCIPR_CLK48SEL    /*!< MSI selected as CLK48 clock     */
 /**
@@ -519,10 +522,10 @@ typedef struct
   */
 #if defined(RCC_HSI48_SUPPORT)
 #define LL_RCC_USB_CLKSOURCE_HSI48         LL_RCC_CLK48_CLKSOURCE_HSI48    /*!< HSI48 selected as USB clock   */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 #if defined(SAI1)
 #define LL_RCC_USB_CLKSOURCE_PLLSAI1       LL_RCC_CLK48_CLKSOURCE_PLLSAI1  /*!< PLLSAI1 selected as USB clock */
-#endif
+#endif /* SAI1 */
 #define LL_RCC_USB_CLKSOURCE_PLL           LL_RCC_CLK48_CLKSOURCE_PLL      /*!< PLL selected as USB clock     */
 #define LL_RCC_USB_CLKSOURCE_MSI           LL_RCC_CLK48_CLKSOURCE_MSI      /*!< MSI selected as USB clock     */
 /**
@@ -535,7 +538,9 @@ typedef struct
 #define LL_RCC_ADC_CLKSOURCE_NONE             0x00000000U        /*!< no Clock used as ADC clock*/
 #if defined(STM32WB55xx) || defined (STM32WB5Mxx) || defined (STM32WB35xx)
 #define LL_RCC_ADC_CLKSOURCE_PLLSAI1          RCC_CCIPR_ADCSEL_0 /*!< PLLSAI1 selected as ADC clock*/
-#endif
+#elif defined (STM32WB15xx) || defined(STM32WB1Mxx)
+#define LL_RCC_ADC_CLKSOURCE_HSI              RCC_CCIPR_ADCSEL_0 /*!< HSI selected as ADC clock     */
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
 #define LL_RCC_ADC_CLKSOURCE_PLL              RCC_CCIPR_ADCSEL_1 /*!< PLL selected as ADC clock     */
 #define LL_RCC_ADC_CLKSOURCE_SYSCLK           RCC_CCIPR_ADCSEL   /*!< SYSCLK selected as ADC clock  */
 /**
@@ -569,7 +574,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* LPUART1 */
 
 /** @defgroup RCC_LL_EC_I2C1 I2C1
   * @{
@@ -597,7 +602,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* SAI1 */
 
 /** @defgroup RCC_LL_EC_CLK48 CLK48
   * @{
@@ -649,6 +654,9 @@ typedef struct
   */
 #define LL_RCC_RFWKP_CLKSOURCE_NONE          0x00000000U                 /*!< No clock used as RF Wakeup clock                             */
 #define LL_RCC_RFWKP_CLKSOURCE_LSE           RCC_CSR_RFWKPSEL_0          /*!< LSE oscillator clock used as RF Wakeup clock                 */
+#if defined(STM32WB15xx) || defined(STM32WB10xx)
+#define LL_RCC_RFWKP_CLKSOURCE_LSI           RCC_CSR_RFWKPSEL_1          /*!< LSI oscillator clock used as RF Wakeup clock                 */
+#endif /* STM32WB15xx || STM32WB10xx */
 #define LL_RCC_RFWKP_CLKSOURCE_HSE_DIV1024   RCC_CSR_RFWKPSEL            /*!< HSE oscillator clock divided by 1024 used as RF Wakeup clock */
 
 /**
@@ -815,7 +823,7 @@ typedef struct
 /**
   * @}
   */
-#endif
+#endif /* SAI1 */
 
 /**
   * @}
@@ -878,7 +886,7 @@ typedef struct
   * @retval PLL clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLCLK_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLR__) ((__INPUTFREQ__) * (__PLLN__)  / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
-                   (((__PLLR__) >> RCC_PLLCFGR_PLLR_Pos) + 1U))
+                                                                                (((__PLLR__) >> RCC_PLLCFGR_PLLR_Pos) + 1U))
 
 #if defined(SAI1)
 /**
@@ -930,8 +938,8 @@ typedef struct
   * @retval PLL clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLCLK_SAI_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__) ((__INPUTFREQ__) * (__PLLN__)  / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U))/ \
-                   (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
-#endif
+    (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
+#endif /* SAI1 */
 
 /**
   * @brief  Helper macro to calculate the PLLPCLK frequency used on ADC domain
@@ -983,7 +991,7 @@ typedef struct
   * @retval PLL clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLCLK_ADC_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLP__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
-                   (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
+    (((__PLLP__) >> RCC_PLLCFGR_PLLP_Pos) + 1U))
 
 
 /**
@@ -1012,7 +1020,7 @@ typedef struct
   * @retval PLL clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLCLK_48M_FREQ(__INPUTFREQ__, __PLLM__, __PLLN__, __PLLQ__) ((__INPUTFREQ__) * (__PLLN__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
-                   (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
+    (((__PLLQ__) >> RCC_PLLCFGR_PLLQ_Pos) + 1U))
 
 #if defined(SAI1)
 /**
@@ -1065,8 +1073,8 @@ typedef struct
   * @retval PLLSAI1 clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLSAI1_SAI_FREQ(__INPUTFREQ__, __PLLM__, __PLLSAI1N__, __PLLSAI1P__) \
-                   ((__INPUTFREQ__) * (__PLLSAI1N__)  / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
-                    (((__PLLSAI1P__) >> RCC_PLLSAI1CFGR_PLLP_Pos) + 1U))
+  ((__INPUTFREQ__) * (__PLLSAI1N__)  / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+   (((__PLLSAI1P__) >> RCC_PLLSAI1CFGR_PLLP_Pos) + 1U))
 
 /**
   * @brief  Helper macro to calculate the PLLSAI1QCLK frequency used on 48M domain
@@ -1094,8 +1102,8 @@ typedef struct
   * @retval PLLSAI1 clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLSAI1_48M_FREQ(__INPUTFREQ__, __PLLM__, __PLLSAI1N__, __PLLSAI1Q__) \
-                   ((__INPUTFREQ__) * (__PLLSAI1N__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
-                    (((__PLLSAI1Q__) >> RCC_PLLSAI1CFGR_PLLQ_Pos) + 1U))
+  ((__INPUTFREQ__) * (__PLLSAI1N__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+   (((__PLLSAI1Q__) >> RCC_PLLSAI1CFGR_PLLQ_Pos) + 1U))
 
 /**
   * @brief  Helper macro to calculate the PLLSAI1RCLK frequency used on ADC domain
@@ -1123,9 +1131,9 @@ typedef struct
   * @retval PLLSAI1 clock frequency (in Hz)
   */
 #define __LL_RCC_CALC_PLLSAI1_ADC_FREQ(__INPUTFREQ__, __PLLM__, __PLLSAI1N__, __PLLSAI1R__) \
-                   ((__INPUTFREQ__) * (__PLLSAI1N__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
-                    (((__PLLSAI1R__) >> RCC_PLLSAI1CFGR_PLLR_Pos) + 1U))
-#endif
+  ((__INPUTFREQ__) * (__PLLSAI1N__) / ((((__PLLM__)>> RCC_PLLCFGR_PLLM_Pos) + 1U)) / \
+   (((__PLLSAI1R__) >> RCC_PLLSAI1CFGR_PLLR_Pos) + 1U))
+#endif /* SAI1 */
 
 /**
   * @brief  Helper macro to calculate the HCLK1 frequency
@@ -1147,7 +1155,8 @@ typedef struct
   *         @arg @ref LL_RCC_SYSCLK_DIV_512
   * @retval HCLK1 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_HCLK1_FREQ(__SYSCLKFREQ__,__CPU1PRESCALER__) ((__SYSCLKFREQ__) / AHBPrescTable[((__CPU1PRESCALER__) & RCC_CFGR_HPRE) >>  RCC_CFGR_HPRE_Pos])
+#define __LL_RCC_CALC_HCLK1_FREQ(__SYSCLKFREQ__,__CPU1PRESCALER__) ((__SYSCLKFREQ__) / AHBPrescTable[((__CPU1PRESCALER__)\
+                                                                    & RCC_CFGR_HPRE) >>  RCC_CFGR_HPRE_Pos])
 
 /**
   * @brief  Helper macro to calculate the HCLK2 frequency
@@ -1169,7 +1178,8 @@ typedef struct
   *         @arg @ref LL_RCC_SYSCLK_DIV_512
   * @retval HCLK2 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_HCLK2_FREQ(__SYSCLKFREQ__, __CPU2PRESCALER__) ((__SYSCLKFREQ__) / AHBPrescTable[((__CPU2PRESCALER__) & RCC_EXTCFGR_C2HPRE) >>  RCC_EXTCFGR_C2HPRE_Pos])
+#define __LL_RCC_CALC_HCLK2_FREQ(__SYSCLKFREQ__, __CPU2PRESCALER__) ((__SYSCLKFREQ__) / AHBPrescTable[((__CPU2PRESCALER__)\
+                                                                     & RCC_EXTCFGR_C2HPRE) >>  RCC_EXTCFGR_C2HPRE_Pos])
 
 /**
   * @brief  Helper macro to calculate the HCLK4 frequency
@@ -1191,7 +1201,8 @@ typedef struct
   *         @arg @ref LL_RCC_SYSCLK_DIV_512
   * @retval HCLK4 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_HCLK4_FREQ(__SYSCLKFREQ__, __AHB4PRESCALER__) ((__SYSCLKFREQ__) / AHBPrescTable[(((__AHB4PRESCALER__) >> 4U) & RCC_EXTCFGR_SHDHPRE) >>  RCC_EXTCFGR_SHDHPRE_Pos])
+#define __LL_RCC_CALC_HCLK4_FREQ(__SYSCLKFREQ__, __AHB4PRESCALER__) ((__SYSCLKFREQ__) / AHBPrescTable[(((__AHB4PRESCALER__) >> 4U)\
+                                                                     & RCC_EXTCFGR_SHDHPRE) >>  RCC_EXTCFGR_SHDHPRE_Pos])
 
 
 /**
@@ -1205,7 +1216,8 @@ typedef struct
   *         @arg @ref LL_RCC_APB1_DIV_16
   * @retval PCLK1 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PCLK1_FREQ(__HCLKFREQ__, __APB1PRESCALER__) ((__HCLKFREQ__) >> (APBPrescTable[(((__APB1PRESCALER__) & RCC_CFGR_PPRE1_Msk) >>  RCC_CFGR_PPRE1_Pos)] & 31U))
+#define __LL_RCC_CALC_PCLK1_FREQ(__HCLKFREQ__, __APB1PRESCALER__) ((__HCLKFREQ__) >> (APBPrescTable[(((__APB1PRESCALER__)\
+                                                                   & RCC_CFGR_PPRE1_Msk) >>  RCC_CFGR_PPRE1_Pos)] & 31U))
 
 /**
   * @brief  Helper macro to calculate the PCLK2 frequency (ABP2)
@@ -1218,7 +1230,8 @@ typedef struct
   *         @arg @ref LL_RCC_APB2_DIV_16
   * @retval PCLK2 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PCLK2_FREQ(__HCLKFREQ__, __APB2PRESCALER__) ((__HCLKFREQ__) >> (APBPrescTable[(((__APB2PRESCALER__) & RCC_CFGR_PPRE2_Msk) >>  RCC_CFGR_PPRE2_Pos)] & 31U))
+#define __LL_RCC_CALC_PCLK2_FREQ(__HCLKFREQ__, __APB2PRESCALER__) ((__HCLKFREQ__) >> (APBPrescTable[(((__APB2PRESCALER__)\
+                                                                   & RCC_CFGR_PPRE2_Msk) >>  RCC_CFGR_PPRE2_Pos)] & 31U))
 
 /**
   * @brief  Helper macro to calculate the MSI frequency (in Hz)
@@ -1238,7 +1251,8 @@ typedef struct
   *         @arg @ref LL_RCC_MSIRANGE_11
   * @retval MSI clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_MSI_FREQ(__MSIRANGE__) MSIRangeTable[((__MSIRANGE__) & RCC_CR_MSIRANGE_Msk) >> RCC_CR_MSIRANGE_Pos]
+#define __LL_RCC_CALC_MSI_FREQ(__MSIRANGE__) MSIRangeTable[((__MSIRANGE__)\
+                                                            & RCC_CR_MSIRANGE_Msk) >> RCC_CR_MSIRANGE_Pos]
 /**
   * @}
   */
@@ -1595,7 +1609,7 @@ __STATIC_INLINE uint32_t LL_RCC_HSI48_GetCalibration(void)
 /**
   * @}
   */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 /** @defgroup RCC_LL_EF_LSE LSE
   * @{
@@ -2078,7 +2092,10 @@ __STATIC_INLINE uint32_t LL_RCC_GetRFClockSource(void)
   * @param  Source This parameter can be one of the following values:
   *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_NONE
   *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_LSE
+  *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_LSI (*)
   *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_HSE_DIV1024
+  * @note   (*) Value not defined for all devices
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_RCC_SetRFWKPClockSource(uint32_t Source)
@@ -2092,7 +2109,10 @@ __STATIC_INLINE void LL_RCC_SetRFWKPClockSource(uint32_t Source)
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_NONE
   *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_LSE
+  *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_LSI (*)
   *         @arg @ref LL_RCC_RFWKP_CLKSOURCE_HSE_DIV1024
+  * @note   (*) Value not defined for all devices
+  *
   */
 __STATIC_INLINE uint32_t LL_RCC_GetRFWKPClockSource(void)
 {
@@ -2430,7 +2450,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetSMPSPrescaler(void)
 /**
   * @}
   */
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 /** @defgroup RCC_LL_EF_MCO MCO
   * @{
@@ -2504,7 +2524,7 @@ __STATIC_INLINE void LL_RCC_SetLPUARTClockSource(uint32_t LPUARTxSource)
 {
   MODIFY_REG(RCC->CCIPR, RCC_CCIPR_LPUART1SEL, LPUARTxSource);
 }
-#endif
+#endif /* LPUART1 */
 
 /**
   * @brief  Configure I2Cx clock source
@@ -2558,7 +2578,7 @@ __STATIC_INLINE void LL_RCC_SetSAIClockSource(uint32_t SAIxSource)
 {
   MODIFY_REG(RCC->CCIPR, RCC_CCIPR_SAI1SEL, SAIxSource);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Configure RNG clock source
@@ -2606,7 +2626,7 @@ __STATIC_INLINE void LL_RCC_SetUSBClockSource(uint32_t USBxSource)
 {
   LL_RCC_SetCLK48ClockSource(USBxSource);
 }
-#endif
+#endif /* USB */
 
 /**
   * @brief  Configure RNG clock source
@@ -2686,7 +2706,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetLPUARTClockSource(uint32_t LPUARTx)
 {
   return (uint32_t)(READ_BIT(RCC->CCIPR, LPUARTx));
 }
-#endif
+#endif /* LPUART1 */
 
 /**
   * @brief  Get I2Cx clock source
@@ -2745,7 +2765,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetSAIClockSource(uint32_t SAIx)
 {
   return (uint32_t)(READ_BIT(RCC->CCIPR, SAIx));
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Get RNGx clock source
@@ -2795,7 +2815,7 @@ __STATIC_INLINE uint32_t LL_RCC_GetUSBClockSource(uint32_t USBx)
 {
   return LL_RCC_GetCLK48ClockSource(USBx);
 }
-#endif
+#endif /* USB */
 
 /**
   * @brief  Get ADCx clock source
@@ -3046,7 +3066,7 @@ __STATIC_INLINE void LL_RCC_PLL_ConfigDomain_SAI(uint32_t Source, uint32_t PLLM,
   MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLM | RCC_PLLCFGR_PLLN | RCC_PLLCFGR_PLLP,
              Source | PLLM | (PLLN << RCC_PLLCFGR_PLLN_Pos) | PLLP);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Configure PLL used for ADC domain clock
@@ -3281,7 +3301,17 @@ __STATIC_INLINE void LL_RCC_PLL_DisableDomain_SAI(void)
 {
   CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN);
 }
-#endif
+#endif /* SAI1 */
+
+/**
+  * @brief  Check if PLL output mapped on SAI domain clock is enabled
+  * @rmtoll PLLCFGR      PLLPEN        LL_RCC_PLL_IsEnabledDomain_SAI
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLL_IsEnabledDomain_SAI(void)
+{
+  return ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN) == (RCC_PLLCFGR_PLLPEN)) ? 1UL : 0UL);
+}
 
 /**
   * @brief  Enable PLL output mapped on ADC domain clock
@@ -3305,6 +3335,15 @@ __STATIC_INLINE void LL_RCC_PLL_DisableDomain_ADC(void)
   CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN);
 }
 
+/**
+  * @brief  Check if PLL output mapped on ADC domain clock is enabled
+  * @rmtoll PLLCFGR      PLLPEN        LL_RCC_PLL_IsEnabledDomain_ADC
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLL_IsEnabledDomain_ADC(void)
+{
+  return ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN) == (RCC_PLLCFGR_PLLPEN)) ? 1UL : 0UL);
+}
 
 /**
   * @brief  Enable PLL output mapped on 48MHz domain clock
@@ -3329,6 +3368,16 @@ __STATIC_INLINE void LL_RCC_PLL_DisableDomain_48M(void)
 }
 
 /**
+  * @brief  Check if PLL output mapped on 48MHz domain clock is enabled
+  * @rmtoll PLLCFGR      PLLQEN        LL_RCC_PLL_IsEnabledDomain_48M
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLL_IsEnabledDomain_48M(void)
+{
+  return ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN) == (RCC_PLLCFGR_PLLQEN)) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Enable PLL output mapped on SYSCLK domain
   * @rmtoll PLLCFGR      PLLREN        LL_RCC_PLL_EnableDomain_SYS
   * @retval None
@@ -3349,6 +3398,16 @@ __STATIC_INLINE void LL_RCC_PLL_EnableDomain_SYS(void)
 __STATIC_INLINE void LL_RCC_PLL_DisableDomain_SYS(void)
 {
   CLEAR_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLREN);
+}
+
+/**
+  * @brief  Check if PLL output mapped on SYSCLK domain clock is enabled
+  * @rmtoll PLLCFGR      RCC_PLLCFGR_PLLREN        LL_RCC_PLL_LL_RCC_PLL_IsEnabledDomain_SYSIsEnabledDomain_SYS
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLL_IsEnabledDomain_SYS(void)
+{
+  return ((READ_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLREN) == (RCC_PLLCFGR_PLLREN)) ? 1UL : 0UL);
 }
 
 /**
@@ -3650,6 +3709,16 @@ __STATIC_INLINE void LL_RCC_PLLSAI1_DisableDomain_SAI(void)
 }
 
 /**
+  * @brief  Check if PLLSAI1 output mapped on SAI domain clock is enabled
+  * @rmtoll PLLSAI1CFGR  PLLPEN        LL_RCC_PLLSAI1_IsEnabledDomain_SAI
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLLSAI1_IsEnabledDomain_SAI(void)
+{
+  return ((READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLPEN) == (RCC_PLLSAI1CFGR_PLLPEN)) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Enable PLLSAI1 output mapped on 48MHz domain clock
   * @rmtoll PLLSAI1CFGR  PLLQEN    LL_RCC_PLLSAI1_EnableDomain_48M
   * @retval None
@@ -3669,6 +3738,16 @@ __STATIC_INLINE void LL_RCC_PLLSAI1_EnableDomain_48M(void)
 __STATIC_INLINE void LL_RCC_PLLSAI1_DisableDomain_48M(void)
 {
   CLEAR_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLQEN);
+}
+
+/**
+  * @brief  Check if PLLSAI1 output mapped on 48MHz domain clock is enabled
+  * @rmtoll PLLSAI1CFGR  PLLQEN        LL_RCC_PLLSAI1_IsEnabledDomain_48M
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLLSAI1_IsEnabledDomain_48M(void)
+{
+  return ((READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLQEN) == (RCC_PLLSAI1CFGR_PLLQEN)) ? 1UL : 0UL);
 }
 
 /**
@@ -3692,7 +3771,17 @@ __STATIC_INLINE void LL_RCC_PLLSAI1_DisableDomain_ADC(void)
 {
   CLEAR_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLREN);
 }
-#endif
+
+/**
+  * @brief  Check if PLLSAI1 output mapped on ADC domain clock is enabled
+  * @rmtoll PLLSAI1CFGR  PLLREN        LL_RCC_PLLSAI1_IsEnabledDomain_ADC
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RCC_PLLSAI1_IsEnabledDomain_ADC(void)
+{
+  return ((READ_BIT(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLREN) == (RCC_PLLSAI1CFGR_PLLREN)) ? 1UL : 0UL);
+}
+#endif /* SAI1 */
 
 /**
   * @}
@@ -3812,7 +3901,7 @@ __STATIC_INLINE void LL_RCC_ClearFlag_HSI48RDY(void)
 {
   SET_BIT(RCC->CICR, RCC_CICR_HSI48RDYC);
 }
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #if defined(SAI1)
 /**
@@ -3824,7 +3913,7 @@ __STATIC_INLINE void LL_RCC_ClearFlag_PLLSAI1RDY(void)
 {
   SET_BIT(RCC->CICR, RCC_CICR_PLLSAI1RDYC);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Clear Clock security system interrupt flag
@@ -3926,7 +4015,7 @@ __STATIC_INLINE uint32_t LL_RCC_IsActiveFlag_HSI48RDY(void)
 {
   return ((READ_BIT(RCC->CIFR, RCC_CIFR_HSI48RDYF) == (RCC_CIFR_HSI48RDYF)) ? 1UL : 0UL);
 }
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #if defined(SAI1)
 /**
@@ -3938,7 +4027,7 @@ __STATIC_INLINE uint32_t LL_RCC_IsActiveFlag_PLLSAI1RDY(void)
 {
   return ((READ_BIT(RCC->CIFR, RCC_CIFR_PLLSAI1RDYF) == (RCC_CIFR_PLLSAI1RDYF)) ? 1UL : 0UL);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Check if Clock security system interrupt occurred or not
@@ -4178,7 +4267,7 @@ __STATIC_INLINE void LL_RCC_EnableIT_HSI48RDY(void)
 {
   SET_BIT(RCC->CIER, RCC_CIER_HSI48RDYIE);
 }
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #if defined(SAI1)
 /**
@@ -4190,7 +4279,7 @@ __STATIC_INLINE void LL_RCC_EnableIT_PLLSAI1RDY(void)
 {
   SET_BIT(RCC->CIER, RCC_CIER_PLLSAI1RDYIE);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Enable LSE clock security system interrupt
@@ -4281,7 +4370,7 @@ __STATIC_INLINE void LL_RCC_DisableIT_HSI48RDY(void)
 {
   CLEAR_BIT(RCC->CIER, RCC_CIER_HSI48RDYIE);
 }
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #if defined(SAI1)
 /**
@@ -4293,7 +4382,7 @@ __STATIC_INLINE void LL_RCC_DisableIT_PLLSAI1RDY(void)
 {
   CLEAR_BIT(RCC->CIER, RCC_CIER_PLLSAI1RDYIE);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Disable LSE clock security system interrupt
@@ -4384,7 +4473,7 @@ __STATIC_INLINE uint32_t LL_RCC_IsEnabledIT_HSI48RDY(void)
 {
   return ((READ_BIT(RCC->CIER, RCC_CIER_HSI48RDYIE) == (RCC_CIER_HSI48RDYIE)) ? 1UL : 0UL);
 }
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
 #if defined(SAI1)
 /**
@@ -4396,7 +4485,7 @@ __STATIC_INLINE uint32_t LL_RCC_IsEnabledIT_PLLSAI1RDY(void)
 {
   return ((READ_BIT(RCC->CIER, RCC_CIER_PLLSAI1RDYIE) == (RCC_CIER_PLLSAI1RDYIE)) ? 1UL : 0UL);
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Checks if LSECSS interrupt source is enabled or disabled.
@@ -4427,21 +4516,21 @@ ErrorStatus LL_RCC_DeInit(void);
 void        LL_RCC_GetSystemClocksFreq(LL_RCC_ClocksTypeDef *RCC_Clocks);
 #if defined(RCC_SMPS_SUPPORT)
 uint32_t    LL_RCC_GetSMPSClockFreq(void);
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 uint32_t    LL_RCC_GetUSARTClockFreq(uint32_t USARTxSource);
 uint32_t    LL_RCC_GetI2CClockFreq(uint32_t I2CxSource);
 #if defined(LPUART1)
 uint32_t    LL_RCC_GetLPUARTClockFreq(uint32_t LPUARTxSource);
-#endif
+#endif /* LPUART1 */
 uint32_t    LL_RCC_GetLPTIMClockFreq(uint32_t LPTIMxSource);
 #if defined(SAI1)
 uint32_t    LL_RCC_GetSAIClockFreq(uint32_t SAIxSource);
-#endif
+#endif /* SAI1 */
 uint32_t    LL_RCC_GetCLK48ClockFreq(uint32_t CLK48xSource);
 uint32_t    LL_RCC_GetRNGClockFreq(uint32_t RNGxSource);
 #if defined(USB)
 uint32_t    LL_RCC_GetUSBClockFreq(uint32_t USBxSource);
-#endif
+#endif /* USB */
 uint32_t    LL_RCC_GetADCClockFreq(uint32_t ADCxSource);
 uint32_t    LL_RCC_GetRTCClockFreq(void);
 uint32_t    LL_RCC_GetRFWKPClockFreq(void);
@@ -4458,7 +4547,7 @@ uint32_t    LL_RCC_GetRFWKPClockFreq(void);
   * @}
   */
 
-#endif /* defined(RCC) */
+#endif /* RCC */
 
 /**
   * @}
@@ -4469,5 +4558,3 @@ uint32_t    LL_RCC_GetRFWKPClockFreq(void);
 #endif
 
 #endif /* STM32WBxx_LL_RCC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_rng.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_rng.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -39,6 +38,7 @@ extern "C" {
   */
 
 /* Private types -------------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
 /* Private macros ------------------------------------------------------------*/
@@ -57,8 +57,8 @@ typedef struct
 {
   uint32_t         ClockErrorDetection; /*!< Clock error detection.
                                       This parameter can be one value of @ref RNG_LL_CED.
-
-                                      This parameter can be modified using unitary functions @ref LL_RNG_EnableClkErrorDetect(). */
+                                      This parameter can be modified using unitary
+                                      functions @ref LL_RNG_EnableClkErrorDetect(). */
 } LL_RNG_InitTypeDef;
 
 /**
@@ -175,7 +175,7 @@ __STATIC_INLINE void LL_RNG_Disable(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsEnabled(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsEnabled(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->CR, RNG_CR_RNGEN) == (RNG_CR_RNGEN)) ? 1UL : 0UL);
 }
@@ -208,7 +208,7 @@ __STATIC_INLINE void LL_RNG_DisableClkErrorDetect(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsEnabledClkErrorDetect(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsEnabledClkErrorDetect(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->CR, RNG_CR_CED) != (RNG_CR_CED)) ? 1UL : 0UL);
 }
@@ -227,7 +227,7 @@ __STATIC_INLINE uint32_t LL_RNG_IsEnabledClkErrorDetect(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_DRDY(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_DRDY(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->SR, RNG_SR_DRDY) == (RNG_SR_DRDY)) ? 1UL : 0UL);
 }
@@ -238,7 +238,7 @@ __STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_DRDY(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_CECS(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_CECS(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->SR, RNG_SR_CECS) == (RNG_SR_CECS)) ? 1UL : 0UL);
 }
@@ -249,7 +249,7 @@ __STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_CECS(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_SECS(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_SECS(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->SR, RNG_SR_SECS) == (RNG_SR_SECS)) ? 1UL : 0UL);
 }
@@ -260,7 +260,7 @@ __STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_SECS(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_CEIS(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_CEIS(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->SR, RNG_SR_CEIS) == (RNG_SR_CEIS)) ? 1UL : 0UL);
 }
@@ -271,7 +271,7 @@ __STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_CEIS(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_SEIS(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsActiveFlag_SEIS(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->SR, RNG_SR_SEIS) == (RNG_SR_SEIS)) ? 1UL : 0UL);
 }
@@ -337,7 +337,7 @@ __STATIC_INLINE void LL_RNG_DisableIT(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_RNG_IsEnabledIT(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_IsEnabledIT(const RNG_TypeDef *RNGx)
 {
   return ((READ_BIT(RNGx->CR, RNG_CR_IE) == (RNG_CR_IE)) ? 1UL : 0UL);
 }
@@ -356,7 +356,7 @@ __STATIC_INLINE uint32_t LL_RNG_IsEnabledIT(RNG_TypeDef *RNGx)
   * @param  RNGx RNG Instance
   * @retval Generated 32-bit random value
   */
-__STATIC_INLINE uint32_t LL_RNG_ReadRandData32(RNG_TypeDef *RNGx)
+__STATIC_INLINE uint32_t LL_RNG_ReadRandData32(const RNG_TypeDef *RNGx)
 {
   return (uint32_t)(READ_REG(RNGx->DR));
 }
@@ -369,9 +369,9 @@ __STATIC_INLINE uint32_t LL_RNG_ReadRandData32(RNG_TypeDef *RNGx)
 /** @defgroup RNG_LL_EF_Init Initialization and de-initialization functions
   * @{
   */
-ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, LL_RNG_InitTypeDef *RNG_InitStruct);
+ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, const LL_RNG_InitTypeDef *RNG_InitStruct);
 void LL_RNG_StructInit(LL_RNG_InitTypeDef *RNG_InitStruct);
-ErrorStatus LL_RNG_DeInit(RNG_TypeDef *RNGx);
+ErrorStatus LL_RNG_DeInit(const RNG_TypeDef *RNGx);
 
 /**
   * @}
@@ -398,4 +398,3 @@ ErrorStatus LL_RNG_DeInit(RNG_TypeDef *RNGx);
 
 #endif /* __STM32WBxx_LL_RNG_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_rtc.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_rtc.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -44,6 +43,9 @@ extern "C" {
 /** @defgroup RTC_LL_Private_Constants RTC Private Constants
   * @{
   */
+/* Masks Definition */
+#define RTC_INIT_MASK                 0xFFFFFFFFU
+#define RTC_RSF_MASK                  ((uint32_t)~(RTC_ISR_INIT | RTC_ISR_RSF))
 
 /* Write protection defines */
 #define RTC_WRITE_PROTECTION_DISABLE  ((uint8_t)0xFFU)
@@ -51,11 +53,11 @@ extern "C" {
 #define RTC_WRITE_PROTECTION_ENABLE_2 ((uint8_t)0x53U)
 
 /* Defines used to combine date & time */
-#define RTC_OFFSET_WEEKDAY            (uint32_t)24U
-#define RTC_OFFSET_DAY                (uint32_t)16U
-#define RTC_OFFSET_MONTH              (uint32_t)8U
-#define RTC_OFFSET_HOUR               (uint32_t)16U
-#define RTC_OFFSET_MINUTE             (uint32_t)8U
+#define RTC_OFFSET_WEEKDAY            24U
+#define RTC_OFFSET_DAY                16U
+#define RTC_OFFSET_MONTH              8U
+#define RTC_OFFSET_HOUR               16U
+#define RTC_OFFSET_MINUTE             8U
 
 /**
   * @}
@@ -165,7 +167,7 @@ typedef struct
                                       This parameter can be a value of @ref RTC_LL_EC_ALMA_MASK for ALARM A or @ref RTC_LL_EC_ALMB_MASK for ALARM B.
 
                                       This feature can be modified afterwards using unitary function @ref LL_RTC_ALMA_SetMask() for ALARM A
-                                      or @ref LL_RTC_ALMB_SetMask() for ALARM B
+                                      or @ref LL_RTC_ALMB_SetMask() for ALARM B.
                                  */
 
   uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on day or WeekDay.
@@ -202,8 +204,8 @@ typedef struct
 /** @defgroup RTC_LL_EC_FORMAT FORMAT
   * @{
   */
-#define LL_RTC_FORMAT_BIN                  0x000000000U /*!< Binary data format */
-#define LL_RTC_FORMAT_BCD                  0x000000001U /*!< BCD data format */
+#define LL_RTC_FORMAT_BIN                  0x00000000U /*!< Binary data format */
+#define LL_RTC_FORMAT_BCD                  0x00000001U /*!< BCD data format */
 /**
   * @}
   */
@@ -236,13 +238,11 @@ typedef struct
 #define LL_RTC_ISR_RECALPF                 RTC_ISR_RECALPF
 #if defined(RTC_TAMPER3_SUPPORT)
 #define LL_RTC_ISR_TAMP3F                  RTC_ISR_TAMP3F
-#endif
-#if defined(RTC_TAMPER2_SUPPORT)
+#endif /* RTC_TAMPER3_SUPPORT */
 #define LL_RTC_ISR_TAMP2F                  RTC_ISR_TAMP2F
-#endif
 #if defined(RTC_TAMPER1_SUPPORT)
 #define LL_RTC_ISR_TAMP1F                  RTC_ISR_TAMP1F
-#endif
+#endif /* RTC_TAMPER1_SUPPORT */
 #define LL_RTC_ISR_TSOVF                   RTC_ISR_TSOVF
 #define LL_RTC_ISR_TSF                     RTC_ISR_TSF
 #define LL_RTC_ISR_WUTF                    RTC_ISR_WUTF
@@ -269,13 +269,11 @@ typedef struct
 #define LL_RTC_CR_ALRAIE                   RTC_CR_ALRAIE
 #if defined(RTC_TAMPER3_SUPPORT)
 #define LL_RTC_TAMPCR_TAMP3IE              RTC_TAMPCR_TAMP3IE
-#endif
-#if defined(RTC_TAMPER2_SUPPORT)
+#endif /* RTC_TAMPER3_SUPPORT */
 #define LL_RTC_TAMPCR_TAMP2IE              RTC_TAMPCR_TAMP2IE
-#endif
 #if defined(RTC_TAMPER1_SUPPORT)
 #define LL_RTC_TAMPCR_TAMP1IE              RTC_TAMPCR_TAMP1IE
-#endif
+#endif /* RTC_TAMPER1_SUPPORT */
 #define LL_RTC_TAMPCR_TAMPIE               RTC_TAMPCR_TAMPIE
 /**
   * @}
@@ -338,7 +336,9 @@ typedef struct
   * @{
   */
 #define LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN  0x00000000U                          /*!< RTC_ALARM, when mapped on PC13, is open-drain output */
+#if defined(RTC_OR_ALARMOUTTYPE)
 #define LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL   RTC_OR_ALARMOUTTYPE /*!< RTC_ALARM, when mapped on PC13, is push-pull output */
+#endif /* RTC_OR_ALARMOUTTYPE */
 /**
   * @}
   */
@@ -395,11 +395,11 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMB_MASK  ALARMB MASK
   * @{
   */
-#define LL_RTC_ALMB_MASK_NONE              0x00000000U             /*!< No masks applied on Alarm B*/
+#define LL_RTC_ALMB_MASK_NONE              0x00000000U             /*!< No masks applied on Alarm B                */
 #define LL_RTC_ALMB_MASK_DATEWEEKDAY       RTC_ALRMBR_MSK4         /*!< Date/day do not care in Alarm B comparison */
-#define LL_RTC_ALMB_MASK_HOURS             RTC_ALRMBR_MSK3         /*!< Hours do not care in Alarm B comparison */
-#define LL_RTC_ALMB_MASK_MINUTES           RTC_ALRMBR_MSK2         /*!< Minutes do not care in Alarm B comparison */
-#define LL_RTC_ALMB_MASK_SECONDS           RTC_ALRMBR_MSK1         /*!< Seconds do not care in Alarm B comparison */
+#define LL_RTC_ALMB_MASK_HOURS             RTC_ALRMBR_MSK3         /*!< Hours do not care in Alarm B comparison    */
+#define LL_RTC_ALMB_MASK_MINUTES           RTC_ALRMBR_MSK2         /*!< Minutes do not care in Alarm B comparison  */
+#define LL_RTC_ALMB_MASK_SECONDS           RTC_ALRMBR_MSK1         /*!< Seconds do not care in Alarm B comparison  */
 #define LL_RTC_ALMB_MASK_ALL               (RTC_ALRMBR_MSK4 | RTC_ALRMBR_MSK3 | RTC_ALRMBR_MSK2 | RTC_ALRMBR_MSK1) /*!< Masks all */
 /**
   * @}
@@ -417,8 +417,8 @@ typedef struct
 /** @defgroup RTC_LL_EC_TIMESTAMP_EDGE  TIMESTAMP EDGE
   * @{
   */
-#define LL_RTC_TIMESTAMP_EDGE_RISING       0x00000000U           /*!< RTC_TS input rising edge generates a time-stamp event */
-#define LL_RTC_TIMESTAMP_EDGE_FALLING      RTC_CR_TSEDGE         /*!< RTC_TS input falling edge generates a time-stamp even */
+#define LL_RTC_TIMESTAMP_EDGE_RISING       0x00000000U           /*!< RTC_TS input rising edge generates a time-stamp event  */
+#define LL_RTC_TIMESTAMP_EDGE_FALLING      RTC_CR_TSEDGE         /*!< RTC_TS input falling edge generates a time-stamp event */
 /**
   * @}
   */
@@ -438,11 +438,7 @@ typedef struct
 #if defined(RTC_TAMPER1_SUPPORT)
 #define LL_RTC_TAMPER_1                    RTC_TAMPCR_TAMP1E /*!< RTC_TAMP1 input detection */
 #endif /* RTC_TAMPER1_SUPPORT */
-#if defined(RTC_TAMPER2_SUPPORT)
-#if defined(RTC_TAMPER2_SUPPORT)
 #define LL_RTC_TAMPER_2                    RTC_TAMPCR_TAMP2E /*!< RTC_TAMP2 input detection */
-#endif
-#endif /* RTC_TAMPER2_SUPPORT */
 #if defined(RTC_TAMPER3_SUPPORT)
 #define LL_RTC_TAMPER_3                    RTC_TAMPCR_TAMP3E /*!< RTC_TAMP3 input detection */
 #endif /* RTC_TAMPER3_SUPPORT */
@@ -456,9 +452,7 @@ typedef struct
 #if defined(RTC_TAMPER1_SUPPORT)
 #define LL_RTC_TAMPER_MASK_TAMPER1         RTC_TAMPCR_TAMP1MF /*!< Tamper 1 event generates a trigger event. TAMP1F is masked and internally cleared by hardware.The backup registers are not erased */
 #endif /* RTC_TAMPER1_SUPPORT */
-#if defined(RTC_TAMPER2_SUPPORT)
 #define LL_RTC_TAMPER_MASK_TAMPER2         RTC_TAMPCR_TAMP2MF /*!< Tamper 2 event generates a trigger event. TAMP2F is masked and internally cleared by hardware. The backup registers are not erased. */
-#endif /* RTC_TAMPER2_SUPPORT */
 #if defined(RTC_TAMPER3_SUPPORT)
 #define LL_RTC_TAMPER_MASK_TAMPER3         RTC_TAMPCR_TAMP3MF /*!< Tamper 3 event generates a trigger event. TAMP3F is masked and internally cleared by hardware. The backup registers are not erased */
 #endif /* RTC_TAMPER3_SUPPORT */
@@ -472,9 +466,7 @@ typedef struct
 #if defined(RTC_TAMPER1_SUPPORT)
 #define LL_RTC_TAMPER_NOERASE_TAMPER1      RTC_TAMPCR_TAMP1NOERASE /*!< Tamper 1 event does not erase the backup registers. */
 #endif /* RTC_TAMPER1_SUPPORT */
-#if defined(RTC_TAMPER2_SUPPORT)
 #define LL_RTC_TAMPER_NOERASE_TAMPER2      RTC_TAMPCR_TAMP2NOERASE /*!< Tamper 2 event does not erase the backup registers. */
-#endif /* RTC_TAMPER2_SUPPORT */
 #if defined(RTC_TAMPER3_SUPPORT)
 #define LL_RTC_TAMPER_NOERASE_TAMPER3      RTC_TAMPCR_TAMP3NOERASE /*!< Tamper 3 event does not erase the backup registers. */
 #endif /* RTC_TAMPER3_SUPPORT */
@@ -482,7 +474,6 @@ typedef struct
   * @}
   */
 
-#if defined(RTC_TAMPCR_TAMPPRCH)
 /** @defgroup RTC_LL_EC_TAMPER_DURATION  TAMPER DURATION
   * @{
   */
@@ -493,9 +484,7 @@ typedef struct
 /**
   * @}
   */
-#endif /* RTC_TAMPCR_TAMPPRCH */
 
-#if defined(RTC_TAMPCR_TAMPFLT)
 /** @defgroup RTC_LL_EC_TAMPER_FILTER  TAMPER FILTER
   * @{
   */
@@ -506,9 +495,7 @@ typedef struct
 /**
   * @}
   */
-#endif /* RTC_TAMPCR_TAMPFLT */
 
-#if defined(RTC_TAMPCR_TAMPFREQ)
 /** @defgroup RTC_LL_EC_TAMPER_SAMPLFREQDIV  TAMPER SAMPLING FREQUENCY DIVIDER
   * @{
   */
@@ -523,19 +510,16 @@ typedef struct
 /**
   * @}
   */
-#endif /* RTC_TAMPCR_TAMPFREQ */
 
 /** @defgroup RTC_LL_EC_TAMPER_ACTIVELEVEL  TAMPER ACTIVE LEVEL
   * @{
   */
 #if defined(RTC_TAMPER1_SUPPORT)
-#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP1    RTC_TAMPCR_TAMP1TRG /*!< RTC_TAMP1 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event*/
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP1    RTC_TAMPCR_TAMP1TRG /*!< RTC_TAMP1 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
 #endif /* RTC_TAMPER1_SUPPORT */
-#if defined(RTC_TAMPER2_SUPPORT)
-#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP2    RTC_TAMPCR_TAMP2TRG /*!< RTC_TAMP2 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event*/
-#endif /* RTC_TAMPER2_SUPPORT */
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP2    RTC_TAMPCR_TAMP2TRG /*!< RTC_TAMP2 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
 #if defined(RTC_TAMPER3_SUPPORT)
-#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP3    RTC_TAMPCR_TAMP3TRG /*!< RTC_TAMP3 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event*/
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP3    RTC_TAMPCR_TAMP3TRG /*!< RTC_TAMP3 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
 #endif /* RTC_TAMPER3_SUPPORT */
 /**
   * @}
@@ -554,7 +538,6 @@ typedef struct
   * @}
   */
 
-#if defined(RTC_BACKUP_SUPPORT)
 /** @defgroup RTC_LL_EC_BKP  BACKUP
   * @{
   */
@@ -563,7 +546,6 @@ typedef struct
 #define LL_RTC_BKP_DR2                     0x00000002U
 #define LL_RTC_BKP_DR3                     0x00000003U
 #define LL_RTC_BKP_DR4                     0x00000004U
-#if RTC_BKP_NUMBER > 5
 #define LL_RTC_BKP_DR5                     0x00000005U
 #define LL_RTC_BKP_DR6                     0x00000006U
 #define LL_RTC_BKP_DR7                     0x00000007U
@@ -575,25 +557,20 @@ typedef struct
 #define LL_RTC_BKP_DR13                    0x0000000DU
 #define LL_RTC_BKP_DR14                    0x0000000EU
 #define LL_RTC_BKP_DR15                    0x0000000FU
-#endif /* RTC_BKP_NUMBER > 5 */
-
-#if RTC_BKP_NUMBER > 16
 #define LL_RTC_BKP_DR16                    0x00000010U
 #define LL_RTC_BKP_DR17                    0x00000011U
 #define LL_RTC_BKP_DR18                    0x00000012U
 #define LL_RTC_BKP_DR19                    0x00000013U
-#endif /* RTC_BKP_NUMBER > 16 */
 /**
   * @}
   */
-#endif /* RTC_BACKUP_SUPPORT */
 
 /** @defgroup RTC_LL_EC_CALIB_OUTPUT  Calibration output
   * @{
   */
 #define LL_RTC_CALIB_OUTPUT_NONE           0x00000000U                 /*!< Calibration output disabled */
-#define LL_RTC_CALIB_OUTPUT_1HZ            (RTC_CR_COE | RTC_CR_COSEL) /*!< Calibration output is 512 Hz */
-#define LL_RTC_CALIB_OUTPUT_512HZ          (RTC_CR_COE)                /*!< Calibration output is 1 Hz */
+#define LL_RTC_CALIB_OUTPUT_1HZ            (RTC_CR_COE | RTC_CR_COSEL) /*!< Calibration output is 1 Hz */
+#define LL_RTC_CALIB_OUTPUT_512HZ          (RTC_CR_COE)                /*!< Calibration output is 512 Hz */
 /**
   * @}
   */
@@ -666,7 +643,7 @@ typedef struct
   * @param  __VALUE__ BCD value to be converted
   * @retval Converted byte
   */
-#define __LL_RTC_CONVERT_BCD2BIN(__VALUE__) (uint8_t)((((uint8_t)((__VALUE__) & (uint8_t)0xF0U) >> (uint8_t)0x4U) * 10U ) + ((__VALUE__) & (uint8_t)0x0FU))
+#define __LL_RTC_CONVERT_BCD2BIN(__VALUE__) (uint8_t)(((uint8_t)((__VALUE__) & (uint8_t)0xF0U) >> (uint8_t)0x4U) * 10U + ((__VALUE__) & (uint8_t)0x0FU))
 
 /**
   * @}
@@ -830,6 +807,7 @@ __STATIC_INLINE uint32_t LL_RTC_GetAlarmOutEvent(RTC_TypeDef *RTCx)
   return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_OSEL));
 }
 
+#if defined(RTC_OR_ALARMOUTTYPE)
 /**
   * @brief  Set RTC_ALARM output type (ALARM in push-pull or open-drain output)
   * @note   Used only when RTC_ALARM is mapped on PC13
@@ -837,7 +815,9 @@ __STATIC_INLINE uint32_t LL_RTC_GetAlarmOutEvent(RTC_TypeDef *RTCx)
   * @param  RTCx RTC Instance
   * @param  Output This parameter can be one of the following values:
   *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN
-  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL
+  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL (*)
+  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_SetAlarmOutputType(RTC_TypeDef *RTCx, uint32_t Output)
@@ -852,12 +832,15 @@ __STATIC_INLINE void LL_RTC_SetAlarmOutputType(RTC_TypeDef *RTCx, uint32_t Outpu
   * @param  RTCx RTC Instance
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN
-  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL
+  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL (*)
+  *
+  *         (*) value not applicable to all devices.
   */
 __STATIC_INLINE uint32_t LL_RTC_GetAlarmOutputType(RTC_TypeDef *RTCx)
 {
   return (uint32_t)(READ_BIT(RTCx->OR, RTC_OR_ALARMOUTTYPE));
 }
+#endif /* RTC_OR_ALARMOUTTYPE */
 
 /**
   * @brief  Enable initialization mode
@@ -871,7 +854,7 @@ __STATIC_INLINE uint32_t LL_RTC_GetAlarmOutputType(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_EnableInitMode(RTC_TypeDef *RTCx)
 {
   /* Set the Initialization mode */
-  WRITE_REG(RTCx->ISR, 0xFFFFFFFFU);
+  WRITE_REG(RTCx->ISR, RTC_INIT_MASK);
 }
 
 /**
@@ -1091,7 +1074,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetFormat(RTC_TypeDef *RTCx, uint32_t TimeForma
 
 /**
   * @brief  Get time format (AM or PM notation)
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1125,7 +1108,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
 
 /**
   * @brief  Get Hours in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1138,10 +1121,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_GetHour(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU));
-  return (uint32_t)((((temp & RTC_TR_HT) >> RTC_TR_HT_Pos) << 4U) | ((temp & RTC_TR_HU) >> RTC_TR_HU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU))) >> RTC_TR_HU_Pos);
 }
 
 /**
@@ -1163,7 +1143,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
 
 /**
   * @brief  Get Minutes in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1176,10 +1156,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_GetMinute(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->TR, (RTC_TR_MNT | RTC_TR_MNU));
-  return (uint32_t)((((temp & RTC_TR_MNT) >> RTC_TR_MNT_Pos) << 4U) | ((temp & RTC_TR_MNU) >> RTC_TR_MNU_Pos));
+  return (uint32_t)(READ_BIT(RTCx->TR, (RTC_TR_MNT | RTC_TR_MNU)) >> RTC_TR_MNU_Pos);
 }
 
 /**
@@ -1201,7 +1178,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
 
 /**
   * @brief  Get Seconds in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1214,10 +1191,7 @@ __STATIC_INLINE void LL_RTC_TIME_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_GetSecond(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->TR, (RTC_TR_ST | RTC_TR_SU));
-  return (uint32_t)((((temp & RTC_TR_ST) >> RTC_TR_ST_Pos) << 4U) | ((temp & RTC_TR_SU) >> RTC_TR_SU_Pos));
+  return (uint32_t)(READ_BIT(RTCx->TR, (RTC_TR_ST | RTC_TR_SU)) >> RTC_TR_SU_Pos);
 }
 
 /**
@@ -1245,16 +1219,16 @@ __STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx, uint32_t Format12_24,
 {
   uint32_t temp;
 
-  temp = Format12_24                                                                                    | \
-         (((Hours & 0xF0U) << (RTC_TR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos))     | \
+  temp = Format12_24                                                                            | \
+         (((Hours   & 0xF0U) << (RTC_TR_HT_Pos  - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos))    | \
          (((Minutes & 0xF0U) << (RTC_TR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_TR_MNU_Pos)) | \
-         (((Seconds & 0xF0U) << (RTC_TR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_TR_SU_Pos));
+         (((Seconds & 0xF0U) << (RTC_TR_ST_Pos  - 4U)) | ((Seconds & 0x0FU) << RTC_TR_SU_Pos));
   MODIFY_REG(RTCx->TR, (RTC_TR_PM | RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU), temp);
 }
 
 /**
   * @brief  Get time (hour, minute and second) in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
   *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
@@ -1271,12 +1245,7 @@ __STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx, uint32_t Format12_24,
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_Get(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU));
-  return (uint32_t)((((((temp & RTC_TR_HT) >> RTC_TR_HT_Pos) << 4U) | ((temp & RTC_TR_HU) >> RTC_TR_HU_Pos)) << RTC_OFFSET_HOUR) |  \
-                    (((((temp & RTC_TR_MNT) >> RTC_TR_MNT_Pos) << 4U) | ((temp & RTC_TR_MNU) >> RTC_TR_MNU_Pos)) << RTC_OFFSET_MINUTE) | \
-                    ((((temp & RTC_TR_ST) >> RTC_TR_ST_Pos) << 4U) | ((temp & RTC_TR_SU) >> RTC_TR_SU_Pos)));
+  return (uint32_t)(READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU)));
 }
 
 /**
@@ -1339,17 +1308,18 @@ __STATIC_INLINE void LL_RTC_TIME_IncHour(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Get Sub second value in the synchronous prescaler counter.
+  * @brief  Get subseconds value in the synchronous prescaler counter.
   * @note  You can use both SubSeconds value and SecondFraction (PREDIV_S through
   *        LL_RTC_GetSynchPrescaler function) terms returned to convert Calendar
   *        SubSeconds value in second fraction ratio with time unit following
   *        generic formula:
-  *          ==> Seconds fraction ratio * time_unit= [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
+  *          ==> Seconds fraction ratio * time_unit =
+  *                 [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
   *        This conversion can be performed only if no shift operation is pending
   *        (ie. SHFP=0) when PREDIV_S >= SS.
   * @rmtoll SSR          SS            LL_RTC_TIME_GetSubSecond
   * @param  RTCx RTC Instance
-  * @retval Sub second value (number between 0 and 65535)
+  * @retval Subseconds value (number between 0 and 65535)
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_GetSubSecond(RTC_TypeDef *RTCx)
 {
@@ -1400,7 +1370,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetYear(RTC_TypeDef *RTCx, uint32_t Year)
 
 /**
   * @brief  Get Year in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Year from BCD to Binary format
   * @rmtoll DR           YT            LL_RTC_DATE_GetYear\n
@@ -1410,10 +1380,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetYear(RTC_TypeDef *RTCx, uint32_t Year)
   */
 __STATIC_INLINE uint32_t LL_RTC_DATE_GetYear(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->DR, (RTC_DR_YT | RTC_DR_YU));
-  return (uint32_t)((((temp & RTC_DR_YT) >> RTC_DR_YT_Pos) << 4U) | ((temp & RTC_DR_YU) >> RTC_DR_YU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->DR, (RTC_DR_YT | RTC_DR_YU))) >> RTC_DR_YU_Pos);
 }
 
 /**
@@ -1437,7 +1404,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
 
 /**
   * @brief  Get Week day
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @rmtoll DR           WDU           LL_RTC_DATE_GetWeekDay
   * @param  RTCx RTC Instance
@@ -1484,7 +1451,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetMonth(RTC_TypeDef *RTCx, uint32_t Month)
 
 /**
   * @brief  Get Month in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Month from BCD to Binary format
   * @rmtoll DR           MT            LL_RTC_DATE_GetMonth\n
@@ -1506,10 +1473,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetMonth(RTC_TypeDef *RTCx, uint32_t Month)
   */
 __STATIC_INLINE uint32_t LL_RTC_DATE_GetMonth(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->DR, (RTC_DR_MT | RTC_DR_MU));
-  return (uint32_t)((((temp & RTC_DR_MT) >> RTC_DR_MT_Pos) << 4U) | ((temp & RTC_DR_MU) >> RTC_DR_MU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->DR, (RTC_DR_MT | RTC_DR_MU))) >> RTC_DR_MU_Pos);
 }
 
 /**
@@ -1529,7 +1493,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
 
 /**
   * @brief  Get Day in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Day from BCD to Binary format
   * @rmtoll DR           DT            LL_RTC_DATE_GetDay\n
@@ -1539,10 +1503,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
   */
 __STATIC_INLINE uint32_t LL_RTC_DATE_GetDay(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->DR, (RTC_DR_DT | RTC_DR_DU));
-  return (uint32_t)((((temp & RTC_DR_DT) >> RTC_DR_DT_Pos) << 4U) | ((temp & RTC_DR_DU) >> RTC_DR_DU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->DR, (RTC_DR_DT | RTC_DR_DU))) >> RTC_DR_DU_Pos);
 }
 
 /**
@@ -1584,17 +1545,17 @@ __STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx, uint32_t WeekDay, uin
 {
   uint32_t temp;
 
-  temp = (WeekDay << RTC_DR_WDU_Pos)                                                        | \
-         (((Year & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year & 0x0FU) << RTC_DR_YU_Pos))   | \
+  temp = (  WeekDay                                                    << RTC_DR_WDU_Pos) | \
+         (((Year  & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year  & 0x0FU) << RTC_DR_YU_Pos)) | \
          (((Month & 0xF0U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)) | \
-         (((Day & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_DR_DU_Pos));
+         (((Day   & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day   & 0x0FU) << RTC_DR_DU_Pos));
 
   MODIFY_REG(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU), temp);
 }
 
 /**
   * @brief  Get date (WeekDay, Day, Month and Year) in BCD format
-  * @note if shadow mode is disabled (BYPSHAD=0), need to check if RSF flag is set
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
   *       before reading this bit
   * @note helper macros __LL_RTC_GET_WEEKDAY, __LL_RTC_GET_YEAR, __LL_RTC_GET_MONTH,
   * and __LL_RTC_GET_DAY are available to get independently each parameter.
@@ -1613,10 +1574,11 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_Get(RTC_TypeDef *RTCx)
   uint32_t temp;
 
   temp = READ_BIT(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU));
-  return (uint32_t)((((temp & RTC_DR_WDU) >> RTC_DR_WDU_Pos) << RTC_OFFSET_WEEKDAY) | \
-                    (((((temp & RTC_DR_DT) >> RTC_DR_DT_Pos) << 4U) | ((temp & RTC_DR_DU) >> RTC_DR_DU_Pos)) << RTC_OFFSET_DAY) | \
-                    (((((temp & RTC_DR_MT) >> RTC_DR_MT_Pos) << 4U) | ((temp & RTC_DR_MU) >> RTC_DR_MU_Pos)) << RTC_OFFSET_MONTH) | \
-                    ((((temp & RTC_DR_YT) >> RTC_DR_YT_Pos) << 4U) | ((temp & RTC_DR_YU) >> RTC_DR_YU_Pos)));
+
+  return (uint32_t)((((temp &              RTC_DR_WDU) >> RTC_DR_WDU_Pos) << RTC_OFFSET_WEEKDAY) | \
+                    (((temp & (RTC_DR_DT | RTC_DR_DU)) >> RTC_DR_DU_Pos)  << RTC_OFFSET_DAY)     | \
+                    (((temp & (RTC_DR_MT | RTC_DR_MU)) >> RTC_DR_MU_Pos)  << RTC_OFFSET_MONTH)   | \
+                     ((temp & (RTC_DR_YT | RTC_DR_YU)) >> RTC_DR_YU_Pos));
 }
 
 /**
@@ -1739,10 +1701,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMA_GetDay(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_DT | RTC_ALRMAR_DU));
-  return (uint32_t)((((temp & RTC_ALRMAR_DT) >> RTC_ALRMAR_DT_Pos) << 4U) | ((temp & RTC_ALRMAR_DU) >> RTC_ALRMAR_DU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_DT | RTC_ALRMAR_DU))) >> RTC_ALRMAR_DU_Pos);
 }
 
 /**
@@ -1834,10 +1793,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMA_GetHour(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_HT | RTC_ALRMAR_HU));
-  return (uint32_t)((((temp & RTC_ALRMAR_HT) >> RTC_ALRMAR_HT_Pos) << 4U) | ((temp & RTC_ALRMAR_HU) >> RTC_ALRMAR_HU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_HT | RTC_ALRMAR_HU))) >> RTC_ALRMAR_HU_Pos);
 }
 
 /**
@@ -1865,10 +1821,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMA_GetMinute(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU));
-  return (uint32_t)((((temp & RTC_ALRMAR_MNT) >> RTC_ALRMAR_MNT_Pos) << 4U) | ((temp & RTC_ALRMAR_MNU) >> RTC_ALRMAR_MNU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU))) >> RTC_ALRMAR_MNU_Pos);
 }
 
 /**
@@ -1896,10 +1849,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMA_GetSecond(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_ST | RTC_ALRMAR_SU));
-  return (uint32_t)((((temp & RTC_ALRMAR_ST) >> RTC_ALRMAR_ST_Pos) << 4U) | ((temp & RTC_ALRMAR_SU) >> RTC_ALRMAR_SU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_ST | RTC_ALRMAR_SU))) >> RTC_ALRMAR_SU_Pos);
 }
 
 /**
@@ -1924,9 +1874,10 @@ __STATIC_INLINE void LL_RTC_ALMA_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12
 {
   uint32_t temp;
 
-  temp = Format12_24 | (((Hours & 0xF0U) << (RTC_ALRMAR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMAR_HU_Pos))    | \
+  temp = Format12_24                                                                                    | \
+         (((Hours   & 0xF0U) << (RTC_ALRMAR_HT_Pos  - 4U)) | ((Hours   & 0x0FU) << RTC_ALRMAR_HU_Pos))  | \
          (((Minutes & 0xF0U) << (RTC_ALRMAR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMAR_MNU_Pos)) | \
-         (((Seconds & 0xF0U) << (RTC_ALRMAR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMAR_SU_Pos));
+         (((Seconds & 0xF0U) << (RTC_ALRMAR_ST_Pos  - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMAR_SU_Pos));
 
   MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_PM | RTC_ALRMAR_HT | RTC_ALRMAR_HU | RTC_ALRMAR_MNT | RTC_ALRMAR_MNU | RTC_ALRMAR_ST | RTC_ALRMAR_SU, temp);
 }
@@ -1950,7 +1901,8 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetTime(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Set Alarm A Mask the most-significant bits starting at this bit
+  * @brief  Mask the most-significant bits of the subseconds field starting from
+  *         the bit specified in parameter Mask
   * @note This register can be written only when ALRAE is reset in RTC_CR register,
   *       or in initialization mode.
   * @rmtoll ALRMASSR     MASKSS        LL_RTC_ALMA_SetSubSecondMask
@@ -1964,7 +1916,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Ma
 }
 
 /**
-  * @brief  Get Alarm A Mask the most-significant bits starting at this bit
+  * @brief  Get Alarm A subseconds mask
   * @rmtoll ALRMASSR     MASKSS        LL_RTC_ALMA_GetSubSecondMask
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xF
@@ -1975,7 +1927,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetSubSecondMask(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Set Alarm A Sub seconds value
+  * @brief  Set Alarm A subseconds value
   * @rmtoll ALRMASSR     SS            LL_RTC_ALMA_SetSubSecond
   * @param  RTCx RTC Instance
   * @param  Subsecond Value between Min_Data=0x00 and Max_Data=0x7FFF
@@ -1987,7 +1939,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetSubSecond(RTC_TypeDef *RTCx, uint32_t Subsec
 }
 
 /**
-  * @brief  Get Alarm A Sub seconds value
+  * @brief  Get Alarm A subseconds value
   * @rmtoll ALRMASSR     SS            LL_RTC_ALMA_GetSubSecond
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0x7FFF
@@ -2117,10 +2069,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMB_GetDay(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_DT | RTC_ALRMBR_DU));
-  return (uint32_t)((((temp & RTC_ALRMBR_DT) >> RTC_ALRMBR_DT_Pos) << 4U) | ((temp & RTC_ALRMBR_DU) >> RTC_ALRMBR_DU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_DT | RTC_ALRMBR_DU))) >> RTC_ALRMBR_DU_Pos);
 }
 
 /**
@@ -2212,10 +2161,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMB_GetHour(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_HT | RTC_ALRMBR_HU));
-  return (uint32_t)((((temp & RTC_ALRMBR_HT) >> RTC_ALRMBR_HT_Pos) << 4U) | ((temp & RTC_ALRMBR_HU) >> RTC_ALRMBR_HU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_HT | RTC_ALRMBR_HU))) >> RTC_ALRMBR_HU_Pos);
 }
 
 /**
@@ -2243,10 +2189,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMB_GetMinute(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU));
-  return (uint32_t)((((temp & RTC_ALRMBR_MNT) >> RTC_ALRMBR_MNT_Pos) << 4U) | ((temp & RTC_ALRMBR_MNU) >> RTC_ALRMBR_MNU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU))) >> RTC_ALRMBR_MNU_Pos);
 }
 
 /**
@@ -2274,10 +2217,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMB_GetSecond(RTC_TypeDef *RTCx)
 {
-  uint32_t temp;
-
-  temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_ST | RTC_ALRMBR_SU));
-  return (uint32_t)((((temp & RTC_ALRMBR_ST) >> RTC_ALRMBR_ST_Pos) << 4U) | ((temp & RTC_ALRMBR_SU) >> RTC_ALRMBR_SU_Pos));
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_ST | RTC_ALRMBR_SU))) >> RTC_ALRMBR_SU_Pos);
 }
 
 /**
@@ -2302,11 +2242,12 @@ __STATIC_INLINE void LL_RTC_ALMB_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12
 {
   uint32_t temp;
 
-  temp = Format12_24 | (((Hours & 0xF0U) << (RTC_ALRMBR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMBR_HU_Pos))    | \
+  temp = Format12_24                                                                                    | \
+         (((Hours   & 0xF0U) << (RTC_ALRMBR_HT_Pos  - 4U)) | ((Hours   & 0x0FU) << RTC_ALRMBR_HU_Pos))  | \
          (((Minutes & 0xF0U) << (RTC_ALRMBR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMBR_MNU_Pos)) | \
-         (((Seconds & 0xF0U) << (RTC_ALRMBR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMBR_SU_Pos));
+         (((Seconds & 0xF0U) << (RTC_ALRMBR_ST_Pos  - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMBR_SU_Pos));
 
-  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_PM| RTC_ALRMBR_HT | RTC_ALRMBR_HU | RTC_ALRMBR_MNT | RTC_ALRMBR_MNU | RTC_ALRMBR_ST | RTC_ALRMBR_SU, temp);
+  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_PM | RTC_ALRMBR_HT | RTC_ALRMBR_HU | RTC_ALRMBR_MNT | RTC_ALRMBR_MNU | RTC_ALRMBR_ST | RTC_ALRMBR_SU, temp);
 }
 
 /**
@@ -2328,7 +2269,8 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetTime(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Set Alarm B Mask the most-significant bits starting at this bit
+  * @brief  Mask the most-significant bits of the subseconds field starting from
+  *         the bit specified in parameter Mask
   * @note This register can be written only when ALRBE is reset in RTC_CR register,
   *       or in initialization mode.
   * @rmtoll ALRMBSSR     MASKSS        LL_RTC_ALMB_SetSubSecondMask
@@ -2342,7 +2284,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Ma
 }
 
 /**
-  * @brief  Get Alarm B Mask the most-significant bits starting at this bit
+  * @brief  Get Alarm B subseconds mask
   * @rmtoll ALRMBSSR     MASKSS        LL_RTC_ALMB_GetSubSecondMask
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xF
@@ -2353,7 +2295,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetSubSecondMask(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Set Alarm B Sub seconds value
+  * @brief  Set Alarm B subseconds value
   * @rmtoll ALRMBSSR     SS            LL_RTC_ALMB_SetSubSecond
   * @param  RTCx RTC Instance
   * @param  Subsecond Value between Min_Data=0x00 and Max_Data=0x7FFF
@@ -2365,7 +2307,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetSubSecond(RTC_TypeDef *RTCx, uint32_t Subsec
 }
 
 /**
-  * @brief  Get Alarm B Sub seconds value
+  * @brief  Get Alarm B subseconds value
   * @rmtoll ALRMBSSR     SS            LL_RTC_ALMB_GetSubSecond
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0x7FFF
@@ -2606,7 +2548,7 @@ __STATIC_INLINE uint32_t LL_RTC_TS_GetDate(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Get time-stamp sub second value
+  * @brief  Get time-stamp subseconds value
   * @rmtoll TSSSR        SS            LL_RTC_TS_GetSubSecond
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xFFFF
@@ -2659,8 +2601,7 @@ __STATIC_INLINE void LL_RTC_TS_DisableOnTamper(RTC_TypeDef *RTCx)
   *         @arg @ref LL_RTC_TAMPER_2
   *         @arg @ref LL_RTC_TAMPER_3 (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_Enable(RTC_TypeDef *RTCx, uint32_t Tamper)
@@ -2679,8 +2620,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_Enable(RTC_TypeDef *RTCx, uint32_t Tamper)
   *         @arg @ref LL_RTC_TAMPER_2
   *         @arg @ref LL_RTC_TAMPER_3 (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_Disable(RTC_TypeDef *RTCx, uint32_t Tamper)
@@ -2700,8 +2640,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_Disable(RTC_TypeDef *RTCx, uint32_t Tamper)
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER2
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER3 (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_EnableMask(RTC_TypeDef *RTCx, uint32_t Mask)
@@ -2720,8 +2659,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnableMask(RTC_TypeDef *RTCx, uint32_t Mask)
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER2
   *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER3 (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_DisableMask(RTC_TypeDef *RTCx, uint32_t Mask)
@@ -2740,8 +2678,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_DisableMask(RTC_TypeDef *RTCx, uint32_t Mask)
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER2
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER3 (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_EnableEraseBKP(RTC_TypeDef *RTCx, uint32_t Tamper)
@@ -2760,8 +2697,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnableEraseBKP(RTC_TypeDef *RTCx, uint32_t Ta
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER2
   *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER3 (*)
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_DisableEraseBKP(RTC_TypeDef *RTCx, uint32_t Tamper)
@@ -2769,7 +2705,6 @@ __STATIC_INLINE void LL_RTC_TAMPER_DisableEraseBKP(RTC_TypeDef *RTCx, uint32_t T
   SET_BIT(RTCx->TAMPCR, Tamper);
 }
 
-#if defined(RTC_TAMPCR_TAMPPUDIS)
 /**
   * @brief  Disable RTC_TAMPx pull-up disable (Disable precharge of RTC_TAMPx pins)
   * @rmtoll TAMPCR       TAMPPUDIS     LL_RTC_TAMPER_DisablePullUp
@@ -2791,9 +2726,7 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnablePullUp(RTC_TypeDef *RTCx)
 {
   CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPPUDIS);
 }
-#endif /* RTC_TAMPCR_TAMPPUDIS */
 
-#if defined(RTC_TAMPCR_TAMPPRCH)
 /**
   * @brief  Set RTC_TAMPx precharge duration
   * @rmtoll TAMPCR       TAMPPRCH      LL_RTC_TAMPER_SetPrecharge
@@ -2824,9 +2757,7 @@ __STATIC_INLINE uint32_t LL_RTC_TAMPER_GetPrecharge(RTC_TypeDef *RTCx)
 {
   return (uint32_t)(READ_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPPRCH));
 }
-#endif /* RTC_TAMPCR_TAMPPRCH */
 
-#if defined(RTC_TAMPCR_TAMPFLT)
 /**
   * @brief  Set RTC_TAMPx filter count
   * @rmtoll TAMPCR       TAMPFLT       LL_RTC_TAMPER_SetFilterCount
@@ -2857,9 +2788,7 @@ __STATIC_INLINE uint32_t LL_RTC_TAMPER_GetFilterCount(RTC_TypeDef *RTCx)
 {
   return (uint32_t)(READ_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPFLT));
 }
-#endif /* RTC_TAMPCR_TAMPFLT */
 
-#if defined(RTC_TAMPCR_TAMPFREQ)
 /**
   * @brief  Set Tamper sampling frequency
   * @rmtoll TAMPCR       TAMPFREQ      LL_RTC_TAMPER_SetSamplingFreq
@@ -2898,7 +2827,6 @@ __STATIC_INLINE uint32_t LL_RTC_TAMPER_GetSamplingFreq(RTC_TypeDef *RTCx)
 {
   return (uint32_t)(READ_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPFREQ));
 }
-#endif /* RTC_TAMPCR_TAMPFREQ */
 
 /**
   * @brief  Enable Active level for Tamper input
@@ -2907,10 +2835,11 @@ __STATIC_INLINE uint32_t LL_RTC_TAMPER_GetSamplingFreq(RTC_TypeDef *RTCx)
   *         TAMPCR       TAMP3TRG      LL_RTC_TAMPER_EnableActiveLevel
   * @param  RTCx RTC Instance
   * @param  Tamper This parameter can be a combination of the following values:
-  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1 (*)
   *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP2
-  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3 (*)
   *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_EnableActiveLevel(RTC_TypeDef *RTCx, uint32_t Tamper)
@@ -2925,10 +2854,11 @@ __STATIC_INLINE void LL_RTC_TAMPER_EnableActiveLevel(RTC_TypeDef *RTCx, uint32_t
   *         TAMPCR       TAMP3TRG      LL_RTC_TAMPER_DisableActiveLevel
   * @param  RTCx RTC Instance
   * @param  Tamper This parameter can be a combination of the following values:
-  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1 (*)
   *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP2
-  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3 (*)
   *
+  *         (*) value not applicable to all devices.
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TAMPER_DisableActiveLevel(RTC_TypeDef *RTCx, uint32_t Tamper)
@@ -2940,7 +2870,6 @@ __STATIC_INLINE void LL_RTC_TAMPER_DisableActiveLevel(RTC_TypeDef *RTCx, uint32_
   * @}
   */
 
-#if defined(RTC_WAKEUP_SUPPORT)
 /** @defgroup RTC_LL_EF_Wakeup Wakeup
   * @{
   */
@@ -2983,7 +2912,7 @@ __STATIC_INLINE uint32_t LL_RTC_WAKEUP_IsEnabled(RTC_TypeDef *RTCx)
 /**
   * @brief  Select Wakeup clock
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
-  * @note Bit can be written only when RTC_CR WUTE bit = 0 and RTC_ISR WUTWF bit = 1
+  * @note   Bit can be written only when RTC_CR WUTE bit = 0 and RTC_ISR WUTWF bit = 1
   * @rmtoll CR           WUCKSEL       LL_RTC_WAKEUP_SetClock
   * @param  RTCx RTC Instance
   * @param  WakeupClock This parameter can be one of the following values:
@@ -3019,7 +2948,7 @@ __STATIC_INLINE uint32_t LL_RTC_WAKEUP_GetClock(RTC_TypeDef *RTCx)
 
 /**
   * @brief  Set Wakeup auto-reload value
-  * @note Bit can be written only when WUTWF is set to 1 in RTC_ISR
+  * @note   Bit can be written only when WUTWF is set to 1 in RTC_ISR
   * @rmtoll WUTR         WUT           LL_RTC_WAKEUP_SetAutoReload
   * @param  RTCx RTC Instance
   * @param  Value Value between Min_Data=0x00 and Max_Data=0xFFFF
@@ -3044,9 +2973,7 @@ __STATIC_INLINE uint32_t LL_RTC_WAKEUP_GetAutoReload(RTC_TypeDef *RTCx)
 /**
   * @}
   */
-#endif /* RTC_WAKEUP_SUPPORT */
 
-#if defined(RTC_BACKUP_SUPPORT)
 /** @defgroup RTC_LL_EF_Backup_Registers Backup_Registers
   * @{
   */
@@ -3081,11 +3008,13 @@ __STATIC_INLINE uint32_t LL_RTC_WAKEUP_GetAutoReload(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_BAK_SetRegister(RTC_TypeDef *RTCx, uint32_t BackupRegister, uint32_t Data)
 {
-  __IO uint32_t* tmp;
+  uint32_t temp;
 
-  tmp = &(RTCx->BKP0R) + BackupRegister;
+  temp = (uint32_t)(&(RTCx->BKP0R));
+  temp += (BackupRegister * 4U);
 
-  *tmp = Data;
+  /* Write the specified register */
+  *(__IO uint32_t *)temp = (uint32_t)Data;
 }
 
 /**
@@ -3117,18 +3046,18 @@ __STATIC_INLINE void LL_RTC_BAK_SetRegister(RTC_TypeDef *RTCx, uint32_t BackupRe
   */
 __STATIC_INLINE uint32_t LL_RTC_BAK_GetRegister(RTC_TypeDef *RTCx, uint32_t BackupRegister)
 {
-  const __IO uint32_t *tmp;
+  uint32_t temp;
 
-  tmp = &(RTCx->BKP0R) + BackupRegister;
+  temp = (uint32_t)(&(RTCx->BKP0R));
+  temp += (BackupRegister * 4U);
 
   /* Read the specified register */
-  return *tmp;
+  return (*(__IO uint32_t *)temp);
 }
 
 /**
   * @}
   */
-#endif /* RTC_BACKUP_SUPPORT */
 
 /** @defgroup RTC_LL_EF_Calibration Calibration
   * @{
@@ -3144,6 +3073,7 @@ __STATIC_INLINE uint32_t LL_RTC_BAK_GetRegister(RTC_TypeDef *RTCx, uint32_t Back
   *         @arg @ref LL_RTC_CALIB_OUTPUT_NONE
   *         @arg @ref LL_RTC_CALIB_OUTPUT_1HZ
   *         @arg @ref LL_RTC_CALIB_OUTPUT_512HZ
+  *
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_CAL_SetOutputFreq(RTC_TypeDef *RTCx, uint32_t Frequency)
@@ -3160,6 +3090,7 @@ __STATIC_INLINE void LL_RTC_CAL_SetOutputFreq(RTC_TypeDef *RTCx, uint32_t Freque
   *         @arg @ref LL_RTC_CALIB_OUTPUT_NONE
   *         @arg @ref LL_RTC_CALIB_OUTPUT_1HZ
   *         @arg @ref LL_RTC_CALIB_OUTPUT_512HZ
+  *
   */
 __STATIC_INLINE uint32_t LL_RTC_CAL_GetOutputFreq(RTC_TypeDef *RTCx)
 {
@@ -3169,7 +3100,7 @@ __STATIC_INLINE uint32_t LL_RTC_CAL_GetOutputFreq(RTC_TypeDef *RTCx)
 /**
   * @brief  Insert or not One RTCCLK pulse every 2exp11 pulses (frequency increased by 488.5 ppm)
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
-  * @note Bit can be written only when RECALPF is set to 0 in RTC_ISR
+  * @note   Bit can be written only when RECALPF is set to 0 in RTC_ISR
   * @rmtoll CALR         CALP          LL_RTC_CAL_SetPulse
   * @param  RTCx RTC Instance
   * @param  Pulse This parameter can be one of the following values:
@@ -3194,7 +3125,7 @@ __STATIC_INLINE uint32_t LL_RTC_CAL_IsPulseInserted(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Set the calibration cycle period
+  * @brief  Set smooth calibration cycle period
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
   * @note   Bit can be written only when RECALPF is set to 0 in RTC_ISR
   * @rmtoll CALR         CALW8         LL_RTC_CAL_SetPeriod\n
@@ -3212,7 +3143,7 @@ __STATIC_INLINE void LL_RTC_CAL_SetPeriod(RTC_TypeDef *RTCx, uint32_t Period)
 }
 
 /**
-  * @brief  Get the calibration cycle period
+  * @brief  Get smooth calibration cycle period
   * @rmtoll CALR         CALW8         LL_RTC_CAL_GetPeriod\n
   *         CALR         CALW16        LL_RTC_CAL_GetPeriod
   * @param  RTCx RTC Instance
@@ -3227,7 +3158,7 @@ __STATIC_INLINE uint32_t LL_RTC_CAL_GetPeriod(RTC_TypeDef *RTCx)
 }
 
 /**
-  * @brief  Set Calibration minus
+  * @brief  Set smooth Calibration minus
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
   * @note   Bit can be written only when RECALPF is set to 0 in RTC_ISR
   * @rmtoll CALR         CALM          LL_RTC_CAL_SetMinus
@@ -3241,7 +3172,7 @@ __STATIC_INLINE void LL_RTC_CAL_SetMinus(RTC_TypeDef *RTCx, uint32_t CalibMinus)
 }
 
 /**
-  * @brief  Get Calibration minus
+  * @brief  Get smooth Calibration minus
   * @rmtoll CALR         CALM          LL_RTC_CAL_GetMinus
   * @param  RTCx RTC Instance
   * @retval Value between Min_Data=0x00 and Max_Data= 0x1FF
@@ -3294,7 +3225,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP3(RTC_TypeDef *RTCx)
 }
 #endif /* RTC_TAMPER3_SUPPORT */
 
-#if defined(RTC_TAMPER2_SUPPORT)
 /**
   * @brief  Get RTC_TAMP2 detection flag
   * @rmtoll ISR          TAMP2F        LL_RTC_IsActiveFlag_TAMP2
@@ -3305,7 +3235,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP2(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->ISR, RTC_ISR_TAMP2F) == (RTC_ISR_TAMP2F)) ? 1UL : 0UL);
 }
-#endif /* RTC_TAMPER2_SUPPORT */
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
@@ -3342,7 +3271,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TS(RTC_TypeDef *RTCx)
   return ((READ_BIT(RTCx->ISR, RTC_ISR_TSF) == (RTC_ISR_TSF)) ? 1UL : 0UL);
 }
 
-#if defined(RTC_WAKEUP_SUPPORT)
 /**
   * @brief  Get Wakeup timer flag
   * @rmtoll ISR          WUTF          LL_RTC_IsActiveFlag_WUT
@@ -3353,7 +3281,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_WUT(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->ISR, RTC_ISR_WUTF) == (RTC_ISR_WUTF)) ? 1UL : 0UL);
 }
-#endif /* RTC_WAKEUP_SUPPORT */
 
 /**
   * @brief  Get Alarm B flag
@@ -3401,7 +3328,6 @@ __STATIC_INLINE void LL_RTC_ClearFlag_TAMP3(RTC_TypeDef *RTCx)
 }
 #endif /* RTC_TAMPER3_SUPPORT */
 
-#if defined(RTC_TAMPER2_SUPPORT)
 /**
   * @brief  Clear RTC_TAMP2 detection flag
   * @rmtoll ISR          TAMP2F        LL_RTC_ClearFlag_TAMP2
@@ -3412,7 +3338,6 @@ __STATIC_INLINE void LL_RTC_ClearFlag_TAMP2(RTC_TypeDef *RTCx)
 {
   WRITE_REG(RTCx->ISR, (~((RTC_ISR_TAMP2F | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
 }
-#endif /* RTC_TAMPER2_SUPPORT */
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
@@ -3449,7 +3374,6 @@ __STATIC_INLINE void LL_RTC_ClearFlag_TS(RTC_TypeDef *RTCx)
   WRITE_REG(RTCx->ISR, (~((RTC_ISR_TSF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
 }
 
-#if defined(RTC_WAKEUP_SUPPORT)
 /**
   * @brief  Clear Wakeup timer flag
   * @rmtoll ISR          WUTF          LL_RTC_ClearFlag_WUT
@@ -3460,7 +3384,6 @@ __STATIC_INLINE void LL_RTC_ClearFlag_WUT(RTC_TypeDef *RTCx)
 {
   WRITE_REG(RTCx->ISR, (~((RTC_ISR_WUTF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
 }
-#endif /* RTC_WAKEUP_SUPPORT */
 
 /**
   * @brief  Clear Alarm B flag
@@ -3539,7 +3462,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_SHP(RTC_TypeDef *RTCx)
   return ((READ_BIT(RTCx->ISR, RTC_ISR_SHPF) == (RTC_ISR_SHPF)) ? 1UL : 0UL);
 }
 
-#if defined(RTC_WAKEUP_SUPPORT)
 /**
   * @brief  Get Wakeup timer write flag
   * @rmtoll ISR          WUTWF         LL_RTC_IsActiveFlag_WUTW
@@ -3550,7 +3472,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_WUTW(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->ISR, RTC_ISR_WUTWF) == (RTC_ISR_WUTWF)) ? 1UL : 0UL);
 }
-#endif /* RTC_WAKEUP_SUPPORT */
 
 /**
   * @brief  Get Alarm B write flag
@@ -3606,7 +3527,6 @@ __STATIC_INLINE void LL_RTC_DisableIT_TS(RTC_TypeDef *RTCx)
   CLEAR_BIT(RTCx->CR, RTC_CR_TSIE);
 }
 
-#if defined(RTC_WAKEUP_SUPPORT)
 /**
   * @brief  Enable Wakeup timer interrupt
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
@@ -3630,7 +3550,6 @@ __STATIC_INLINE void LL_RTC_DisableIT_WUT(RTC_TypeDef *RTCx)
 {
   CLEAR_BIT(RTCx->CR, RTC_CR_WUTIE);
 }
-#endif /* RTC_WAKEUP_SUPPORT */
 
 /**
   * @brief  Enable Alarm B interrupt
@@ -3704,7 +3623,6 @@ __STATIC_INLINE void LL_RTC_DisableIT_TAMP3(RTC_TypeDef *RTCx)
 }
 #endif /* RTC_TAMPER3_SUPPORT */
 
-#if defined(RTC_TAMPER2_SUPPORT)
 /**
   * @brief  Enable Tamper 2 interrupt
   * @rmtoll TAMPCR       TAMP2IE       LL_RTC_EnableIT_TAMP2
@@ -3726,7 +3644,6 @@ __STATIC_INLINE void LL_RTC_DisableIT_TAMP2(RTC_TypeDef *RTCx)
 {
   CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP2IE);
 }
-#endif /* RTC_TAMPER2_SUPPORT */
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
@@ -3785,7 +3702,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TS(RTC_TypeDef *RTCx)
   return ((READ_BIT(RTCx->CR, RTC_CR_TSIE) == (RTC_CR_TSIE)) ? 1UL : 0UL);
 }
 
-#if defined(RTC_WAKEUP_SUPPORT)
 /**
   * @brief  Check if  Wakeup timer interrupt is enabled or not
   * @rmtoll CR           WUTIE         LL_RTC_IsEnabledIT_WUT
@@ -3796,7 +3712,6 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_WUT(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->CR, RTC_CR_WUTIE) == (RTC_CR_WUTIE)) ? 1UL : 0UL);
 }
-#endif /* RTC_WAKEUP_SUPPORT */
 
 /**
   * @brief  Check if  Alarm B interrupt is enabled or not
@@ -3830,11 +3745,10 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_ALRA(RTC_TypeDef *RTCx)
 __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP3(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->TAMPCR,
-                   RTC_TAMPCR_TAMP3IE) == (RTC_TAMPCR_TAMP3IE)) ? 1UL : 0UL);
+                    RTC_TAMPCR_TAMP3IE) == (RTC_TAMPCR_TAMP3IE)) ? 1UL : 0UL);
 }
 #endif /* RTC_TAMPER3_SUPPORT */
 
-#if defined(RTC_TAMPER2_SUPPORT)
 /**
   * @brief  Check if  Tamper 2 interrupt is enabled or not
   * @rmtoll TAMPCR       TAMP2IE       LL_RTC_IsEnabledIT_TAMP2
@@ -3844,10 +3758,9 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP3(RTC_TypeDef *RTCx)
 __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP2(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->TAMPCR,
-                   RTC_TAMPCR_TAMP2IE) == (RTC_TAMPCR_TAMP2IE)) ? 1UL : 0UL);
+                    RTC_TAMPCR_TAMP2IE) == (RTC_TAMPCR_TAMP2IE)) ? 1UL : 0UL);
 
 }
-#endif /* RTC_TAMPER2_SUPPORT */
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
@@ -3859,7 +3772,7 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP2(RTC_TypeDef *RTCx)
 __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP1(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->TAMPCR,
-                   RTC_TAMPCR_TAMP1IE) == (RTC_TAMPCR_TAMP1IE)) ? 1UL : 0UL);
+                    RTC_TAMPCR_TAMP1IE) == (RTC_TAMPCR_TAMP1IE)) ? 1UL : 0UL);
 }
 #endif /* RTC_TAMPER1_SUPPORT */
 
@@ -3872,7 +3785,7 @@ __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP1(RTC_TypeDef *RTCx)
 __STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP(RTC_TypeDef *RTCx)
 {
   return ((READ_BIT(RTCx->TAMPCR,
-                   RTC_TAMPCR_TAMPIE) == (RTC_TAMPCR_TAMPIE)) ? 1UL : 0UL);
+                    RTC_TAMPCR_TAMPIE) == (RTC_TAMPCR_TAMPIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -3923,5 +3836,3 @@ ErrorStatus LL_RTC_WaitForSynchro(RTC_TypeDef *RTCx);
 #endif
 
 #endif /* STM32WBxx_LL_RTC_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_spi.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_spi.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -56,53 +55,66 @@ typedef struct
   uint32_t TransferDirection;       /*!< Specifies the SPI unidirectional or bidirectional data mode.
                                          This parameter can be a value of @ref SPI_LL_EC_TRANSFER_MODE.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetTransferDirection().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetTransferDirection().*/
 
   uint32_t Mode;                    /*!< Specifies the SPI mode (Master/Slave).
                                          This parameter can be a value of @ref SPI_LL_EC_MODE.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetMode().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetMode().*/
 
   uint32_t DataWidth;               /*!< Specifies the SPI data width.
                                          This parameter can be a value of @ref SPI_LL_EC_DATAWIDTH.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetDataWidth().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetDataWidth().*/
 
   uint32_t ClockPolarity;           /*!< Specifies the serial clock steady state.
                                          This parameter can be a value of @ref SPI_LL_EC_POLARITY.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetClockPolarity().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetClockPolarity().*/
 
   uint32_t ClockPhase;              /*!< Specifies the clock active edge for the bit capture.
                                          This parameter can be a value of @ref SPI_LL_EC_PHASE.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetClockPhase().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetClockPhase().*/
 
-  uint32_t NSS;                     /*!< Specifies whether the NSS signal is managed by hardware (NSS pin) or by software using the SSI bit.
+  uint32_t NSS;                     /*!< Specifies whether the NSS signal is managed by hardware (NSS pin)
+                                         or by software using the SSI bit.
                                          This parameter can be a value of @ref SPI_LL_EC_NSS_MODE.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetNSSMode().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetNSSMode().*/
 
-  uint32_t BaudRate;                /*!< Specifies the BaudRate prescaler value which will be used to configure the transmit and receive SCK clock.
+  uint32_t BaudRate;                /*!< Specifies the BaudRate prescaler value which will be used
+                                         to configure the transmit and receive SCK clock.
                                          This parameter can be a value of @ref SPI_LL_EC_BAUDRATEPRESCALER.
-                                         @note The communication clock is derived from the master clock. The slave clock does not need to be set.
+                                         @note The communication clock is derived from the master clock.
+                                               The slave clock does not need to be set.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetBaudRatePrescaler().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetBaudRatePrescaler().*/
 
   uint32_t BitOrder;                /*!< Specifies whether data transfers start from MSB or LSB bit.
                                          This parameter can be a value of @ref SPI_LL_EC_BIT_ORDER.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetTransferBitOrder().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetTransferBitOrder().*/
 
   uint32_t CRCCalculation;          /*!< Specifies if the CRC calculation is enabled or not.
                                          This parameter can be a value of @ref SPI_LL_EC_CRC_CALCULATION.
 
-                                         This feature can be modified afterwards using unitary functions @ref LL_SPI_EnableCRC() and @ref LL_SPI_DisableCRC().*/
+                                         This feature can be modified afterwards using unitary
+                                         functions @ref LL_SPI_EnableCRC() and @ref LL_SPI_DisableCRC().*/
 
   uint32_t CRCPoly;                 /*!< Specifies the polynomial used for the CRC calculation.
                                          This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFFFF.
 
-                                         This feature can be modified afterwards using unitary function @ref LL_SPI_SetCRCPolynomial().*/
+                                         This feature can be modified afterwards using unitary
+                                         function @ref LL_SPI_SetCRCPolynomial().*/
 
 } LL_SPI_InitTypeDef;
 
@@ -379,7 +391,7 @@ __STATIC_INLINE void LL_SPI_Disable(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabled(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabled(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR1, SPI_CR1_SPE) == (SPI_CR1_SPE)) ? 1UL : 0UL);
 }
@@ -409,7 +421,7 @@ __STATIC_INLINE void LL_SPI_SetMode(SPI_TypeDef *SPIx, uint32_t Mode)
   *         @arg @ref LL_SPI_MODE_MASTER
   *         @arg @ref LL_SPI_MODE_SLAVE
   */
-__STATIC_INLINE uint32_t LL_SPI_GetMode(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetMode(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_MSTR | SPI_CR1_SSI));
 }
@@ -437,7 +449,7 @@ __STATIC_INLINE void LL_SPI_SetStandard(SPI_TypeDef *SPIx, uint32_t Standard)
   *         @arg @ref LL_SPI_PROTOCOL_MOTOROLA
   *         @arg @ref LL_SPI_PROTOCOL_TI
   */
-__STATIC_INLINE uint32_t LL_SPI_GetStandard(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetStandard(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR2, SPI_CR2_FRF));
 }
@@ -466,7 +478,7 @@ __STATIC_INLINE void LL_SPI_SetClockPhase(SPI_TypeDef *SPIx, uint32_t ClockPhase
   *         @arg @ref LL_SPI_PHASE_1EDGE
   *         @arg @ref LL_SPI_PHASE_2EDGE
   */
-__STATIC_INLINE uint32_t LL_SPI_GetClockPhase(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetClockPhase(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_CPHA));
 }
@@ -495,7 +507,7 @@ __STATIC_INLINE void LL_SPI_SetClockPolarity(SPI_TypeDef *SPIx, uint32_t ClockPo
   *         @arg @ref LL_SPI_POLARITY_LOW
   *         @arg @ref LL_SPI_POLARITY_HIGH
   */
-__STATIC_INLINE uint32_t LL_SPI_GetClockPolarity(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetClockPolarity(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_CPOL));
 }
@@ -535,7 +547,7 @@ __STATIC_INLINE void LL_SPI_SetBaudRatePrescaler(SPI_TypeDef *SPIx, uint32_t Bau
   *         @arg @ref LL_SPI_BAUDRATEPRESCALER_DIV128
   *         @arg @ref LL_SPI_BAUDRATEPRESCALER_DIV256
   */
-__STATIC_INLINE uint32_t LL_SPI_GetBaudRatePrescaler(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetBaudRatePrescaler(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_BR));
 }
@@ -563,7 +575,7 @@ __STATIC_INLINE void LL_SPI_SetTransferBitOrder(SPI_TypeDef *SPIx, uint32_t BitO
   *         @arg @ref LL_SPI_LSB_FIRST
   *         @arg @ref LL_SPI_MSB_FIRST
   */
-__STATIC_INLINE uint32_t LL_SPI_GetTransferBitOrder(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetTransferBitOrder(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_LSBFIRST));
 }
@@ -600,7 +612,7 @@ __STATIC_INLINE void LL_SPI_SetTransferDirection(SPI_TypeDef *SPIx, uint32_t Tra
   *         @arg @ref LL_SPI_HALF_DUPLEX_RX
   *         @arg @ref LL_SPI_HALF_DUPLEX_TX
   */
-__STATIC_INLINE uint32_t LL_SPI_GetTransferDirection(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetTransferDirection(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_RXONLY | SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE));
 }
@@ -649,7 +661,7 @@ __STATIC_INLINE void LL_SPI_SetDataWidth(SPI_TypeDef *SPIx, uint32_t DataWidth)
   *         @arg @ref LL_SPI_DATAWIDTH_15BIT
   *         @arg @ref LL_SPI_DATAWIDTH_16BIT
   */
-__STATIC_INLINE uint32_t LL_SPI_GetDataWidth(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetDataWidth(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR2, SPI_CR2_DS));
 }
@@ -676,7 +688,7 @@ __STATIC_INLINE void LL_SPI_SetRxFIFOThreshold(SPI_TypeDef *SPIx, uint32_t Thres
   *         @arg @ref LL_SPI_RX_FIFO_TH_HALF
   *         @arg @ref LL_SPI_RX_FIFO_TH_QUARTER
   */
-__STATIC_INLINE uint32_t LL_SPI_GetRxFIFOThreshold(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetRxFIFOThreshold(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR2, SPI_CR2_FRXTH));
 }
@@ -720,7 +732,7 @@ __STATIC_INLINE void LL_SPI_DisableCRC(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledCRC(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledCRC(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR1, SPI_CR1_CRCEN) == (SPI_CR1_CRCEN)) ? 1UL : 0UL);
 }
@@ -748,7 +760,7 @@ __STATIC_INLINE void LL_SPI_SetCRCWidth(SPI_TypeDef *SPIx, uint32_t CRCLength)
   *         @arg @ref LL_SPI_CRC_8BIT
   *         @arg @ref LL_SPI_CRC_16BIT
   */
-__STATIC_INLINE uint32_t LL_SPI_GetCRCWidth(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetCRCWidth(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR1, SPI_CR1_CRCL));
 }
@@ -783,7 +795,7 @@ __STATIC_INLINE void LL_SPI_SetCRCPolynomial(SPI_TypeDef *SPIx, uint32_t CRCPoly
   * @param  SPIx SPI Instance
   * @retval Returned value is a number between Min_Data = 0x00 and Max_Data = 0xFFFF
   */
-__STATIC_INLINE uint32_t LL_SPI_GetCRCPolynomial(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetCRCPolynomial(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_REG(SPIx->CRCPR));
 }
@@ -794,7 +806,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetCRCPolynomial(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval Returned value is a number between Min_Data = 0x00 and Max_Data = 0xFFFF
   */
-__STATIC_INLINE uint32_t LL_SPI_GetRxCRC(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetRxCRC(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_REG(SPIx->RXCRCR));
 }
@@ -805,7 +817,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxCRC(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval Returned value is a number between Min_Data = 0x00 and Max_Data = 0xFFFF
   */
-__STATIC_INLINE uint32_t LL_SPI_GetTxCRC(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetTxCRC(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_REG(SPIx->TXCRCR));
 }
@@ -846,7 +858,7 @@ __STATIC_INLINE void LL_SPI_SetNSSMode(SPI_TypeDef *SPIx, uint32_t NSS)
   *         @arg @ref LL_SPI_NSS_HARD_INPUT
   *         @arg @ref LL_SPI_NSS_HARD_OUTPUT
   */
-__STATIC_INLINE uint32_t LL_SPI_GetNSSMode(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetNSSMode(const SPI_TypeDef *SPIx)
 {
   uint32_t Ssm  = (READ_BIT(SPIx->CR1, SPI_CR1_SSM));
   uint32_t Ssoe = (READ_BIT(SPIx->CR2,  SPI_CR2_SSOE) << 16U);
@@ -884,7 +896,7 @@ __STATIC_INLINE void LL_SPI_DisableNSSPulseMgt(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledNSSPulse(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledNSSPulse(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR2, SPI_CR2_NSSP) == (SPI_CR2_NSSP)) ? 1UL : 0UL);
 }
@@ -903,7 +915,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsEnabledNSSPulse(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_RXNE(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_RXNE(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_RXNE) == (SPI_SR_RXNE)) ? 1UL : 0UL);
 }
@@ -914,7 +926,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_RXNE(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_TXE(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_TXE(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_TXE) == (SPI_SR_TXE)) ? 1UL : 0UL);
 }
@@ -925,7 +937,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_TXE(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_CRCERR(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_CRCERR(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_CRCERR) == (SPI_SR_CRCERR)) ? 1UL : 0UL);
 }
@@ -936,7 +948,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_CRCERR(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_MODF(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_MODF(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_MODF) == (SPI_SR_MODF)) ? 1UL : 0UL);
 }
@@ -947,7 +959,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_MODF(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_OVR(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_OVR(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_OVR) == (SPI_SR_OVR)) ? 1UL : 0UL);
 }
@@ -965,7 +977,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_OVR(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_BSY(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_BSY(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_BSY) == (SPI_SR_BSY)) ? 1UL : 0UL);
 }
@@ -976,7 +988,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_BSY(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_FRE(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_FRE(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->SR, SPI_SR_FRE) == (SPI_SR_FRE)) ? 1UL : 0UL);
 }
@@ -991,7 +1003,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsActiveFlag_FRE(SPI_TypeDef *SPIx)
   *         @arg @ref LL_SPI_RX_FIFO_HALF_FULL
   *         @arg @ref LL_SPI_RX_FIFO_FULL
   */
-__STATIC_INLINE uint32_t LL_SPI_GetRxFIFOLevel(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetRxFIFOLevel(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->SR, SPI_SR_FRLVL));
 }
@@ -1006,7 +1018,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetRxFIFOLevel(SPI_TypeDef *SPIx)
   *         @arg @ref LL_SPI_TX_FIFO_HALF_FULL
   *         @arg @ref LL_SPI_TX_FIFO_FULL
   */
-__STATIC_INLINE uint32_t LL_SPI_GetTxFIFOLevel(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetTxFIFOLevel(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->SR, SPI_SR_FTLVL));
 }
@@ -1046,7 +1058,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_MODF(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval None
   */
-__STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
+__STATIC_INLINE void LL_SPI_ClearFlag_OVR(const SPI_TypeDef *SPIx)
 {
   __IO uint32_t tmpreg;
   tmpreg = SPIx->DR;
@@ -1062,7 +1074,7 @@ __STATIC_INLINE void LL_SPI_ClearFlag_OVR(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval None
   */
-__STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
+__STATIC_INLINE void LL_SPI_ClearFlag_FRE(const SPI_TypeDef *SPIx)
 {
   __IO uint32_t tmpreg;
   tmpreg = SPIx->SR;
@@ -1079,7 +1091,8 @@ __STATIC_INLINE void LL_SPI_ClearFlag_FRE(SPI_TypeDef *SPIx)
 
 /**
   * @brief  Enable error interrupt
-  * @note   This bit controls the generation of an interrupt when an error condition occurs (CRCERR, OVR, MODF in SPI mode, FRE at TI mode).
+  * @note   This bit controls the generation of an interrupt when an error condition
+  *         occurs (CRCERR, OVR, MODF in SPI mode, FRE at TI mode).
   * @rmtoll CR2          ERRIE         LL_SPI_EnableIT_ERR
   * @param  SPIx SPI Instance
   * @retval None
@@ -1113,7 +1126,8 @@ __STATIC_INLINE void LL_SPI_EnableIT_TXE(SPI_TypeDef *SPIx)
 
 /**
   * @brief  Disable error interrupt
-  * @note   This bit controls the generation of an interrupt when an error condition occurs (CRCERR, OVR, MODF in SPI mode, FRE at TI mode).
+  * @note   This bit controls the generation of an interrupt when an error condition
+  *         occurs (CRCERR, OVR, MODF in SPI mode, FRE at TI mode).
   * @rmtoll CR2          ERRIE         LL_SPI_DisableIT_ERR
   * @param  SPIx SPI Instance
   * @retval None
@@ -1151,7 +1165,7 @@ __STATIC_INLINE void LL_SPI_DisableIT_TXE(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_ERR(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_ERR(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR2, SPI_CR2_ERRIE) == (SPI_CR2_ERRIE)) ? 1UL : 0UL);
 }
@@ -1162,7 +1176,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_ERR(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_RXNE(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_RXNE(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR2, SPI_CR2_RXNEIE) == (SPI_CR2_RXNEIE)) ? 1UL : 0UL);
 }
@@ -1173,7 +1187,7 @@ __STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_RXNE(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_TXE(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledIT_TXE(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR2, SPI_CR2_TXEIE) == (SPI_CR2_TXEIE)) ? 1UL : 0UL);
 }
@@ -1214,7 +1228,7 @@ __STATIC_INLINE void LL_SPI_DisableDMAReq_RX(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledDMAReq_RX(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledDMAReq_RX(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR2, SPI_CR2_RXDMAEN) == (SPI_CR2_RXDMAEN)) ? 1UL : 0UL);
 }
@@ -1247,7 +1261,7 @@ __STATIC_INLINE void LL_SPI_DisableDMAReq_TX(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_SPI_IsEnabledDMAReq_TX(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_IsEnabledDMAReq_TX(const SPI_TypeDef *SPIx)
 {
   return ((READ_BIT(SPIx->CR2, SPI_CR2_TXDMAEN) == (SPI_CR2_TXDMAEN)) ? 1UL : 0UL);
 }
@@ -1274,7 +1288,7 @@ __STATIC_INLINE void LL_SPI_SetDMAParity_RX(SPI_TypeDef *SPIx, uint32_t Parity)
   *         @arg @ref LL_SPI_DMA_PARITY_ODD
   *         @arg @ref LL_SPI_DMA_PARITY_EVEN
   */
-__STATIC_INLINE uint32_t LL_SPI_GetDMAParity_RX(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetDMAParity_RX(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR2, SPI_CR2_LDMARX) >> SPI_CR2_LDMARX_Pos);
 }
@@ -1301,7 +1315,7 @@ __STATIC_INLINE void LL_SPI_SetDMAParity_TX(SPI_TypeDef *SPIx, uint32_t Parity)
   *         @arg @ref LL_SPI_DMA_PARITY_ODD
   *         @arg @ref LL_SPI_DMA_PARITY_EVEN
   */
-__STATIC_INLINE uint32_t LL_SPI_GetDMAParity_TX(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_GetDMAParity_TX(const SPI_TypeDef *SPIx)
 {
   return (uint32_t)(READ_BIT(SPIx->CR2, SPI_CR2_LDMATX) >> SPI_CR2_LDMATX_Pos);
 }
@@ -1312,7 +1326,7 @@ __STATIC_INLINE uint32_t LL_SPI_GetDMAParity_TX(SPI_TypeDef *SPIx)
   * @param  SPIx SPI Instance
   * @retval Address of data register
   */
-__STATIC_INLINE uint32_t LL_SPI_DMA_GetRegAddr(SPI_TypeDef *SPIx)
+__STATIC_INLINE uint32_t LL_SPI_DMA_GetRegAddr(const SPI_TypeDef *SPIx)
 {
   return (uint32_t) &(SPIx->DR);
 }
@@ -1333,7 +1347,7 @@ __STATIC_INLINE uint32_t LL_SPI_DMA_GetRegAddr(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE uint8_t LL_SPI_ReceiveData8(SPI_TypeDef *SPIx)
 {
-  return (uint8_t)(READ_REG(SPIx->DR));
+  return (*((__IO uint8_t *)&SPIx->DR));
 }
 
 /**
@@ -1389,7 +1403,7 @@ __STATIC_INLINE void LL_SPI_TransmitData16(SPI_TypeDef *SPIx, uint16_t TxData)
   * @{
   */
 
-ErrorStatus LL_SPI_DeInit(SPI_TypeDef *SPIx);
+ErrorStatus LL_SPI_DeInit(const SPI_TypeDef *SPIx);
 ErrorStatus LL_SPI_Init(SPI_TypeDef *SPIx, LL_SPI_InitTypeDef *SPI_InitStruct);
 void        LL_SPI_StructInit(LL_SPI_InitTypeDef *SPI_InitStruct);
 
@@ -1417,4 +1431,3 @@ void        LL_SPI_StructInit(LL_SPI_InitTypeDef *SPI_InitStruct);
 
 #endif /* STM32WBxx_LL_SPI_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_system.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_system.h
@@ -3,6 +3,17 @@
   * @file    stm32wbxx_ll_system.h
   * @author  MCD Application Team
   * @brief   Header file of SYSTEM LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -16,17 +27,6 @@
       (+) Access to VREFBUF registers
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -59,8 +59,8 @@ extern "C" {
   * @{
   */
 /**
- * @brief VREFBUF VREF_SC0 & VREF_SC1 calibration values
- */
+  * @brief VREFBUF VREF_SC0 & VREF_SC1 calibration values
+  */
 #define VREFBUF_SC0_CAL_ADDR   ((uint8_t*) (0x1FFF75F0UL)) /*!<  Address of VREFBUF trimming value for VRS=0,
                                                                  VREF_SC0 in STM32WB datasheet */
 #define VREFBUF_SC1_CAL_ADDR   ((uint8_t*) (0x1FFF7530UL)) /*!<  Address of VREFBUF trimming value for VRS=1,
@@ -78,14 +78,14 @@ extern "C" {
   */
 
 /** @defgroup SYSTEM_LL_EC_REMAP SYSCFG REMAP
-* @{
-*/
+  * @{
+  */
 #define LL_SYSCFG_REMAP_FLASH                   0x00000000U                                           /*!< Main Flash memory mapped at 0x00000000   */
 #define LL_SYSCFG_REMAP_SYSTEMFLASH             SYSCFG_MEMRMP_MEM_MODE_0                              /*!< System Flash memory mapped at 0x00000000 */
 #define LL_SYSCFG_REMAP_SRAM                    (SYSCFG_MEMRMP_MEM_MODE_1 | SYSCFG_MEMRMP_MEM_MODE_0) /*!< SRAM1 mapped at 0x00000000               */
 #if defined(QUADSPI)
 #define LL_SYSCFG_REMAP_QUADSPI                 (SYSCFG_MEMRMP_MEM_MODE_2 | SYSCFG_MEMRMP_MEM_MODE_1) /*!< QUADSPI memory mapped at 0x00000000      */
-#endif
+#endif /* QUADSPI */
 /**
   * @}
   */
@@ -100,7 +100,7 @@ extern "C" {
 #define LL_SYSCFG_I2C_FASTMODEPLUS_I2C1         SYSCFG_CFGR1_I2C1_FMP    /*!< Enable Fast Mode Plus on I2C1 pins */
 #if defined(I2C3)
 #define LL_SYSCFG_I2C_FASTMODEPLUS_I2C3         SYSCFG_CFGR1_I2C3_FMP    /*!< Enable Fast Mode Plus on I2C3 pins */
-#endif
+#endif /* I2C3 */
 /**
   * @}
   */
@@ -144,15 +144,16 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_TIMBREAK SYSCFG TIMER BREAK
   * @{
   */
-#define LL_SYSCFG_TIMBREAK_ECC                  SYSCFG_CFGR2_ECCL       /*!< Enables and locks the ECC error signal
-                                                                              with Break Input of TIM1/16/17                                */
-#define LL_SYSCFG_TIMBREAK_PVD                  SYSCFG_CFGR2_PVDL       /*!< Enables and locks the PVD connection
-                                                                              with TIM1/16/17 Break Input
-                                                                              and also the PVDE and PLS bits of the Power Control Interface */
-#define LL_SYSCFG_TIMBREAK_SRAM2_PARITY         SYSCFG_CFGR2_SPL        /*!< Enables and locks the SRAM2_PARITY error signal
-                                                                              with Break Input of TIM1/16/17                                */
-#define LL_SYSCFG_TIMBREAK_LOCKUP               SYSCFG_CFGR2_CLL        /*!< Enables and locks the LOCKUP output of CortexM4
-                                                                              with Break Input of TIM1/16/17                                */
+#define LL_SYSCFG_TIMBREAK_ECC                  SYSCFG_CFGR2_ECCL   /*!< Enables and locks the ECC error signal
+                                                                         with Break Input of TIM1/16/17               */
+#define LL_SYSCFG_TIMBREAK_PVD                  SYSCFG_CFGR2_PVDL   /*!< Enables and locks the PVD connection
+                                                                         with TIM1/16/17 Break Input
+                                                                         and also the PVDE
+                                                                         and PLS bits of the Power Control Interface  */
+#define LL_SYSCFG_TIMBREAK_SRAM2_PARITY         SYSCFG_CFGR2_SPL    /*!< Enables and locks the SRAM2_PARITY error signal
+                                                                         with Break Input of TIM1/16/17               */
+#define LL_SYSCFG_TIMBREAK_LOCKUP               SYSCFG_CFGR2_CLL    /*!< Enables and locks the LOCKUP output of CortexM4
+                                                                         with Break Input of TIM1/16/17               */
 /**
   * @}
   */
@@ -226,7 +227,7 @@ extern "C" {
 #define LL_SYSCFG_SRAM2WRP_PAGE61               SYSCFG_SWPR2_PAGE61      /*!< SRAM2B Write protection page 61 */
 #define LL_SYSCFG_SRAM2WRP_PAGE62               SYSCFG_SWPR2_PAGE62      /*!< SRAM2B Write protection page 62 */
 #define LL_SYSCFG_SRAM2WRP_PAGE63               SYSCFG_SWPR2_PAGE63      /*!< SRAM2B Write protection page 63 */
-#endif
+#endif /* SYSCFG_SWPR2_PAGE36 */
 /**
   * @}
   */
@@ -237,10 +238,10 @@ extern "C" {
 #define LL_SYSCFG_GRP1_TIM1                     SYSCFG_IMR1_TIM1IM     /*!< Enabling of interrupt from Timer 1 to CPU1                    */
 #if defined(TIM16)
 #define LL_SYSCFG_GRP1_TIM16                    SYSCFG_IMR1_TIM16IM    /*!< Enabling of interrupt from Timer 16 to CPU1                   */
-#endif
+#endif /* TIM16 */
 #if defined(TIM17)
 #define LL_SYSCFG_GRP1_TIM17                    SYSCFG_IMR1_TIM17IM    /*!< Enabling of interrupt from Timer 17 to CPU1                   */
-#endif
+#endif /* TIM17 */
 
 #define LL_SYSCFG_GRP1_EXTI5                    SYSCFG_IMR1_EXTI5IM    /*!< Enabling of interrupt from External Interrupt Line 5 to CPU1  */
 #define LL_SYSCFG_GRP1_EXTI6                    SYSCFG_IMR1_EXTI6IM    /*!< Enabling of interrupt from External Interrupt Line 6 to CPU1  */
@@ -256,7 +257,7 @@ extern "C" {
 
 #if defined(SYSCFG_IMR2_PVM1IM)
 #define LL_SYSCFG_GRP2_PVM1                     SYSCFG_IMR2_PVM1IM     /*!< Enabling of interrupt from Power Voltage Monitoring 1 to CPU1 */
-#endif
+#endif /* SYSCFG_IMR2_PVM1IM */
 #define LL_SYSCFG_GRP2_PVM3                     SYSCFG_IMR2_PVM3IM     /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU1 */
 #define LL_SYSCFG_GRP2_PVD                      SYSCFG_IMR2_PVDIM      /*!< Enabling of interrupt from Power Voltage Detector to CPU1     */
 /**
@@ -267,7 +268,7 @@ extern "C" {
   * @{
   */
 #define LL_C2_SYSCFG_GRP1_RTCSTAMP_RTCTAMP_LSECSS  SYSCFG_C2IMR1_RTCSTAMPTAMPLSECSSIM /*!< Enabling of interrupt from RTC TimeStamp, RTC Tampers
-                                                                                      and LSE Clock Security System to CPU2                             */
+                                                                                      and LSE Clock Security System to CPU2                     */
 #define LL_C2_SYSCFG_GRP1_RTCWKUP               SYSCFG_C2IMR1_RTCWKUPIM  /*!< Enabling of interrupt from RTC Wakeup to CPU2                     */
 #define LL_C2_SYSCFG_GRP1_RTCALARM              SYSCFG_C2IMR1_RTCALARMIM /*!< Enabling of interrupt from RTC Alarms to CPU2                     */
 #define LL_C2_SYSCFG_GRP1_RCC                   SYSCFG_C2IMR1_RCCIM      /*!< Enabling of interrupt from RCC to CPU2                            */
@@ -276,10 +277,10 @@ extern "C" {
 #define LL_C2_SYSCFG_GRP1_RNG                   SYSCFG_C2IMR1_RNGIM      /*!< Enabling of interrupt from Random Number Generator to CPU2        */
 #if defined(AES1)
 #define LL_C2_SYSCFG_GRP1_AES1                  SYSCFG_C2IMR1_AES1IM     /*!< Enabling of interrupt from Advanced Encryption Standard 1 to CPU2 */
-#endif
+#endif /* AES1 */
 #if defined(COMP1)
 #define LL_C2_SYSCFG_GRP1_COMP                  SYSCFG_C2IMR1_COMPIM     /*!< Enabling of interrupt from Comparator to CPU2                     */
-#endif
+#endif /* COMP1 */
 #define LL_C2_SYSCFG_GRP1_ADC                   SYSCFG_C2IMR1_ADCIM      /*!< Enabling of interrupt from Analog Digital Converter to CPU2       */
 
 #define LL_C2_SYSCFG_GRP1_EXTI0                 SYSCFG_C2IMR1_EXTI0IM    /*!< Enabling of interrupt from External Interrupt Line 0 to CPU2      */
@@ -315,18 +316,18 @@ extern "C" {
 #define LL_C2_SYSCFG_GRP2_DMA2CH5               SYSCFG_C2IMR2_DMA2CH5IM  /*!< Enabling of interrupt from DMA2 Channel 5 to CPU2                 */
 #define LL_C2_SYSCFG_GRP2_DMA2CH6               SYSCFG_C2IMR2_DMA2CH6IM  /*!< Enabling of interrupt from DMA2 Channel 6 to CPU2                 */
 #define LL_C2_SYSCFG_GRP2_DMA2CH7               SYSCFG_C2IMR2_DMA2CH7IM  /*!< Enabling of interrupt from DMA2 Channel 7 to CPU2                 */
-#endif
+#endif /* DMA2 */
 
 #define LL_C2_SYSCFG_GRP2_DMAMUX1               SYSCFG_C2IMR2_DMAMUX1IM  /*!< Enabling of interrupt from DMAMUX1 to CPU2                        */
 #if defined(SYSCFG_C2IMR2_PVM1IM)
 #define LL_C2_SYSCFG_GRP2_PVM1                  SYSCFG_C2IMR2_PVM1IM     /*!< Enabling of interrupt from Power Voltage Monitoring 1 to CPU2     */
-#endif
+#endif /* SYSCFG_C2IMR2_PVM1IM */
 #define LL_C2_SYSCFG_GRP2_PVM3                  SYSCFG_C2IMR2_PVM3IM     /*!< Enabling of interrupt from Power Voltage Monitoring 3 to CPU2     */
 #define LL_C2_SYSCFG_GRP2_PVD                   SYSCFG_C2IMR2_PVDIM      /*!< Enabling of interrupt from Power Voltage Detector to CPU2         */
 #define LL_C2_SYSCFG_GRP2_TSC                   SYSCFG_C2IMR2_TSCIM      /*!< Enabling of interrupt from Touch Sensing Controller to CPU2       */
 #if defined(LCD)
 #define LL_C2_SYSCFG_GRP2_LCD                   SYSCFG_C2IMR2_LCDIM      /*!< Enabling of interrupt from Liquid Crystal Display to CPU2         */
-#endif
+#endif /* LCD */
 /**
   * @}
   */
@@ -336,7 +337,7 @@ extern "C" {
   */
 #if defined(AES1)
 #define LL_SYSCFG_SECURE_ACCESS_AES1            SYSCFG_SIPCR_SAES1       /*!< Enabling the security access of Advanced Encryption Standard 1 KEY[7:0] */
-#endif
+#endif /* AES1 */
 #define LL_SYSCFG_SECURE_ACCESS_AES2            SYSCFG_SIPCR_SAES2       /*!< Enabling the security access of Advanced Encryption Standard 2          */
 #define LL_SYSCFG_SECURE_ACCESS_PKA             SYSCFG_SIPCR_SPKA        /*!< Enabling the security access of Public Key Accelerator                  */
 #define LL_SYSCFG_SECURE_ACCESS_RNG             SYSCFG_SIPCR_SRNG        /*!< Enabling the security access of Random Number Generator                 */
@@ -354,7 +355,7 @@ extern "C" {
 #define LL_DBGMCU_APB1_GRP1_I2C1_STOP      DBGMCU_APB1FZR1_DBG_I2C1_STOP   /*!< The I2C1 SMBus timeout is frozen                                          */
 #if defined(I2C3)
 #define LL_DBGMCU_APB1_GRP1_I2C3_STOP      DBGMCU_APB1FZR1_DBG_I2C3_STOP   /*!< The I2C3 SMBus timeout is frozen                                          */
-#endif
+#endif /* I2C3 */
 #define LL_DBGMCU_APB1_GRP1_LPTIM1_STOP    DBGMCU_APB1FZR1_DBG_LPTIM1_STOP /*!< The counter clock of LPTIM1 is stopped when the core is halted            */
 /**
   * @}
@@ -369,7 +370,7 @@ extern "C" {
 #define LL_C2_DBGMCU_APB1_GRP1_I2C1_STOP   DBGMCU_C2APB1FZR1_DBG_I2C1_STOP   /*!< The I2C1 SMBus timeout is frozen                                          */
 #if defined(I2C3)
 #define LL_C2_DBGMCU_APB1_GRP1_I2C3_STOP   DBGMCU_C2APB1FZR1_DBG_I2C3_STOP   /*!< The I2C3 SMBus timeout is frozen                                          */
-#endif
+#endif /* I2C3 */
 #define LL_C2_DBGMCU_APB1_GRP1_LPTIM1_STOP DBGMCU_C2APB1FZR1_DBG_LPTIM1_STOP /*!< The counter clock of LPTIM1 is stopped when the core is halted            */
 /**
   * @}
@@ -386,7 +387,7 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_C2_APB1_GRP2_STOP_IP DBGMCU CPU2 APB1 GRP2 STOP IP
   * @{
   */
-#define LL_C2_DBGMCU_APB1_GRP2_LPTIM2_STOP DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP /*!< The counter clock of LPTIM2 is stopped when the core is halted            */
+#define LL_C2_DBGMCU_APB1_GRP2_LPTIM2_STOP DBGMCU_C2APB1FZR2_DBG_LPTIM2_STOP /*!< The counter clock of LPTIM2 is stopped when the core is halted         */
 /**
   * @}
   */
@@ -397,10 +398,10 @@ extern "C" {
 #define LL_DBGMCU_APB2_GRP1_TIM1_STOP      DBGMCU_APB2FZR_DBG_TIM1_STOP   /*!< The counter clock of TIM1 is stopped when the core is halted              */
 #if defined(TIM16)
 #define LL_DBGMCU_APB2_GRP1_TIM16_STOP     DBGMCU_APB2FZR_DBG_TIM16_STOP  /*!< The counter clock of TIM16 is stopped when the core is halted             */
-#endif
+#endif /* TIM16 */
 #if defined(TIM17)
 #define LL_DBGMCU_APB2_GRP1_TIM17_STOP     DBGMCU_APB2FZR_DBG_TIM17_STOP  /*!< The counter clock of TIM17 is stopped when the core is halted             */
-#endif
+#endif /* TIM17 */
 /**
   * @}
   */
@@ -408,13 +409,13 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_C2_APB2_GRP1_STOP_IP DBGMCU CPU2 APB2 GRP1 STOP IP
   * @{
   */
-#define LL_C2_DBGMCU_APB2_GRP1_TIM1_STOP   DBGMCU_C2APB2FZR_DBG_TIM1_STOP   /*!< The counter clock of TIM1 is stopped when the core is halted              */
+#define LL_C2_DBGMCU_APB2_GRP1_TIM1_STOP   DBGMCU_C2APB2FZR_DBG_TIM1_STOP   /*!< The counter clock of TIM1 is stopped when the core is halted            */
 #if defined(TIM16)
-#define LL_C2_DBGMCU_APB2_GRP1_TIM16_STOP  DBGMCU_C2APB2FZR_DBG_TIM16_STOP  /*!< The counter clock of TIM16 is stopped when the core is halted             */
-#endif
+#define LL_C2_DBGMCU_APB2_GRP1_TIM16_STOP  DBGMCU_C2APB2FZR_DBG_TIM16_STOP  /*!< The counter clock of TIM16 is stopped when the core is halted           */
+#endif /* TIM16 */
 #if defined(TIM17)
-#define LL_C2_DBGMCU_APB2_GRP1_TIM17_STOP  DBGMCU_C2APB2FZR_DBG_TIM17_STOP  /*!< The counter clock of TIM17 is stopped when the core is halted             */
-#endif
+#define LL_C2_DBGMCU_APB2_GRP1_TIM17_STOP  DBGMCU_C2APB2FZR_DBG_TIM17_STOP  /*!< The counter clock of TIM17 is stopped when the core is halted           */
+#endif /* TIM17 */
 /**
   * @}
   */
@@ -548,7 +549,7 @@ __STATIC_INLINE void LL_SYSCFG_DisableAnalogGpioSwitch(void)
 {
   CLEAR_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_ANASWVDD);
 }
-#endif
+#endif /* SYSCFG_CFGR1_ANASWVDD */
 
 /**
   * @brief  Enable the I2C fast mode plus driving capability.
@@ -766,6 +767,7 @@ __STATIC_INLINE uint32_t LL_SYSCFG_IsEnabledIT_FPU_IXC(void)
   return ((READ_BIT(SYSCFG->CFGR1, SYSCFG_CFGR1_FPU_IE_5) == (SYSCFG_CFGR1_FPU_IE_5)) ? 1UL : 0UL);
 }
 
+
 /**
   * @brief  Configure source input for the EXTI external interrupt.
   * @rmtoll SYSCFG_EXTICR1 EXTIx         LL_SYSCFG_SetEXTISource\n
@@ -837,7 +839,7 @@ __STATIC_INLINE void LL_SYSCFG_SetEXTISource(uint32_t Port, uint32_t Line)
   */
 __STATIC_INLINE uint32_t LL_SYSCFG_GetEXTISource(uint32_t Line)
 {
-  return (uint32_t)(READ_BIT(SYSCFG->EXTICR[Line & 0x03U], (Line >> 16U)) >> (POSITION_VAL(Line >> 16U) & 0x0000000FUL) );
+  return (uint32_t)(READ_BIT(SYSCFG->EXTICR[Line & 0x03U], (Line >> 16U)) >> (POSITION_VAL(Line >> 16U) & 0x0000000FUL));
 }
 
 /**
@@ -1614,7 +1616,7 @@ __STATIC_INLINE uint32_t LL_DBGMCU_IsEnabledTraceClock(void)
 }
 
 /**
-  * @brief  Enable the external trigger ouput
+  * @brief  Enable the external trigger output
   * @note   When enable the external trigger is output (state of bit 1),
   *         TRGIO pin is connected to TRGOUT.
   * @rmtoll DBGMCU_CR TRGOEN         LL_DBGMCU_EnableTriggerOutput\n
@@ -1625,7 +1627,7 @@ __STATIC_INLINE void LL_DBGMCU_EnableTriggerOutput(void)
 }
 
 /**
-  * @brief  Disable the external trigger ouput
+  * @brief  Disable the external trigger output
   * @note   When disable external trigger is input (state of bit 0),
   *         TRGIO pin is connected to TRGIN.
   * @rmtoll DBGMCU_CR TRGOEN         LL_DBGMCU_DisableTriggerOutput\n
@@ -2228,7 +2230,7 @@ __STATIC_INLINE uint32_t LL_FLASH_GetUDN(void)
   * @note   The 64-bit UID64 may be used by Firmware to derive BLE 48-bit Device Address EUI-48 or
   *         802.15.4 64-bit Device Address EUI-64.
   *         For STM32WBxxxx devices, the device ID is 0x26
-  * @retval Values between Min_Data=0x00 and Max_Data=0xFF (ex: Device ID is 0x26 fo STM32WB55x)
+  * @retval Values between Min_Data=0x00 and Max_Data=0xFF (ex: Device ID is 0x26 for STM32WB55x)
   */
 __STATIC_INLINE uint32_t LL_FLASH_GetDeviceID(void)
 {
@@ -2239,12 +2241,12 @@ __STATIC_INLINE uint32_t LL_FLASH_GetDeviceID(void)
   * @brief  Return the ST Company ID
   * @note   The 64-bit UID64 may be used by Firmware to derive BLE 48-bit Device Address EUI-48 or
   *         802.15.4 64-bit Device Address EUI-64.
-  *         For STM32WBxxxx devices, the ST Compagny ID is 0x0080E1
-  * @retval Values between Min_Data=0x00 and Max_Data=0xFFFFFF (ex: ST Compagny ID is 0x0080E1)
+  *         For STM32WBxxxx devices, the ST Company ID is 0x0080E1
+  * @retval Values between Min_Data=0x00 and Max_Data=0xFFFFFF (ex: ST Company ID is 0x0080E1)
   */
 __STATIC_INLINE uint32_t LL_FLASH_GetSTCompanyID(void)
 {
-  return (uint32_t)(((READ_REG(*((uint32_t *)UID64_BASE + 1U))) >> 8U ) & 0x00FFFFFFU);
+  return (uint32_t)(((READ_REG(*((uint32_t *)UID64_BASE + 1U))) >> 8U) & 0x00FFFFFFU);
 }
 /**
   * @}
@@ -2273,5 +2275,3 @@ __STATIC_INLINE uint32_t LL_FLASH_GetSTCompanyID(void)
 #endif
 
 #endif /* STM32WBxx_LL_SYSTEM_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_tim.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_tim.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -216,24 +215,29 @@ typedef struct
   uint16_t Prescaler;         /*!< Specifies the prescaler value used to divide the TIM clock.
                                    This parameter can be a number between Min_Data=0x0000 and Max_Data=0xFFFF.
 
-                                   This feature can be modified afterwards using unitary function @ref LL_TIM_SetPrescaler().*/
+                                   This feature can be modified afterwards using unitary function
+                                   @ref LL_TIM_SetPrescaler().*/
 
   uint32_t CounterMode;       /*!< Specifies the counter mode.
                                    This parameter can be a value of @ref TIM_LL_EC_COUNTERMODE.
 
-                                   This feature can be modified afterwards using unitary function @ref LL_TIM_SetCounterMode().*/
+                                   This feature can be modified afterwards using unitary function
+                                   @ref LL_TIM_SetCounterMode().*/
 
   uint32_t Autoreload;        /*!< Specifies the auto reload value to be loaded into the active
                                    Auto-Reload Register at the next update event.
                                    This parameter must be a number between Min_Data=0x0000 and Max_Data=0xFFFF.
-                                   Some timer instances may support 32 bits counters. In that case this parameter must be a number between 0x0000 and 0xFFFFFFFF.
+                                   Some timer instances may support 32 bits counters. In that case this parameter must
+                                   be a number between 0x0000 and 0xFFFFFFFF.
 
-                                   This feature can be modified afterwards using unitary function @ref LL_TIM_SetAutoReload().*/
+                                   This feature can be modified afterwards using unitary function
+                                   @ref LL_TIM_SetAutoReload().*/
 
   uint32_t ClockDivision;     /*!< Specifies the clock division.
                                    This parameter can be a value of @ref TIM_LL_EC_CLOCKDIVISION.
 
-                                   This feature can be modified afterwards using unitary function @ref LL_TIM_SetClockDivision().*/
+                                   This feature can be modified afterwards using unitary function
+                                   @ref LL_TIM_SetClockDivision().*/
 
   uint32_t RepetitionCounter;  /*!< Specifies the repetition counter value. Each time the RCR downcounter
                                    reaches zero, an update event is generated and counting restarts
@@ -241,10 +245,13 @@ typedef struct
                                    This means in PWM mode that (N+1) corresponds to:
                                       - the number of PWM periods in edge-aligned mode
                                       - the number of half PWM period in center-aligned mode
-                                   GP timers: this parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF.
-                                   Advanced timers: this parameter must be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF.
+                                   GP timers: this parameter must be a number between Min_Data = 0x00 and
+                                   Max_Data = 0xFF.
+                                   Advanced timers: this parameter must be a number between Min_Data = 0x0000 and
+                                   Max_Data = 0xFFFF.
 
-                                   This feature can be modified afterwards using unitary function @ref LL_TIM_SetRepetitionCounter().*/
+                                   This feature can be modified afterwards using unitary function
+                                   @ref LL_TIM_SetRepetitionCounter().*/
 } LL_TIM_InitTypeDef;
 
 /**
@@ -255,43 +262,51 @@ typedef struct
   uint32_t OCMode;        /*!< Specifies the output mode.
                                This parameter can be a value of @ref TIM_LL_EC_OCMODE.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetMode().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_OC_SetMode().*/
 
   uint32_t OCState;       /*!< Specifies the TIM Output Compare state.
                                This parameter can be a value of @ref TIM_LL_EC_OCSTATE.
 
-                               This feature can be modified afterwards using unitary functions @ref LL_TIM_CC_EnableChannel() or @ref LL_TIM_CC_DisableChannel().*/
+                               This feature can be modified afterwards using unitary functions
+                               @ref LL_TIM_CC_EnableChannel() or @ref LL_TIM_CC_DisableChannel().*/
 
   uint32_t OCNState;      /*!< Specifies the TIM complementary Output Compare state.
                                This parameter can be a value of @ref TIM_LL_EC_OCSTATE.
 
-                               This feature can be modified afterwards using unitary functions @ref LL_TIM_CC_EnableChannel() or @ref LL_TIM_CC_DisableChannel().*/
+                               This feature can be modified afterwards using unitary functions
+                               @ref LL_TIM_CC_EnableChannel() or @ref LL_TIM_CC_DisableChannel().*/
 
   uint32_t CompareValue;  /*!< Specifies the Compare value to be loaded into the Capture Compare Register.
                                This parameter can be a number between Min_Data=0x0000 and Max_Data=0xFFFF.
 
-                               This feature can be modified afterwards using unitary function LL_TIM_OC_SetCompareCHx (x=1..6).*/
+                               This feature can be modified afterwards using unitary function
+                               LL_TIM_OC_SetCompareCHx (x=1..6).*/
 
   uint32_t OCPolarity;    /*!< Specifies the output polarity.
                                This parameter can be a value of @ref TIM_LL_EC_OCPOLARITY.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetPolarity().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_OC_SetPolarity().*/
 
   uint32_t OCNPolarity;   /*!< Specifies the complementary output polarity.
                                This parameter can be a value of @ref TIM_LL_EC_OCPOLARITY.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetPolarity().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_OC_SetPolarity().*/
 
 
   uint32_t OCIdleState;   /*!< Specifies the TIM Output Compare pin state during Idle state.
                                This parameter can be a value of @ref TIM_LL_EC_OCIDLESTATE.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetIdleState().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_OC_SetIdleState().*/
 
   uint32_t OCNIdleState;  /*!< Specifies the TIM Output Compare pin state during Idle state.
                                This parameter can be a value of @ref TIM_LL_EC_OCIDLESTATE.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetIdleState().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_OC_SetIdleState().*/
 } LL_TIM_OC_InitTypeDef;
 
 /**
@@ -304,22 +319,26 @@ typedef struct
   uint32_t ICPolarity;    /*!< Specifies the active edge of the input signal.
                                This parameter can be a value of @ref TIM_LL_EC_IC_POLARITY.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPolarity().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_IC_SetPolarity().*/
 
   uint32_t ICActiveInput; /*!< Specifies the input.
                                This parameter can be a value of @ref TIM_LL_EC_ACTIVEINPUT.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetActiveInput().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_IC_SetActiveInput().*/
 
   uint32_t ICPrescaler;   /*!< Specifies the Input Capture Prescaler.
                                This parameter can be a value of @ref TIM_LL_EC_ICPSC.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPrescaler().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_IC_SetPrescaler().*/
 
   uint32_t ICFilter;      /*!< Specifies the input capture filter.
                                This parameter can be a value of @ref TIM_LL_EC_IC_FILTER.
 
-                               This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetFilter().*/
+                               This feature can be modified afterwards using unitary function
+                               @ref LL_TIM_IC_SetFilter().*/
 } LL_TIM_IC_InitTypeDef;
 
 
@@ -331,47 +350,56 @@ typedef struct
   uint32_t EncoderMode;     /*!< Specifies the encoder resolution (x2 or x4).
                                  This parameter can be a value of @ref TIM_LL_EC_ENCODERMODE.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_SetEncoderMode().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_SetEncoderMode().*/
 
   uint32_t IC1Polarity;     /*!< Specifies the active edge of TI1 input.
                                  This parameter can be a value of @ref TIM_LL_EC_IC_POLARITY.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPolarity().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetPolarity().*/
 
   uint32_t IC1ActiveInput;  /*!< Specifies the TI1 input source
                                  This parameter can be a value of @ref TIM_LL_EC_ACTIVEINPUT.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetActiveInput().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetActiveInput().*/
 
   uint32_t IC1Prescaler;    /*!< Specifies the TI1 input prescaler value.
                                  This parameter can be a value of @ref TIM_LL_EC_ICPSC.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPrescaler().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetPrescaler().*/
 
   uint32_t IC1Filter;       /*!< Specifies the TI1 input filter.
                                  This parameter can be a value of @ref TIM_LL_EC_IC_FILTER.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetFilter().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetFilter().*/
 
   uint32_t IC2Polarity;      /*!< Specifies the active edge of TI2 input.
                                  This parameter can be a value of @ref TIM_LL_EC_IC_POLARITY.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPolarity().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetPolarity().*/
 
   uint32_t IC2ActiveInput;  /*!< Specifies the TI2 input source
                                  This parameter can be a value of @ref TIM_LL_EC_ACTIVEINPUT.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetActiveInput().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetActiveInput().*/
 
   uint32_t IC2Prescaler;    /*!< Specifies the TI2 input prescaler value.
                                  This parameter can be a value of @ref TIM_LL_EC_ICPSC.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPrescaler().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetPrescaler().*/
 
   uint32_t IC2Filter;       /*!< Specifies the TI2 input filter.
                                  This parameter can be a value of @ref TIM_LL_EC_IC_FILTER.
 
-                                 This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetFilter().*/
+                                 This feature can be modified afterwards using unitary function
+                                 @ref LL_TIM_IC_SetFilter().*/
 
 } LL_TIM_ENCODER_InitTypeDef;
 
@@ -384,26 +412,31 @@ typedef struct
   uint32_t IC1Polarity;        /*!< Specifies the active edge of TI1 input.
                                     This parameter can be a value of @ref TIM_LL_EC_IC_POLARITY.
 
-                                    This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPolarity().*/
+                                    This feature can be modified afterwards using unitary function
+                                    @ref LL_TIM_IC_SetPolarity().*/
 
   uint32_t IC1Prescaler;       /*!< Specifies the TI1 input prescaler value.
                                     Prescaler must be set to get a maximum counter period longer than the
                                     time interval between 2 consecutive changes on the Hall inputs.
                                     This parameter can be a value of @ref TIM_LL_EC_ICPSC.
 
-                                    This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetPrescaler().*/
+                                    This feature can be modified afterwards using unitary function
+                                    @ref LL_TIM_IC_SetPrescaler().*/
 
   uint32_t IC1Filter;          /*!< Specifies the TI1 input filter.
-                                    This parameter can be a value of @ref TIM_LL_EC_IC_FILTER.
+                                    This parameter can be a value of
+                                    @ref TIM_LL_EC_IC_FILTER.
 
-                                    This feature can be modified afterwards using unitary function @ref LL_TIM_IC_SetFilter().*/
+                                    This feature can be modified afterwards using unitary function
+                                    @ref LL_TIM_IC_SetFilter().*/
 
   uint32_t CommutationDelay;   /*!< Specifies the compare value to be loaded into the Capture Compare Register.
                                     A positive pulse (TRGO event) is generated with a programmable delay every time
                                     a change occurs on the Hall inputs.
                                     This parameter can be a number between Min_Data = 0x0000 and Max_Data = 0xFFFF.
 
-                                    This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetCompareCH2().*/
+                                    This feature can be modified afterwards using unitary function
+                                    @ref LL_TIM_OC_SetCompareCH2().*/
 } LL_TIM_HALLSENSOR_InitTypeDef;
 
 /**
@@ -414,97 +447,121 @@ typedef struct
   uint32_t OSSRState;            /*!< Specifies the Off-State selection used in Run mode.
                                       This parameter can be a value of @ref TIM_LL_EC_OSSR
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_SetOffStates()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_SetOffStates()
 
-                                      @note This bit-field cannot be modified as long as LOCK level 2 has been programmed. */
+                                      @note This bit-field cannot be modified as long as LOCK level 2 has been
+                                       programmed. */
 
   uint32_t OSSIState;            /*!< Specifies the Off-State used in Idle state.
                                       This parameter can be a value of @ref TIM_LL_EC_OSSI
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_SetOffStates()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_SetOffStates()
 
-                                      @note This bit-field cannot be modified as long as LOCK level 2 has been programmed. */
+                                      @note This bit-field cannot be modified as long as LOCK level 2 has been
+                                      programmed. */
 
   uint32_t LockLevel;            /*!< Specifies the LOCK level parameters.
                                       This parameter can be a value of @ref TIM_LL_EC_LOCKLEVEL
 
-                                      @note The LOCK bits can be written only once after the reset. Once the TIMx_BDTR register
-                                            has been written, their content is frozen until the next reset.*/
+                                      @note The LOCK bits can be written only once after the reset. Once the TIMx_BDTR
+                                      register has been written, their content is frozen until the next reset.*/
 
   uint8_t DeadTime;              /*!< Specifies the delay time between the switching-off and the
                                       switching-on of the outputs.
                                       This parameter can be a number between Min_Data = 0x00 and Max_Data = 0xFF.
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetDeadTime()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_OC_SetDeadTime()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1, 2 or 3 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1, 2 or 3 has been
+                                       programmed. */
 
   uint16_t BreakState;           /*!< Specifies whether the TIM Break input is enabled or not.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK_ENABLE
 
-                                      This feature can be modified afterwards using unitary functions @ref LL_TIM_EnableBRK() or @ref LL_TIM_DisableBRK()
+                                      This feature can be modified afterwards using unitary functions
+                                      @ref LL_TIM_EnableBRK() or @ref LL_TIM_DisableBRK()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t BreakPolarity;        /*!< Specifies the TIM Break Input pin polarity.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK_POLARITY
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_ConfigBRK()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_ConfigBRK()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t BreakFilter;          /*!< Specifies the TIM Break Filter.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK_FILTER
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_ConfigBRK()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_ConfigBRK()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t BreakAFMode;           /*!< Specifies the alternate function mode of the break input.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK_AFMODE
 
-                                      This feature can be modified afterwards using unitary functions @ref LL_TIM_ConfigBRK()
+                                      This feature can be modified afterwards using unitary functions
+                                      @ref LL_TIM_ConfigBRK()
 
                                       @note Bidirectional break input is only supported by advanced timers instances.
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t Break2State;          /*!< Specifies whether the TIM Break2 input is enabled or not.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK2_ENABLE
 
-                                      This feature can be modified afterwards using unitary functions @ref LL_TIM_EnableBRK2() or @ref LL_TIM_DisableBRK2()
+                                      This feature can be modified afterwards using unitary functions
+                                      @ref LL_TIM_EnableBRK2() or @ref LL_TIM_DisableBRK2()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t Break2Polarity;        /*!< Specifies the TIM Break2 Input pin polarity.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK2_POLARITY
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_ConfigBRK2()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_ConfigBRK2()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t Break2Filter;          /*!< Specifies the TIM Break2 Filter.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK2_FILTER
 
-                                      This feature can be modified afterwards using unitary function @ref LL_TIM_ConfigBRK2()
+                                      This feature can be modified afterwards using unitary function
+                                      @ref LL_TIM_ConfigBRK2()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t Break2AFMode;          /*!< Specifies the alternate function mode of the break2 input.
                                       This parameter can be a value of @ref TIM_LL_EC_BREAK2_AFMODE
 
-                                      This feature can be modified afterwards using unitary functions @ref LL_TIM_ConfigBRK2()
+                                      This feature can be modified afterwards using unitary functions
+                                      @ref LL_TIM_ConfigBRK2()
 
                                       @note Bidirectional break input is only supported by advanced timers instances.
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 
   uint32_t AutomaticOutput;      /*!< Specifies whether the TIM Automatic Output feature is enabled or not.
                                       This parameter can be a value of @ref TIM_LL_EC_AUTOMATICOUTPUT_ENABLE
 
-                                      This feature can be modified afterwards using unitary functions @ref LL_TIM_EnableAutomaticOutput() or @ref LL_TIM_DisableAutomaticOutput()
+                                      This feature can be modified afterwards using unitary functions
+                                      @ref LL_TIM_EnableAutomaticOutput() or @ref LL_TIM_DisableAutomaticOutput()
 
-                                      @note This bit-field can not be modified as long as LOCK level 1 has been programmed. */
+                                      @note This bit-field can not be modified as long as LOCK level 1 has been
+                                      programmed. */
 } LL_TIM_BDTR_InitTypeDef;
 
 /**
@@ -598,8 +655,8 @@ typedef struct
 /** @defgroup TIM_LL_EC_ONEPULSEMODE One Pulse Mode
   * @{
   */
-#define LL_TIM_ONEPULSEMODE_SINGLE             TIM_CR1_OPM          /*!< Counter is not stopped at update event */
-#define LL_TIM_ONEPULSEMODE_REPETITIVE         0x00000000U          /*!< Counter stops counting at the next update event */
+#define LL_TIM_ONEPULSEMODE_SINGLE             TIM_CR1_OPM          /*!< Counter stops counting at the next update event */
+#define LL_TIM_ONEPULSEMODE_REPETITIVE         0x00000000U          /*!< Counter is not stopped at update event */
 /**
   * @}
   */
@@ -607,10 +664,10 @@ typedef struct
 /** @defgroup TIM_LL_EC_COUNTERMODE Counter Mode
   * @{
   */
-#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!<Counter used as upcounter */
+#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!< Counter used as upcounter */
 #define LL_TIM_COUNTERMODE_DOWN                TIM_CR1_DIR          /*!< Counter used as downcounter */
 #define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
-#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_1        /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
+#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_1        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
 #define LL_TIM_COUNTERMODE_CENTER_UP_DOWN      TIM_CR1_CMS          /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up or down. */
 /**
   * @}
@@ -691,6 +748,15 @@ typedef struct
   */
 #endif /* USE_FULL_LL_DRIVER */
 
+/** Legacy definitions for compatibility purpose
+@cond 0
+  */
+#define LL_TIM_OCMODE_ASSYMETRIC_PWM1 LL_TIM_OCMODE_ASYMMETRIC_PWM1
+#define LL_TIM_OCMODE_ASSYMETRIC_PWM2 LL_TIM_OCMODE_ASYMMETRIC_PWM2
+/**
+@endcond
+  */
+
 /** @defgroup TIM_LL_EC_OCMODE Output Configuration Mode
   * @{
   */
@@ -706,8 +772,8 @@ typedef struct
 #define LL_TIM_OCMODE_RETRIG_OPM2              (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)                    /*!<Retrigerrable OPM mode 2*/
 #define LL_TIM_OCMODE_COMBINED_PWM1            (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)                    /*!<Combined PWM mode 1*/
 #define LL_TIM_OCMODE_COMBINED_PWM2            (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2) /*!<Combined PWM mode 2*/
-#define LL_TIM_OCMODE_ASSYMETRIC_PWM1          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2) /*!<Asymmetric PWM mode 1*/
-#define LL_TIM_OCMODE_ASSYMETRIC_PWM2          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M)                      /*!<Asymmetric PWM mode 2*/
+#define LL_TIM_OCMODE_ASYMMETRIC_PWM1          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2) /*!<Asymmetric PWM mode 1*/
+#define LL_TIM_OCMODE_ASYMMETRIC_PWM2          (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M)                      /*!<Asymmetric PWM mode 2*/
 /**
   * @}
   */
@@ -911,11 +977,11 @@ typedef struct
 #define LL_TIM_ETR_FILTER_FDIV2_N8             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_0)                    /*!< fSAMPLING=fDTS/2, N=8 */
 #define LL_TIM_ETR_FILTER_FDIV4_N6             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1)                    /*!< fSAMPLING=fDTS/4, N=6 */
 #define LL_TIM_ETR_FILTER_FDIV4_N8             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/4, N=8 */
-#define LL_TIM_ETR_FILTER_FDIV8_N6             TIM_SMCR_ETF_3                                       /*!< fSAMPLING=fDTS/8, N=8 */
-#define LL_TIM_ETR_FILTER_FDIV8_N8             (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_0)                    /*!< fSAMPLING=fDTS/16, N=5 */
-#define LL_TIM_ETR_FILTER_FDIV16_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1)                    /*!< fSAMPLING=fDTS/16, N=6 */
-#define LL_TIM_ETR_FILTER_FDIV16_N6            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/16, N=8 */
-#define LL_TIM_ETR_FILTER_FDIV16_N8            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2)                    /*!< fSAMPLING=fDTS/16, N=5 */
+#define LL_TIM_ETR_FILTER_FDIV8_N6             TIM_SMCR_ETF_3                                       /*!< fSAMPLING=fDTS/8, N=6 */
+#define LL_TIM_ETR_FILTER_FDIV8_N8             (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_0)                    /*!< fSAMPLING=fDTS/16, N=8 */
+#define LL_TIM_ETR_FILTER_FDIV16_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1)                    /*!< fSAMPLING=fDTS/16, N=5 */
+#define LL_TIM_ETR_FILTER_FDIV16_N6            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/16, N=6 */
+#define LL_TIM_ETR_FILTER_FDIV16_N8            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2)                    /*!< fSAMPLING=fDTS/16, N=8 */
 #define LL_TIM_ETR_FILTER_FDIV32_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/32, N=5 */
 #define LL_TIM_ETR_FILTER_FDIV32_N6            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1)   /*!< fSAMPLING=fDTS/32, N=6 */
 #define LL_TIM_ETR_FILTER_FDIV32_N8            TIM_SMCR_ETF                                         /*!< fSAMPLING=fDTS/32, N=8 */
@@ -1075,6 +1141,15 @@ typedef struct
   * @}
   */
 
+/** Legacy definitions for compatibility purpose
+@cond 0
+  */
+#define LL_TIM_ReArmBRK(_PARAM_)
+#define LL_TIM_ReArmBRK2(_PARAM_)
+/**
+@endcond
+  */
+
 /** @defgroup TIM_LL_EC_DMABURST_BASEADDR DMA Burst Base Address
   * @{
   */
@@ -1158,9 +1233,9 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM2_ITR1_RMP  TIM2 Internal Trigger1 Remap
   * @{
   */
-#define LL_TIM_TIM2_ITR1_RMP_NONE          TIM2_OR_RMP_MASK                                           /* !< No internal trigger on TIM2_ITR1 */
+#define LL_TIM_TIM2_ITR1_RMP_NONE          TIM2_OR_RMP_MASK                                           /*!< No internal trigger on TIM2_ITR1 */
 #if defined(USB)
-#define LL_TIM_TIM2_ITR1_RMP_USB_SOF       (TIM2_OR_ITR1_RMP)                                         /* !< TIM2_ITR1 is connected to USB SOF */
+#define LL_TIM_TIM2_ITR1_RMP_USB_SOF       (TIM2_OR_ITR1_RMP)                                         /*!< TIM2_ITR1 is connected to USB SOF */
 #endif /* USB */
 /**
   * @}
@@ -1221,8 +1296,8 @@ typedef struct
 /** @defgroup TIM_LL_EC_OCREF_CLR_INT OCREF clear input selection
   * @{
   */
-#define LL_TIM_OCREF_CLR_INT_OCREF_CLR     0x00000000U         /*!< OCREF_CLR_INT is connected to the OCREF_CLR input */
-#define LL_TIM_OCREF_CLR_INT_ETR    TIM_SMCR_OCCS       /*!< OCREF_CLR_INT is connected to ETRF */
+#define LL_TIM_OCREF_CLR_INT_OCREF_CLR   0x00000000U                 /*!< OCREF_CLR_INT is connected to the OCREF_CLR input */
+#define LL_TIM_OCREF_CLR_INT_ETR         TIM_SMCR_OCCS               /*!< OCREF_CLR_INT is connected to ETRF */
 /**
   * @}
   */
@@ -1234,6 +1309,7 @@ typedef struct
 /**
 @endcond
   */
+
 /**
   * @}
   */
@@ -1266,10 +1342,6 @@ typedef struct
   * @}
   */
 
-/** @defgroup TIM_LL_EM_Exported_Macros Exported_Macros
-  * @{
-  */
-
 /**
   * @brief  HELPER macro retrieving the UIFCPY flag from the counter value.
   * @note ex: @ref __LL_TIM_GETFLAG_UIFCPY (@ref LL_TIM_GetCounter ());
@@ -1293,10 +1365,17 @@ typedef struct
   * @retval DTG[0:7]
   */
 #define __LL_TIM_CALC_DEADTIME(__TIMCLK__, __CKD__, __DT__)  \
-  ( (((uint64_t)((__DT__)*1000U)) < ((DT_DELAY_1+1U) * TIM_CALC_DTS((__TIMCLK__), (__CKD__))))    ? (uint8_t)(((uint64_t)((__DT__)*1000U) / TIM_CALC_DTS((__TIMCLK__), (__CKD__)))  & DT_DELAY_1) :                                               \
-    (((uint64_t)((__DT__)*1000U)) < ((64U + (DT_DELAY_2+1U)) * 2U * TIM_CALC_DTS((__TIMCLK__), (__CKD__))))  ? (uint8_t)(DT_RANGE_2 | ((uint8_t)((uint8_t)((((uint64_t)((__DT__)*1000U))/ TIM_CALC_DTS((__TIMCLK__), (__CKD__))) >> 1U) - (uint8_t) 64) & DT_DELAY_2)) :\
-    (((uint64_t)((__DT__)*1000U)) < ((32U + (DT_DELAY_3+1U)) * 8U * TIM_CALC_DTS((__TIMCLK__), (__CKD__))))  ? (uint8_t)(DT_RANGE_3 | ((uint8_t)((uint8_t)(((((uint64_t)(__DT__)*1000U))/ TIM_CALC_DTS((__TIMCLK__), (__CKD__))) >> 3U) - (uint8_t) 32) & DT_DELAY_3)) :\
-    (((uint64_t)((__DT__)*1000U)) < ((32U + (DT_DELAY_4+1U)) * 16U * TIM_CALC_DTS((__TIMCLK__), (__CKD__)))) ? (uint8_t)(DT_RANGE_4 | ((uint8_t)((uint8_t)(((((uint64_t)(__DT__)*1000U))/ TIM_CALC_DTS((__TIMCLK__), (__CKD__))) >> 4U) - (uint8_t) 32) & DT_DELAY_4)) :\
+  ( (((uint64_t)((__DT__)*1000U)) < ((DT_DELAY_1+1U) * TIM_CALC_DTS((__TIMCLK__), (__CKD__))))    ?  \
+    (uint8_t)(((uint64_t)((__DT__)*1000U) / TIM_CALC_DTS((__TIMCLK__), (__CKD__)))  & DT_DELAY_1) :      \
+    (((uint64_t)((__DT__)*1000U)) < ((64U + (DT_DELAY_2+1U)) * 2U * TIM_CALC_DTS((__TIMCLK__), (__CKD__))))  ?  \
+    (uint8_t)(DT_RANGE_2 | ((uint8_t)((uint8_t)((((uint64_t)((__DT__)*1000U))/ TIM_CALC_DTS((__TIMCLK__),   \
+                                                 (__CKD__))) >> 1U) - (uint8_t) 64) & DT_DELAY_2)) :\
+    (((uint64_t)((__DT__)*1000U)) < ((32U + (DT_DELAY_3+1U)) * 8U * TIM_CALC_DTS((__TIMCLK__), (__CKD__))))  ?  \
+    (uint8_t)(DT_RANGE_3 | ((uint8_t)((uint8_t)(((((uint64_t)(__DT__)*1000U))/ TIM_CALC_DTS((__TIMCLK__),  \
+                                                 (__CKD__))) >> 3U) - (uint8_t) 32) & DT_DELAY_3)) :\
+    (((uint64_t)((__DT__)*1000U)) < ((32U + (DT_DELAY_4+1U)) * 16U * TIM_CALC_DTS((__TIMCLK__), (__CKD__)))) ?  \
+    (uint8_t)(DT_RANGE_4 | ((uint8_t)((uint8_t)(((((uint64_t)(__DT__)*1000U))/ TIM_CALC_DTS((__TIMCLK__),  \
+                                                 (__CKD__))) >> 4U) - (uint8_t) 32) & DT_DELAY_4)) :\
     0U)
 
 /**
@@ -1307,7 +1386,7 @@ typedef struct
   * @retval Prescaler value  (between Min_Data=0 and Max_Data=65535)
   */
 #define __LL_TIM_CALC_PSC(__TIMCLK__, __CNTCLK__)   \
-  (((__TIMCLK__) >= (__CNTCLK__)) ? (uint32_t)(((__TIMCLK__)/(__CNTCLK__)) - 1U) : 0U)
+  (((__TIMCLK__) >= (__CNTCLK__)) ? (uint32_t)((((__TIMCLK__) + (__CNTCLK__)/2U)/(__CNTCLK__)) - 1U) : 0U)
 
 /**
   * @brief  HELPER macro calculating the auto-reload value to achieve the required output signal frequency.
@@ -1321,7 +1400,8 @@ typedef struct
   ((((__TIMCLK__)/((__PSC__) + 1U)) >= (__FREQ__)) ? (((__TIMCLK__)/((__FREQ__) * ((__PSC__) + 1U))) - 1U) : 0U)
 
 /**
-  * @brief  HELPER macro calculating the compare value required to achieve the required timer output compare active/inactive delay.
+  * @brief  HELPER macro calculating the compare value required to achieve the required timer output compare
+  *         active/inactive delay.
   * @note ex: @ref __LL_TIM_CALC_DELAY (1000000, @ref LL_TIM_GetPrescaler (), 10);
   * @param  __TIMCLK__ timer input clock frequency (in Hz)
   * @param  __PSC__ prescaler
@@ -1333,7 +1413,8 @@ typedef struct
               / ((uint64_t)1000000U * (uint64_t)((__PSC__) + 1U))))
 
 /**
-  * @brief  HELPER macro calculating the auto-reload value to achieve the required pulse duration (when the timer operates in one pulse mode).
+  * @brief  HELPER macro calculating the auto-reload value to achieve the required pulse duration
+  *         (when the timer operates in one pulse mode).
   * @note ex: @ref __LL_TIM_CALC_PULSE (1000000, @ref LL_TIM_GetPrescaler (), 10, 20);
   * @param  __TIMCLK__ timer input clock frequency (in Hz)
   * @param  __PSC__ prescaler
@@ -1357,11 +1438,6 @@ typedef struct
   */
 #define __LL_TIM_GET_ICPSC_RATIO(__ICPSC__)  \
   ((uint32_t)(0x01U << (((__ICPSC__) >> 16U) >> TIM_CCMR1_IC1PSC_Pos)))
-
-
-/**
-  * @}
-  */
 
 
 /**
@@ -1404,7 +1480,7 @@ __STATIC_INLINE void LL_TIM_DisableCounter(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledCounter(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledCounter(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->CR1, TIM_CR1_CEN) == (TIM_CR1_CEN)) ? 1UL : 0UL);
 }
@@ -1437,7 +1513,7 @@ __STATIC_INLINE void LL_TIM_DisableUpdateEvent(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval Inverted state of bit (0 or 1).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledUpdateEvent(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledUpdateEvent(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->CR1, TIM_CR1_UDIS) == (uint32_t)RESET) ? 1UL : 0UL);
 }
@@ -1471,7 +1547,7 @@ __STATIC_INLINE void LL_TIM_SetUpdateSource(TIM_TypeDef *TIMx, uint32_t UpdateSo
   *         @arg @ref LL_TIM_UPDATESOURCE_REGULAR
   *         @arg @ref LL_TIM_UPDATESOURCE_COUNTER
   */
-__STATIC_INLINE uint32_t LL_TIM_GetUpdateSource(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetUpdateSource(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_URS));
 }
@@ -1498,7 +1574,7 @@ __STATIC_INLINE void LL_TIM_SetOnePulseMode(TIM_TypeDef *TIMx, uint32_t OnePulse
   *         @arg @ref LL_TIM_ONEPULSEMODE_SINGLE
   *         @arg @ref LL_TIM_ONEPULSEMODE_REPETITIVE
   */
-__STATIC_INLINE uint32_t LL_TIM_GetOnePulseMode(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetOnePulseMode(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_OPM));
 }
@@ -1542,9 +1618,18 @@ __STATIC_INLINE void LL_TIM_SetCounterMode(TIM_TypeDef *TIMx, uint32_t CounterMo
   *         @arg @ref LL_TIM_COUNTERMODE_CENTER_DOWN
   *         @arg @ref LL_TIM_COUNTERMODE_CENTER_UP_DOWN
   */
-__STATIC_INLINE uint32_t LL_TIM_GetCounterMode(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetCounterMode(const TIM_TypeDef *TIMx)
 {
-  return (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_DIR | TIM_CR1_CMS));
+  uint32_t counter_mode;
+
+  counter_mode = (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_CMS));
+
+  if (counter_mode == 0U)
+  {
+    counter_mode = (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_DIR));
+  }
+
+  return counter_mode;
 }
 
 /**
@@ -1575,13 +1660,14 @@ __STATIC_INLINE void LL_TIM_DisableARRPreload(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledARRPreload(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledARRPreload(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->CR1, TIM_CR1_ARPE) == (TIM_CR1_ARPE)) ? 1UL : 0UL);
 }
 
 /**
-  * @brief  Set the division ratio between the timer clock  and the sampling clock used by the dead-time generators (when supported) and the digital filters.
+  * @brief  Set the division ratio between the timer clock  and the sampling clock used by the dead-time generators
+  *         (when supported) and the digital filters.
   * @note Macro IS_TIM_CLOCK_DIVISION_INSTANCE(TIMx) can be used to check
   *       whether or not the clock division feature is supported by the timer
   *       instance.
@@ -1599,7 +1685,8 @@ __STATIC_INLINE void LL_TIM_SetClockDivision(TIM_TypeDef *TIMx, uint32_t ClockDi
 }
 
 /**
-  * @brief  Get the actual division ratio between the timer clock  and the sampling clock used by the dead-time generators (when supported) and the digital filters.
+  * @brief  Get the actual division ratio between the timer clock  and the sampling clock used by the dead-time
+  *         generators (when supported) and the digital filters.
   * @note Macro IS_TIM_CLOCK_DIVISION_INSTANCE(TIMx) can be used to check
   *       whether or not the clock division feature is supported by the timer
   *       instance.
@@ -1610,7 +1697,7 @@ __STATIC_INLINE void LL_TIM_SetClockDivision(TIM_TypeDef *TIMx, uint32_t ClockDi
   *         @arg @ref LL_TIM_CLOCKDIVISION_DIV2
   *         @arg @ref LL_TIM_CLOCKDIVISION_DIV4
   */
-__STATIC_INLINE uint32_t LL_TIM_GetClockDivision(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetClockDivision(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_CKD));
 }
@@ -1637,7 +1724,7 @@ __STATIC_INLINE void LL_TIM_SetCounter(TIM_TypeDef *TIMx, uint32_t Counter)
   * @param  TIMx Timer instance
   * @retval Counter value (between Min_Data=0 and Max_Data=0xFFFF or 0xFFFFFFFF)
   */
-__STATIC_INLINE uint32_t LL_TIM_GetCounter(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetCounter(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CNT));
 }
@@ -1650,7 +1737,7 @@ __STATIC_INLINE uint32_t LL_TIM_GetCounter(TIM_TypeDef *TIMx)
   *         @arg @ref LL_TIM_COUNTERDIRECTION_UP
   *         @arg @ref LL_TIM_COUNTERDIRECTION_DOWN
   */
-__STATIC_INLINE uint32_t LL_TIM_GetDirection(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetDirection(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_BIT(TIMx->CR1, TIM_CR1_DIR));
 }
@@ -1677,7 +1764,7 @@ __STATIC_INLINE void LL_TIM_SetPrescaler(TIM_TypeDef *TIMx, uint32_t Prescaler)
   * @param  TIMx Timer instance
   * @retval  Prescaler value between Min_Data=0 and Max_Data=65535
   */
-__STATIC_INLINE uint32_t LL_TIM_GetPrescaler(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetPrescaler(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->PSC));
 }
@@ -1706,7 +1793,7 @@ __STATIC_INLINE void LL_TIM_SetAutoReload(TIM_TypeDef *TIMx, uint32_t AutoReload
   * @param  TIMx Timer instance
   * @retval Auto-reload value
   */
-__STATIC_INLINE uint32_t LL_TIM_GetAutoReload(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetAutoReload(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->ARR));
 }
@@ -1734,14 +1821,15 @@ __STATIC_INLINE void LL_TIM_SetRepetitionCounter(TIM_TypeDef *TIMx, uint32_t Rep
   * @param  TIMx Timer instance
   * @retval Repetition counter value
   */
-__STATIC_INLINE uint32_t LL_TIM_GetRepetitionCounter(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_GetRepetitionCounter(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->RCR));
 }
 
 /**
   * @brief  Force a continuous copy of the update interrupt flag (UIF) into the timer counter register (bit 31).
-  * @note This allows both the counter value and a potential roll-over condition signalled by the UIFCPY flag to be read in an atomic way.
+  * @note This allows both the counter value and a potential roll-over condition signalled by the UIFCPY flag to be read
+  *       in an atomic way.
   * @rmtoll CR1          UIFREMAP      LL_TIM_EnableUIFRemap
   * @param  TIMx Timer instance
   * @retval None
@@ -1767,7 +1855,7 @@ __STATIC_INLINE void LL_TIM_DisableUIFRemap(TIM_TypeDef *TIMx)
   * @param  Counter Counter value
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveUIFCPY(uint32_t Counter)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveUIFCPY(const uint32_t Counter)
 {
   return (((Counter & TIM_CNT_UIFCPY) == (TIM_CNT_UIFCPY)) ? 1UL : 0UL);
 }
@@ -1809,6 +1897,17 @@ __STATIC_INLINE void LL_TIM_CC_DisablePreload(TIM_TypeDef *TIMx)
 }
 
 /**
+  * @brief  Indicates whether the capture/compare control bits (CCxE, CCxNE and OCxM) preload is enabled.
+  * @rmtoll CR2          CCPC          LL_TIM_CC_IsEnabledPreload
+  * @param  TIMx Timer instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_TIM_CC_IsEnabledPreload(const TIM_TypeDef *TIMx)
+{
+  return ((READ_BIT(TIMx->CR2, TIM_CR2_CCPC) == (TIM_CR2_CCPC)) ? 1UL : 0UL);
+}
+
+/**
   * @brief  Set the updated source of the capture/compare control bits (CCxE, CCxNE and OCxM).
   * @note Macro IS_TIM_COMMUTATION_EVENT_INSTANCE(TIMx) can be used to check
   *       whether or not a timer instance is able to generate a commutation event.
@@ -1846,7 +1945,7 @@ __STATIC_INLINE void LL_TIM_CC_SetDMAReqTrigger(TIM_TypeDef *TIMx, uint32_t DMAR
   *         @arg @ref LL_TIM_CCDMAREQUEST_CC
   *         @arg @ref LL_TIM_CCDMAREQUEST_UPDATE
   */
-__STATIC_INLINE uint32_t LL_TIM_CC_GetDMAReqTrigger(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_CC_GetDMAReqTrigger(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_BIT(TIMx->CR2, TIM_CR2_CCDS));
 }
@@ -1952,7 +2051,7 @@ __STATIC_INLINE void LL_TIM_CC_DisableChannel(TIM_TypeDef *TIMx, uint32_t Channe
   *         @arg @ref LL_TIM_CHANNEL_CH6
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_CC_IsEnabledChannel(TIM_TypeDef *TIMx, uint32_t Channels)
+__STATIC_INLINE uint32_t LL_TIM_CC_IsEnabledChannel(const TIM_TypeDef *TIMx, uint32_t Channels)
 {
   return ((READ_BIT(TIMx->CCER, Channels) == (Channels)) ? 1UL : 0UL);
 }
@@ -2038,15 +2137,15 @@ __STATIC_INLINE void LL_TIM_OC_ConfigOutput(TIM_TypeDef *TIMx, uint32_t Channel,
   *         @arg @ref LL_TIM_OCMODE_RETRIG_OPM2
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM1
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM2
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM1
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM2
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM1
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM2
   * @retval None
   */
 __STATIC_INLINE void LL_TIM_OC_SetMode(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Mode)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
-  MODIFY_REG(*pReg, ((TIM_CCMR1_OC1M  | TIM_CCMR1_CC1S) << SHIFT_TAB_OCxx[iChannel]),  Mode << SHIFT_TAB_OCxx[iChannel]);
+  MODIFY_REG(*pReg, ((TIM_CCMR1_OC1M  | TIM_CCMR1_CC1S) << SHIFT_TAB_OCxx[iChannel]), Mode << SHIFT_TAB_OCxx[iChannel]);
 }
 
 /**
@@ -2078,14 +2177,14 @@ __STATIC_INLINE void LL_TIM_OC_SetMode(TIM_TypeDef *TIMx, uint32_t Channel, uint
   *         @arg @ref LL_TIM_OCMODE_RETRIG_OPM2
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM1
   *         @arg @ref LL_TIM_OCMODE_COMBINED_PWM2
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM1
-  *         @arg @ref LL_TIM_OCMODE_ASSYMETRIC_PWM2
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM1
+  *         @arg @ref LL_TIM_OCMODE_ASYMMETRIC_PWM2
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetMode(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetMode(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
-  return (READ_BIT(*pReg, ((TIM_CCMR1_OC1M  | TIM_CCMR1_CC1S) << SHIFT_TAB_OCxx[iChannel])) >> SHIFT_TAB_OCxx[iChannel]);
+  return (READ_BIT(*pReg, ((TIM_CCMR1_OC1M | TIM_CCMR1_CC1S) << SHIFT_TAB_OCxx[iChannel])) >> SHIFT_TAB_OCxx[iChannel]);
 }
 
 /**
@@ -2147,7 +2246,7 @@ __STATIC_INLINE void LL_TIM_OC_SetPolarity(TIM_TypeDef *TIMx, uint32_t Channel, 
   *         @arg @ref LL_TIM_OCPOLARITY_HIGH
   *         @arg @ref LL_TIM_OCPOLARITY_LOW
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetPolarity(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetPolarity(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   return (READ_BIT(TIMx->CCER, (TIM_CCER_CC1P << SHIFT_TAB_CCxP[iChannel])) >> SHIFT_TAB_CCxP[iChannel]);
@@ -2216,7 +2315,7 @@ __STATIC_INLINE void LL_TIM_OC_SetIdleState(TIM_TypeDef *TIMx, uint32_t Channel,
   *         @arg @ref LL_TIM_OCIDLESTATE_LOW
   *         @arg @ref LL_TIM_OCIDLESTATE_HIGH
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetIdleState(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetIdleState(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   return (READ_BIT(TIMx->CR2, (TIM_CR2_OIS1 << SHIFT_TAB_OISx[iChannel])) >> SHIFT_TAB_OISx[iChannel]);
@@ -2293,7 +2392,7 @@ __STATIC_INLINE void LL_TIM_OC_DisableFast(TIM_TypeDef *TIMx, uint32_t Channel)
   *         @arg @ref LL_TIM_CHANNEL_CH6
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledFast(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledFast(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
@@ -2369,7 +2468,7 @@ __STATIC_INLINE void LL_TIM_OC_DisablePreload(TIM_TypeDef *TIMx, uint32_t Channe
   *         @arg @ref LL_TIM_CHANNEL_CH6
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledPreload(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledPreload(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
@@ -2454,7 +2553,7 @@ __STATIC_INLINE void LL_TIM_OC_DisableClear(TIM_TypeDef *TIMx, uint32_t Channel)
   *         @arg @ref LL_TIM_CHANNEL_CH6
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledClear(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledClear(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
@@ -2463,7 +2562,8 @@ __STATIC_INLINE uint32_t LL_TIM_OC_IsEnabledClear(TIM_TypeDef *TIMx, uint32_t Ch
 }
 
 /**
-  * @brief  Set the dead-time delay (delay inserted between the rising edge of the OCxREF signal and the rising edge of the Ocx and OCxN signals).
+  * @brief  Set the dead-time delay (delay inserted between the rising edge of the OCxREF signal and the rising edge of
+  *         the Ocx and OCxN signals).
   * @note Macro IS_TIM_BREAK_INSTANCE(TIMx) can be used to check whether or not
   *       dead-time insertion feature is supported by a timer instance.
   * @note Helper macro @ref __LL_TIM_CALC_DEADTIME can be used to calculate the DeadTime parameter
@@ -2584,7 +2684,7 @@ __STATIC_INLINE void LL_TIM_OC_SetCompareCH6(TIM_TypeDef *TIMx, uint32_t Compare
   * @param  TIMx Timer instance
   * @retval CompareValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH1(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH1(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR1));
 }
@@ -2600,7 +2700,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH1(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CompareValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH2(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH2(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR2));
 }
@@ -2616,7 +2716,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH2(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CompareValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH3(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH3(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR3));
 }
@@ -2632,7 +2732,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH3(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CompareValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH4(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH4(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR4));
 }
@@ -2645,7 +2745,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH4(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CompareValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH5(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH5(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_BIT(TIMx->CCR5, TIM_CCR5_CCR5));
 }
@@ -2658,7 +2758,7 @@ __STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH5(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CompareValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH6(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_OC_GetCompareCH6(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR6));
 }
@@ -2730,7 +2830,8 @@ __STATIC_INLINE void LL_TIM_IC_Config(TIM_TypeDef *TIMx, uint32_t Channel, uint3
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
   MODIFY_REG(*pReg, ((TIM_CCMR1_IC1F | TIM_CCMR1_IC1PSC | TIM_CCMR1_CC1S) << SHIFT_TAB_ICxx[iChannel]),
-             ((Configuration >> 16U) & (TIM_CCMR1_IC1F | TIM_CCMR1_IC1PSC | TIM_CCMR1_CC1S))  << SHIFT_TAB_ICxx[iChannel]);
+             ((Configuration >> 16U) & (TIM_CCMR1_IC1F | TIM_CCMR1_IC1PSC | TIM_CCMR1_CC1S))                \
+             << SHIFT_TAB_ICxx[iChannel]);
   MODIFY_REG(TIMx->CCER, ((TIM_CCER_CC1NP | TIM_CCER_CC1P) << SHIFT_TAB_CCxP[iChannel]),
              (Configuration & (TIM_CCER_CC1NP | TIM_CCER_CC1P)) << SHIFT_TAB_CCxP[iChannel]);
 }
@@ -2777,7 +2878,7 @@ __STATIC_INLINE void LL_TIM_IC_SetActiveInput(TIM_TypeDef *TIMx, uint32_t Channe
   *         @arg @ref LL_TIM_ACTIVEINPUT_INDIRECTTI
   *         @arg @ref LL_TIM_ACTIVEINPUT_TRC
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetActiveInput(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetActiveInput(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
@@ -2828,7 +2929,7 @@ __STATIC_INLINE void LL_TIM_IC_SetPrescaler(TIM_TypeDef *TIMx, uint32_t Channel,
   *         @arg @ref LL_TIM_ICPSC_DIV4
   *         @arg @ref LL_TIM_ICPSC_DIV8
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetPrescaler(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetPrescaler(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
@@ -2903,7 +3004,7 @@ __STATIC_INLINE void LL_TIM_IC_SetFilter(TIM_TypeDef *TIMx, uint32_t Channel, ui
   *         @arg @ref LL_TIM_IC_FILTER_FDIV32_N6
   *         @arg @ref LL_TIM_IC_FILTER_FDIV32_N8
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetFilter(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetFilter(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   const __IO uint32_t *pReg = (__IO uint32_t *)((uint32_t)((uint32_t)(&TIMx->CCMR1) + OFFSET_TAB_CCMRx[iChannel]));
@@ -2960,7 +3061,7 @@ __STATIC_INLINE void LL_TIM_IC_SetPolarity(TIM_TypeDef *TIMx, uint32_t Channel, 
   *         @arg @ref LL_TIM_IC_POLARITY_FALLING
   *         @arg @ref LL_TIM_IC_POLARITY_BOTHEDGE
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetPolarity(TIM_TypeDef *TIMx, uint32_t Channel)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetPolarity(const TIM_TypeDef *TIMx, uint32_t Channel)
 {
   uint8_t iChannel = TIM_GET_CHANNEL_INDEX(Channel);
   return (READ_BIT(TIMx->CCER, ((TIM_CCER_CC1NP | TIM_CCER_CC1P) << SHIFT_TAB_CCxP[iChannel])) >>
@@ -3001,7 +3102,7 @@ __STATIC_INLINE void LL_TIM_IC_DisableXORCombination(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_IsEnabledXORCombination(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IC_IsEnabledXORCombination(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->CR2, TIM_CR2_TI1S) == (TIM_CR2_TI1S)) ? 1UL : 0UL);
 }
@@ -3017,7 +3118,7 @@ __STATIC_INLINE uint32_t LL_TIM_IC_IsEnabledXORCombination(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CapturedValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH1(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH1(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR1));
 }
@@ -3033,7 +3134,7 @@ __STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH1(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CapturedValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH2(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH2(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR2));
 }
@@ -3049,7 +3150,7 @@ __STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH2(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CapturedValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH3(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH3(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR3));
 }
@@ -3065,7 +3166,7 @@ __STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH3(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval CapturedValue (between Min_Data=0 and Max_Data=65535)
   */
-__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH4(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IC_GetCaptureCH4(const TIM_TypeDef *TIMx)
 {
   return (uint32_t)(READ_REG(TIMx->CCR4));
 }
@@ -3112,7 +3213,7 @@ __STATIC_INLINE void LL_TIM_DisableExternalClock(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledExternalClock(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledExternalClock(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SMCR, TIM_SMCR_ECE) == (TIM_SMCR_ECE)) ? 1UL : 0UL);
 }
@@ -3292,7 +3393,7 @@ __STATIC_INLINE void LL_TIM_DisableMasterSlaveMode(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledMasterSlaveMode(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledMasterSlaveMode(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SMCR, TIM_SMCR_MSM) == (TIM_SMCR_MSM)) ? 1UL : 0UL);
 }
@@ -3461,18 +3562,6 @@ __STATIC_INLINE void LL_TIM_DisarmBRK(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Re-arm the break input (when it operates in bidirectional mode).
-  * @note  The Break input is automatically armed as soon as MOE bit is set.
-  * @rmtoll BDTR         BKDSRM        LL_TIM_ReArmBRK
-  * @param  TIMx Timer instance
-  * @retval None
-  */
-__STATIC_INLINE void LL_TIM_ReArmBRK(TIM_TypeDef *TIMx)
-{
-  CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BKDSRM);
-}
-
-/**
   * @brief  Enable the break 2 function.
   * @note Macro IS_TIM_BKIN2_INSTANCE(TIMx) can be used to check whether or not
   *       a timer instance provides a second break input.
@@ -3562,18 +3651,6 @@ __STATIC_INLINE void LL_TIM_DisarmBRK2(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Re-arm the break 2 input (when it operates in bidirectional mode).
-  * @note  The Break 2 input is automatically armed as soon as MOE bit is set.
-  * @rmtoll BDTR         BK2DSRM       LL_TIM_ReArmBRK2
-  * @param  TIMx Timer instance
-  * @retval None
-  */
-__STATIC_INLINE void LL_TIM_ReArmBRK2(TIM_TypeDef *TIMx)
-{
-  CLEAR_BIT(TIMx->BDTR, TIM_BDTR_BK2DSRM);
-}
-
-/**
   * @brief  Select the outputs off state (enabled v.s. disabled) in Idle and Run modes.
   * @note Macro IS_TIM_BREAK_INSTANCE(TIMx) can be used to check whether or not
   *       a timer instance provides a break input.
@@ -3627,7 +3704,7 @@ __STATIC_INLINE void LL_TIM_DisableAutomaticOutput(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledAutomaticOutput(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledAutomaticOutput(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->BDTR, TIM_BDTR_AOE) == (TIM_BDTR_AOE)) ? 1UL : 0UL);
 }
@@ -3670,7 +3747,7 @@ __STATIC_INLINE void LL_TIM_DisableAllOutputs(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledAllOutputs(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledAllOutputs(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->BDTR, TIM_BDTR_MOE) == (TIM_BDTR_MOE)) ? 1UL : 0UL);
 }
@@ -3950,7 +4027,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_UPDATE(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_UPDATE(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_UPDATE(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_UIF) == (TIM_SR_UIF)) ? 1UL : 0UL);
 }
@@ -3972,7 +4049,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC1(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC1(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC1(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC1IF) == (TIM_SR_CC1IF)) ? 1UL : 0UL);
 }
@@ -3994,7 +4071,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC2(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC2(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC2(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC2IF) == (TIM_SR_CC2IF)) ? 1UL : 0UL);
 }
@@ -4016,7 +4093,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC3(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC3(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC3(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC3IF) == (TIM_SR_CC3IF)) ? 1UL : 0UL);
 }
@@ -4038,7 +4115,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC4(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC4(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC4(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC4IF) == (TIM_SR_CC4IF)) ? 1UL : 0UL);
 }
@@ -4060,7 +4137,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC5(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC5(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC5(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC5IF) == (TIM_SR_CC5IF)) ? 1UL : 0UL);
 }
@@ -4082,7 +4159,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC6(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC6(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC6(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC6IF) == (TIM_SR_CC6IF)) ? 1UL : 0UL);
 }
@@ -4104,7 +4181,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_COM(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_COM(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_COM(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_COMIF) == (TIM_SR_COMIF)) ? 1UL : 0UL);
 }
@@ -4126,7 +4203,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_TRIG(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_TRIG(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_TRIG(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_TIF) == (TIM_SR_TIF)) ? 1UL : 0UL);
 }
@@ -4148,7 +4225,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_BRK(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_BRK(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_BRK(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_BIF) == (TIM_SR_BIF)) ? 1UL : 0UL);
 }
@@ -4170,7 +4247,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_BRK2(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_BRK2(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_BRK2(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_B2IF) == (TIM_SR_B2IF)) ? 1UL : 0UL);
 }
@@ -4187,12 +4264,13 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC1OVR(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Indicate whether Capture/Compare 1 over-capture interrupt flag (CC1OF) is set (Capture/Compare 1 interrupt is pending).
+  * @brief  Indicate whether Capture/Compare 1 over-capture interrupt flag (CC1OF) is set
+  *         (Capture/Compare 1 interrupt is pending).
   * @rmtoll SR           CC1OF         LL_TIM_IsActiveFlag_CC1OVR
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC1OVR(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC1OVR(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC1OF) == (TIM_SR_CC1OF)) ? 1UL : 0UL);
 }
@@ -4209,12 +4287,13 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC2OVR(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Indicate whether Capture/Compare 2 over-capture interrupt flag (CC2OF) is set (Capture/Compare 2 over-capture interrupt is pending).
+  * @brief  Indicate whether Capture/Compare 2 over-capture interrupt flag (CC2OF) is set
+  *         (Capture/Compare 2 over-capture interrupt is pending).
   * @rmtoll SR           CC2OF         LL_TIM_IsActiveFlag_CC2OVR
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC2OVR(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC2OVR(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC2OF) == (TIM_SR_CC2OF)) ? 1UL : 0UL);
 }
@@ -4231,12 +4310,13 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC3OVR(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Indicate whether Capture/Compare 3 over-capture interrupt flag (CC3OF) is set (Capture/Compare 3 over-capture interrupt is pending).
+  * @brief  Indicate whether Capture/Compare 3 over-capture interrupt flag (CC3OF) is set
+  *         (Capture/Compare 3 over-capture interrupt is pending).
   * @rmtoll SR           CC3OF         LL_TIM_IsActiveFlag_CC3OVR
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC3OVR(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC3OVR(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC3OF) == (TIM_SR_CC3OF)) ? 1UL : 0UL);
 }
@@ -4253,12 +4333,13 @@ __STATIC_INLINE void LL_TIM_ClearFlag_CC4OVR(TIM_TypeDef *TIMx)
 }
 
 /**
-  * @brief  Indicate whether Capture/Compare 4 over-capture interrupt flag (CC4OF) is set (Capture/Compare 4 over-capture interrupt is pending).
+  * @brief  Indicate whether Capture/Compare 4 over-capture interrupt flag (CC4OF) is set
+  *         (Capture/Compare 4 over-capture interrupt is pending).
   * @rmtoll SR           CC4OF         LL_TIM_IsActiveFlag_CC4OVR
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC4OVR(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_CC4OVR(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_CC4OF) == (TIM_SR_CC4OF)) ? 1UL : 0UL);
 }
@@ -4280,7 +4361,7 @@ __STATIC_INLINE void LL_TIM_ClearFlag_SYSBRK(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_SYSBRK(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsActiveFlag_SYSBRK(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->SR, TIM_SR_SBIF) == (TIM_SR_SBIF)) ? 1UL : 0UL);
 }
@@ -4320,7 +4401,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_UPDATE(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_UPDATE(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_UPDATE(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_UIE) == (TIM_DIER_UIE)) ? 1UL : 0UL);
 }
@@ -4353,7 +4434,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_CC1(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC1(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC1(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC1IE) == (TIM_DIER_CC1IE)) ? 1UL : 0UL);
 }
@@ -4386,7 +4467,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_CC2(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC2(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC2(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC2IE) == (TIM_DIER_CC2IE)) ? 1UL : 0UL);
 }
@@ -4419,7 +4500,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_CC3(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC3(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC3(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC3IE) == (TIM_DIER_CC3IE)) ? 1UL : 0UL);
 }
@@ -4452,7 +4533,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_CC4(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC4(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_CC4(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC4IE) == (TIM_DIER_CC4IE)) ? 1UL : 0UL);
 }
@@ -4485,7 +4566,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_COM(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_COM(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_COM(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_COMIE) == (TIM_DIER_COMIE)) ? 1UL : 0UL);
 }
@@ -4518,7 +4599,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_TRIG(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_TRIG(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_TRIG(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_TIE) == (TIM_DIER_TIE)) ? 1UL : 0UL);
 }
@@ -4551,7 +4632,7 @@ __STATIC_INLINE void LL_TIM_DisableIT_BRK(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_BRK(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_BRK(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_BIE) == (TIM_DIER_BIE)) ? 1UL : 0UL);
 }
@@ -4560,7 +4641,7 @@ __STATIC_INLINE uint32_t LL_TIM_IsEnabledIT_BRK(TIM_TypeDef *TIMx)
   * @}
   */
 
-/** @defgroup TIM_LL_EF_DMA_Management DMA-Management
+/** @defgroup TIM_LL_EF_DMA_Management DMA Management
   * @{
   */
 /**
@@ -4591,7 +4672,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_UPDATE(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_UPDATE(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_UPDATE(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_UDE) == (TIM_DIER_UDE)) ? 1UL : 0UL);
 }
@@ -4624,7 +4705,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_CC1(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC1(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC1(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC1DE) == (TIM_DIER_CC1DE)) ? 1UL : 0UL);
 }
@@ -4657,7 +4738,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_CC2(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC2(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC2(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC2DE) == (TIM_DIER_CC2DE)) ? 1UL : 0UL);
 }
@@ -4690,7 +4771,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_CC3(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC3(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC3(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC3DE) == (TIM_DIER_CC3DE)) ? 1UL : 0UL);
 }
@@ -4723,7 +4804,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_CC4(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC4(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_CC4(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_CC4DE) == (TIM_DIER_CC4DE)) ? 1UL : 0UL);
 }
@@ -4756,7 +4837,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_COM(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_COM(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_COM(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_COMDE) == (TIM_DIER_COMDE)) ? 1UL : 0UL);
 }
@@ -4789,7 +4870,7 @@ __STATIC_INLINE void LL_TIM_DisableDMAReq_TRIG(TIM_TypeDef *TIMx)
   * @param  TIMx Timer instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_TRIG(TIM_TypeDef *TIMx)
+__STATIC_INLINE uint32_t LL_TIM_IsEnabledDMAReq_TRIG(const TIM_TypeDef *TIMx)
 {
   return ((READ_BIT(TIMx->DIER, TIM_DIER_TDE) == (TIM_DIER_TDE)) ? 1UL : 0UL);
 }
@@ -4909,19 +4990,19 @@ __STATIC_INLINE void LL_TIM_GenerateEvent_BRK2(TIM_TypeDef *TIMx)
   * @{
   */
 
-ErrorStatus LL_TIM_DeInit(TIM_TypeDef *TIMx);
+ErrorStatus LL_TIM_DeInit(const TIM_TypeDef *TIMx);
 void LL_TIM_StructInit(LL_TIM_InitTypeDef *TIM_InitStruct);
-ErrorStatus LL_TIM_Init(TIM_TypeDef *TIMx, LL_TIM_InitTypeDef *TIM_InitStruct);
+ErrorStatus LL_TIM_Init(TIM_TypeDef *TIMx, const LL_TIM_InitTypeDef *TIM_InitStruct);
 void LL_TIM_OC_StructInit(LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct);
-ErrorStatus LL_TIM_OC_Init(TIM_TypeDef *TIMx, uint32_t Channel, LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct);
+ErrorStatus LL_TIM_OC_Init(TIM_TypeDef *TIMx, uint32_t Channel, const LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct);
 void LL_TIM_IC_StructInit(LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
-ErrorStatus LL_TIM_IC_Init(TIM_TypeDef *TIMx, uint32_t Channel, LL_TIM_IC_InitTypeDef *TIM_IC_InitStruct);
+ErrorStatus LL_TIM_IC_Init(TIM_TypeDef *TIMx, uint32_t Channel, const LL_TIM_IC_InitTypeDef *TIM_IC_InitStruct);
 void LL_TIM_ENCODER_StructInit(LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct);
-ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct);
+ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, const LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct);
 void LL_TIM_HALLSENSOR_StructInit(LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorInitStruct);
-ErrorStatus LL_TIM_HALLSENSOR_Init(TIM_TypeDef *TIMx, LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorInitStruct);
+ErrorStatus LL_TIM_HALLSENSOR_Init(TIM_TypeDef *TIMx, const LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorInitStruct);
 void LL_TIM_BDTR_StructInit(LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct);
-ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct);
+ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, const LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct);
 /**
   * @}
   */
@@ -4946,4 +5027,3 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDT
 #endif
 
 #endif /* __STM32WBxx_LL_TIM_H */
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_usart.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_usart.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -44,20 +43,20 @@ extern "C" {
   * @{
   */
 /* Array used to get the USART prescaler division decimal values versus @ref USART_LL_EC_PRESCALER values */
-static const uint16_t USART_PRESCALER_TAB[] =
+static const uint32_t USART_PRESCALER_TAB[] =
 {
-  (uint16_t)1,
-  (uint16_t)2,
-  (uint16_t)4,
-  (uint16_t)6,
-  (uint16_t)8,
-  (uint16_t)10,
-  (uint16_t)12,
-  (uint16_t)16,
-  (uint16_t)32,
-  (uint16_t)64,
-  (uint16_t)128,
-  (uint16_t)256
+  1UL,
+  2UL,
+  4UL,
+  6UL,
+  8UL,
+  10UL,
+  12UL,
+  16UL,
+  32UL,
+  64UL,
+  128UL,
+  256UL
 };
 /**
   * @}
@@ -95,41 +94,49 @@ typedef struct
   uint32_t PrescalerValue;            /*!< Specifies the Prescaler to compute the communication baud rate.
                                            This parameter can be a value of @ref USART_LL_EC_PRESCALER.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetPrescaler().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetPrescaler().*/
 
   uint32_t BaudRate;                  /*!< This field defines expected Usart communication baud rate.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetBaudRate().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetBaudRate().*/
 
   uint32_t DataWidth;                 /*!< Specifies the number of data bits transmitted or received in a frame.
                                            This parameter can be a value of @ref USART_LL_EC_DATAWIDTH.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetDataWidth().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetDataWidth().*/
 
   uint32_t StopBits;                  /*!< Specifies the number of stop bits transmitted.
                                            This parameter can be a value of @ref USART_LL_EC_STOPBITS.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetStopBitsLength().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetStopBitsLength().*/
 
   uint32_t Parity;                    /*!< Specifies the parity mode.
                                            This parameter can be a value of @ref USART_LL_EC_PARITY.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetParity().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetParity().*/
 
   uint32_t TransferDirection;         /*!< Specifies whether the Receive and/or Transmit mode is enabled or disabled.
                                            This parameter can be a value of @ref USART_LL_EC_DIRECTION.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetTransferDirection().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetTransferDirection().*/
 
   uint32_t HardwareFlowControl;       /*!< Specifies whether the hardware flow control mode is enabled or disabled.
                                            This parameter can be a value of @ref USART_LL_EC_HWCONTROL.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetHWFlowCtrl().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetHWFlowCtrl().*/
 
   uint32_t OverSampling;              /*!< Specifies whether USART oversampling mode is 16 or 8.
                                            This parameter can be a value of @ref USART_LL_EC_OVERSAMPLING.
 
-                                           This feature can be modified afterwards using unitary function @ref LL_USART_SetOverSampling().*/
+                                           This feature can be modified afterwards using unitary
+                                           function @ref LL_USART_SetOverSampling().*/
 
 } LL_USART_InitTypeDef;
 
@@ -148,20 +155,23 @@ typedef struct
   uint32_t ClockPolarity;             /*!< Specifies the steady state of the serial clock.
                                            This parameter can be a value of @ref USART_LL_EC_POLARITY.
 
-                                           USART HW configuration can be modified afterwards using unitary functions @ref LL_USART_SetClockPolarity().
+                                           USART HW configuration can be modified afterwards using unitary
+                                           functions @ref LL_USART_SetClockPolarity().
                                            For more details, refer to description of this function. */
 
   uint32_t ClockPhase;                /*!< Specifies the clock transition on which the bit capture is made.
                                            This parameter can be a value of @ref USART_LL_EC_PHASE.
 
-                                           USART HW configuration can be modified afterwards using unitary functions @ref LL_USART_SetClockPhase().
+                                           USART HW configuration can be modified afterwards using unitary
+                                           functions @ref LL_USART_SetClockPhase().
                                            For more details, refer to description of this function. */
 
   uint32_t LastBitClockPulse;         /*!< Specifies whether the clock pulse corresponding to the last transmitted
                                            data bit (MSB) has to be output on the SCLK pin in synchronous mode.
                                            This parameter can be a value of @ref USART_LL_EC_LASTCLKPULSE.
 
-                                           USART HW configuration can be modified afterwards using unitary functions @ref LL_USART_SetLastClkPulseOutput().
+                                           USART HW configuration can be modified afterwards using unitary
+                                           functions @ref LL_USART_SetLastClkPulseOutput().
                                            For more details, refer to description of this function. */
 
 } LL_USART_ClockInitTypeDef;
@@ -180,21 +190,21 @@ typedef struct
   * @brief    Flags defines which can be used with LL_USART_WriteReg function
   * @{
   */
-#define LL_USART_ICR_PECF                       USART_ICR_PECF                /*!< Parity error flag */
-#define LL_USART_ICR_FECF                       USART_ICR_FECF                /*!< Framing error flag */
-#define LL_USART_ICR_NECF                       USART_ICR_NECF                /*!< Noise error detected flag */
-#define LL_USART_ICR_ORECF                      USART_ICR_ORECF               /*!< Overrun error flag */
-#define LL_USART_ICR_IDLECF                     USART_ICR_IDLECF              /*!< Idle line detected flag */
-#define LL_USART_ICR_TXFECF                     USART_ICR_TXFECF              /*!< TX FIFO Empty Clear flag */
-#define LL_USART_ICR_TCCF                       USART_ICR_TCCF                /*!< Transmission complete flag */
-#define LL_USART_ICR_TCBGTCF                    USART_ICR_TCBGTCF             /*!< Transmission completed before guard time flag */
-#define LL_USART_ICR_LBDCF                      USART_ICR_LBDCF               /*!< LIN break detection flag */
-#define LL_USART_ICR_CTSCF                      USART_ICR_CTSCF               /*!< CTS flag */
-#define LL_USART_ICR_RTOCF                      USART_ICR_RTOCF               /*!< Receiver timeout flag */
-#define LL_USART_ICR_EOBCF                      USART_ICR_EOBCF               /*!< End of block flag */
-#define LL_USART_ICR_UDRCF                      USART_ICR_UDRCF               /*!< SPI Slave Underrun Clear flag */
-#define LL_USART_ICR_CMCF                       USART_ICR_CMCF                /*!< Character match flag */
-#define LL_USART_ICR_WUCF                       USART_ICR_WUCF                /*!< Wakeup from Stop mode flag */
+#define LL_USART_ICR_PECF                       USART_ICR_PECF                /*!< Parity error clear flag */
+#define LL_USART_ICR_FECF                       USART_ICR_FECF                /*!< Framing error clear flag */
+#define LL_USART_ICR_NECF                       USART_ICR_NECF                /*!< Noise error detected clear flag */
+#define LL_USART_ICR_ORECF                      USART_ICR_ORECF               /*!< Overrun error clear flag */
+#define LL_USART_ICR_IDLECF                     USART_ICR_IDLECF              /*!< Idle line detected clear flag */
+#define LL_USART_ICR_TXFECF                     USART_ICR_TXFECF              /*!< TX FIFO Empty clear flag */
+#define LL_USART_ICR_TCCF                       USART_ICR_TCCF                /*!< Transmission complete clear flag */
+#define LL_USART_ICR_TCBGTCF                    USART_ICR_TCBGTCF             /*!< Transmission completed before guard time clear flag */
+#define LL_USART_ICR_LBDCF                      USART_ICR_LBDCF               /*!< LIN break detection clear flag */
+#define LL_USART_ICR_CTSCF                      USART_ICR_CTSCF               /*!< CTS clear flag */
+#define LL_USART_ICR_RTOCF                      USART_ICR_RTOCF               /*!< Receiver timeout clear flag */
+#define LL_USART_ICR_EOBCF                      USART_ICR_EOBCF               /*!< End of block clear flag */
+#define LL_USART_ICR_UDRCF                      USART_ICR_UDRCF               /*!< SPI Slave Underrun clear flag */
+#define LL_USART_ICR_CMCF                       USART_ICR_CMCF                /*!< Character match clear flag */
+#define LL_USART_ICR_WUCF                       USART_ICR_WUCF                /*!< Wakeup from Stop mode clear flag */
 /**
   * @}
   */
@@ -364,18 +374,18 @@ typedef struct
 /** @defgroup USART_LL_EC_PRESCALER Clock Source Prescaler
   * @{
   */
-#define LL_USART_PRESCALER_DIV1                 0x00000000U                                                                   /*!< Input clock not devided   */
-#define LL_USART_PRESCALER_DIV2                 (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock devided by 2  */
-#define LL_USART_PRESCALER_DIV4                 (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock devided by 4  */
-#define LL_USART_PRESCALER_DIV6                 (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 6  */
-#define LL_USART_PRESCALER_DIV8                 (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock devided by 8  */
-#define LL_USART_PRESCALER_DIV10                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 10 */
-#define LL_USART_PRESCALER_DIV12                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 12 */
-#define LL_USART_PRESCALER_DIV16                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 16 */
-#define LL_USART_PRESCALER_DIV32                (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock devided by 32 */
-#define LL_USART_PRESCALER_DIV64                (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock devided by 64 */
-#define LL_USART_PRESCALER_DIV128               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock devided by 128 */
-#define LL_USART_PRESCALER_DIV256               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock devided by 256 */
+#define LL_USART_PRESCALER_DIV1                 0x00000000U                                                                   /*!< Input clock not divided   */
+#define LL_USART_PRESCALER_DIV2                 (USART_PRESC_PRESCALER_0)                                                     /*!< Input clock divided by 2  */
+#define LL_USART_PRESCALER_DIV4                 (USART_PRESC_PRESCALER_1)                                                     /*!< Input clock divided by 4  */
+#define LL_USART_PRESCALER_DIV6                 (USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 6  */
+#define LL_USART_PRESCALER_DIV8                 (USART_PRESC_PRESCALER_2)                                                     /*!< Input clock divided by 8  */
+#define LL_USART_PRESCALER_DIV10                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 10 */
+#define LL_USART_PRESCALER_DIV12                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1)                           /*!< Input clock divided by 12 */
+#define LL_USART_PRESCALER_DIV16                (USART_PRESC_PRESCALER_2 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock divided by 16 */
+#define LL_USART_PRESCALER_DIV32                (USART_PRESC_PRESCALER_3)                                                     /*!< Input clock divided by 32 */
+#define LL_USART_PRESCALER_DIV64                (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_0)                           /*!< Input clock divided by 64 */
+#define LL_USART_PRESCALER_DIV128               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1)                           /*!< Input clock divided by 128 */
+#define LL_USART_PRESCALER_DIV256               (USART_PRESC_PRESCALER_3 | USART_PRESC_PRESCALER_1 | USART_PRESC_PRESCALER_0) /*!< Input clock divided by 256 */
 /**
   * @}
   */
@@ -570,7 +580,9 @@ typedef struct
   * @param  __BAUDRATE__ Baud rate value to achieve
   * @retval USARTDIV value to be used for BRR register filling in OverSampling_8 case
   */
-#define __LL_USART_DIV_SAMPLING8(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) (((((__PERIPHCLK__)/(uint32_t)(USART_PRESCALER_TAB[(__PRESCALER__)]))*2U) + ((__BAUDRATE__)/2U))/(__BAUDRATE__))
+#define __LL_USART_DIV_SAMPLING8(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) \
+  (((((__PERIPHCLK__)/(USART_PRESCALER_TAB[(__PRESCALER__)]))*2U)\
+    + ((__BAUDRATE__)/2U))/(__BAUDRATE__))
 
 /**
   * @brief  Compute USARTDIV value according to Peripheral Clock and
@@ -592,7 +604,9 @@ typedef struct
   * @param  __BAUDRATE__ Baud rate value to achieve
   * @retval USARTDIV value to be used for BRR register filling in OverSampling_16 case
   */
-#define __LL_USART_DIV_SAMPLING16(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) ((((__PERIPHCLK__)/(uint32_t)(USART_PRESCALER_TAB[(__PRESCALER__)])) + ((__BAUDRATE__)/2U))/(__BAUDRATE__))
+#define __LL_USART_DIV_SAMPLING16(__PERIPHCLK__, __PRESCALER__, __BAUDRATE__) \
+  ((((__PERIPHCLK__)/(USART_PRESCALER_TAB[(__PRESCALER__)]))\
+    + ((__BAUDRATE__)/2U))/(__BAUDRATE__))
 
 /**
   * @}
@@ -643,14 +657,14 @@ __STATIC_INLINE void LL_USART_Disable(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabled(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabled(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_UE) == (USART_CR1_UE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_UE) == (USART_CR1_UE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  FIFO Mode Enable
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          FIFOEN        LL_USART_EnableFIFO
   * @param  USARTx USART Instance
@@ -663,7 +677,7 @@ __STATIC_INLINE void LL_USART_EnableFIFO(USART_TypeDef *USARTx)
 
 /**
   * @brief  FIFO Mode Disable
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          FIFOEN        LL_USART_DisableFIFO
   * @param  USARTx USART Instance
@@ -676,20 +690,20 @@ __STATIC_INLINE void LL_USART_DisableFIFO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if FIFO Mode is enabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          FIFOEN        LL_USART_IsEnabledFIFO
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledFIFO(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledFIFO(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_FIFOEN) == (USART_CR1_FIFOEN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_FIFOEN) == (USART_CR1_FIFOEN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Configure TX FIFO Threshold
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTCFG       LL_USART_SetTXFIFOThreshold
   * @param  USARTx USART Instance
@@ -704,12 +718,12 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledFIFO(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_SetTXFIFOThreshold(USART_TypeDef *USARTx, uint32_t Threshold)
 {
-  MODIFY_REG(USARTx->CR3, USART_CR3_TXFTCFG, Threshold << USART_CR3_TXFTCFG_Pos);
+  ATOMIC_MODIFY_REG(USARTx->CR3, USART_CR3_TXFTCFG, Threshold << USART_CR3_TXFTCFG_Pos);
 }
 
 /**
   * @brief  Return TX FIFO Threshold Configuration
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTCFG       LL_USART_GetTXFIFOThreshold
   * @param  USARTx USART Instance
@@ -721,14 +735,14 @@ __STATIC_INLINE void LL_USART_SetTXFIFOThreshold(USART_TypeDef *USARTx, uint32_t
   *         @arg @ref LL_USART_FIFOTHRESHOLD_7_8
   *         @arg @ref LL_USART_FIFOTHRESHOLD_8_8
   */
-__STATIC_INLINE uint32_t LL_USART_GetTXFIFOThreshold(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetTXFIFOThreshold(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos);
 }
 
 /**
   * @brief  Configure RX FIFO Threshold
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTCFG       LL_USART_SetRXFIFOThreshold
   * @param  USARTx USART Instance
@@ -743,12 +757,12 @@ __STATIC_INLINE uint32_t LL_USART_GetTXFIFOThreshold(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_SetRXFIFOThreshold(USART_TypeDef *USARTx, uint32_t Threshold)
 {
-  MODIFY_REG(USARTx->CR3, USART_CR3_RXFTCFG, Threshold << USART_CR3_RXFTCFG_Pos);
+  ATOMIC_MODIFY_REG(USARTx->CR3, USART_CR3_RXFTCFG, Threshold << USART_CR3_RXFTCFG_Pos);
 }
 
 /**
   * @brief  Return RX FIFO Threshold Configuration
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTCFG       LL_USART_GetRXFIFOThreshold
   * @param  USARTx USART Instance
@@ -760,14 +774,14 @@ __STATIC_INLINE void LL_USART_SetRXFIFOThreshold(USART_TypeDef *USARTx, uint32_t
   *         @arg @ref LL_USART_FIFOTHRESHOLD_7_8
   *         @arg @ref LL_USART_FIFOTHRESHOLD_8_8
   */
-__STATIC_INLINE uint32_t LL_USART_GetRXFIFOThreshold(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetRXFIFOThreshold(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos);
 }
 
 /**
   * @brief  Configure TX and RX FIFOs Threshold
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTCFG       LL_USART_ConfigFIFOsThreshold\n
   *         CR3          RXFTCFG       LL_USART_ConfigFIFOsThreshold
@@ -790,14 +804,15 @@ __STATIC_INLINE uint32_t LL_USART_GetRXFIFOThreshold(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_ConfigFIFOsThreshold(USART_TypeDef *USARTx, uint32_t TXThreshold, uint32_t RXThreshold)
 {
-  MODIFY_REG(USARTx->CR3, USART_CR3_TXFTCFG | USART_CR3_RXFTCFG, (TXThreshold << USART_CR3_TXFTCFG_Pos) | (RXThreshold << USART_CR3_RXFTCFG_Pos));
+  ATOMIC_MODIFY_REG(USARTx->CR3, USART_CR3_TXFTCFG | USART_CR3_RXFTCFG, (TXThreshold << USART_CR3_TXFTCFG_Pos) |
+                    (RXThreshold << USART_CR3_RXFTCFG_Pos));
 }
 
 /**
   * @brief  USART enabled in STOP Mode.
   * @note   When this function is enabled, USART is able to wake up the MCU from Stop mode, provided that
   *         USART clock selection is HSI or LSE in RCC.
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR1          UESM          LL_USART_EnableInStopMode
   * @param  USARTx USART Instance
@@ -805,13 +820,13 @@ __STATIC_INLINE void LL_USART_ConfigFIFOsThreshold(USART_TypeDef *USARTx, uint32
   */
 __STATIC_INLINE void LL_USART_EnableInStopMode(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_UESM);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_UESM);
 }
 
 /**
   * @brief  USART disabled in STOP Mode.
   * @note   When this function is disabled, USART is not able to wake up the MCU from Stop mode
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR1          UESM          LL_USART_DisableInStopMode
   * @param  USARTx USART Instance
@@ -819,20 +834,20 @@ __STATIC_INLINE void LL_USART_EnableInStopMode(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableInStopMode(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_UESM);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_UESM);
 }
 
 /**
   * @brief  Indicate if USART is enabled in STOP Mode (able to wake up MCU from Stop mode or not)
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR1          UESM          LL_USART_IsEnabledInStopMode
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledInStopMode(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledInStopMode(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_UESM) == (USART_CR1_UESM)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_UESM) == (USART_CR1_UESM)) ? 1UL : 0UL);
 }
 
 /**
@@ -843,7 +858,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledInStopMode(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableDirectionRx(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_RE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_RE);
 }
 
 /**
@@ -854,7 +869,7 @@ __STATIC_INLINE void LL_USART_EnableDirectionRx(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableDirectionRx(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_RE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_RE);
 }
 
 /**
@@ -865,7 +880,7 @@ __STATIC_INLINE void LL_USART_DisableDirectionRx(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableDirectionTx(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_TE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_TE);
 }
 
 /**
@@ -876,7 +891,7 @@ __STATIC_INLINE void LL_USART_EnableDirectionTx(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableDirectionTx(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_TE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_TE);
 }
 
 /**
@@ -894,7 +909,7 @@ __STATIC_INLINE void LL_USART_DisableDirectionTx(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_SetTransferDirection(USART_TypeDef *USARTx, uint32_t TransferDirection)
 {
-  MODIFY_REG(USARTx->CR1, USART_CR1_RE | USART_CR1_TE, TransferDirection);
+  ATOMIC_MODIFY_REG(USARTx->CR1, USART_CR1_RE | USART_CR1_TE, TransferDirection);
 }
 
 /**
@@ -908,7 +923,7 @@ __STATIC_INLINE void LL_USART_SetTransferDirection(USART_TypeDef *USARTx, uint32
   *         @arg @ref LL_USART_DIRECTION_TX
   *         @arg @ref LL_USART_DIRECTION_TX_RX
   */
-__STATIC_INLINE uint32_t LL_USART_GetTransferDirection(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetTransferDirection(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_RE | USART_CR1_TE));
 }
@@ -942,7 +957,7 @@ __STATIC_INLINE void LL_USART_SetParity(USART_TypeDef *USARTx, uint32_t Parity)
   *         @arg @ref LL_USART_PARITY_EVEN
   *         @arg @ref LL_USART_PARITY_ODD
   */
-__STATIC_INLINE uint32_t LL_USART_GetParity(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetParity(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_PS | USART_CR1_PCE));
 }
@@ -969,7 +984,7 @@ __STATIC_INLINE void LL_USART_SetWakeUpMethod(USART_TypeDef *USARTx, uint32_t Me
   *         @arg @ref LL_USART_WAKEUP_IDLELINE
   *         @arg @ref LL_USART_WAKEUP_ADDRESSMARK
   */
-__STATIC_INLINE uint32_t LL_USART_GetWakeUpMethod(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetWakeUpMethod(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_WAKE));
 }
@@ -1000,7 +1015,7 @@ __STATIC_INLINE void LL_USART_SetDataWidth(USART_TypeDef *USARTx, uint32_t DataW
   *         @arg @ref LL_USART_DATAWIDTH_8B
   *         @arg @ref LL_USART_DATAWIDTH_9B
   */
-__STATIC_INLINE uint32_t LL_USART_GetDataWidth(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetDataWidth(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_M));
 }
@@ -1013,7 +1028,7 @@ __STATIC_INLINE uint32_t LL_USART_GetDataWidth(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableMuteMode(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_MME);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_MME);
 }
 
 /**
@@ -1024,7 +1039,7 @@ __STATIC_INLINE void LL_USART_EnableMuteMode(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableMuteMode(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_MME);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_MME);
 }
 
 /**
@@ -1033,9 +1048,9 @@ __STATIC_INLINE void LL_USART_DisableMuteMode(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledMuteMode(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledMuteMode(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_MME) == (USART_CR1_MME)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_MME) == (USART_CR1_MME)) ? 1UL : 0UL);
 }
 
 /**
@@ -1060,14 +1075,14 @@ __STATIC_INLINE void LL_USART_SetOverSampling(USART_TypeDef *USARTx, uint32_t Ov
   *         @arg @ref LL_USART_OVERSAMPLING_16
   *         @arg @ref LL_USART_OVERSAMPLING_8
   */
-__STATIC_INLINE uint32_t LL_USART_GetOverSampling(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetOverSampling(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_OVER8));
 }
 
 /**
   * @brief  Configure if Clock pulse of the last data bit is output to the SCLK pin or not
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          LBCL          LL_USART_SetLastClkPulseOutput
   * @param  USARTx USART Instance
@@ -1084,7 +1099,7 @@ __STATIC_INLINE void LL_USART_SetLastClkPulseOutput(USART_TypeDef *USARTx, uint3
 /**
   * @brief  Retrieve Clock pulse of the last data bit output configuration
   *         (Last bit Clock pulse output to the SCLK pin or not)
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          LBCL          LL_USART_GetLastClkPulseOutput
   * @param  USARTx USART Instance
@@ -1092,14 +1107,14 @@ __STATIC_INLINE void LL_USART_SetLastClkPulseOutput(USART_TypeDef *USARTx, uint3
   *         @arg @ref LL_USART_LASTCLKPULSE_NO_OUTPUT
   *         @arg @ref LL_USART_LASTCLKPULSE_OUTPUT
   */
-__STATIC_INLINE uint32_t LL_USART_GetLastClkPulseOutput(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetLastClkPulseOutput(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_LBCL));
 }
 
 /**
   * @brief  Select the phase of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPHA          LL_USART_SetClockPhase
   * @param  USARTx USART Instance
@@ -1115,7 +1130,7 @@ __STATIC_INLINE void LL_USART_SetClockPhase(USART_TypeDef *USARTx, uint32_t Cloc
 
 /**
   * @brief  Return phase of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPHA          LL_USART_GetClockPhase
   * @param  USARTx USART Instance
@@ -1123,14 +1138,14 @@ __STATIC_INLINE void LL_USART_SetClockPhase(USART_TypeDef *USARTx, uint32_t Cloc
   *         @arg @ref LL_USART_PHASE_1EDGE
   *         @arg @ref LL_USART_PHASE_2EDGE
   */
-__STATIC_INLINE uint32_t LL_USART_GetClockPhase(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetClockPhase(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_CPHA));
 }
 
 /**
   * @brief  Select the polarity of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPOL          LL_USART_SetClockPolarity
   * @param  USARTx USART Instance
@@ -1146,7 +1161,7 @@ __STATIC_INLINE void LL_USART_SetClockPolarity(USART_TypeDef *USARTx, uint32_t C
 
 /**
   * @brief  Return polarity of the clock output on the SCLK pin in synchronous mode
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CPOL          LL_USART_GetClockPolarity
   * @param  USARTx USART Instance
@@ -1154,14 +1169,14 @@ __STATIC_INLINE void LL_USART_SetClockPolarity(USART_TypeDef *USARTx, uint32_t C
   *         @arg @ref LL_USART_POLARITY_LOW
   *         @arg @ref LL_USART_POLARITY_HIGH
   */
-__STATIC_INLINE uint32_t LL_USART_GetClockPolarity(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetClockPolarity(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_CPOL));
 }
 
 /**
   * @brief  Configure Clock signal format (Phase Polarity and choice about output of last bit clock pulse)
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clock Phase configuration using @ref LL_USART_SetClockPhase() function
@@ -1189,7 +1204,7 @@ __STATIC_INLINE void LL_USART_ConfigClock(USART_TypeDef *USARTx, uint32_t Phase,
 
 /**
   * @brief  Configure Clock source prescaler for baudrate generator and oversampling
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll PRESC        PRESCALER     LL_USART_SetPrescaler
   * @param  USARTx USART Instance
@@ -1215,7 +1230,7 @@ __STATIC_INLINE void LL_USART_SetPrescaler(USART_TypeDef *USARTx, uint32_t Presc
 
 /**
   * @brief  Retrieve the Clock source prescaler for baudrate generator and oversampling
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll PRESC        PRESCALER     LL_USART_GetPrescaler
   * @param  USARTx USART Instance
@@ -1233,14 +1248,14 @@ __STATIC_INLINE void LL_USART_SetPrescaler(USART_TypeDef *USARTx, uint32_t Presc
   *         @arg @ref LL_USART_PRESCALER_DIV128
   *         @arg @ref LL_USART_PRESCALER_DIV256
   */
-__STATIC_INLINE uint32_t LL_USART_GetPrescaler(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetPrescaler(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->PRESC, USART_PRESC_PRESCALER));
 }
 
 /**
   * @brief  Enable Clock output on SCLK pin
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CLKEN         LL_USART_EnableSCLKOutput
   * @param  USARTx USART Instance
@@ -1253,7 +1268,7 @@ __STATIC_INLINE void LL_USART_EnableSCLKOutput(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Clock output on SCLK pin
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CLKEN         LL_USART_DisableSCLKOutput
   * @param  USARTx USART Instance
@@ -1266,15 +1281,15 @@ __STATIC_INLINE void LL_USART_DisableSCLKOutput(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Clock output on SCLK pin is enabled
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @rmtoll CR2          CLKEN         LL_USART_IsEnabledSCLKOutput
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledSCLKOutput(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledSCLKOutput(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_CLKEN) == (USART_CR2_CLKEN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_CLKEN) == (USART_CR2_CLKEN)) ? 1UL : 0UL);
 }
 
 /**
@@ -1303,7 +1318,7 @@ __STATIC_INLINE void LL_USART_SetStopBitsLength(USART_TypeDef *USARTx, uint32_t 
   *         @arg @ref LL_USART_STOPBITS_1_5
   *         @arg @ref LL_USART_STOPBITS_2
   */
-__STATIC_INLINE uint32_t LL_USART_GetStopBitsLength(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetStopBitsLength(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_STOP));
 }
@@ -1364,7 +1379,7 @@ __STATIC_INLINE void LL_USART_SetTXRXSwap(USART_TypeDef *USARTx, uint32_t SwapCo
   *         @arg @ref LL_USART_TXRX_STANDARD
   *         @arg @ref LL_USART_TXRX_SWAPPED
   */
-__STATIC_INLINE uint32_t LL_USART_GetTXRXSwap(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetTXRXSwap(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_SWAP));
 }
@@ -1391,7 +1406,7 @@ __STATIC_INLINE void LL_USART_SetRXPinLevel(USART_TypeDef *USARTx, uint32_t PinI
   *         @arg @ref LL_USART_RXPIN_LEVEL_STANDARD
   *         @arg @ref LL_USART_RXPIN_LEVEL_INVERTED
   */
-__STATIC_INLINE uint32_t LL_USART_GetRXPinLevel(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetRXPinLevel(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_RXINV));
 }
@@ -1418,7 +1433,7 @@ __STATIC_INLINE void LL_USART_SetTXPinLevel(USART_TypeDef *USARTx, uint32_t PinI
   *         @arg @ref LL_USART_TXPIN_LEVEL_STANDARD
   *         @arg @ref LL_USART_TXPIN_LEVEL_INVERTED
   */
-__STATIC_INLINE uint32_t LL_USART_GetTXPinLevel(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetTXPinLevel(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_TXINV));
 }
@@ -1447,7 +1462,7 @@ __STATIC_INLINE void LL_USART_SetBinaryDataLogic(USART_TypeDef *USARTx, uint32_t
   *         @arg @ref LL_USART_BINARY_LOGIC_POSITIVE
   *         @arg @ref LL_USART_BINARY_LOGIC_NEGATIVE
   */
-__STATIC_INLINE uint32_t LL_USART_GetBinaryDataLogic(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetBinaryDataLogic(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_DATAINV));
 }
@@ -1478,14 +1493,14 @@ __STATIC_INLINE void LL_USART_SetTransferBitOrder(USART_TypeDef *USARTx, uint32_
   *         @arg @ref LL_USART_BITORDER_LSBFIRST
   *         @arg @ref LL_USART_BITORDER_MSBFIRST
   */
-__STATIC_INLINE uint32_t LL_USART_GetTransferBitOrder(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetTransferBitOrder(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_MSBFIRST));
 }
 
 /**
   * @brief  Enable Auto Baud-Rate Detection
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABREN         LL_USART_EnableAutoBaudRate
   * @param  USARTx USART Instance
@@ -1498,7 +1513,7 @@ __STATIC_INLINE void LL_USART_EnableAutoBaudRate(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Auto Baud-Rate Detection
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABREN         LL_USART_DisableAutoBaudRate
   * @param  USARTx USART Instance
@@ -1511,20 +1526,20 @@ __STATIC_INLINE void LL_USART_DisableAutoBaudRate(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Auto Baud-Rate Detection mechanism is enabled
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABREN         LL_USART_IsEnabledAutoBaud
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledAutoBaud(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledAutoBaud(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_ABREN) == (USART_CR2_ABREN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_ABREN) == (USART_CR2_ABREN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Set Auto Baud-Rate mode bits
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABRMODE       LL_USART_SetAutoBaudRateMode
   * @param  USARTx USART Instance
@@ -1542,7 +1557,7 @@ __STATIC_INLINE void LL_USART_SetAutoBaudRateMode(USART_TypeDef *USARTx, uint32_
 
 /**
   * @brief  Return Auto Baud-Rate mode
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll CR2          ABRMODE       LL_USART_GetAutoBaudRateMode
   * @param  USARTx USART Instance
@@ -1552,7 +1567,7 @@ __STATIC_INLINE void LL_USART_SetAutoBaudRateMode(USART_TypeDef *USARTx, uint32_
   *         @arg @ref LL_USART_AUTOBAUD_DETECT_ON_7F_FRAME
   *         @arg @ref LL_USART_AUTOBAUD_DETECT_ON_55_FRAME
   */
-__STATIC_INLINE uint32_t LL_USART_GetAutoBaudRateMode(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetAutoBaudRateMode(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_ABRMODE));
 }
@@ -1585,9 +1600,9 @@ __STATIC_INLINE void LL_USART_DisableRxTimeout(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledRxTimeout(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledRxTimeout(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_RTOEN) == (USART_CR2_RTOEN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_RTOEN) == (USART_CR2_RTOEN)) ? 1UL : 0UL);
 }
 
 /**
@@ -1629,7 +1644,7 @@ __STATIC_INLINE void LL_USART_ConfigNodeAddress(USART_TypeDef *USARTx, uint32_t 
   * @param  USARTx USART Instance
   * @retval Address of the USART node (Value between Min_Data=0 and Max_Data=255)
   */
-__STATIC_INLINE uint32_t LL_USART_GetNodeAddress(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetNodeAddress(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_ADD) >> USART_CR2_ADD_Pos);
 }
@@ -1642,14 +1657,14 @@ __STATIC_INLINE uint32_t LL_USART_GetNodeAddress(USART_TypeDef *USARTx)
   *         @arg @ref LL_USART_ADDRESS_DETECT_4B
   *         @arg @ref LL_USART_ADDRESS_DETECT_7B
   */
-__STATIC_INLINE uint32_t LL_USART_GetNodeAddressLen(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetNodeAddressLen(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_ADDM7));
 }
 
 /**
   * @brief  Enable RTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_EnableRTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1662,7 +1677,7 @@ __STATIC_INLINE void LL_USART_EnableRTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable RTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_DisableRTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1675,7 +1690,7 @@ __STATIC_INLINE void LL_USART_DisableRTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable CTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSE          LL_USART_EnableCTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1688,7 +1703,7 @@ __STATIC_INLINE void LL_USART_EnableCTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable CTS HW Flow Control
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSE          LL_USART_DisableCTSHWFlowCtrl
   * @param  USARTx USART Instance
@@ -1701,7 +1716,7 @@ __STATIC_INLINE void LL_USART_DisableCTSHWFlowCtrl(USART_TypeDef *USARTx)
 
 /**
   * @brief  Configure HW Flow Control mode (both CTS and RTS)
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_SetHWFlowCtrl\n
   *         CR3          CTSE          LL_USART_SetHWFlowCtrl
@@ -1720,7 +1735,7 @@ __STATIC_INLINE void LL_USART_SetHWFlowCtrl(USART_TypeDef *USARTx, uint32_t Hard
 
 /**
   * @brief  Return HW Flow Control configuration (both CTS and RTS)
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          RTSE          LL_USART_GetHWFlowCtrl\n
   *         CR3          CTSE          LL_USART_GetHWFlowCtrl
@@ -1731,7 +1746,7 @@ __STATIC_INLINE void LL_USART_SetHWFlowCtrl(USART_TypeDef *USARTx, uint32_t Hard
   *         @arg @ref LL_USART_HWCONTROL_CTS
   *         @arg @ref LL_USART_HWCONTROL_RTS_CTS
   */
-__STATIC_INLINE uint32_t LL_USART_GetHWFlowCtrl(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetHWFlowCtrl(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_RTSE | USART_CR3_CTSE));
 }
@@ -1764,9 +1779,9 @@ __STATIC_INLINE void LL_USART_DisableOneBitSamp(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledOneBitSamp(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledOneBitSamp(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_ONEBIT) == (USART_CR3_ONEBIT)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_ONEBIT) == (USART_CR3_ONEBIT)) ? 1UL : 0UL);
 }
 
 /**
@@ -1797,14 +1812,14 @@ __STATIC_INLINE void LL_USART_DisableOverrunDetect(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledOverrunDetect(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledOverrunDetect(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_OVRDIS) != USART_CR3_OVRDIS) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_OVRDIS) != USART_CR3_OVRDIS) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Select event type for Wake UP Interrupt Flag (WUS[1:0] bits)
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUS           LL_USART_SetWKUPType
   * @param  USARTx USART Instance
@@ -1821,7 +1836,7 @@ __STATIC_INLINE void LL_USART_SetWKUPType(USART_TypeDef *USARTx, uint32_t Type)
 
 /**
   * @brief  Return event type for Wake UP Interrupt Flag (WUS[1:0] bits)
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUS           LL_USART_GetWKUPType
   * @param  USARTx USART Instance
@@ -1830,7 +1845,7 @@ __STATIC_INLINE void LL_USART_SetWKUPType(USART_TypeDef *USARTx, uint32_t Type)
   *         @arg @ref LL_USART_WAKEUP_ON_STARTBIT
   *         @arg @ref LL_USART_WAKEUP_ON_RXNE
   */
-__STATIC_INLINE uint32_t LL_USART_GetWKUPType(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetWKUPType(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_WUS));
 }
@@ -1864,22 +1879,31 @@ __STATIC_INLINE uint32_t LL_USART_GetWKUPType(USART_TypeDef *USARTx)
   * @param  BaudRate Baud Rate
   * @retval None
   */
-__STATIC_INLINE void LL_USART_SetBaudRate(USART_TypeDef *USARTx, uint32_t PeriphClk, uint32_t PrescalerValue, uint32_t OverSampling,
+__STATIC_INLINE void LL_USART_SetBaudRate(USART_TypeDef *USARTx, uint32_t PeriphClk, uint32_t PrescalerValue,
+                                          uint32_t OverSampling,
                                           uint32_t BaudRate)
 {
   uint32_t usartdiv;
   uint32_t brrtemp;
 
-  if (OverSampling == LL_USART_OVERSAMPLING_8)
+  if (PrescalerValue > LL_USART_PRESCALER_DIV256)
   {
-    usartdiv = (uint16_t)(__LL_USART_DIV_SAMPLING8(PeriphClk, (uint16_t)PrescalerValue, BaudRate));
+    /* Do not overstep the size of USART_PRESCALER_TAB */
+  }
+  else if (BaudRate == 0U)
+  {
+    /* Can Not divide per 0 */
+  }
+  else if (OverSampling == LL_USART_OVERSAMPLING_8)
+  {
+    usartdiv = (uint16_t)(__LL_USART_DIV_SAMPLING8(PeriphClk, (uint8_t)PrescalerValue, BaudRate));
     brrtemp = usartdiv & 0xFFF0U;
     brrtemp |= (uint16_t)((usartdiv & (uint16_t)0x000FU) >> 1U);
     USARTx->BRR = brrtemp;
   }
   else
   {
-    USARTx->BRR = (uint16_t)(__LL_USART_DIV_SAMPLING16(PeriphClk, (uint16_t)PrescalerValue, BaudRate));
+    USARTx->BRR = (uint16_t)(__LL_USART_DIV_SAMPLING16(PeriphClk, (uint8_t)PrescalerValue, BaudRate));
   }
 }
 
@@ -1909,22 +1933,23 @@ __STATIC_INLINE void LL_USART_SetBaudRate(USART_TypeDef *USARTx, uint32_t Periph
   *         @arg @ref LL_USART_OVERSAMPLING_8
   * @retval Baud Rate
   */
-__STATIC_INLINE uint32_t LL_USART_GetBaudRate(USART_TypeDef *USARTx, uint32_t PeriphClk, uint32_t PrescalerValue, uint32_t OverSampling)
+__STATIC_INLINE uint32_t LL_USART_GetBaudRate(const USART_TypeDef *USARTx, uint32_t PeriphClk, uint32_t PrescalerValue,
+                                              uint32_t OverSampling)
 {
   uint32_t usartdiv;
   uint32_t brrresult = 0x0U;
-  uint32_t periphclkpresc = (uint32_t)(PeriphClk / (uint32_t)(USART_PRESCALER_TAB[(uint16_t)PrescalerValue]));
+  uint32_t periphclkpresc = (uint32_t)(PeriphClk / (USART_PRESCALER_TAB[(uint8_t)PrescalerValue]));
 
   usartdiv = USARTx->BRR;
 
-  if(usartdiv == 0U)
+  if (usartdiv == 0U)
   {
     /* Do not perform a division by 0 */
   }
   else if (OverSampling == LL_USART_OVERSAMPLING_8)
   {
     usartdiv = (uint16_t)((usartdiv & 0xFFF0U) | ((usartdiv & 0x0007U) << 1U)) ;
-    if(usartdiv != 0U)
+    if (usartdiv != 0U)
     {
       brrresult = (periphclkpresc * 2U) / usartdiv;
     }
@@ -1957,7 +1982,7 @@ __STATIC_INLINE void LL_USART_SetRxTimeout(USART_TypeDef *USARTx, uint32_t Timeo
   * @param  USARTx USART Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0x00FFFFFF
   */
-__STATIC_INLINE uint32_t LL_USART_GetRxTimeout(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetRxTimeout(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->RTOR, USART_RTOR_RTO));
 }
@@ -1980,7 +2005,7 @@ __STATIC_INLINE void LL_USART_SetBlockLength(USART_TypeDef *USARTx, uint32_t Blo
   * @param  USARTx USART Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint32_t LL_USART_GetBlockLength(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetBlockLength(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->RTOR, USART_RTOR_BLEN) >> USART_RTOR_BLEN_Pos);
 }
@@ -1995,7 +2020,7 @@ __STATIC_INLINE uint32_t LL_USART_GetBlockLength(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable IrDA mode
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IREN          LL_USART_EnableIrda
   * @param  USARTx USART Instance
@@ -2008,7 +2033,7 @@ __STATIC_INLINE void LL_USART_EnableIrda(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable IrDA mode
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IREN          LL_USART_DisableIrda
   * @param  USARTx USART Instance
@@ -2021,20 +2046,20 @@ __STATIC_INLINE void LL_USART_DisableIrda(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if IrDA mode is enabled
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IREN          LL_USART_IsEnabledIrda
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIrda(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIrda(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_IREN) == (USART_CR3_IREN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_IREN) == (USART_CR3_IREN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Configure IrDA Power Mode (Normal or Low Power)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IRLP          LL_USART_SetIrdaPowerMode
   * @param  USARTx USART Instance
@@ -2050,7 +2075,7 @@ __STATIC_INLINE void LL_USART_SetIrdaPowerMode(USART_TypeDef *USARTx, uint32_t P
 
 /**
   * @brief  Retrieve IrDA Power Mode configuration (Normal or Low Power)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll CR3          IRLP          LL_USART_GetIrdaPowerMode
   * @param  USARTx USART Instance
@@ -2058,7 +2083,7 @@ __STATIC_INLINE void LL_USART_SetIrdaPowerMode(USART_TypeDef *USARTx, uint32_t P
   *         @arg @ref LL_USART_IRDA_POWER_NORMAL
   *         @arg @ref LL_USART_PHASE_2EDGE
   */
-__STATIC_INLINE uint32_t LL_USART_GetIrdaPowerMode(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetIrdaPowerMode(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_IRLP));
 }
@@ -2066,7 +2091,7 @@ __STATIC_INLINE uint32_t LL_USART_GetIrdaPowerMode(USART_TypeDef *USARTx)
 /**
   * @brief  Set Irda prescaler value, used for dividing the USART clock source
   *         to achieve the Irda Low Power frequency (8 bits value)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_SetIrdaPrescaler
   * @param  USARTx USART Instance
@@ -2081,13 +2106,13 @@ __STATIC_INLINE void LL_USART_SetIrdaPrescaler(USART_TypeDef *USARTx, uint32_t P
 /**
   * @brief  Return Irda prescaler value, used for dividing the USART clock source
   *         to achieve the Irda Low Power frequency (8 bits value)
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_GetIrdaPrescaler
   * @param  USARTx USART Instance
   * @retval Irda prescaler value (Value between Min_Data=0x00 and Max_Data=0xFF)
   */
-__STATIC_INLINE uint32_t LL_USART_GetIrdaPrescaler(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetIrdaPrescaler(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->GTPR, USART_GTPR_PSC));
 }
@@ -2102,7 +2127,7 @@ __STATIC_INLINE uint32_t LL_USART_GetIrdaPrescaler(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Smartcard NACK transmission
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          NACK          LL_USART_EnableSmartcardNACK
   * @param  USARTx USART Instance
@@ -2115,7 +2140,7 @@ __STATIC_INLINE void LL_USART_EnableSmartcardNACK(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Smartcard NACK transmission
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          NACK          LL_USART_DisableSmartcardNACK
   * @param  USARTx USART Instance
@@ -2128,20 +2153,20 @@ __STATIC_INLINE void LL_USART_DisableSmartcardNACK(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Smartcard NACK transmission is enabled
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          NACK          LL_USART_IsEnabledSmartcardNACK
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledSmartcardNACK(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledSmartcardNACK(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_NACK) == (USART_CR3_NACK)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_NACK) == (USART_CR3_NACK)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable Smartcard mode
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCEN          LL_USART_EnableSmartcard
   * @param  USARTx USART Instance
@@ -2154,7 +2179,7 @@ __STATIC_INLINE void LL_USART_EnableSmartcard(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Smartcard mode
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCEN          LL_USART_DisableSmartcard
   * @param  USARTx USART Instance
@@ -2167,20 +2192,20 @@ __STATIC_INLINE void LL_USART_DisableSmartcard(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Smartcard mode is enabled
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCEN          LL_USART_IsEnabledSmartcard
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledSmartcard(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledSmartcard(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_SCEN) == (USART_CR3_SCEN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_SCEN) == (USART_CR3_SCEN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Set Smartcard Auto-Retry Count value (SCARCNT[2:0] bits)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @note   This bit-field specifies the number of retries in transmit and receive, in Smartcard mode.
   *         In transmission mode, it specifies the number of automatic retransmission retries, before
@@ -2199,13 +2224,13 @@ __STATIC_INLINE void LL_USART_SetSmartcardAutoRetryCount(USART_TypeDef *USARTx, 
 
 /**
   * @brief  Return Smartcard Auto-Retry Count value (SCARCNT[2:0] bits)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          SCARCNT       LL_USART_GetSmartcardAutoRetryCount
   * @param  USARTx USART Instance
   * @retval Smartcard Auto-Retry Count value (Value between Min_Data=0 and Max_Data=7)
   */
-__STATIC_INLINE uint32_t LL_USART_GetSmartcardAutoRetryCount(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetSmartcardAutoRetryCount(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_SCARCNT) >> USART_CR3_SCARCNT_Pos);
 }
@@ -2213,7 +2238,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardAutoRetryCount(USART_TypeDef *USAR
 /**
   * @brief  Set Smartcard prescaler value, used for dividing the USART clock
   *         source to provide the SMARTCARD Clock (5 bits value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_SetSmartcardPrescaler
   * @param  USARTx USART Instance
@@ -2228,13 +2253,13 @@ __STATIC_INLINE void LL_USART_SetSmartcardPrescaler(USART_TypeDef *USARTx, uint3
 /**
   * @brief  Return Smartcard prescaler value, used for dividing the USART clock
   *         source to provide the SMARTCARD Clock (5 bits value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         PSC           LL_USART_GetSmartcardPrescaler
   * @param  USARTx USART Instance
   * @retval Smartcard prescaler value (Value between Min_Data=0 and Max_Data=31)
   */
-__STATIC_INLINE uint32_t LL_USART_GetSmartcardPrescaler(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetSmartcardPrescaler(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->GTPR, USART_GTPR_PSC));
 }
@@ -2242,7 +2267,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardPrescaler(USART_TypeDef *USARTx)
 /**
   * @brief  Set Smartcard Guard time value, expressed in nb of baud clocks periods
   *         (GT[7:0] bits : Guard time value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         GT            LL_USART_SetSmartcardGuardTime
   * @param  USARTx USART Instance
@@ -2251,19 +2276,19 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardPrescaler(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_SetSmartcardGuardTime(USART_TypeDef *USARTx, uint32_t GuardTime)
 {
-  MODIFY_REG(USARTx->GTPR, USART_GTPR_GT, GuardTime << USART_GTPR_GT_Pos);
+  MODIFY_REG(USARTx->GTPR, USART_GTPR_GT, (uint16_t)(GuardTime << USART_GTPR_GT_Pos));
 }
 
 /**
   * @brief  Return Smartcard Guard time value, expressed in nb of baud clocks periods
   *         (GT[7:0] bits : Guard time value)
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll GTPR         GT            LL_USART_GetSmartcardGuardTime
   * @param  USARTx USART Instance
   * @retval Smartcard Guard time value (Value between Min_Data=0x00 and Max_Data=0xFF)
   */
-__STATIC_INLINE uint32_t LL_USART_GetSmartcardGuardTime(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetSmartcardGuardTime(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->GTPR, USART_GTPR_GT) >> USART_GTPR_GT_Pos);
 }
@@ -2278,7 +2303,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardGuardTime(USART_TypeDef *USARTx)
 
 /**
   * @brief  Enable Single Wire Half-Duplex mode
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @rmtoll CR3          HDSEL         LL_USART_EnableHalfDuplex
   * @param  USARTx USART Instance
@@ -2291,7 +2316,7 @@ __STATIC_INLINE void LL_USART_EnableHalfDuplex(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Single Wire Half-Duplex mode
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @rmtoll CR3          HDSEL         LL_USART_DisableHalfDuplex
   * @param  USARTx USART Instance
@@ -2304,15 +2329,15 @@ __STATIC_INLINE void LL_USART_DisableHalfDuplex(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Single Wire Half-Duplex mode is enabled
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @rmtoll CR3          HDSEL         LL_USART_IsEnabledHalfDuplex
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledHalfDuplex(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledHalfDuplex(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_HDSEL) == (USART_CR3_HDSEL)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_HDSEL) == (USART_CR3_HDSEL)) ? 1UL : 0UL);
 }
 
 /**
@@ -2324,7 +2349,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledHalfDuplex(USART_TypeDef *USARTx)
   */
 /**
   * @brief  Enable SPI Synchronous Slave mode
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          SLVEN         LL_USART_EnableSPISlave
   * @param  USARTx USART Instance
@@ -2337,7 +2362,7 @@ __STATIC_INLINE void LL_USART_EnableSPISlave(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable SPI Synchronous Slave mode
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          SLVEN         LL_USART_DisableSPISlave
   * @param  USARTx USART Instance
@@ -2350,20 +2375,20 @@ __STATIC_INLINE void LL_USART_DisableSPISlave(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if  SPI Synchronous Slave mode is enabled
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          SLVEN         LL_USART_IsEnabledSPISlave
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlave(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlave(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_SLVEN) == (USART_CR2_SLVEN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_SLVEN) == (USART_CR2_SLVEN)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Enable SPI Slave Selection using NSS input pin
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @note   SPI Slave Selection depends on NSS input pin
   *         (The slave is selected when NSS is low and deselected when NSS is high).
@@ -2378,7 +2403,7 @@ __STATIC_INLINE void LL_USART_EnableSPISlaveSelect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable SPI Slave Selection using NSS input pin
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @note   SPI Slave will be always selected and NSS input pin will be ignored.
   * @rmtoll CR2          DIS_NSS       LL_USART_DisableSPISlaveSelect
@@ -2392,15 +2417,15 @@ __STATIC_INLINE void LL_USART_DisableSPISlaveSelect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if  SPI Slave Selection depends on NSS input pin
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll CR2          DIS_NSS       LL_USART_IsEnabledSPISlaveSelect
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlaveSelect(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlaveSelect(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_DIS_NSS) != (USART_CR2_DIS_NSS)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_DIS_NSS) != (USART_CR2_DIS_NSS)) ? 1UL : 0UL);
 }
 
 /**
@@ -2413,7 +2438,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledSPISlaveSelect(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set LIN Break Detection Length
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDL          LL_USART_SetLINBrkDetectionLen
   * @param  USARTx USART Instance
@@ -2429,7 +2454,7 @@ __STATIC_INLINE void LL_USART_SetLINBrkDetectionLen(USART_TypeDef *USARTx, uint3
 
 /**
   * @brief  Return LIN Break Detection Length
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDL          LL_USART_GetLINBrkDetectionLen
   * @param  USARTx USART Instance
@@ -2437,14 +2462,14 @@ __STATIC_INLINE void LL_USART_SetLINBrkDetectionLen(USART_TypeDef *USARTx, uint3
   *         @arg @ref LL_USART_LINBREAK_DETECT_10B
   *         @arg @ref LL_USART_LINBREAK_DETECT_11B
   */
-__STATIC_INLINE uint32_t LL_USART_GetLINBrkDetectionLen(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetLINBrkDetectionLen(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR2, USART_CR2_LBDL));
 }
 
 /**
   * @brief  Enable LIN mode
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LINEN         LL_USART_EnableLIN
   * @param  USARTx USART Instance
@@ -2457,7 +2482,7 @@ __STATIC_INLINE void LL_USART_EnableLIN(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable LIN mode
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LINEN         LL_USART_DisableLIN
   * @param  USARTx USART Instance
@@ -2470,15 +2495,15 @@ __STATIC_INLINE void LL_USART_DisableLIN(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if LIN mode is enabled
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LINEN         LL_USART_IsEnabledLIN
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledLIN(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledLIN(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_LINEN) == (USART_CR2_LINEN)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_LINEN) == (USART_CR2_LINEN)) ? 1UL : 0UL);
 }
 
 /**
@@ -2491,7 +2516,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledLIN(USART_TypeDef *USARTx)
 
 /**
   * @brief  Set DEDT (Driver Enable De-Assertion Time), Time value expressed on 5 bits ([4:0] bits).
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEDT          LL_USART_SetDEDeassertionTime
   * @param  USARTx USART Instance
@@ -2505,20 +2530,20 @@ __STATIC_INLINE void LL_USART_SetDEDeassertionTime(USART_TypeDef *USARTx, uint32
 
 /**
   * @brief  Return DEDT (Driver Enable De-Assertion Time)
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEDT          LL_USART_GetDEDeassertionTime
   * @param  USARTx USART Instance
   * @retval Time value expressed on 5 bits ([4:0] bits) : Value between Min_Data=0 and Max_Data=31
   */
-__STATIC_INLINE uint32_t LL_USART_GetDEDeassertionTime(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetDEDeassertionTime(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_DEDT) >> USART_CR1_DEDT_Pos);
 }
 
 /**
   * @brief  Set DEAT (Driver Enable Assertion Time), Time value expressed on 5 bits ([4:0] bits).
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEAT          LL_USART_SetDEAssertionTime
   * @param  USARTx USART Instance
@@ -2532,20 +2557,20 @@ __STATIC_INLINE void LL_USART_SetDEAssertionTime(USART_TypeDef *USARTx, uint32_t
 
 /**
   * @brief  Return DEAT (Driver Enable Assertion Time)
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR1          DEAT          LL_USART_GetDEAssertionTime
   * @param  USARTx USART Instance
   * @retval Time value expressed on 5 bits ([4:0] bits) : Value between Min_Data=0 and Max_Data=31
   */
-__STATIC_INLINE uint32_t LL_USART_GetDEAssertionTime(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetDEAssertionTime(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR1, USART_CR1_DEAT) >> USART_CR1_DEAT_Pos);
 }
 
 /**
   * @brief  Enable Driver Enable (DE) Mode
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEM           LL_USART_EnableDEMode
   * @param  USARTx USART Instance
@@ -2558,7 +2583,7 @@ __STATIC_INLINE void LL_USART_EnableDEMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Disable Driver Enable (DE) Mode
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEM           LL_USART_DisableDEMode
   * @param  USARTx USART Instance
@@ -2571,20 +2596,20 @@ __STATIC_INLINE void LL_USART_DisableDEMode(USART_TypeDef *USARTx)
 
 /**
   * @brief  Indicate if Driver Enable (DE) Mode is enabled
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEM           LL_USART_IsEnabledDEMode
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledDEMode(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledDEMode(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_DEM) == (USART_CR3_DEM)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_DEM) == (USART_CR3_DEM)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Select Driver Enable Polarity
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEP           LL_USART_SetDESignalPolarity
   * @param  USARTx USART Instance
@@ -2600,7 +2625,7 @@ __STATIC_INLINE void LL_USART_SetDESignalPolarity(USART_TypeDef *USARTx, uint32_
 
 /**
   * @brief  Return Driver Enable Polarity
-  * @note   Macro @ref IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_DRIVER_ENABLE_INSTANCE(USARTx) can be used to check whether or not
   *         Driver Enable feature is supported by the USARTx instance.
   * @rmtoll CR3          DEP           LL_USART_GetDESignalPolarity
   * @param  USARTx USART Instance
@@ -2608,7 +2633,7 @@ __STATIC_INLINE void LL_USART_SetDESignalPolarity(USART_TypeDef *USARTx, uint32_
   *         @arg @ref LL_USART_DE_POLARITY_HIGH
   *         @arg @ref LL_USART_DE_POLARITY_LOW
   */
-__STATIC_INLINE uint32_t LL_USART_GetDESignalPolarity(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_GetDESignalPolarity(const USART_TypeDef *USARTx)
 {
   return (uint32_t)(READ_BIT(USARTx->CR3, USART_CR3_DEP));
 }
@@ -2650,7 +2675,8 @@ __STATIC_INLINE void LL_USART_ConfigAsyncMode(USART_TypeDef *USARTx)
 {
   /* In Asynchronous mode, the following bits must be kept cleared:
   - LINEN, CLKEN bits in the USART_CR2 register,
-  - SCEN, IREN and HDSEL bits in the USART_CR3 register.*/
+  - SCEN, IREN and HDSEL bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_LINEN | USART_CR2_CLKEN));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_SCEN | USART_CR3_IREN | USART_CR3_HDSEL));
 }
@@ -2663,7 +2689,7 @@ __STATIC_INLINE void LL_USART_ConfigAsyncMode(USART_TypeDef *USARTx)
   *           - IREN bit in the USART_CR3 register,
   *           - HDSEL bit in the USART_CR3 register.
   *         This function also sets the USART in Synchronous mode.
-  * @note   Macro @ref IS_USART_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_INSTANCE(USARTx) can be used to check whether or not
   *         Synchronous mode is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2686,7 +2712,8 @@ __STATIC_INLINE void LL_USART_ConfigSyncMode(USART_TypeDef *USARTx)
 {
   /* In Synchronous mode, the following bits must be kept cleared:
   - LINEN bit in the USART_CR2 register,
-  - SCEN, IREN and HDSEL bits in the USART_CR3 register.*/
+  - SCEN, IREN and HDSEL bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_LINEN));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_SCEN | USART_CR3_IREN | USART_CR3_HDSEL));
   /* set the UART/USART in Synchronous mode */
@@ -2701,7 +2728,7 @@ __STATIC_INLINE void LL_USART_ConfigSyncMode(USART_TypeDef *USARTx)
   *           - IREN bit in the USART_CR3 register,
   *           - HDSEL bit in the USART_CR3 register.
   *         This function also set the UART/USART in LIN mode.
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear CLKEN in CR2 using @ref LL_USART_DisableSCLKOutput() function
@@ -2726,7 +2753,8 @@ __STATIC_INLINE void LL_USART_ConfigLINMode(USART_TypeDef *USARTx)
 {
   /* In LIN mode, the following bits must be kept cleared:
   - STOP and CLKEN bits in the USART_CR2 register,
-  - IREN, SCEN and HDSEL bits in the USART_CR3 register.*/
+  - IREN, SCEN and HDSEL bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_CLKEN | USART_CR2_STOP));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_IREN | USART_CR3_SCEN | USART_CR3_HDSEL));
   /* Set the UART/USART in LIN mode */
@@ -2741,7 +2769,7 @@ __STATIC_INLINE void LL_USART_ConfigLINMode(USART_TypeDef *USARTx)
   *           - SCEN bit in the USART_CR3 register,
   *           - IREN bit in the USART_CR3 register,
   *         This function also sets the UART/USART in Half Duplex mode.
-  * @note   Macro @ref IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HALFDUPLEX_INSTANCE(USARTx) can be used to check whether or not
   *         Half-Duplex mode is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2764,7 +2792,8 @@ __STATIC_INLINE void LL_USART_ConfigHalfDuplexMode(USART_TypeDef *USARTx)
 {
   /* In Half Duplex mode, the following bits must be kept cleared:
   - LINEN and CLKEN bits in the USART_CR2 register,
-  - SCEN and IREN bits in the USART_CR3 register.*/
+  - SCEN and IREN bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_LINEN | USART_CR2_CLKEN));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_SCEN | USART_CR3_IREN));
   /* set the UART/USART in Half Duplex mode */
@@ -2780,7 +2809,7 @@ __STATIC_INLINE void LL_USART_ConfigHalfDuplexMode(USART_TypeDef *USARTx)
   *         This function also configures Stop bits to 1.5 bits and
   *         sets the USART in Smartcard mode (SCEN bit).
   *         Clock Output is also enabled (CLKEN).
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2804,7 +2833,8 @@ __STATIC_INLINE void LL_USART_ConfigSmartcardMode(USART_TypeDef *USARTx)
 {
   /* In Smartcard mode, the following bits must be kept cleared:
   - LINEN bit in the USART_CR2 register,
-  - IREN and HDSEL bits in the USART_CR3 register.*/
+  - IREN and HDSEL bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_LINEN));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_IREN | USART_CR3_HDSEL));
   /* Configure Stop bits to 1.5 bits */
@@ -2822,7 +2852,7 @@ __STATIC_INLINE void LL_USART_ConfigSmartcardMode(USART_TypeDef *USARTx)
   *           - SCEN bit in the USART_CR3 register,
   *           - HDSEL bit in the USART_CR3 register.
   *         This function also sets the UART/USART in IRDA mode (IREN bit).
-  * @note   Macro @ref IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_IRDA_INSTANCE(USARTx) can be used to check whether or not
   *         IrDA feature is supported by the USARTx instance.
   * @note   Call of this function is equivalent to following function call sequence :
   *         - Clear LINEN in CR2 using @ref LL_USART_DisableLIN() function
@@ -2847,7 +2877,8 @@ __STATIC_INLINE void LL_USART_ConfigIrdaMode(USART_TypeDef *USARTx)
 {
   /* In IRDA mode, the following bits must be kept cleared:
   - LINEN, STOP and CLKEN bits in the USART_CR2 register,
-  - SCEN and HDSEL bits in the USART_CR3 register.*/
+  - SCEN and HDSEL bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_LINEN | USART_CR2_CLKEN | USART_CR2_STOP));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_SCEN | USART_CR3_HDSEL));
   /* set the UART/USART in IRDA mode */
@@ -2885,7 +2916,8 @@ __STATIC_INLINE void LL_USART_ConfigMultiProcessMode(USART_TypeDef *USARTx)
 {
   /* In Multi Processor mode, the following bits must be kept cleared:
   - LINEN and CLKEN bits in the USART_CR2 register,
-  - IREN, SCEN and HDSEL bits in the USART_CR3 register.*/
+  - IREN, SCEN and HDSEL bits in the USART_CR3 register.
+  */
   CLEAR_BIT(USARTx->CR2, (USART_CR2_LINEN | USART_CR2_CLKEN));
   CLEAR_BIT(USARTx->CR3, (USART_CR3_SCEN | USART_CR3_HDSEL | USART_CR3_IREN));
 }
@@ -2904,9 +2936,9 @@ __STATIC_INLINE void LL_USART_ConfigMultiProcessMode(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_PE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_PE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_PE) == (USART_ISR_PE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_PE) == (USART_ISR_PE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2915,9 +2947,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_PE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_FE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_FE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_FE) == (USART_ISR_FE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_FE) == (USART_ISR_FE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2926,9 +2958,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_FE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_NE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_NE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_NE) == (USART_ISR_NE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_NE) == (USART_ISR_NE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2937,9 +2969,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_NE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ORE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ORE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_ORE) == (USART_ISR_ORE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_ORE) == (USART_ISR_ORE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2948,25 +2980,24 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ORE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_IDLE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_IDLE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_IDLE) == (USART_ISR_IDLE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_IDLE) == (USART_ISR_IDLE)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_USART_IsActiveFlag_RXNE  LL_USART_IsActiveFlag_RXNE_RXFNE
+#define LL_USART_IsActiveFlag_RXNE  LL_USART_IsActiveFlag_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the USART Read Data Register or USART RX FIFO Not Empty Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          RXNE_RXFNE    LL_USART_IsActiveFlag_RXNE_RXFNE
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXNE_RXFNE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXNE_RXFNE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_RXNE_RXFNE) == (USART_ISR_RXNE_RXFNE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_RXNE_RXFNE) == (USART_ISR_RXNE_RXFNE)) ? 1UL : 0UL);
 }
 
 /**
@@ -2975,64 +3006,63 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXNE_RXFNE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TC(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TC(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_TC) == (USART_ISR_TC)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_TC) == (USART_ISR_TC)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_USART_IsActiveFlag_TXE  LL_USART_IsActiveFlag_TXE_TXFNF
+#define LL_USART_IsActiveFlag_TXE  LL_USART_IsActiveFlag_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the USART Transmit Data Register Empty or USART TX FIFO Not Full Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          TXE_TXFNF     LL_USART_IsActiveFlag_TXE_TXFNF
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXE_TXFNF(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXE_TXFNF(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_TXE_TXFNF) == (USART_ISR_TXE_TXFNF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_TXE_TXFNF) == (USART_ISR_TXE_TXFNF)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART LIN Break Detection Flag is set or not
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll ISR          LBDF          LL_USART_IsActiveFlag_LBD
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_LBD(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_LBD(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_LBDF) == (USART_ISR_LBDF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_LBDF) == (USART_ISR_LBDF)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART CTS interrupt Flag is set or not
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll ISR          CTSIF         LL_USART_IsActiveFlag_nCTS
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_nCTS(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_nCTS(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_CTSIF) == (USART_ISR_CTSIF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_CTSIF) == (USART_ISR_CTSIF)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART CTS Flag is set or not
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll ISR          CTS           LL_USART_IsActiveFlag_CTS
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_CTS(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_CTS(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_CTS) == (USART_ISR_CTS)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_CTS) == (USART_ISR_CTS)) ? 1UL : 0UL);
 }
 
 /**
@@ -3041,61 +3071,61 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_CTS(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RTO(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RTO(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_RTOF) == (USART_ISR_RTOF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_RTOF) == (USART_ISR_RTOF)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART End Of Block Flag is set or not
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll ISR          EOBF          LL_USART_IsActiveFlag_EOB
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_EOB(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_EOB(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_EOBF) == (USART_ISR_EOBF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_EOBF) == (USART_ISR_EOBF)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the SPI Slave Underrun error flag is set or not
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll ISR          UDR           LL_USART_IsActiveFlag_UDR
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_UDR(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_UDR(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_UDR) == (USART_ISR_UDR)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_UDR) == (USART_ISR_UDR)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART Auto-Baud Rate Error Flag is set or not
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll ISR          ABRE          LL_USART_IsActiveFlag_ABRE
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ABRE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ABRE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_ABRE) == (USART_ISR_ABRE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_ABRE) == (USART_ISR_ABRE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART Auto-Baud Rate Flag is set or not
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll ISR          ABRF          LL_USART_IsActiveFlag_ABR
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ABR(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ABR(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_ABRF) == (USART_ISR_ABRF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_ABRF) == (USART_ISR_ABRF)) ? 1UL : 0UL);
 }
 
 /**
@@ -3104,9 +3134,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_ABR(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_BUSY(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_BUSY(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_BUSY) == (USART_ISR_BUSY)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_BUSY) == (USART_ISR_BUSY)) ? 1UL : 0UL);
 }
 
 /**
@@ -3115,9 +3145,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_BUSY(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_CM(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_CM(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_CMF) == (USART_ISR_CMF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_CMF) == (USART_ISR_CMF)) ? 1UL : 0UL);
 }
 
 /**
@@ -3126,9 +3156,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_CM(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_SBK(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_SBK(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_SBKF) == (USART_ISR_SBKF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_SBKF) == (USART_ISR_SBKF)) ? 1UL : 0UL);
 }
 
 /**
@@ -3137,22 +3167,22 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_SBK(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RWU(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RWU(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_RWU) == (USART_ISR_RWU)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_RWU) == (USART_ISR_RWU)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART Wake Up from stop mode Flag is set or not
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll ISR          WUF           LL_USART_IsActiveFlag_WKUP
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_WKUP(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_WKUP(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_WUF) == (USART_ISR_WUF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_WUF) == (USART_ISR_WUF)) ? 1UL : 0UL);
 }
 
 /**
@@ -3161,9 +3191,9 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_WKUP(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TEACK(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TEACK(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_TEACK) == (USART_ISR_TEACK)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_TEACK) == (USART_ISR_TEACK)) ? 1UL : 0UL);
 }
 
 /**
@@ -3172,35 +3202,35 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TEACK(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_REACK(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_REACK(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_REACK) == (USART_ISR_REACK)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_REACK) == (USART_ISR_REACK)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART TX FIFO Empty Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          TXFE          LL_USART_IsActiveFlag_TXFE
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXFE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXFE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_TXFE) == (USART_ISR_TXFE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_TXFE) == (USART_ISR_TXFE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART RX FIFO Full Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          RXFF          LL_USART_IsActiveFlag_RXFF
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXFF(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXFF(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_RXFF) == (USART_ISR_RXFF)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_RXFF) == (USART_ISR_RXFF)) ? 1UL : 0UL);
 }
 
 /**
@@ -3209,35 +3239,35 @@ __STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXFF(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TCBGT(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TCBGT(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_TCBGT) == (USART_ISR_TCBGT)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_TCBGT) == (USART_ISR_TCBGT)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART TX FIFO Threshold Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          TXFT          LL_USART_IsActiveFlag_TXFT
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXFT(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_TXFT(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_TXFT) == (USART_ISR_TXFT)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_TXFT) == (USART_ISR_TXFT)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART RX FIFO Threshold Flag is set or not
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ISR          RXFT          LL_USART_IsActiveFlag_RXFT
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXFT(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsActiveFlag_RXFT(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->ISR, USART_ISR_RXFT) == (USART_ISR_RXFT)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->ISR, USART_ISR_RXFT) == (USART_ISR_RXFT)) ? 1UL : 0UL);
 }
 
 /**
@@ -3264,7 +3294,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_FE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear Noise Error detected Flag
-  * @rmtoll ICR          NECF           LL_USART_ClearFlag_NE
+  * @rmtoll ICR          NECF          LL_USART_ClearFlag_NE
   * @param  USARTx USART Instance
   * @retval None
   */
@@ -3297,7 +3327,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_IDLE(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear TX FIFO Empty Flag
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll ICR          TXFECF        LL_USART_ClearFlag_TXFE
   * @param  USARTx USART Instance
@@ -3332,7 +3362,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_TCBGT(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear LIN Break Detection Flag
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll ICR          LBDCF         LL_USART_ClearFlag_LBD
   * @param  USARTx USART Instance
@@ -3345,7 +3375,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_LBD(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear CTS Interrupt Flag
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll ICR          CTSCF         LL_USART_ClearFlag_nCTS
   * @param  USARTx USART Instance
@@ -3369,7 +3399,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_RTO(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear End Of Block Flag
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll ICR          EOBCF         LL_USART_ClearFlag_EOB
   * @param  USARTx USART Instance
@@ -3382,7 +3412,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_EOB(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear SPI Slave Underrun Flag
-  * @note   Macro @ref IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_SPI_SLAVE_INSTANCE(USARTx) can be used to check whether or not
   *         SPI Slave mode feature is supported by the USARTx instance.
   * @rmtoll ICR          UDRCF         LL_USART_ClearFlag_UDR
   * @param  USARTx USART Instance
@@ -3406,7 +3436,7 @@ __STATIC_INLINE void LL_USART_ClearFlag_CM(USART_TypeDef *USARTx)
 
 /**
   * @brief  Clear Wake Up from stop mode Flag
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll ICR          WUCF          LL_USART_ClearFlag_WKUP
   * @param  USARTx USART Instance
@@ -3433,15 +3463,14 @@ __STATIC_INLINE void LL_USART_ClearFlag_WKUP(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_IDLE(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_IDLEIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_IDLEIE);
 }
 
-/* Legacy define */
-#define LL_USART_EnableIT_RXNE  LL_USART_EnableIT_RXNE_RXFNE
+#define LL_USART_EnableIT_RXNE  LL_USART_EnableIT_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Enable RX Not Empty and RX FIFO Not Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        RXNEIE_RXFNEIE  LL_USART_EnableIT_RXNE_RXFNE
   * @param  USARTx USART Instance
@@ -3449,7 +3478,7 @@ __STATIC_INLINE void LL_USART_EnableIT_IDLE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_RXNE_RXFNE(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
 }
 
 /**
@@ -3460,15 +3489,14 @@ __STATIC_INLINE void LL_USART_EnableIT_RXNE_RXFNE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_TC(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_TCIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_TCIE);
 }
 
-/* Legacy define */
-#define LL_USART_EnableIT_TXE  LL_USART_EnableIT_TXE_TXFNF
+#define LL_USART_EnableIT_TXE  LL_USART_EnableIT_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Enable TX Empty and TX FIFO Not Full Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1         TXEIE_TXFNFIE  LL_USART_EnableIT_TXE_TXFNF
   * @param  USARTx USART Instance
@@ -3476,7 +3504,7 @@ __STATIC_INLINE void LL_USART_EnableIT_TC(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_TXE_TXFNF(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
 }
 
 /**
@@ -3487,7 +3515,7 @@ __STATIC_INLINE void LL_USART_EnableIT_TXE_TXFNF(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_PE(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_PEIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_PEIE);
 }
 
 /**
@@ -3498,7 +3526,7 @@ __STATIC_INLINE void LL_USART_EnableIT_PE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_CM(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_CMIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_CMIE);
 }
 
 /**
@@ -3509,12 +3537,12 @@ __STATIC_INLINE void LL_USART_EnableIT_CM(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_RTO(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_RTOIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_RTOIE);
 }
 
 /**
   * @brief  Enable End Of Block Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR1          EOBIE         LL_USART_EnableIT_EOB
   * @param  USARTx USART Instance
@@ -3522,12 +3550,12 @@ __STATIC_INLINE void LL_USART_EnableIT_RTO(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_EOB(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_EOBIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_EOBIE);
 }
 
 /**
   * @brief  Enable TX FIFO Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          TXFEIE        LL_USART_EnableIT_TXFE
   * @param  USARTx USART Instance
@@ -3535,7 +3563,7 @@ __STATIC_INLINE void LL_USART_EnableIT_EOB(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_TXFE(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_TXFEIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_TXFEIE);
 }
 
 /**
@@ -3546,12 +3574,12 @@ __STATIC_INLINE void LL_USART_EnableIT_TXFE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_RXFF(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR1, USART_CR1_RXFFIE);
+  ATOMIC_SET_BIT(USARTx->CR1, USART_CR1_RXFFIE);
 }
 
 /**
   * @brief  Enable LIN Break Detection Interrupt
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDIE         LL_USART_EnableIT_LBD
   * @param  USARTx USART Instance
@@ -3574,12 +3602,12 @@ __STATIC_INLINE void LL_USART_EnableIT_LBD(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_ERROR(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_EIE);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_EIE);
 }
 
 /**
   * @brief  Enable CTS Interrupt
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSIE         LL_USART_EnableIT_CTS
   * @param  USARTx USART Instance
@@ -3587,12 +3615,12 @@ __STATIC_INLINE void LL_USART_EnableIT_ERROR(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_CTS(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_CTSIE);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_CTSIE);
 }
 
 /**
   * @brief  Enable Wake Up from Stop Mode Interrupt
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUFIE         LL_USART_EnableIT_WKUP
   * @param  USARTx USART Instance
@@ -3600,12 +3628,12 @@ __STATIC_INLINE void LL_USART_EnableIT_CTS(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_WKUP(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_WUFIE);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_WUFIE);
 }
 
 /**
   * @brief  Enable TX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTIE        LL_USART_EnableIT_TXFT
   * @param  USARTx USART Instance
@@ -3613,12 +3641,12 @@ __STATIC_INLINE void LL_USART_EnableIT_WKUP(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_TXFT(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_TXFTIE);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_TXFTIE);
 }
 
 /**
   * @brief  Enable Smartcard Transmission Complete Before Guard Time Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          TCBGTIE       LL_USART_EnableIT_TCBGT
   * @param  USARTx USART Instance
@@ -3626,12 +3654,12 @@ __STATIC_INLINE void LL_USART_EnableIT_TXFT(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_TCBGT(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_TCBGTIE);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_TCBGTIE);
 }
 
 /**
   * @brief  Enable RX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTIE        LL_USART_EnableIT_RXFT
   * @param  USARTx USART Instance
@@ -3639,7 +3667,7 @@ __STATIC_INLINE void LL_USART_EnableIT_TCBGT(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableIT_RXFT(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_RXFTIE);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_RXFTIE);
 }
 
 /**
@@ -3650,15 +3678,14 @@ __STATIC_INLINE void LL_USART_EnableIT_RXFT(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_IDLE(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_IDLEIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_IDLEIE);
 }
 
-/* Legacy define */
-#define LL_USART_DisableIT_RXNE  LL_USART_DisableIT_RXNE_RXFNE
+#define LL_USART_DisableIT_RXNE  LL_USART_DisableIT_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Disable RX Not Empty and RX FIFO Not Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        RXNEIE_RXFNEIE  LL_USART_DisableIT_RXNE_RXFNE
   * @param  USARTx USART Instance
@@ -3666,7 +3693,7 @@ __STATIC_INLINE void LL_USART_DisableIT_IDLE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_RXNE_RXFNE(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_RXNEIE_RXFNEIE);
 }
 
 /**
@@ -3677,15 +3704,14 @@ __STATIC_INLINE void LL_USART_DisableIT_RXNE_RXFNE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_TC(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_TCIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_TCIE);
 }
 
-/* Legacy define */
-#define LL_USART_DisableIT_TXE  LL_USART_DisableIT_TXE_TXFNF
+#define LL_USART_DisableIT_TXE  LL_USART_DisableIT_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Disable TX Empty and TX FIFO Not Full Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        TXEIE_TXFNFIE  LL_USART_DisableIT_TXE_TXFNF
   * @param  USARTx USART Instance
@@ -3693,7 +3719,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TC(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_TXE_TXFNF(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_TXEIE_TXFNFIE);
 }
 
 /**
@@ -3704,7 +3730,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TXE_TXFNF(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_PE(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_PEIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_PEIE);
 }
 
 /**
@@ -3715,7 +3741,7 @@ __STATIC_INLINE void LL_USART_DisableIT_PE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_CM(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_CMIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_CMIE);
 }
 
 /**
@@ -3726,12 +3752,12 @@ __STATIC_INLINE void LL_USART_DisableIT_CM(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_RTO(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_RTOIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_RTOIE);
 }
 
 /**
   * @brief  Disable End Of Block Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR1          EOBIE         LL_USART_DisableIT_EOB
   * @param  USARTx USART Instance
@@ -3739,12 +3765,12 @@ __STATIC_INLINE void LL_USART_DisableIT_RTO(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_EOB(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_EOBIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_EOBIE);
 }
 
 /**
   * @brief  Disable TX FIFO Empty Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          TXFEIE        LL_USART_DisableIT_TXFE
   * @param  USARTx USART Instance
@@ -3752,12 +3778,12 @@ __STATIC_INLINE void LL_USART_DisableIT_EOB(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_TXFE(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_TXFEIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_TXFEIE);
 }
 
 /**
   * @brief  Disable RX FIFO Full Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          RXFFIE        LL_USART_DisableIT_RXFF
   * @param  USARTx USART Instance
@@ -3765,12 +3791,12 @@ __STATIC_INLINE void LL_USART_DisableIT_TXFE(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_RXFF(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR1, USART_CR1_RXFFIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR1, USART_CR1_RXFFIE);
 }
 
 /**
   * @brief  Disable LIN Break Detection Interrupt
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDIE         LL_USART_DisableIT_LBD
   * @param  USARTx USART Instance
@@ -3793,12 +3819,12 @@ __STATIC_INLINE void LL_USART_DisableIT_LBD(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_ERROR(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_EIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_EIE);
 }
 
 /**
   * @brief  Disable CTS Interrupt
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSIE         LL_USART_DisableIT_CTS
   * @param  USARTx USART Instance
@@ -3806,12 +3832,12 @@ __STATIC_INLINE void LL_USART_DisableIT_ERROR(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_CTS(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_CTSIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_CTSIE);
 }
 
 /**
   * @brief  Disable Wake Up from Stop Mode Interrupt
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUFIE         LL_USART_DisableIT_WKUP
   * @param  USARTx USART Instance
@@ -3819,12 +3845,12 @@ __STATIC_INLINE void LL_USART_DisableIT_CTS(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_WKUP(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_WUFIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_WUFIE);
 }
 
 /**
   * @brief  Disable TX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTIE        LL_USART_DisableIT_TXFT
   * @param  USARTx USART Instance
@@ -3832,12 +3858,12 @@ __STATIC_INLINE void LL_USART_DisableIT_WKUP(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_TXFT(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_TXFTIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_TXFTIE);
 }
 
 /**
   * @brief  Disable Smartcard Transmission Complete Before Guard Time Interrupt
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          TCBGTIE       LL_USART_DisableIT_TCBGT
   * @param  USARTx USART Instance
@@ -3845,12 +3871,12 @@ __STATIC_INLINE void LL_USART_DisableIT_TXFT(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_TCBGT(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_TCBGTIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_TCBGTIE);
 }
 
 /**
   * @brief  Disable RX FIFO Threshold Interrupt
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTIE        LL_USART_DisableIT_RXFT
   * @param  USARTx USART Instance
@@ -3858,7 +3884,7 @@ __STATIC_INLINE void LL_USART_DisableIT_TCBGT(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableIT_RXFT(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_RXFTIE);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_RXFTIE);
 }
 
 /**
@@ -3867,25 +3893,24 @@ __STATIC_INLINE void LL_USART_DisableIT_RXFT(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_IDLE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_IDLE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_IDLEIE) == (USART_CR1_IDLEIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_IDLEIE) == (USART_CR1_IDLEIE)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_USART_IsEnabledIT_RXNE  LL_USART_IsEnabledIT_RXNE_RXFNE
+#define LL_USART_IsEnabledIT_RXNE  LL_USART_IsEnabledIT_RXNE_RXFNE /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the USART RX Not Empty and USART RX FIFO Not Empty Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1        RXNEIE_RXFNEIE  LL_USART_IsEnabledIT_RXNE_RXFNE
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXNE_RXFNE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXNE_RXFNE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_RXNEIE_RXFNEIE) == (USART_CR1_RXNEIE_RXFNEIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_RXNEIE_RXFNEIE) == (USART_CR1_RXNEIE_RXFNEIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -3894,25 +3919,24 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXNE_RXFNE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TC(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TC(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_TCIE) == (USART_CR1_TCIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_TCIE) == (USART_CR1_TCIE)) ? 1UL : 0UL);
 }
 
-/* Legacy define */
-#define LL_USART_IsEnabledIT_TXE  LL_USART_IsEnabledIT_TXE_TXFNF
+#define LL_USART_IsEnabledIT_TXE  LL_USART_IsEnabledIT_TXE_TXFNF /* Redefinition for legacy purpose */
 
 /**
   * @brief  Check if the USART TX Empty and USART TX FIFO Not Full Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1         TXEIE_TXFNFIE  LL_USART_IsEnabledIT_TXE_TXFNF
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXE_TXFNF(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXE_TXFNF(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_TXEIE_TXFNFIE) == (USART_CR1_TXEIE_TXFNFIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_TXEIE_TXFNFIE) == (USART_CR1_TXEIE_TXFNFIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -3921,9 +3945,9 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXE_TXFNF(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_PE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_PE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_PEIE) == (USART_CR1_PEIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_PEIE) == (USART_CR1_PEIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -3932,9 +3956,9 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_PE(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_CM(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_CM(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_CMIE) == (USART_CR1_CMIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_CMIE) == (USART_CR1_CMIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -3943,61 +3967,61 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_CM(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RTO(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RTO(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_RTOIE) == (USART_CR1_RTOIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_RTOIE) == (USART_CR1_RTOIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART End Of Block Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR1          EOBIE         LL_USART_IsEnabledIT_EOB
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_EOB(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_EOB(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_EOBIE) == (USART_CR1_EOBIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_EOBIE) == (USART_CR1_EOBIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART TX FIFO Empty Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          TXFEIE        LL_USART_IsEnabledIT_TXFE
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXFE(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXFE(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_TXFEIE) == (USART_CR1_TXFEIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_TXFEIE) == (USART_CR1_TXFEIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART RX FIFO Full Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR1          RXFFIE        LL_USART_IsEnabledIT_RXFF
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXFF(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXFF(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR1, USART_CR1_RXFFIE) == (USART_CR1_RXFFIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR1, USART_CR1_RXFFIE) == (USART_CR1_RXFFIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART LIN Break Detection Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_LIN_INSTANCE(USARTx) can be used to check whether or not
   *         LIN feature is supported by the USARTx instance.
   * @rmtoll CR2          LBDIE         LL_USART_IsEnabledIT_LBD
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_LBD(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_LBD(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR2, USART_CR2_LBDIE) == (USART_CR2_LBDIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR2, USART_CR2_LBDIE) == (USART_CR2_LBDIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -4006,74 +4030,74 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_LBD(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_ERROR(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_ERROR(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_EIE) == (USART_CR3_EIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_EIE) == (USART_CR3_EIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART CTS Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_HWFLOW_INSTANCE(USARTx) can be used to check whether or not
   *         Hardware Flow control feature is supported by the USARTx instance.
   * @rmtoll CR3          CTSIE         LL_USART_IsEnabledIT_CTS
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_CTS(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_CTS(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_CTSIE) == (USART_CR3_CTSIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_CTSIE) == (USART_CR3_CTSIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the USART Wake Up from Stop Mode Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_WAKEUP_FROMSTOP_INSTANCE(USARTx) can be used to check whether or not
   *         Wake-up from Stop mode feature is supported by the USARTx instance.
   * @rmtoll CR3          WUFIE         LL_USART_IsEnabledIT_WKUP
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_WKUP(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_WKUP(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_WUFIE) == (USART_CR3_WUFIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_WUFIE) == (USART_CR3_WUFIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if USART TX FIFO Threshold Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          TXFTIE        LL_USART_IsEnabledIT_TXFT
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXFT(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TXFT(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_TXFTIE) == (USART_CR3_TXFTIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_TXFTIE) == (USART_CR3_TXFTIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if the Smartcard Transmission Complete Before Guard Time Interrupt is enabled or disabled.
-  * @note   Macro @ref IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_SMARTCARD_INSTANCE(USARTx) can be used to check whether or not
   *         Smartcard feature is supported by the USARTx instance.
   * @rmtoll CR3          TCBGTIE       LL_USART_IsEnabledIT_TCBGT
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TCBGT(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_TCBGT(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_TCBGTIE) == (USART_CR3_TCBGTIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_TCBGTIE) == (USART_CR3_TCBGTIE)) ? 1UL : 0UL);
 }
 
 /**
   * @brief  Check if USART RX FIFO Threshold Interrupt is enabled or disabled
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll CR3          RXFTIE        LL_USART_IsEnabledIT_RXFT
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXFT(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXFT(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_RXFTIE) == (USART_CR3_RXFTIE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_RXFTIE) == (USART_CR3_RXFTIE)) ? 1UL : 0UL);
 }
 
 /**
@@ -4092,7 +4116,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledIT_RXFT(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableDMAReq_RX(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_DMAR);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_DMAR);
 }
 
 /**
@@ -4103,7 +4127,7 @@ __STATIC_INLINE void LL_USART_EnableDMAReq_RX(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableDMAReq_RX(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_DMAR);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_DMAR);
 }
 
 /**
@@ -4112,9 +4136,9 @@ __STATIC_INLINE void LL_USART_DisableDMAReq_RX(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledDMAReq_RX(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledDMAReq_RX(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_DMAR) == (USART_CR3_DMAR)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_DMAR) == (USART_CR3_DMAR)) ? 1UL : 0UL);
 }
 
 /**
@@ -4125,7 +4149,7 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledDMAReq_RX(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_EnableDMAReq_TX(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->CR3, USART_CR3_DMAT);
+  ATOMIC_SET_BIT(USARTx->CR3, USART_CR3_DMAT);
 }
 
 /**
@@ -4136,7 +4160,7 @@ __STATIC_INLINE void LL_USART_EnableDMAReq_TX(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_DisableDMAReq_TX(USART_TypeDef *USARTx)
 {
-  CLEAR_BIT(USARTx->CR3, USART_CR3_DMAT);
+  ATOMIC_CLEAR_BIT(USARTx->CR3, USART_CR3_DMAT);
 }
 
 /**
@@ -4145,9 +4169,9 @@ __STATIC_INLINE void LL_USART_DisableDMAReq_TX(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledDMAReq_TX(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledDMAReq_TX(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_DMAT) == (USART_CR3_DMAT)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_DMAT) == (USART_CR3_DMAT)) ? 1UL : 0UL);
 }
 
 /**
@@ -4178,9 +4202,9 @@ __STATIC_INLINE void LL_USART_DisableDMADeactOnRxErr(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_USART_IsEnabledDMADeactOnRxErr(USART_TypeDef *USARTx)
+__STATIC_INLINE uint32_t LL_USART_IsEnabledDMADeactOnRxErr(const USART_TypeDef *USARTx)
 {
-  return ((READ_BIT(USARTx->CR3, USART_CR3_DDRE) == (USART_CR3_DDRE)) ? 1U : 0U);
+  return ((READ_BIT(USARTx->CR3, USART_CR3_DDRE) == (USART_CR3_DDRE)) ? 1UL : 0UL);
 }
 
 /**
@@ -4193,19 +4217,19 @@ __STATIC_INLINE uint32_t LL_USART_IsEnabledDMADeactOnRxErr(USART_TypeDef *USARTx
   *         @arg @ref LL_USART_DMA_REG_DATA_RECEIVE
   * @retval Address of data register
   */
-__STATIC_INLINE uint32_t LL_USART_DMA_GetRegAddr(USART_TypeDef *USARTx, uint32_t Direction)
+__STATIC_INLINE uint32_t LL_USART_DMA_GetRegAddr(const USART_TypeDef *USARTx, uint32_t Direction)
 {
   uint32_t data_reg_addr;
 
   if (Direction == LL_USART_DMA_REG_DATA_TRANSMIT)
   {
     /* return address of TDR register */
-    data_reg_addr = (uint32_t) & (USARTx->TDR);
+    data_reg_addr = (uint32_t) &(USARTx->TDR);
   }
   else
   {
     /* return address of RDR register */
-    data_reg_addr = (uint32_t) & (USARTx->RDR);
+    data_reg_addr = (uint32_t) &(USARTx->RDR);
   }
 
   return data_reg_addr;
@@ -4225,7 +4249,7 @@ __STATIC_INLINE uint32_t LL_USART_DMA_GetRegAddr(USART_TypeDef *USARTx, uint32_t
   * @param  USARTx USART Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0xFF
   */
-__STATIC_INLINE uint8_t LL_USART_ReceiveData8(USART_TypeDef *USARTx)
+__STATIC_INLINE uint8_t LL_USART_ReceiveData8(const USART_TypeDef *USARTx)
 {
   return (uint8_t)(READ_BIT(USARTx->RDR, USART_RDR_RDR) & 0xFFU);
 }
@@ -4236,7 +4260,7 @@ __STATIC_INLINE uint8_t LL_USART_ReceiveData8(USART_TypeDef *USARTx)
   * @param  USARTx USART Instance
   * @retval Value between Min_Data=0x00 and Max_Data=0x1FF
   */
-__STATIC_INLINE uint16_t LL_USART_ReceiveData9(USART_TypeDef *USARTx)
+__STATIC_INLINE uint16_t LL_USART_ReceiveData9(const USART_TypeDef *USARTx)
 {
   return (uint16_t)(READ_BIT(USARTx->RDR, USART_RDR_RDR));
 }
@@ -4262,7 +4286,7 @@ __STATIC_INLINE void LL_USART_TransmitData8(USART_TypeDef *USARTx, uint8_t Value
   */
 __STATIC_INLINE void LL_USART_TransmitData9(USART_TypeDef *USARTx, uint16_t Value)
 {
-  USARTx->TDR = Value & 0x1FFUL;
+  USARTx->TDR = (uint16_t)(Value & 0x1FFUL);
 }
 
 /**
@@ -4275,7 +4299,7 @@ __STATIC_INLINE void LL_USART_TransmitData9(USART_TypeDef *USARTx, uint16_t Valu
 
 /**
   * @brief  Request an Automatic Baud Rate measurement on next received data frame
-  * @note   Macro @ref IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_USART_AUTOBAUDRATE_DETECTION_INSTANCE(USARTx) can be used to check whether or not
   *         Auto Baud Rate detection feature is supported by the USARTx instance.
   * @rmtoll RQR          ABRRQ         LL_USART_RequestAutoBaudRate
   * @param  USARTx USART Instance
@@ -4283,7 +4307,7 @@ __STATIC_INLINE void LL_USART_TransmitData9(USART_TypeDef *USARTx, uint16_t Valu
   */
 __STATIC_INLINE void LL_USART_RequestAutoBaudRate(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->RQR, USART_RQR_ABRRQ);
+  SET_BIT(USARTx->RQR, (uint16_t)USART_RQR_ABRRQ);
 }
 
 /**
@@ -4294,7 +4318,7 @@ __STATIC_INLINE void LL_USART_RequestAutoBaudRate(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_RequestBreakSending(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->RQR, USART_RQR_SBKRQ);
+  SET_BIT(USARTx->RQR, (uint16_t)USART_RQR_SBKRQ);
 }
 
 /**
@@ -4305,12 +4329,12 @@ __STATIC_INLINE void LL_USART_RequestBreakSending(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_RequestEnterMuteMode(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->RQR, USART_RQR_MMRQ);
+  SET_BIT(USARTx->RQR, (uint16_t)USART_RQR_MMRQ);
 }
 
 /**
   * @brief  Request a Receive Data and FIFO flush
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @note   Allows to discard the received data without reading them, and avoid an overrun
   *         condition.
@@ -4320,12 +4344,12 @@ __STATIC_INLINE void LL_USART_RequestEnterMuteMode(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_RequestRxDataFlush(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->RQR, USART_RQR_RXFRQ);
+  SET_BIT(USARTx->RQR, (uint16_t)USART_RQR_RXFRQ);
 }
 
 /**
   * @brief  Request a Transmit data and FIFO flush
-  * @note   Macro @ref IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
+  * @note   Macro IS_UART_FIFO_INSTANCE(USARTx) can be used to check whether or not
   *         FIFO mode feature is supported by the USARTx instance.
   * @rmtoll RQR          TXFRQ         LL_USART_RequestTxDataFlush
   * @param  USARTx USART Instance
@@ -4333,7 +4357,7 @@ __STATIC_INLINE void LL_USART_RequestRxDataFlush(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_RequestTxDataFlush(USART_TypeDef *USARTx)
 {
-  SET_BIT(USARTx->RQR, USART_RQR_TXFRQ);
+  SET_BIT(USARTx->RQR, (uint16_t)USART_RQR_TXFRQ);
 }
 
 /**
@@ -4344,10 +4368,10 @@ __STATIC_INLINE void LL_USART_RequestTxDataFlush(USART_TypeDef *USARTx)
 /** @defgroup USART_LL_EF_Init Initialization and de-initialization functions
   * @{
   */
-ErrorStatus LL_USART_DeInit(USART_TypeDef *USARTx);
-ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, LL_USART_InitTypeDef *USART_InitStruct);
+ErrorStatus LL_USART_DeInit(const USART_TypeDef *USARTx);
+ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, const LL_USART_InitTypeDef *USART_InitStruct);
 void        LL_USART_StructInit(LL_USART_InitTypeDef *USART_InitStruct);
-ErrorStatus LL_USART_ClockInit(USART_TypeDef *USARTx, LL_USART_ClockInitTypeDef *USART_ClockInitStruct);
+ErrorStatus LL_USART_ClockInit(USART_TypeDef *USARTx, const LL_USART_ClockInitTypeDef *USART_ClockInitStruct);
 void        LL_USART_ClockStructInit(LL_USART_ClockInitTypeDef *USART_ClockInitStruct);
 /**
   * @}
@@ -4374,4 +4398,3 @@ void        LL_USART_ClockStructInit(LL_USART_ClockInitTypeDef *USART_ClockInitS
 
 #endif /* STM32WBxx_LL_USART_H */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_usb.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_usb.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -23,7 +22,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif /* __cplusplus */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_hal_def.h"
@@ -43,98 +42,96 @@ extern "C" {
   * @brief  USB Mode definition
   */
 
-
-
 typedef enum
 {
-  USB_DEVICE_MODE  = 0
+  USB_DEVICE_MODE = 0
 } USB_ModeTypeDef;
 
+
 /**
-  * @brief  USB Initialization Structure definition
+  * @brief  USB Instance Initialization Structure definition
   */
 typedef struct
 {
-  uint32_t dev_endpoints;           /*!< Device Endpoints number.
+  uint8_t dev_endpoints;            /*!< Device Endpoints number.
                                          This parameter depends on the used USB core.
                                          This parameter must be a number between Min_Data = 1 and Max_Data = 15 */
 
-  uint32_t speed;                   /*!< USB Core speed.
-                                         This parameter can be any value of @ref USB_Core_Speed                 */
+  uint8_t speed;                   /*!< USB Core speed.
+                                        This parameter can be any value of @ref PCD_Speed/HCD_Speed
+                                                                                (HCD_SPEED_xxx, HCD_SPEED_xxx) */
 
-  uint32_t ep0_mps;                 /*!< Set the Endpoint 0 Max Packet size.                                    */
+  uint8_t ep0_mps;                 /*!< Set the Endpoint 0 Max Packet size.                                    */
 
-  uint32_t phy_itface;              /*!< Select the used PHY interface.
-                                         This parameter can be any value of @ref USB_Core_PHY                   */
+  uint8_t phy_itface;              /*!< Select the used PHY interface.
+                                        This parameter can be any value of @ref PCD_PHY_Module/HCD_PHY_Module  */
 
-  uint32_t Sof_enable;              /*!< Enable or disable the output of the SOF signal.                        */
+  uint8_t Sof_enable;              /*!< Enable or disable the output of the SOF signal.                        */
 
-  uint32_t low_power_enable;        /*!< Enable or disable Low Power mode                                       */
+  uint8_t low_power_enable;        /*!< Enable or disable the low Power Mode.                                  */
 
-  uint32_t lpm_enable;              /*!< Enable or disable Battery charging.                                    */
+  uint8_t lpm_enable;              /*!< Enable or disable Link Power Management.                               */
 
-  uint32_t battery_charging_enable; /*!< Enable or disable Battery charging.                                    */
+  uint8_t battery_charging_enable; /*!< Enable or disable Battery charging.                                    */
 } USB_CfgTypeDef;
 
 typedef struct
 {
-  uint8_t   num;             /*!< Endpoint number
-                                  This parameter must be a number between Min_Data = 1 and Max_Data = 15    */
+  uint8_t   num;                  /*!< Endpoint number
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 15   */
 
-  uint8_t   is_in;           /*!< Endpoint direction
-                                  This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+  uint8_t   is_in;                /*!< Endpoint direction
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
 
-  uint8_t   is_stall;        /*!< Endpoint stall condition
-                                  This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+  uint8_t   is_stall;             /*!< Endpoint stall condition
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
 
-  uint8_t   type;            /*!< Endpoint type
-                                  This parameter can be any value of @ref USB_EP_Type                       */
+  uint8_t   type;                 /*!< Endpoint type
+                                       This parameter can be any value of @ref USB_LL_EP_Type                   */
 
-  uint8_t   data_pid_start;  /*!< Initial data PID
-                                  This parameter must be a number between Min_Data = 0 and Max_Data = 1     */
+  uint8_t   data_pid_start;       /*!< Initial data PID
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 1    */
 
-  uint16_t  pmaadress;       /*!< PMA Address
-                                  This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
 
-  uint16_t  pmaaddr0;        /*!< PMA Address0
-                                  This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+  uint16_t  pmaadress;            /*!< PMA Address
+                                       This parameter can be any value between Min_addr = 0 and Max_addr = 1K   */
 
-  uint16_t  pmaaddr1;        /*!< PMA Address1
-                                  This parameter can be any value between Min_addr = 0 and Max_addr = 1K    */
+  uint16_t  pmaaddr0;             /*!< PMA Address0
+                                       This parameter can be any value between Min_addr = 0 and Max_addr = 1K   */
 
-  uint8_t   doublebuffer;    /*!< Double buffer enable
-                                  This parameter can be 0 or 1                                              */
+  uint16_t  pmaaddr1;             /*!< PMA Address1
+                                       This parameter can be any value between Min_addr = 0 and Max_addr = 1K   */
 
-  uint16_t  tx_fifo_num;     /*!< This parameter is not required by USB Device FS peripheral, it is used
-                                  only by USB OTG FS peripheral
-                                  This parameter is added to ensure compatibility across USB peripherals    */
+  uint8_t   doublebuffer;         /*!< Double buffer enable
+                                       This parameter can be 0 or 1                                             */
 
-  uint32_t  maxpacket;       /*!< Endpoint Max packet size
-                                  This parameter must be a number between Min_Data = 0 and Max_Data = 64KB  */
 
-  uint8_t   *xfer_buff;      /*!< Pointer to transfer buffer                                                */
+  uint32_t  maxpacket;            /*!< Endpoint Max packet size
+                                       This parameter must be a number between Min_Data = 0 and Max_Data = 64KB */
 
-  uint32_t  xfer_len;        /*!< Current transfer length                                                   */
+  uint8_t   *xfer_buff;           /*!< Pointer to transfer buffer                                               */
 
-  uint32_t  xfer_count;      /*!< Partial transfer length in case of multi packet transfer                  */
+  uint32_t  xfer_len;             /*!< Current transfer length                                                  */
 
+  uint32_t  xfer_count;           /*!< Partial transfer length in case of multi packet transfer                 */
+
+  uint32_t  xfer_len_db;          /*!< double buffer transfer length used with bulk double buffer in            */
+
+  uint8_t   xfer_fill_db;         /*!< double buffer Need to Fill new buffer  used with bulk_in                 */
 } USB_EPTypeDef;
-
 
 /* Exported constants --------------------------------------------------------*/
 
 /** @defgroup PCD_Exported_Constants PCD Exported Constants
   * @{
   */
-
-
 /** @defgroup USB_LL_EP0_MPS USB Low Layer EP0 MPS
   * @{
   */
-#define DEP0CTL_MPS_64                         0U
-#define DEP0CTL_MPS_32                         1U
-#define DEP0CTL_MPS_16                         2U
-#define DEP0CTL_MPS_8                          3U
+#define EP_MPS_64                              0U
+#define EP_MPS_32                              1U
+#define EP_MPS_16                              2U
+#define EP_MPS_8                               3U
 /**
   * @}
   */
@@ -159,10 +156,21 @@ typedef struct
   * @}
   */
 
+
 #define BTABLE_ADDRESS                         0x000U
 #define PMA_ACCESS                             1U
 
+#ifndef USB_EP_RX_STRX
+#define USB_EP_RX_STRX                         (0x3U << 12)
+#endif /* USB_EP_RX_STRX */
+
 #define EP_ADDR_MSK                            0x7U
+
+#ifndef USE_USB_DOUBLE_BUFFER
+#define USE_USB_DOUBLE_BUFFER                  1U
+#endif /* USE_USB_DOUBLE_BUFFER */
+
+
 /**
   * @}
   */
@@ -183,32 +191,32 @@ HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg);
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode);
-HAL_StatusTypeDef USB_SetDevSpeed(USB_TypeDef *USBx, uint8_t speed);
-HAL_StatusTypeDef USB_FlushRxFifo(USB_TypeDef *USBx);
-HAL_StatusTypeDef USB_FlushTxFifo(USB_TypeDef *USBx, uint32_t num);
+
+HAL_StatusTypeDef USB_FlushRxFifo(USB_TypeDef const *USBx);
+HAL_StatusTypeDef USB_FlushTxFifo(USB_TypeDef const *USBx, uint32_t num);
+
+#if defined (HAL_PCD_MODULE_ENABLED)
 HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep);
 HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep);
 HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx, USB_EPTypeDef *ep);
-HAL_StatusTypeDef USB_WritePacket(USB_TypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len);
-void             *USB_ReadPacket(USB_TypeDef *USBx, uint8_t *dest, uint16_t len);
 HAL_StatusTypeDef USB_EPSetStall(USB_TypeDef *USBx, USB_EPTypeDef *ep);
 HAL_StatusTypeDef USB_EPClearStall(USB_TypeDef *USBx, USB_EPTypeDef *ep);
+HAL_StatusTypeDef USB_EPStopXfer(USB_TypeDef *USBx, USB_EPTypeDef *ep);
+#endif /* defined (HAL_PCD_MODULE_ENABLED) */
+
 HAL_StatusTypeDef USB_SetDevAddress(USB_TypeDef *USBx, uint8_t address);
 HAL_StatusTypeDef USB_DevConnect(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DevDisconnect(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_StopDevice(USB_TypeDef *USBx);
-HAL_StatusTypeDef USB_EP0_OutStart(USB_TypeDef *USBx, uint8_t *psetup);
-uint32_t          USB_ReadInterrupts(USB_TypeDef *USBx);
-uint32_t          USB_ReadDevAllOutEpInterrupt(USB_TypeDef *USBx);
-uint32_t          USB_ReadDevOutEPInterrupt(USB_TypeDef *USBx, uint8_t epnum);
-uint32_t          USB_ReadDevAllInEpInterrupt(USB_TypeDef *USBx);
-uint32_t          USB_ReadDevInEPInterrupt(USB_TypeDef *USBx, uint8_t epnum);
-void              USB_ClearInterrupts(USB_TypeDef *USBx, uint32_t interrupt);
-
+uint32_t          USB_ReadInterrupts(USB_TypeDef const *USBx);
 HAL_StatusTypeDef USB_ActivateRemoteWakeup(USB_TypeDef *USBx);
 HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_TypeDef *USBx);
-void USB_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
-void USB_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes);
+
+void              USB_WritePMA(USB_TypeDef const *USBx, uint8_t *pbUsrBuf,
+                               uint16_t wPMABufAddr, uint16_t wNBytes);
+
+void              USB_ReadPMA(USB_TypeDef const *USBx, uint8_t *pbUsrBuf,
+                              uint16_t wPMABufAddr, uint16_t wNBytes);
 
 /**
   * @}
@@ -229,9 +237,7 @@ void USB_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, ui
 
 #ifdef __cplusplus
 }
-#endif
+#endif /* __cplusplus */
 
 
 #endif /* STM32WBxx_LL_USB_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_utils.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_utils.h
@@ -3,6 +3,17 @@
   * @file    stm32wbxx_ll_utils.h
   * @author  MCD Application Team
   * @brief   Header file of UTILS LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -15,17 +26,6 @@
       (+) PLL configuration functions
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -60,18 +60,18 @@ extern "C" {
 #define LL_MAX_DELAY                  0xFFFFFFFFU
 
 /**
- * @brief Unique device ID register base address
- */
+  * @brief Unique device ID register base address
+  */
 #define UID_BASE_ADDRESS              UID_BASE
 
 /**
- * @brief Flash size data register base address
- */
+  * @brief Flash size data register base address
+  */
 #define FLASHSIZE_BASE_ADDRESS        FLASHSIZE_BASE
 
 /**
- * @brief Package data register base address
- */
+  * @brief Package data register base address
+  */
 #define PACKAGE_BASE_ADDRESS          PACKAGE_BASE
 
 /**
@@ -256,7 +256,7 @@ __STATIC_INLINE uint32_t LL_GetPackageType(void)
   * @param  HCLKFrequency HCLK frequency in Hz (can be calculated thanks to RCC helper macro or function @ref LL_RCC_GetSystemClocksFreq (HCLK1_Frequency field))
   * @note   When a RTOS is used, it is recommended to avoid changing the SysTick
   *         configuration by calling this function, for a delay use rather osDelay RTOS service.
-  * @param  Ticks Number of ticks
+  * @param  Ticks Frequency of Ticks (Hz)
   * @retval None
   */
 __STATIC_INLINE void LL_InitTick(uint32_t HCLKFrequency, uint32_t Ticks)
@@ -310,5 +310,3 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass,
 #endif
 
 #endif /* STM32WBxx_LL_UTILS_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_wwdg.h
+++ b/STM32WBxx_HAL_Driver/Inc/stm32wbxx_ll_wwdg.h
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -327,5 +326,3 @@ __STATIC_INLINE uint32_t LL_WWDG_IsEnabledIT_EWKUP(WWDG_TypeDef *WWDGx)
 #endif
 
 #endif /* STM32WBxx_LL_WWDG_H */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal.c
@@ -4,7 +4,17 @@
   * @author  MCD Application Team
   * @brief   HAL module driver.
   *          This is the common part of the HAL initialization
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -18,17 +28,6 @@
          (+) Services HAL APIs
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -53,20 +52,20 @@
   * @{
   */
 /**
- * @brief STM32WBxx HAL Driver version number
+  * @brief STM32WBxx HAL Driver version number
    */
 #define __STM32WBxx_HAL_VERSION_MAIN   (0x01U) /*!< [31:24] main version */
-#define __STM32WBxx_HAL_VERSION_SUB1   (0x07U) /*!< [23:16] sub1 version */
-#define __STM32WBxx_HAL_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
+#define __STM32WBxx_HAL_VERSION_SUB1   (0x0EU) /*!< [23:16] sub1 version */
+#define __STM32WBxx_HAL_VERSION_SUB2   (0x06U) /*!< [15:8]  sub2 version */
 #define __STM32WBxx_HAL_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
 #define __STM32WBxx_HAL_VERSION         ((__STM32WBxx_HAL_VERSION_MAIN << 24U)\
-                                        |(__STM32WBxx_HAL_VERSION_SUB1 << 16U)\
-                                        |(__STM32WBxx_HAL_VERSION_SUB2 << 8U )\
-                                        |(__STM32WBxx_HAL_VERSION_RC))
+                                         |(__STM32WBxx_HAL_VERSION_SUB1 << 16U)\
+                                         |(__STM32WBxx_HAL_VERSION_SUB2 << 8U )\
+                                         |(__STM32WBxx_HAL_VERSION_RC))
 
 #if defined(VREFBUF)
 #define VREFBUF_TIMEOUT_VALUE     10U   /* 10 ms */
-#endif
+#endif /* VREFBUF */
 
 /**
   * @}
@@ -92,8 +91,8 @@ HAL_TickFreqTypeDef uwTickFreq = HAL_TICK_FREQ_DEFAULT;  /* 1KHz */
   */
 
 /** @addtogroup HAL_Exported_Functions_Group1
- *  @brief    HAL Initialization and Configuration functions
- *
+  *  @brief    HAL Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
            ##### HAL Initialization and Configuration functions #####
@@ -149,11 +148,11 @@ HAL_StatusTypeDef HAL_Init(void)
   /* - Instruction cache enabled                             */
   /* - Data cache enabled                                    */
 #if (INSTRUCTION_CACHE_ENABLE == 0U)
-   __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
+  __HAL_FLASH_INSTRUCTION_CACHE_DISABLE();
 #endif /* INSTRUCTION_CACHE_ENABLE */
 
 #if (DATA_CACHE_ENABLE == 0U)
-   __HAL_FLASH_DATA_CACHE_DISABLE();
+  __HAL_FLASH_DATA_CACHE_DISABLE();
 #endif /* DATA_CACHE_ENABLE */
 
 #if (PREFETCH_ENABLE != 0U)
@@ -256,7 +255,7 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   if ((uint32_t)uwTickFreq != 0U)
   {
     /*Configure the SysTick to have interrupt in 1ms time basis*/
-    if (HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/ (1000U / (uint32_t)uwTickFreq)) == 0U)
+    if (HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq() / (1000U / (uint32_t)uwTickFreq)) == 0U)
     {
       /* Configure the SysTick IRQ priority */
       if (TickPriority < (1UL << __NVIC_PRIO_BITS))
@@ -288,8 +287,8 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   */
 
 /** @addtogroup HAL_Exported_Functions_Group2
- *  @brief    HAL Control functions
- *
+  *  @brief    HAL Control functions
+  *
 @verbatim
  ===============================================================================
                       ##### HAL Control functions #####
@@ -313,7 +312,7 @@ __weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
   *        used as application time base.
   * @note In the default implementation, this variable is incremented each 1ms
   *       in SysTick ISR.
- * @note This function is declared as __weak to be overwritten in case of other
+  * @note This function is declared as __weak to be overwritten in case of other
   *      implementations in user file.
   * @retval None
   */
@@ -361,7 +360,7 @@ HAL_StatusTypeDef HAL_SetTickFreq(HAL_TickFreqTypeDef Freq)
     /* Update uwTickFreq global variable used by HAL_InitTick() */
     uwTickFreq = Freq;
 
-    /* Apply the new tick Freq  */
+    /* Apply the new tick Freq */
     status = HAL_InitTick(uwTickPrio);
 
     if (status != HAL_OK)
@@ -376,7 +375,8 @@ HAL_StatusTypeDef HAL_SetTickFreq(HAL_TickFreqTypeDef Freq)
 
 /**
   * @brief Return tick frequency.
-  * @retval tick period in Hz
+  * @retval Tick frequency.
+  *         Value of @ref HAL_TickFreqTypeDef.
   */
 HAL_TickFreqTypeDef HAL_GetTickFreq(void)
 {
@@ -394,21 +394,21 @@ HAL_TickFreqTypeDef HAL_GetTickFreq(void)
   * @param Delay  specifies the delay time length, in milliseconds.
   * @retval None
   */
-  __weak void HAL_Delay(uint32_t Delay)
+__weak void HAL_Delay(uint32_t Delay)
+{
+  uint32_t tickstart = HAL_GetTick();
+  uint32_t wait = Delay;
+
+  /* Add a freq to guarantee minimum wait */
+  if (wait < HAL_MAX_DELAY)
   {
-    uint32_t tickstart = HAL_GetTick();
-    uint32_t wait = Delay;
-
-    /* Add a freq to guarantee minimum wait */
-    if (wait < HAL_MAX_DELAY)
-    {
-      wait += (uint32_t)(uwTickFreq);
-    }
-
-    while ((HAL_GetTick() - tickstart) < wait)
-    {
-    }
+    wait += (uint32_t)(uwTickFreq);
   }
+
+  while ((HAL_GetTick() - tickstart) < wait)
+  {
+  }
+}
 
 
 /**
@@ -424,7 +424,7 @@ HAL_TickFreqTypeDef HAL_GetTickFreq(void)
 __weak void HAL_SuspendTick(void)
 {
   /* Disable SysTick Interrupt */
-  CLEAR_BIT(SysTick->CTRL,SysTick_CTRL_TICKINT_Msk);
+  CLEAR_BIT(SysTick->CTRL, SysTick_CTRL_TICKINT_Msk);
 }
 
 /**
@@ -440,7 +440,7 @@ __weak void HAL_SuspendTick(void)
 __weak void HAL_ResumeTick(void)
 {
   /* Enable SysTick Interrupt */
-  SET_BIT(SysTick->CTRL,SysTick_CTRL_TICKINT_Msk);
+  SET_BIT(SysTick->CTRL, SysTick_CTRL_TICKINT_Msk);
 }
 
 /**
@@ -449,7 +449,7 @@ __weak void HAL_ResumeTick(void)
   */
 uint32_t HAL_GetHalVersion(void)
 {
- return __STM32WBxx_HAL_VERSION;
+  return __STM32WBxx_HAL_VERSION;
 }
 
 /**
@@ -458,7 +458,7 @@ uint32_t HAL_GetHalVersion(void)
   */
 uint32_t HAL_GetREVID(void)
 {
-   return(LL_DBGMCU_GetRevisionID());
+  return (LL_DBGMCU_GetRevisionID());
 }
 
 /**
@@ -467,7 +467,7 @@ uint32_t HAL_GetREVID(void)
   */
 uint32_t HAL_GetDEVID(void)
 {
-   return(LL_DBGMCU_GetDeviceID());
+  return (LL_DBGMCU_GetDeviceID());
 }
 
 /**
@@ -476,7 +476,7 @@ uint32_t HAL_GetDEVID(void)
   */
 uint32_t HAL_GetUIDw0(void)
 {
-  return(READ_REG(*((uint32_t *)UID_BASE)));
+  return (READ_REG(*((uint32_t *)UID_BASE)));
 }
 
 /**
@@ -485,7 +485,7 @@ uint32_t HAL_GetUIDw0(void)
   */
 uint32_t HAL_GetUIDw1(void)
 {
-  return(READ_REG(*((uint32_t *)(UID_BASE + 4U))));
+  return (READ_REG(*((uint32_t *)(UID_BASE + 4U))));
 }
 
 /**
@@ -494,7 +494,7 @@ uint32_t HAL_GetUIDw1(void)
   */
 uint32_t HAL_GetUIDw2(void)
 {
-  return(READ_REG(*((uint32_t *)(UID_BASE + 8U))));
+  return (READ_REG(*((uint32_t *)(UID_BASE + 8U))));
 }
 
 /**
@@ -502,8 +502,8 @@ uint32_t HAL_GetUIDw2(void)
   */
 
 /** @addtogroup HAL_Exported_Functions_Group3
- *  @brief    HAL Debug functions
- *
+  *  @brief    HAL Debug functions
+  *
 @verbatim
  ===============================================================================
                       ##### HAL Debug functions #####
@@ -576,8 +576,8 @@ void HAL_DBGMCU_DisableDBGStandbyMode(void)
   */
 
 /** @defgroup HAL_Exported_Functions_Group4 HAL System Configuration functions
- *  @brief    HAL System Configuration functions
- *
+  *  @brief    HAL System Configuration functions
+  *
 @verbatim
  ===============================================================================
                  ##### HAL system configuration functions #####
@@ -654,11 +654,11 @@ void HAL_SYSCFG_VREFBUF_VoltageScalingConfig(uint32_t VoltageScaling)
   /* Restrieve Calibration data and store them into trimming field */
   if (VoltageScaling == SYSCFG_VREFBUF_VOLTAGE_SCALE0)
   {
-    TrimmingValue = ((uint32_t) *VREFBUF_SC0_CAL_ADDR) & 0x3FU;
+    TrimmingValue = ((uint32_t) * VREFBUF_SC0_CAL_ADDR) & 0x3FU;
   }
   else
   {
-    TrimmingValue = ((uint32_t) *VREFBUF_SC1_CAL_ADDR) & 0x3FU;
+    TrimmingValue = ((uint32_t) * VREFBUF_SC1_CAL_ADDR) & 0x3FU;
   }
   assert_param(IS_SYSCFG_VREFBUF_TRIMMING(TrimmingValue));
 
@@ -717,9 +717,9 @@ HAL_StatusTypeDef HAL_SYSCFG_EnableVREFBUF(void)
   tickstart = HAL_GetTick();
 
   /* Wait for VRR bit  */
-  while(READ_BIT(VREFBUF->CSR, VREFBUF_CSR_VRR) == 0U)
+  while (READ_BIT(VREFBUF->CSR, VREFBUF_CSR_VRR) == 0U)
   {
-    if((HAL_GetTick() - tickstart) > VREFBUF_TIMEOUT_VALUE)
+    if ((HAL_GetTick() - tickstart) > VREFBUF_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     }
@@ -850,5 +850,3 @@ uint32_t HAL_SYSCFG_IsEnabledSecurityAccess(uint32_t SecurityAccess)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_adc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_adc.c
@@ -18,7 +18,17 @@
   *             ++ Interrupts and flags management
   *          Other functions (extended functions) are available in file
   *          "stm32wbxx_hal_adc_ex.c".
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### ADC peripheral features #####
@@ -215,11 +225,11 @@
 
      The compilation flag USE_HAL_ADC_REGISTER_CALLBACKS, when set to 1,
      allows the user to configure dynamically the driver callbacks.
-     Use Functions @ref HAL_ADC_RegisterCallback()
+     Use Functions HAL_ADC_RegisterCallback()
      to register an interrupt callback.
     [..]
 
-     Function @ref HAL_ADC_RegisterCallback() allows to register following callbacks:
+     Function HAL_ADC_RegisterCallback() allows to register following callbacks:
        (+) ConvCpltCallback               : ADC conversion complete callback
        (+) ConvHalfCpltCallback           : ADC conversion DMA half-transfer callback
        (+) LevelOutOfWindowCallback       : ADC analog watchdog 1 callback
@@ -235,11 +245,11 @@
      and a pointer to the user callback function.
     [..]
 
-     Use function @ref HAL_ADC_UnRegisterCallback to reset a callback to the default
+     Use function HAL_ADC_UnRegisterCallback to reset a callback to the default
      weak function.
     [..]
 
-     @ref HAL_ADC_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     HAL_ADC_UnRegisterCallback takes as parameters the HAL peripheral handle,
      and the Callback ID.
      This function allows to reset following callbacks:
        (+) ConvCpltCallback               : ADC conversion complete callback
@@ -255,27 +265,27 @@
        (+) MspDeInitCallback              : ADC Msp DeInit callback
      [..]
 
-     By default, after the @ref HAL_ADC_Init() and when the state is @ref HAL_ADC_STATE_RESET
+     By default, after the HAL_ADC_Init() and when the state is HAL_ADC_STATE_RESET
      all callbacks are set to the corresponding weak functions:
-     examples @ref HAL_ADC_ConvCpltCallback(), @ref HAL_ADC_ErrorCallback().
+     examples HAL_ADC_ConvCpltCallback(), HAL_ADC_ErrorCallback().
      Exception done for MspInit and MspDeInit functions that are
-     reset to the legacy weak functions in the @ref HAL_ADC_Init()/ @ref HAL_ADC_DeInit() only when
+     reset to the legacy weak functions in the HAL_ADC_Init()/ HAL_ADC_DeInit() only when
      these callbacks are null (not registered beforehand).
     [..]
 
-     If MspInit or MspDeInit are not null, the @ref HAL_ADC_Init()/ @ref HAL_ADC_DeInit()
+     If MspInit or MspDeInit are not null, the HAL_ADC_Init()/ HAL_ADC_DeInit()
      keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
      [..]
 
-     Callbacks can be registered/unregistered in @ref HAL_ADC_STATE_READY state only.
+     Callbacks can be registered/unregistered in HAL_ADC_STATE_READY state only.
      Exception done MspInit/MspDeInit functions that can be registered/unregistered
-     in @ref HAL_ADC_STATE_READY or @ref HAL_ADC_STATE_RESET state,
+     in HAL_ADC_STATE_READY or HAL_ADC_STATE_RESET state,
      thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
     [..]
 
      Then, the user first registers the MspInit/MspDeInit user callbacks
-     using @ref HAL_ADC_RegisterCallback() before calling @ref HAL_ADC_DeInit()
-     or @ref HAL_ADC_Init() function.
+     using HAL_ADC_RegisterCallback() before calling HAL_ADC_DeInit()
+     or HAL_ADC_Init() function.
      [..]
 
      When the compilation flag USE_HAL_ADC_REGISTER_CALLBACKS is set to 0 or
@@ -283,17 +293,6 @@
      are set to the corresponding weak functions.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -341,10 +340,10 @@
 /* Unit: cycles of CPU clock.                                                 */
 #define ADC_CONVERSION_TIME_MAX_CPU_CYCLES (653UL * 4096UL * 256UL)  /*!< ADC conversion completion time-out value */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Register CHSELR bits corresponding to ranks 2 to 8 .                     */
 #define ADC_CHSELR_SQ2_TO_SQ8           (ADC_CHSELR_SQ2 | ADC_CHSELR_SQ3 | ADC_CHSELR_SQ4 | ADC_CHSELR_SQ5 | ADC_CHSELR_SQ6 | ADC_CHSELR_SQ7 | ADC_CHSELR_SQ8)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 
 /**
@@ -402,12 +401,12 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
   uint32_t tmpCFGR = 0UL;
   uint32_t tmp_adc_reg_is_conversion_on_going;
   __IO uint32_t wait_loop_index = 0UL;
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t tmpCFGR2 = 0UL;
 #else
   uint32_t tmp_adc_is_conversion_on_going_regular;
   uint32_t tmp_adc_is_conversion_on_going_injected;
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
   /* Check ADC handle */
   if (hadc == NULL)
@@ -428,7 +427,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
   assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
   assert_param(IS_ADC_OVERRUN(hadc->Init.Overrun));
   assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoWait));
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoPowerOff));
   assert_param(IS_ADC_SAMPLE_TIME(hadc->Init.SamplingTimeCommon1));
   assert_param(IS_ADC_SAMPLE_TIME(hadc->Init.SamplingTimeCommon2));
@@ -472,10 +471,10 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
     hadc->ConvHalfCpltCallback          = HAL_ADC_ConvHalfCpltCallback;             /* Legacy weak callback */
     hadc->LevelOutOfWindowCallback      = HAL_ADC_LevelOutOfWindowCallback;         /* Legacy weak callback */
     hadc->ErrorCallback                 = HAL_ADC_ErrorCallback;                    /* Legacy weak callback */
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
     hadc->InjectedConvCpltCallback      = HAL_ADCEx_InjectedConvCpltCallback;       /* Legacy weak callback */
     hadc->InjectedQueueOverflowCallback = HAL_ADCEx_InjectedQueueOverflowCallback;  /* Legacy weak callback */
-#endif
+#endif  /* !ADC_SUPPORT_2_5_MSPS */
     hadc->LevelOutOfWindow2Callback     = HAL_ADCEx_LevelOutOfWindow2Callback;      /* Legacy weak callback */
     hadc->LevelOutOfWindow3Callback     = HAL_ADCEx_LevelOutOfWindow3Callback;      /* Legacy weak callback */
     hadc->EndOfSamplingCallback         = HAL_ADCEx_EndOfSamplingCallback;          /* Legacy weak callback */
@@ -500,7 +499,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
   }
 
   /* - Exit from deep power-down mode and ADC voltage regulator enable        */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* Feature "deep power-down" not available on ADC peripheral of this STM32WB device */
 #else
   if (LL_ADC_IsDeepPowerDownEnabled(hadc->Instance) != 0UL)
@@ -512,7 +511,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
      be relaunched or a previously saved calibration factor
      re-applied once the ADC voltage regulator is enabled */
   }
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
   if (LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
   {
@@ -522,7 +521,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
     /* Note: Variable divided by 2 to compensate partially              */
     /*       CPU processing cycles, scaling in us split to not          */
     /*       exceed 32 bits register capacity and handle low frequency. */
-    wait_loop_index = ((LL_ADC_DELAY_INTERNAL_REGUL_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL)));
+    wait_loop_index = ((LL_ADC_DELAY_INTERNAL_REGUL_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
     while (wait_loop_index != 0UL)
     {
       wait_loop_index--;
@@ -558,7 +557,7 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
                       HAL_ADC_STATE_REG_BUSY,
                       HAL_ADC_STATE_BUSY_INTERNAL);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     /* Configuration of common ADC parameters                                 */
 
     /* Parameters update conditioned to ADC state:                            */
@@ -667,17 +666,18 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
 
     /* Update ADC configuration register with previous settings */
     MODIFY_REG(hadc->Instance->CFGR1,
-               ADC_CFGR1_DISCEN  |
-               ADC_CFGR1_AUTOFF  |
-               ADC_CFGR1_WAIT    |
-               ADC_CFGR1_CONT    |
-               ADC_CFGR1_OVRMOD  |
-               ADC_CFGR1_EXTSEL  |
-               ADC_CFGR1_EXTEN   |
-               ADC_CFGR1_ALIGN   |
-               ADC_CFGR1_SCANDIR |
-               ADC_CFGR1_DMACFG     ,
-               tmpCFGR              );
+               ADC_CFGR1_DISCEN    |
+               ADC_CFGR1_AUTOFF    |
+               ADC_CFGR1_CHSELRMOD |
+               ADC_CFGR1_WAIT      |
+               ADC_CFGR1_CONT      |
+               ADC_CFGR1_OVRMOD    |
+               ADC_CFGR1_EXTSEL    |
+               ADC_CFGR1_EXTEN     |
+               ADC_CFGR1_ALIGN     |
+               ADC_CFGR1_SCANDIR   |
+               ADC_CFGR1_DMACFG,
+               tmpCFGR);
 
     /* Channel sampling time configuration */
     LL_ADC_SetSamplingTimeCommonChannels(hadc->Instance, LL_ADC_SAMPLINGTIME_COMMON_1, hadc->Init.SamplingTimeCommon1);
@@ -702,43 +702,20 @@ HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
     }
     else if(hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
     {
-      /* Count number of ranks available in HAL ADC handle variable */
-      uint32_t ADCGroupRegularSequencerRanksCount;
-
-      /* Parse all ranks from 1 to 8 */
-      for(ADCGroupRegularSequencerRanksCount = 0UL; ADCGroupRegularSequencerRanksCount < (8UL); ADCGroupRegularSequencerRanksCount++)
-      {
-        /* Check each sequencer rank until value of end of sequence */
-        if(((hadc->ADCGroupRegularSequencerRanks >> (ADCGroupRegularSequencerRanksCount * 4UL)) & ADC_CHSELR_SQ1) == ADC_CHSELR_SQ1)
-        {
-          break;
-        }
-      }
-
-      if(ADCGroupRegularSequencerRanksCount == 1UL)
-      {
-        /* Set ADC group regular sequencer:                                   */
-        /* Set sequencer scan length by clearing ranks above rank 1           */
-        /* and do not modify rank 1 value.                                    */
-        SET_BIT(hadc->Instance->CHSELR,
-                ADC_CHSELR_SQ2_TO_SQ8);
-      }
-      else
-      {
-        /* Set ADC group regular sequencer:                                   */
-        /*  - Set ADC group regular sequencer to value memorized              */
-        /*    in HAL ADC handle                                               */
-        /*    Note: This value maybe be initialized at a unknown value,       */
-        /*          therefore afer the first call of "HAL_ADC_Init()",        */
-        /*          each rank corresponding to parameter "NbrOfConversion"    */
-        /*          must be set using "HAL_ADC_ConfigChannel()".              */
-        /*  - Set sequencer scan length by clearing ranks above maximum rank  */
-        /*    and do not modify other ranks value.                            */
-        MODIFY_REG(hadc->Instance->CHSELR,
-                   ADC_CHSELR_SQ_ALL,
-                   (ADC_CHSELR_SQ2_TO_SQ8 << (((hadc->Init.NbrOfConversion - 1UL) * ADC_REGULAR_RANK_2) & 0x1FUL)) | (hadc->ADCGroupRegularSequencerRanks)
-                  );
-      }
+      /* Set ADC group regular sequencer:                                   */
+      /*  - Set ADC group regular sequencer to value memorized              */
+      /*    in HAL ADC handle                                               */
+      /*    Note: This value maybe be initialized at a unknown value,       */
+      /*          therefore after the first call of "HAL_ADC_Init()",       */
+      /*          each rank corresponding to parameter "NbrOfConversion"    */
+      /*          must be set using "HAL_ADC_ConfigChannel()".              */
+      /*  - Set sequencer scan length by clearing ranks above maximum rank  */
+      /*    and do not modify other ranks value.                            */
+      MODIFY_REG(hadc->Instance->CHSELR,
+                  ADC_CHSELR_SQ_ALL,
+                  ((ADC_CHSELR_SQ2_TO_SQ8 << (((hadc->Init.NbrOfConversion - 1UL) * ADC_REGULAR_RANK_2) & 0x1FUL)) |
+                   (hadc->ADCGroupRegularSequencerRanks))
+                );
     }
 
     /* Check back that ADC registers have effectively been configured to      */
@@ -957,13 +934,13 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
   SET_BIT(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL);
 
   /* Stop potential conversion on going */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
 #else
   tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
   /* Disable ADC peripheral if conversions are effectively stopped            */
@@ -996,7 +973,7 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
   /*       system RCC hard reset.                                             */
 
   /* ========== Reset ADC registers ========== */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   /* Reset register IER */
   __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 |
                               ADC_IT_AWD1  | ADC_IT_OVR  |
@@ -1014,10 +991,11 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
   /* "read-set": no direct reset applicable.                                */
 
   /* Reset register CFGR1 */
-  hadc->Instance->CFGR1 &= ~(ADC_CFGR1_AWD1CH   | ADC_CFGR1_AWD1EN  | ADC_CFGR1_AWD1SGL | ADC_CFGR1_DISCEN |
-                             ADC_CFGR1_AUTOFF  | ADC_CFGR1_WAIT   | ADC_CFGR1_CONT   | ADC_CFGR1_OVRMOD |
-                             ADC_CFGR1_EXTEN   | ADC_CFGR1_EXTSEL | ADC_CFGR1_ALIGN  | ADC_CFGR1_RES    |
-                             ADC_CFGR1_SCANDIR | ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN                      );
+  hadc->Instance->CFGR1 &= ~(ADC_CFGR1_AWD1CH  | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL | ADC_CFGR1_DISCEN |
+                             ADC_CFGR1_AUTOFF  | ADC_CFGR1_WAIT   | ADC_CFGR1_CONT    | ADC_CFGR1_OVRMOD |
+                             ADC_CFGR1_EXTEN   | ADC_CFGR1_EXTSEL | ADC_CFGR1_ALIGN   | ADC_CFGR1_RES    |
+                             ADC_CFGR1_SCANDIR | ADC_CFGR1_DMACFG | ADC_CFGR1_DMAEN   |
+                             ADC_CFGR1_CHSELRMOD);
 
   /* Reset register CFGR2 */
   /* Note: Update of ADC clock mode is conditioned to ADC state disabled:   */
@@ -1027,8 +1005,8 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
   /* Reset register SMPR */
   hadc->Instance->SMPR &= ~ADC_SMPR_SMP1;
 
-  /* Reset register TR1 */
-  hadc->Instance->TR1 &= ~(ADC_TR1_HT1 | ADC_TR1_LT1);
+  /* Reset register TR */
+  hadc->Instance->TR &= ~(ADC_TR_HT | ADC_TR_LT);
 
   /* Reset register CHSELR */
   hadc->Instance->CHSELR &= ~(ADC_CHSELR_SQ_ALL);
@@ -1038,27 +1016,25 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
 
 #else
   /* Reset register IER */
-  __HAL_ADC_DISABLE_IT(hadc, (
-#if defined (ADC_SUPPORT_2_5_MSPS)
-                              ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
-                              ADC_IT_EOCAL | ADC_IT_CCRDY |
+#if defined(ADC_SUPPORT_2_5_MSPS)
+  __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
+                              ADC_IT_EOCAL | ADC_IT_CCRDY));
 #else
-                              ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
-                              ADC_IT_JEOS  | ADC_IT_JEOC | ADC_IT_JQOVF |
-#endif
-                              ADC_IT_EOS   | ADC_IT_EOC  | ADC_IT_OVR   |
+  __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
+                              ADC_IT_JEOS  | ADC_IT_JEOC | ADC_IT_JQOVF));
+#endif /* ADC_SUPPORT_2_5_MSPS */
+  __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOS   | ADC_IT_EOC  | ADC_IT_OVR   |
                               ADC_IT_EOSMP | ADC_IT_RDY));
 
   /* Reset register ISR */
-  __HAL_ADC_CLEAR_FLAG(hadc, (
-#if defined (ADC_SUPPORT_2_5_MSPS)
-                              ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
-                              ADC_FLAG_EOCAL | ADC_FLAG_CCRDY |
+#if defined(ADC_SUPPORT_2_5_MSPS)
+  __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
+                              ADC_FLAG_EOCAL | ADC_FLAG_CCRDY));
 #else
-                              ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
-                              ADC_FLAG_JEOS  | ADC_FLAG_JEOC | ADC_FLAG_JQOVF |
-#endif
-                              ADC_FLAG_EOS   | ADC_FLAG_EOC  | ADC_FLAG_OVR  |
+  __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
+                              ADC_FLAG_JEOS  | ADC_FLAG_JEOC | ADC_FLAG_JQOVF));
+#endif /* ADC_SUPPORT_2_5_MSPS */
+  __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOS   | ADC_FLAG_EOC  | ADC_FLAG_OVR  |
                               ADC_FLAG_EOSMP | ADC_FLAG_RDY));
 
   /* Reset register CR */
@@ -1183,7 +1159,7 @@ HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
   /* Set ADC error code to none */
   ADC_CLEAR_ERRORCODE(hadc);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   /* Reset HAL ADC handle variable */
   hadc->ADCGroupRegularSequencerRanks = 0x00000000UL;
 #else
@@ -1406,7 +1382,7 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
         hadc->ErrorCallback = HAL_ADC_ErrorCallback;
         break;
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
       case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
@@ -1416,7 +1392,7 @@ HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_Ca
       case HAL_ADC_INJ_QUEUE_OVEFLOW_CB_ID :
         hadc->InjectedQueueOverflowCallback = HAL_ADCEx_InjectedQueueOverflowCallback;
         break;
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
       case HAL_ADC_LEVEL_OUT_OF_WINDOW_2_CB_ID :
         hadc->LevelOutOfWindow2Callback = HAL_ADCEx_LevelOutOfWindow2Callback;
@@ -1541,7 +1517,7 @@ HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef *hadc)
                         HAL_ADC_STATE_REG_BUSY);
 
       /* Set ADC error code */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
       /* Reset all ADC error code fields */
       ADC_CLEAR_ERRORCODE(hadc);
 #else
@@ -1608,7 +1584,7 @@ HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef *hadc)
   /* Process locked */
   __HAL_LOCK(hadc);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* 1. Stop potential conversion on going, on ADC group regular */
   tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
 #else
@@ -1626,7 +1602,7 @@ HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef *hadc)
     if (tmp_hal_status == HAL_OK)
     {
       /* Set ADC state */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
       ADC_STATE_CLR_SET(hadc->State,
                         HAL_ADC_STATE_REG_BUSY,
                         HAL_ADC_STATE_READY);
@@ -1685,11 +1661,11 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Ti
     /* several ranks and polling for end of each conversion.                  */
     /* For code simplicity sake, this particular case is generalized to       */
     /* ADC configured in DMA mode and and polling for end of each conversion. */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     if(READ_BIT(hadc->Instance->CFGR1, ADC_CFGR1_DMAEN) != 0UL)
 #else
     if(READ_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN) != 0UL)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
     {
       /* Update ADC state machine to error */
       SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
@@ -1713,13 +1689,17 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Ti
     {
       if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
       {
-        /* Update ADC state machine to timeout */
-        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        /* New check to avoid false timeout detection in case of preemption */
+        if ((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
 
-        /* Process unlocked */
-        __HAL_UNLOCK(hadc);
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
 
-        return HAL_TIMEOUT;
+          return HAL_TIMEOUT;
+        }
       }
     }
   }
@@ -1756,11 +1736,11 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Ti
     /* Clear end of conversion EOC flag of regular group if low power feature */
     /* "LowPowerAutoWait " is disabled, to not interfere with this feature    */
     /* until data register is read using function HAL_ADC_GetValue().         */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     if (READ_BIT(hadc->Instance->CFGR1, ADC_CFGR1_WAIT) == 0UL)
 #else
     if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_AUTDLY) == 0UL)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
     {
       __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS));
     }
@@ -1782,7 +1762,7 @@ HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Ti
   *            @arg @ref ADC_OVR_EVENT    ADC Overrun event
   *            @arg @ref ADC_JQOVF_EVENT  ADC Injected context queue overflow event (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @param Timeout Timeout value in millisecond.
   * @note   The relevant flag is cleared if found to be set, except for ADC_FLAG_OVR.
   *         Indeed, the latter is reset only if hadc->Init.Overrun field is set
@@ -1811,13 +1791,17 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventTy
     {
       if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
       {
-        /* Update ADC state machine to timeout */
-        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        /* New check to avoid false timeout detection in case of preemption */
+        if (__HAL_ADC_GET_FLAG(hadc, EventType) == 0UL)
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
 
-        /* Process unlocked */
-        __HAL_UNLOCK(hadc);
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
 
-        return HAL_TIMEOUT;
+          return HAL_TIMEOUT;
+        }
       }
     }
   }
@@ -1873,7 +1857,7 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventTy
 
       break;
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
     /* Injected context queue overflow event */
@@ -1888,7 +1872,7 @@ HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventTy
       __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
 
       break;
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
     /* Overrun event */
     default: /* Case ADC_OVR_EVENT */
@@ -1963,7 +1947,7 @@ HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef *hadc)
                         HAL_ADC_STATE_REG_BUSY);
 
       /* Set ADC error code */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
       /* Reset all ADC error code fields */
       ADC_CLEAR_ERRORCODE(hadc);
 #else
@@ -2053,7 +2037,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef *hadc)
   /* Process locked */
   __HAL_LOCK(hadc);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* 1. Stop potential conversion on going, on ADC group regular */
   tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
 #else
@@ -2075,7 +2059,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef *hadc)
     if (tmp_hal_status == HAL_OK)
     {
       /* Set ADC state */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
       ADC_STATE_CLR_SET(hadc->State,
                         HAL_ADC_STATE_REG_BUSY,
                         HAL_ADC_STATE_READY);
@@ -2130,7 +2114,7 @@ HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, ui
                           HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
                           HAL_ADC_STATE_REG_BUSY);
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
         /* Reset all ADC error code fields */
         ADC_CLEAR_ERRORCODE(hadc);
 #else
@@ -2176,11 +2160,11 @@ HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, ui
         __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
 
         /* Enable ADC DMA mode */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
         SET_BIT(hadc->Instance->CFGR1, ADC_CFGR1_DMAEN);
 #else
         SET_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
         /* Start the DMA channel */
         tmp_hal_status = HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
@@ -2228,7 +2212,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc)
   __HAL_LOCK(hadc);
 
   /* 1. Stop potential ADC group regular conversion on going */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
 #else
   tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
@@ -2237,12 +2221,12 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc)
   /* Disable ADC peripheral if conversions are effectively stopped */
   if (tmp_hal_status == HAL_OK)
   {
-    /* Disable ADC DMA (ADC DMA configuration of continous requests is kept) */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+    /* Disable ADC DMA (ADC DMA configuration of continuous requests is kept) */
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     CLEAR_BIT(hadc->Instance->CFGR1, ADC_CFGR1_DMAEN);
 #else
     CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_DMAEN);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
     /* Disable the DMA channel (in case of DMA in circular mode or stop       */
     /* while DMA transfer is on going)                                        */
@@ -2277,7 +2261,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc)
     if (tmp_hal_status == HAL_OK)
     {
       /* Set ADC state */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
       ADC_STATE_CLR_SET(hadc->State,
                         HAL_ADC_STATE_REG_BUSY,
                         HAL_ADC_STATE_READY);
@@ -2316,7 +2300,7 @@ HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc)
   * @param hadc ADC handle
   * @retval ADC group regular conversion data
   */
-uint32_t HAL_ADC_GetValue(ADC_HandleTypeDef *hadc)
+uint32_t HAL_ADC_GetValue(const ADC_HandleTypeDef *hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -2338,11 +2322,11 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc)
   uint32_t overrun_error = 0UL; /* flag set if overrun occurrence has to be considered as an error */
   uint32_t tmp_isr = hadc->Instance->ISR;
   uint32_t tmp_ier = hadc->Instance->IER;
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t tmp_adc_inj_is_trigger_source_sw_start;
   uint32_t tmp_adc_reg_is_trigger_source_sw_start;
   uint32_t tmp_cfgr;
-#endif
+#endif  /* !ADC_SUPPORT_2_5_MSPS */
 
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -2386,11 +2370,11 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc)
     if (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
     {
       /* Carry on if continuous mode is disabled */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
       if (READ_BIT (hadc->Instance->CFGR1, ADC_CFGR1_CONT) != ADC_CFGR1_CONT)
 #else
       if (READ_BIT (hadc->Instance->CFGR, ADC_CFGR_CONT) != ADC_CFGR_CONT)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
       {
         /* If End of Sequence is reached, disable interrupts */
         if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))
@@ -2444,7 +2428,7 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc)
     __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS));
   }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
   /* ====== Check ADC group injected end of unitary conversion sequence conversions ===== */
@@ -2627,7 +2611,7 @@ void HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc)
     __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
   }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
   /* ========== Check Injected context queue overflow flag ========== */
@@ -2756,9 +2740,9 @@ __weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
   * @param sConfig Structure of ADC channel assigned to ADC group regular.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConfTypeDef *sConfig)
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, const ADC_ChannelConfTypeDef *sConfig)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmp_config_internal_channel;
   __IO uint32_t wait_loop_index = 0UL;
@@ -2857,7 +2841,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConf
           /* Note: Variable divided by 2 to compensate partially              */
           /*       CPU processing cycles, scaling in us split to not          */
           /*       exceed 32 bits register capacity and handle low frequency. */
-          wait_loop_index = (((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL))) + 1UL);
+          wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
           while(wait_loop_index != 0UL)
           {
             wait_loop_index--;
@@ -2938,10 +2922,10 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConf
   uint32_t tmpOffsetShifted;
   uint32_t tmp_config_internal_channel;
   __IO uint32_t wait_loop_index = 0;
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t tmp_adc_is_conversion_on_going_regular;
   uint32_t tmp_adc_is_conversion_on_going_injected;
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -2983,7 +2967,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConf
     /* conversion on going on regular group:                                    */
     /*  - Channel sampling time                                                 */
     /*  - Channel offset                                                        */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
 #else
     tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
@@ -3079,7 +3063,7 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConf
               /* Note: Variable divided by 2 to compensate partially              */
               /*       CPU processing cycles, scaling in us split to not          */
               /*       exceed 32 bits register capacity and handle low frequency. */
-              wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL)));
+              wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
               while(wait_loop_index != 0UL)
               {
                 wait_loop_index--;
@@ -3148,21 +3132,21 @@ HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConf
   *         The setting of these parameters is conditioned to ADC state.
   *         For parameters constraints, see comments of structure
   *         "ADC_AnalogWDGConfTypeDef".
-  * @note   On this STM32 serie, analog watchdog thresholds cannot be modified
+  * @note   On this STM32 series, analog watchdog thresholds cannot be modified
   *         while ADC conversion is on going.
   * @param hadc ADC handle
   * @param AnalogWDGConfig Structure of ADC analog watchdog configuration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDGConfTypeDef *AnalogWDGConfig)
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, const ADC_AnalogWDGConfTypeDef *AnalogWDGConfig)
 {
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmpAWDHighThresholdShifted;
   uint32_t tmpAWDLowThresholdShifted;
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
   uint32_t tmp_adc_is_conversion_on_going_regular;
   uint32_t tmp_adc_is_conversion_on_going_injected;
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -3170,19 +3154,19 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
   assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
   assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   if(AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)
 #else
   if ((AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)     ||
       (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_INJEC)   ||
       (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC))
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   {
     assert_param(IS_ADC_CHANNEL(hadc, AnalogWDGConfig->Channel));
   }
 
   /* Verify thresholds range */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   /* Verify if thresholds are within the selected ADC resolution */
   assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold));
   assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold));
@@ -3211,7 +3195,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
   /* conversion on going on ADC groups regular and injected:                  */
   /*  - Analog watchdog channels                                              */
   /*  - Analog watchdog thresholds                                            */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
 #else
   tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
@@ -3234,7 +3218,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
                                           LL_ADC_GROUP_REGULAR));
           break;
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
         case ADC_ANALOGWATCHDOG_SINGLE_INJEC:
@@ -3252,7 +3236,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
           LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, LL_ADC_AWD_ALL_CHANNELS_REG);
           break;
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
         case ADC_ANALOGWATCHDOG_ALL_INJEC:
@@ -3297,7 +3281,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
         LL_ADC_DisableIT_AWD1(hadc->Instance);
       }
     }
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     /* Feature "ADC analog watchdog 2 and 3" not available on ADC peripheral of this STM32WB device */
 #else
     /* Case of ADC_ANALOGWATCHDOG_2 or ADC_ANALOGWATCHDOG_3 */
@@ -3306,10 +3290,10 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
       switch (AnalogWDGConfig->WatchdogMode)
       {
         case ADC_ANALOGWATCHDOG_SINGLE_REG:
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
         case ADC_ANALOGWATCHDOG_SINGLE_INJEC:
         case ADC_ANALOGWATCHDOG_SINGLE_REGINJEC:
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
           /* Update AWD by bitfield to keep the possibility to monitor        */
           /* several channels by successive calls of this function.           */
           if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
@@ -3323,15 +3307,15 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
           break;
 
         case ADC_ANALOGWATCHDOG_ALL_REG:
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
         case ADC_ANALOGWATCHDOG_ALL_INJEC:
         case ADC_ANALOGWATCHDOG_ALL_REGINJEC:
-#endif
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#endif /* !ADC_SUPPORT_2_5_MSPS */
+#if defined(ADC_SUPPORT_2_5_MSPS)
           LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, AnalogWDGConfig->WatchdogNumber, LL_ADC_AWD_ALL_CHANNELS_REG);
 #else
           LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, AnalogWDGConfig->WatchdogNumber, LL_ADC_AWD_ALL_CHANNELS_REG_INJ);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
           break;
 
         default: /* ADC_ANALOGWATCHDOG_NONE */
@@ -3442,7 +3426,7 @@ HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDG
   * @param hadc ADC handle
   * @retval ADC handle state (bitfield on 32 bits)
   */
-uint32_t HAL_ADC_GetState(ADC_HandleTypeDef *hadc)
+uint32_t HAL_ADC_GetState(const ADC_HandleTypeDef *hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -3456,7 +3440,7 @@ uint32_t HAL_ADC_GetState(ADC_HandleTypeDef *hadc)
   * @param hadc ADC handle
   * @retval ADC error code (bitfield on 32 bits)
   */
-uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
+uint32_t HAL_ADC_GetError(const ADC_HandleTypeDef *hadc)
 {
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
@@ -3485,12 +3469,12 @@ uint32_t HAL_ADC_GetError(ADC_HandleTypeDef *hadc)
   *            @arg @ref ADC_INJECTED_GROUP         (1)  ADC injected conversion type.
   *            @arg @ref ADC_REGULAR_INJECTED_GROUP (1)  ADC regular and injected conversion type.
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval HAL status.
   */
 HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef *hadc, uint32_t ConversionGroup)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
   UNUSED(ConversionGroup);
 
   uint32_t tickstart;
@@ -3633,13 +3617,17 @@ HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef *hadc, uint32_t Conversio
     {
       if ((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
       {
-        /* Update ADC state machine to error */
-        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        /* New check to avoid false timeout detection in case of preemption */
+        if ((hadc->Instance->CR & tmp_ADC_CR_ADSTART_JADSTART) != 0UL)
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
 
-        /* Set ADC error code to ADC peripheral internal error */
-        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+          /* Set ADC error code to ADC peripheral internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
 
-        return HAL_ERROR;
+          return HAL_ERROR;
+        }
       }
     }
 
@@ -3671,11 +3659,11 @@ HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef *hadc)
   if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
   {
     /* Check if conditions to enable the ADC are fulfilled */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     if ((hadc->Instance->CR & (ADC_CR_ADCAL | ADC_CR_ADSTP | ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN)) != 0UL)
 #else
     if ((hadc->Instance->CR & (ADC_CR_ADCAL | ADC_CR_JADSTP | ADC_CR_ADSTP | ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN)) != 0UL)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
     {
       /* Update ADC state machine to error */
       SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
@@ -3696,14 +3684,14 @@ HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef *hadc)
       /* Note: Variable divided by 2 to compensate partially              */
       /*       CPU processing cycles, scaling in us split to not          */
       /*       exceed 32 bits register capacity and handle low frequency. */
-      wait_loop_index = (((LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL))) + 1UL);
+      wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_BUFFER_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
       while(wait_loop_index != 0UL)
       {
         wait_loop_index--;
       }
     }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     /* If low power mode AutoPowerOff is enabled, power-on/off phases are     */
     /* performed automatically by hardware and flag ADC ready is not set.     */
     if (hadc->Init.LowPowerAutoPowerOff != ENABLE)
@@ -3765,11 +3753,11 @@ HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef *hadc)
      )
   {
     /* Check if conditions to disable the ADC are fulfilled */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     if ((hadc->Instance->CR & (ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN)
 #else
     if ((hadc->Instance->CR & (ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
     {
       /* Disable the ADC peripheral */
       LL_ADC_Disable(hadc->Instance);
@@ -3794,13 +3782,17 @@ HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef *hadc)
     {
       if ((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
       {
-        /* Update ADC state machine to error */
-        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+        /* New check to avoid false timeout detection in case of preemption */
+        if ((hadc->Instance->CR & ADC_CR_ADEN) != 0UL)
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
 
-        /* Set ADC error code to ADC peripheral internal error */
-        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+          /* Set ADC error code to ADC peripheral internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
 
-        return HAL_ERROR;
+          return HAL_ERROR;
+        }
       }
     }
   }
@@ -3829,7 +3821,7 @@ void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
     /* by external trigger, continuous mode or scan sequence on going         */
     /* to disable interruption.                                               */
     /* Is it the end of the regular sequence ? */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
     if(   (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
        && (hadc->Init.ContinuousConvMode == DISABLE)
       )
@@ -3977,5 +3969,3 @@ void ADC_DMAError(DMA_HandleTypeDef *hdma)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_adc_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_adc_ex.c
@@ -7,34 +7,33 @@
   *          peripheral:
   *           + Operation functions
   *             ++ Start, stop, get result of conversions of ADC group injected,
-  *                using 2 possible modes: polling, interruption (not available on devices: STM32WB10xx, STM32WB15xx).
+  *                using 2 possible modes: polling, interruption (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
   *             ++ Calibration
   *               +++ ADC automatic self-calibration
   *               +++ Calibration factors get or set
   *           + Control functions
-  *             ++ Channels configuration on ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx)
+  *             ++ Channels configuration on ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx )
   *           + State functions
-  *             ++ ADC group injected contexts queue management (not available on devices: STM32WB10xx, STM32WB15xx)
+  *             ++ ADC group injected contexts queue management (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx )
   *          Other functions (generic functions) are available in file
   *          "stm32wbxx_hal_adc.c".
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   [..]
   (@) Sections "ADC peripheral features" and "How to use this driver" are
       available in file of generic functions "stm32wbxx_hal_adc.c".
   [..]
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -72,6 +71,7 @@
 /* Calibration time max = 116 / fADC (refer to datasheet)                     */
 /*                      = 158 379 CPU cycles                                  */
 #define ADC_CALIBRATION_TIMEOUT         (158379UL)   /*!< ADC calibration time-out value (unit: CPU cycles) */
+#define ADC_DISABLE_TIMEOUT             (2UL)
 
 /**
   * @}
@@ -99,12 +99,12 @@
       (+) Get calibration factors for single or differential ending.
       (+) Set calibration factors for single or differential ending.
 
-      (+) Start conversion of ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx).
-      (+) Stop conversion of ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx).
-      (+) Poll for conversion complete on ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx).
-      (+) Get result of ADC group injected channel conversion (not available on devices: STM32WB10xx, STM32WB15xx).
-      (+) Start conversion of ADC group injected and enable interruptions (not available on devices: STM32WB10xx, STM32WB15xx).
-      (+) Stop conversion of ADC group injected and disable interruptions (not available on devices: STM32WB10xx, STM32WB15xx).
+      (+) Start conversion of ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
+      (+) Stop conversion of ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
+      (+) Poll for conversion complete on ADC group injected (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
+      (+) Get result of ADC group injected channel conversion (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
+      (+) Start conversion of ADC group injected and enable interruptions (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
+      (+) Stop conversion of ADC group injected and disable interruptions (not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx ).
 
 @endverbatim
   * @{
@@ -120,14 +120,21 @@
   *           @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
   *           @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t SingleDiff)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   UNUSED(SingleDiff);
-#endif
+
+  uint32_t calibration_index;
+  uint32_t calibration_factor_accumulated = 0;
+  uint32_t backup_setting_cfgr1;
+  uint32_t tickstart;
+  uint32_t adc_clk_async_presc;
+  __IO uint32_t delay_cpu_cycles;
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
   HAL_StatusTypeDef tmp_hal_status;
   __IO uint32_t wait_loop_index = 0UL;
@@ -148,7 +155,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t 
   if (tmp_hal_status == HAL_OK)
   {
     /* Set ADC state */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     ADC_STATE_CLR_SET(hadc->State,
                       HAL_ADC_STATE_REG_BUSY,
                       HAL_ADC_STATE_BUSY_INTERNAL);
@@ -159,8 +166,25 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t 
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
     /* Start ADC calibration in mode single-ended or differential */
-#if defined (ADC_SUPPORT_2_5_MSPS)
-    LL_ADC_StartCalibration(hadc->Instance);
+#if defined(ADC_SUPPORT_2_5_MSPS)
+    /* Manage settings impacting calibration */
+    /* - Disable ADC mode auto power-off */
+    /* - Disable ADC DMA transfer request during calibration */
+    /* Note: Specificity of this STM32 series: Calibration factor is          */
+    /*       available in data register and also transferred by DMA.          */
+    /*       To not insert ADC calibration factor among ADC conversion data   */
+    /*       in array variable, DMA transfer must be disabled during          */
+    /*       calibration.                                                     */
+    backup_setting_cfgr1 = READ_BIT(hadc->Instance->CFGR1, ADC_CFGR1_DMAEN | ADC_CFGR1_DMACFG | ADC_CFGR1_AUTOFF);
+    CLEAR_BIT(hadc->Instance->CFGR1, ADC_CFGR1_DMAEN | ADC_CFGR1_DMACFG | ADC_CFGR1_AUTOFF);
+
+    /* ADC calibration procedure */
+    /* Note: Perform an averaging of 8 calibrations for optimized accuracy */
+    for (calibration_index = 0UL; calibration_index < 8UL; calibration_index++)
+    {
+      /* Start ADC calibration */
+      LL_ADC_StartCalibration(hadc->Instance);
+
 #else
     LL_ADC_StartCalibration(hadc->Instance, SingleDiff);
 #endif /* ADC_SUPPORT_2_5_MSPS */
@@ -182,6 +206,62 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t 
         return HAL_ERROR;
       }
     }
+#if defined(ADC_SUPPORT_2_5_MSPS)
+      calibration_factor_accumulated += LL_ADC_GetCalibrationFactor(hadc->Instance);
+    }
+    /* Compute average */
+    calibration_factor_accumulated /= calibration_index;
+    /* Apply calibration factor (requires ADC enable and disable process) */
+    LL_ADC_Enable(hadc->Instance);
+
+    /* Case of ADC clocked at low frequency: Delay required between ADC enable and disable actions */
+    if(LL_ADC_GetClock(hadc->Instance) == LL_ADC_CLOCK_ASYNC)
+    {
+      adc_clk_async_presc = LL_ADC_GetCommonClock(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+      if(adc_clk_async_presc >= LL_ADC_CLOCK_ASYNC_DIV16)
+      {
+        /* Delay loop initialization and execution */
+        /* Delay depends on ADC clock prescaler: Compute ADC clock asynchronous prescaler to decimal format */
+        delay_cpu_cycles = (1U << ((adc_clk_async_presc >> ADC_CCR_PRESC_Pos) - 3U));
+        /* Divide variable by 2 to compensate partially CPU processing cycles */
+        delay_cpu_cycles >>= 1U;
+
+        while(delay_cpu_cycles != 0)
+        {
+          delay_cpu_cycles--;
+        }
+      }
+    }
+
+    LL_ADC_SetCalibrationFactor(hadc->Instance, calibration_factor_accumulated);
+    LL_ADC_Disable(hadc->Instance);
+
+    /* Wait for ADC effectively disabled before changing configuration */
+    /* Get tick count */
+    tickstart = HAL_GetTick();
+
+    while (LL_ADC_IsEnabled(hadc->Instance) != 0UL)
+    {
+      if ((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        if (LL_ADC_IsEnabled(hadc->Instance) != 0UL)
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+          /* Set ADC error code to ADC peripheral internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+
+    /* Restore configuration after calibration */
+    SET_BIT(hadc->Instance->CFGR1, backup_setting_cfgr1);
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
     /* Set ADC state */
     ADC_STATE_CLR_SET(hadc->State,
@@ -210,25 +290,25 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t 
   *           @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
   *           @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @retval Calibration value.
   */
-uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff)
+uint32_t HAL_ADCEx_Calibration_GetValue(const ADC_HandleTypeDef *hadc, uint32_t SingleDiff)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   UNUSED(SingleDiff);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
   assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
 
   /* Return the selected ADC calibration value */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   return LL_ADC_GetCalibrationFactor(hadc->Instance);
 #else
   return LL_ADC_GetCalibrationFactor(hadc->Instance, SingleDiff);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 }
 
 /**
@@ -239,19 +319,19 @@ uint32_t HAL_ADCEx_Calibration_GetValue(ADC_HandleTypeDef *hadc, uint32_t Single
   *           @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
   *           @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended (1)
   *
-  *         (1) On STM32WB serie, parameter not available on devices: STM32WB10xx, STM32WB15xx.
+  *         (1) On STM32WB series, parameter not available on devices: STM32WB10xx, STM32WB15xx, STM32WB1Mxx.
   * @param CalibrationFactor Calibration factor (coded on 7 bits maximum)
   * @retval HAL state
   */
 HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff, uint32_t CalibrationFactor)
 {
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   UNUSED(SingleDiff);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmp_adc_is_conversion_on_going_regular;
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
   uint32_t tmp_adc_is_conversion_on_going_injected;
@@ -268,7 +348,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32
   /* Verification of hardware constraints before modifying the calibration    */
   /* factors register: ADC must be enabled, no conversion on going.           */
   tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
   tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
@@ -276,7 +356,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32
 
   if ((LL_ADC_IsEnabled(hadc->Instance) != 0UL)
       && (tmp_adc_is_conversion_on_going_regular == 0UL)
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
       && (tmp_adc_is_conversion_on_going_injected == 0UL)
@@ -284,11 +364,11 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32
      )
   {
     /* Set the selected ADC calibration value */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     LL_ADC_SetCalibrationFactor(hadc->Instance, CalibrationFactor);
 #else
     LL_ADC_SetCalibrationFactor(hadc->Instance, SingleDiff, CalibrationFactor);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   }
   else
   {
@@ -308,7 +388,7 @@ HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32
   return tmp_hal_status;
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -505,13 +585,17 @@ HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef *hadc, u
     {
       if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
       {
-        /* Update ADC state machine to timeout */
-        SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+        /* New check to avoid false timeout detection in case of preemption */
+        if ((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
 
-        /* Process unlocked */
-        __HAL_UNLOCK(hadc);
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
 
-        return HAL_TIMEOUT;
+          return HAL_TIMEOUT;
+        }
       }
     }
   }
@@ -758,7 +842,7 @@ HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef *hadc)
 }
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -789,7 +873,7 @@ HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef *hadc)
   *            @arg @ref ADC_INJECTED_RANK_4 ADC group injected rank 4
   * @retval ADC group injected conversion data
   */
-uint32_t HAL_ADCEx_InjectedGetValue(ADC_HandleTypeDef *hadc, uint32_t InjectedRank)
+uint32_t HAL_ADCEx_InjectedGetValue(const ADC_HandleTypeDef *hadc, uint32_t InjectedRank)
 {
   uint32_t tmp_jdr;
 
@@ -900,7 +984,7 @@ __weak void HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef *hadc)
   */
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -1103,7 +1187,7 @@ HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef *hadc)
   * @}
   */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /** @defgroup ADCEx_Exported_Functions_Group2 ADC Extended Peripheral Control functions
@@ -1157,7 +1241,7 @@ HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef *hadc)
   *         injected group.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc, ADC_InjectionConfTypeDef *sConfigInjected)
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc, const ADC_InjectionConfTypeDef *sConfigInjected)
 {
   HAL_StatusTypeDef tmp_hal_status = HAL_OK;
   uint32_t tmpOffsetShifted;
@@ -1571,7 +1655,7 @@ HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc, ADC_I
 }
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -1683,7 +1767,7 @@ HAL_StatusTypeDef HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef *hadc)
   return tmp_hal_status;
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature " ADC deep power-down" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -1722,7 +1806,7 @@ HAL_StatusTypeDef HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef *hadc)
 
   return tmp_hal_status;
 }
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @}
@@ -1740,5 +1824,3 @@ HAL_StatusTypeDef HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef *hadc)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_comp.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_comp.c
@@ -6,22 +6,29 @@
   *          This file provides firmware functions to manage the following
   *          functionalities of the COMP peripheral:
   *           + Initialization and de-initialization functions
-  *           + Start/Stop operation functions in polling mode
-  *           + Start/Stop operation functions in interrupt mode (through EXTI interrupt)
   *           + Peripheral control functions
   *           + Peripheral state functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
-================================================================================
+  ==============================================================================
           ##### COMP Peripheral features #####
-================================================================================
+  ==============================================================================
 
   [..]
       The STM32WBxx device family integrates two analog comparators instances:
       COMP1, COMP2 except for the STM32WB15xx, STM32WB10xx products featuring only
-      one instance: COMP1.
-      In the rest of the file, all comments related to a pair of comparators are not
-      applicable to STM32WB15xx, STM32WB10xx.
+      one instance: COMP1 (in this case, all comments related to pair of comparators are not applicable)
       (#) Comparators input minus (inverting input) and input plus (non inverting input)
           can be set to internal references or to GPIO pins
           (refer to GPIO list in reference manual).
@@ -41,7 +48,7 @@
           using macro __HAL_COMP_COMPx_EXTI_GET_FLAG().
 
             ##### How to use this driver #####
-================================================================================
+  ==============================================================================
   [..]
       This driver provides functions to configure and program the comparator instances
       of STM32WBxx devices.
@@ -147,19 +154,6 @@
 
   @endverbatim
   ******************************************************************************
-
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -189,7 +183,7 @@
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tSTART").                                                       */
 /* Unit: us                                                                   */
-#define COMP_DELAY_STARTUP_US          (80UL) /*!< Delay for COMP startup time */
+#define COMP_DELAY_STARTUP_US          (80UL)      /*!< Delay for COMP startup time */
 
 /* Delay for COMP voltage scaler stabilization time.                          */
 /* Literal set to maximum value (refer to device datasheet,                   */
@@ -242,11 +236,11 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if(hcomp == NULL)
+  if (hcomp == NULL)
   {
     status = HAL_ERROR;
   }
-  else if(__HAL_COMP_IS_LOCKED(hcomp))
+  else if (__HAL_COMP_IS_LOCKED(hcomp))
   {
     status = HAL_ERROR;
   }
@@ -261,18 +255,19 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
     assert_param(IS_COMP_HYSTERESIS(hcomp->Init.Hysteresis));
     assert_param(IS_COMP_BLANKINGSRC_INSTANCE(hcomp->Instance, hcomp->Init.BlankingSrce));
     assert_param(IS_COMP_TRIGGERMODE(hcomp->Init.TriggerMode));
+
 #if defined(COMP2)
     assert_param(IS_COMP_WINDOWMODE(hcomp->Init.WindowMode));
-#endif
+#endif /* COMP2 */
 
-    if(hcomp->State == HAL_COMP_STATE_RESET)
+
+    if (hcomp->State == HAL_COMP_STATE_RESET)
     {
       /* Allocate lock resource and initialize it */
       hcomp->Lock = HAL_UNLOCKED;
 
       /* Set COMP error code to none */
       COMP_CLEAR_ERRORCODE(hcomp);
-
 
 #if (USE_HAL_COMP_REGISTER_CALLBACKS == 1)
       /* Init the COMP Callback settings */
@@ -301,7 +296,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
     comp_voltage_scaler_initialized = READ_BIT(hcomp->Instance->CSR, COMP_CSR_SCALEN);
 
     /* Set COMP parameters */
-    tmp_csr = (  hcomp->Init.InputMinus
+    tmp_csr = (hcomp->Init.InputMinus
                | hcomp->Init.InputPlus
                | hcomp->Init.BlankingSrce
                | hcomp->Init.Hysteresis
@@ -321,18 +316,19 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
 #else
     MODIFY_REG(hcomp->Instance->CSR,
                COMP_CSR_PWRMODE  | COMP_CSR_INMSEL   | COMP_CSR_INPSEL  |
-                                   COMP_CSR_POLARITY | COMP_CSR_HYST    |
+               COMP_CSR_POLARITY | COMP_CSR_HYST     |
                COMP_CSR_BLANKING | COMP_CSR_BRGEN    | COMP_CSR_SCALEN  | COMP_CSR_INMESEL,
                tmp_csr
               );
-#endif
+#endif /* COMP_CSR_WINMODE */
+
 
 #if defined(COMP2)
     /* Set window mode */
     /* Note: Window mode bit is located into 1 out of the 2 pairs of COMP     */
     /*       instances. Therefore, this function can update another COMP      */
     /*       instance that the one currently selected.                        */
-    if(hcomp->Init.WindowMode == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)
+    if (hcomp->Init.WindowMode == COMP_WINDOWMODE_COMP1_INPUT_PLUS_COMMON)
     {
       SET_BIT(COMP12_COMMON->CSR, COMP_CSR_WINMODE);
     }
@@ -342,17 +338,18 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
     }
 #endif /* COMP2 */
 
+
     /* Delay for COMP scaler bridge voltage stabilization */
     /* Apply the delay if voltage scaler bridge is required and not already enabled */
     if ((READ_BIT(hcomp->Instance->CSR, COMP_CSR_SCALEN) != 0UL) &&
-        (comp_voltage_scaler_initialized == 0UL)               )
+        (comp_voltage_scaler_initialized == 0UL))
     {
       /* Wait loop initialization and execution */
       /* Note: Variable divided by 2 to compensate partially              */
       /*       CPU processing cycles, scaling in us split to not          */
       /*       exceed 32 bits register capacity and handle low frequency. */
-      wait_loop_index = ((COMP_DELAY_VOLTAGE_SCALER_STAB_US / 10UL) * (SystemCoreClock / (100000UL * 2UL)));
-      while(wait_loop_index != 0UL)
+      wait_loop_index = ((COMP_DELAY_VOLTAGE_SCALER_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
+      while (wait_loop_index != 0UL)
       {
         wait_loop_index--;
       }
@@ -362,10 +359,10 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
     exti_line = COMP_GET_EXTI_LINE(hcomp->Instance);
 
     /* Manage EXTI settings */
-    if((hcomp->Init.TriggerMode & (COMP_EXTI_IT | COMP_EXTI_EVENT)) != 0UL)
+    if ((hcomp->Init.TriggerMode & (COMP_EXTI_IT | COMP_EXTI_EVENT)) != 0UL)
     {
       /* Configure EXTI rising edge */
-      if((hcomp->Init.TriggerMode & COMP_EXTI_RISING) != 0UL)
+      if ((hcomp->Init.TriggerMode & COMP_EXTI_RISING) != 0UL)
       {
         LL_EXTI_EnableRisingTrig_0_31(exti_line);
       }
@@ -375,7 +372,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
       }
 
       /* Configure EXTI falling edge */
-      if((hcomp->Init.TriggerMode & COMP_EXTI_FALLING) != 0UL)
+      if ((hcomp->Init.TriggerMode & COMP_EXTI_FALLING) != 0UL)
       {
         LL_EXTI_EnableFallingTrig_0_31(exti_line);
       }
@@ -388,7 +385,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
       LL_EXTI_ClearFlag_0_31(exti_line);
 
       /* Configure EXTI event mode */
-      if((hcomp->Init.TriggerMode & COMP_EXTI_EVENT) != 0UL)
+      if ((hcomp->Init.TriggerMode & COMP_EXTI_EVENT) != 0UL)
       {
         LL_EXTI_EnableEvent_0_31(exti_line);
       }
@@ -398,7 +395,7 @@ HAL_StatusTypeDef HAL_COMP_Init(COMP_HandleTypeDef *hcomp)
       }
 
       /* Configure EXTI interrupt mode */
-      if((hcomp->Init.TriggerMode & COMP_EXTI_IT) != 0UL)
+      if ((hcomp->Init.TriggerMode & COMP_EXTI_IT) != 0UL)
       {
         LL_EXTI_EnableIT_0_31(exti_line);
       }
@@ -440,11 +437,11 @@ HAL_StatusTypeDef HAL_COMP_DeInit(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if(hcomp == NULL)
+  if (hcomp == NULL)
   {
     status = HAL_ERROR;
   }
-  else if(__HAL_COMP_IS_LOCKED(hcomp))
+  else if (__HAL_COMP_IS_LOCKED(hcomp))
   {
     status = HAL_ERROR;
   }
@@ -523,7 +520,8 @@ __weak void HAL_COMP_MspDeInit(COMP_HandleTypeDef *hcomp)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_COMP_RegisterCallback(COMP_HandleTypeDef *hcomp, HAL_COMP_CallbackIDTypeDef CallbackID, pCOMP_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_COMP_RegisterCallback(COMP_HandleTypeDef *hcomp, HAL_COMP_CallbackIDTypeDef CallbackID,
+                                            pCOMP_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -699,11 +697,11 @@ HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if(hcomp == NULL)
+  if (hcomp == NULL)
   {
     status = HAL_ERROR;
   }
-  else if(__HAL_COMP_IS_LOCKED(hcomp))
+  else if (__HAL_COMP_IS_LOCKED(hcomp))
   {
     status = HAL_ERROR;
   }
@@ -712,7 +710,7 @@ HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp)
     /* Check the parameter */
     assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
 
-    if(hcomp->State == HAL_COMP_STATE_READY)
+    if (hcomp->State == HAL_COMP_STATE_READY)
     {
       /* Enable the selected comparator */
       SET_BIT(hcomp->Instance->CSR, COMP_CSR_EN);
@@ -725,8 +723,8 @@ HAL_StatusTypeDef HAL_COMP_Start(COMP_HandleTypeDef *hcomp)
       /* Note: Variable divided by 2 to compensate partially              */
       /*       CPU processing cycles, scaling in us split to not          */
       /*       exceed 32 bits register capacity and handle low frequency. */
-      wait_loop_index = ((COMP_DELAY_STARTUP_US / 10UL) * (SystemCoreClock / (100000UL * 2UL)));
-      while(wait_loop_index != 0UL)
+      wait_loop_index = ((COMP_DELAY_STARTUP_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
+      while (wait_loop_index != 0UL)
       {
         wait_loop_index--;
       }
@@ -750,11 +748,11 @@ HAL_StatusTypeDef HAL_COMP_Stop(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if(hcomp == NULL)
+  if (hcomp == NULL)
   {
     status = HAL_ERROR;
   }
-  else if(__HAL_COMP_IS_LOCKED(hcomp))
+  else if (__HAL_COMP_IS_LOCKED(hcomp))
   {
     status = HAL_ERROR;
   }
@@ -765,7 +763,7 @@ HAL_StatusTypeDef HAL_COMP_Stop(COMP_HandleTypeDef *hcomp)
 
     /* Check compliant states: HAL_COMP_STATE_READY or HAL_COMP_STATE_BUSY    */
     /* (all states except HAL_COMP_STATE_RESET and except locked status.      */
-    if(hcomp->State != HAL_COMP_STATE_RESET)
+    if (hcomp->State != HAL_COMP_STATE_RESET)
     {
       /* Disable the selected comparator */
       CLEAR_BIT(hcomp->Instance->CSR, COMP_CSR_EN);
@@ -793,11 +791,11 @@ void HAL_COMP_IRQHandler(COMP_HandleTypeDef *hcomp)
   uint32_t exti_line = COMP_GET_EXTI_LINE(hcomp->Instance);
 
   /* Check COMP EXTI flag */
-  if(LL_EXTI_IsActiveFlag_0_31(exti_line) != 0UL)
+  if (LL_EXTI_IsActiveFlag_0_31(exti_line) != 0UL)
   {
 #if defined(COMP2)
     /* Check whether comparator is in independent or window mode */
-    if(READ_BIT(COMP12_COMMON->CSR, COMP_CSR_WINMODE) != 0UL)
+    if (READ_BIT(COMP12_COMMON->CSR, COMP_CSR_WINMODE) != 0UL)
     {
       /* Clear COMP EXTI line pending bit of the pair of comparators          */
       /* in window mode.                                                      */
@@ -855,11 +853,11 @@ HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the COMP handle allocation and lock status */
-  if(hcomp == NULL)
+  if (hcomp == NULL)
   {
     status = HAL_ERROR;
   }
-  else if(__HAL_COMP_IS_LOCKED(hcomp))
+  else if (__HAL_COMP_IS_LOCKED(hcomp))
   {
     status = HAL_ERROR;
   }
@@ -869,7 +867,7 @@ HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp)
     assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
 
     /* Set HAL COMP handle state */
-    switch(hcomp->State)
+    switch (hcomp->State)
     {
       case HAL_COMP_STATE_RESET:
         hcomp->State = HAL_COMP_STATE_RESET_LOCKED;
@@ -881,10 +879,7 @@ HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp)
         hcomp->State = HAL_COMP_STATE_BUSY_LOCKED;
         break;
     }
-  }
 
-  if(status == HAL_OK)
-  {
     /* Set the lock bit corresponding to selected comparator */
     __HAL_COMP_LOCK(hcomp);
   }
@@ -911,7 +906,7 @@ HAL_StatusTypeDef HAL_COMP_Lock(COMP_HandleTypeDef *hcomp)
   *         @arg COMP_OUTPUT_LEVEL_HIGH
   *
   */
-uint32_t HAL_COMP_GetOutputLevel(COMP_HandleTypeDef *hcomp)
+uint32_t HAL_COMP_GetOutputLevel(const COMP_HandleTypeDef *hcomp)
 {
   /* Check the parameter */
   assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
@@ -959,10 +954,10 @@ __weak void HAL_COMP_TriggerCallback(COMP_HandleTypeDef *hcomp)
   * @param  hcomp  COMP handle
   * @retval HAL state
   */
-HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp)
+HAL_COMP_StateTypeDef HAL_COMP_GetState(const COMP_HandleTypeDef *hcomp)
 {
   /* Check the COMP handle allocation */
-  if(hcomp == NULL)
+  if (hcomp == NULL)
   {
     return HAL_COMP_STATE_RESET;
   }
@@ -979,7 +974,7 @@ HAL_COMP_StateTypeDef HAL_COMP_GetState(COMP_HandleTypeDef *hcomp)
   * @param hcomp COMP handle
   * @retval COMP error code
   */
-uint32_t HAL_COMP_GetError(COMP_HandleTypeDef *hcomp)
+uint32_t HAL_COMP_GetError(const COMP_HandleTypeDef *hcomp)
 {
   /* Check the parameters */
   assert_param(IS_COMP_ALL_INSTANCE(hcomp->Instance));
@@ -1006,5 +1001,3 @@ uint32_t HAL_COMP_GetError(COMP_HandleTypeDef *hcomp)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_cortex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_cortex.c
@@ -7,7 +7,17 @@
   *          functionalities of the CORTEX:
   *           + Initialization and Configuration functions
   *           + Peripheral Control functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -37,7 +47,7 @@
     [..]
     Setup SysTick Timer for time base.
 
-   (+) The HAL_SYSTICK_Config()function calls the SysTick_Config() function which
+   (+) The HAL_SYSTICK_Config() function calls the SysTick_Config() function which
        is a CMSIS function that:
         (++) Configures the SysTick Reload register with value passed as function parameter.
         (++) Configures the SysTick IRQ priority to the lowest value (0x03).
@@ -63,17 +73,6 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -93,7 +92,7 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
 /* Private macros ------------------------------------------------------------*/
-/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
 /* Exported functions --------------------------------------------------------*/
 
 /** @addtogroup CORTEX_Exported_Functions
@@ -102,15 +101,15 @@
 
 
 /** @addtogroup CORTEX_Exported_Functions_Group1
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
   ==============================================================================
               ##### Initialization and Configuration functions #####
   ==============================================================================
     [..]
       This section provides the CORTEX HAL driver functions allowing to configure Interrupts
-      Systick functionalities
+      SysTick functionalities
 
 @endverbatim
   * @{
@@ -119,7 +118,7 @@
 /**
   * @brief  Set the priority grouping field (pre-emption priority and subpriority)
   *         using the required unlock sequence.
-  * @param PriorityGroup The priority grouping bits length.
+  * @param  PriorityGroup The priority grouping bits length.
   *         This parameter can be one of the following values:
   *         @arg NVIC_PRIORITYGROUP_0: 0 bit  for pre-emption priority,
   *                                    4 bits for subpriority
@@ -221,15 +220,15 @@ void HAL_NVIC_SystemReset(void)
   */
 uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
 {
-   return SysTick_Config(TicksNumb);
+  return SysTick_Config(TicksNumb);
 }
 /**
   * @}
   */
 
 /** @addtogroup CORTEX_Exported_Functions_Group2
- *  @brief   Cortex control functions
- *
+  *  @brief   Cortex control functions
+  *
 @verbatim
   ==============================================================================
                       ##### Peripheral Control functions #####
@@ -279,7 +278,7 @@ void HAL_NVIC_GetPriority(IRQn_Type IRQn, uint32_t PriorityGroup, uint32_t *pPre
 {
   /* Check the parameters */
   assert_param(IS_NVIC_PRIORITY_GROUP(PriorityGroup));
- /* Get priority for Cortex-M system or device specific interrupts */
+  /* Get priority for Cortex-M system or device specific interrupts */
   NVIC_DecodePriority(NVIC_GetPriority(IRQn), PriorityGroup, pPreemptPriority, pSubPriority);
 }
 
@@ -406,7 +405,7 @@ void HAL_MPU_Disable(void)
 void HAL_MPU_Enable(uint32_t MPU_Control)
 {
   /* Enable the MPU */
-  MPU->CTRL = MPU_Control | MPU_CTRL_ENABLE_Msk;
+  MPU->CTRL = (MPU_Control | MPU_CTRL_ENABLE_Msk);
 
   /* Enable fault exceptions */
   SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
@@ -414,6 +413,38 @@ void HAL_MPU_Enable(uint32_t MPU_Control)
   /* Ensure MPU setting take effects */
   __DSB();
   __ISB();
+}
+
+/**
+  * @brief  Enable the MPU Region.
+  * @retval None
+  */
+void HAL_MPU_EnableRegion(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(RegionNumber));
+
+  /* Set the Region number */
+  MPU->RNR = RegionNumber;
+
+  /* Enable the Region */
+  SET_BIT(MPU->RASR, MPU_RASR_ENABLE_Msk);
+}
+
+/**
+  * @brief  Disable the MPU Region.
+  * @retval None
+  */
+void HAL_MPU_DisableRegion(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(RegionNumber));
+
+  /* Set the Region number */
+  MPU->RNR = RegionNumber;
+
+  /* Disable the Region */
+  CLEAR_BIT(MPU->RASR, MPU_RASR_ENABLE_Msk);
 }
 
 /**
@@ -427,38 +458,32 @@ void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init)
   /* Check the parameters */
   assert_param(IS_MPU_REGION_NUMBER(MPU_Init->Number));
   assert_param(IS_MPU_REGION_ENABLE(MPU_Init->Enable));
+  assert_param(IS_MPU_INSTRUCTION_ACCESS(MPU_Init->DisableExec));
+  assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(MPU_Init->AccessPermission));
+  assert_param(IS_MPU_TEX_LEVEL(MPU_Init->TypeExtField));
+  assert_param(IS_MPU_ACCESS_SHAREABLE(MPU_Init->IsShareable));
+  assert_param(IS_MPU_ACCESS_CACHEABLE(MPU_Init->IsCacheable));
+  assert_param(IS_MPU_ACCESS_BUFFERABLE(MPU_Init->IsBufferable));
+  assert_param(IS_MPU_SUB_REGION_DISABLE(MPU_Init->SubRegionDisable));
+  assert_param(IS_MPU_REGION_SIZE(MPU_Init->Size));
 
   /* Set the Region number */
   MPU->RNR = MPU_Init->Number;
 
-  if ((MPU_Init->Enable) != 0U)
-  {
-    /* Check the parameters */
-    assert_param(IS_MPU_INSTRUCTION_ACCESS(MPU_Init->DisableExec));
-    assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(MPU_Init->AccessPermission));
-    assert_param(IS_MPU_TEX_LEVEL(MPU_Init->TypeExtField));
-    assert_param(IS_MPU_ACCESS_SHAREABLE(MPU_Init->IsShareable));
-    assert_param(IS_MPU_ACCESS_CACHEABLE(MPU_Init->IsCacheable));
-    assert_param(IS_MPU_ACCESS_BUFFERABLE(MPU_Init->IsBufferable));
-    assert_param(IS_MPU_SUB_REGION_DISABLE(MPU_Init->SubRegionDisable));
-    assert_param(IS_MPU_REGION_SIZE(MPU_Init->Size));
+  /* Disable the Region */
+  CLEAR_BIT(MPU->RASR, MPU_RASR_ENABLE_Msk);
 
-    MPU->RBAR = MPU_Init->BaseAddress;
-    MPU->RASR = ((uint32_t)MPU_Init->DisableExec             << MPU_RASR_XN_Pos)   |
-                ((uint32_t)MPU_Init->AccessPermission        << MPU_RASR_AP_Pos)   |
-                ((uint32_t)MPU_Init->TypeExtField            << MPU_RASR_TEX_Pos)  |
-                ((uint32_t)MPU_Init->IsShareable             << MPU_RASR_S_Pos)    |
-                ((uint32_t)MPU_Init->IsCacheable             << MPU_RASR_C_Pos)    |
-                ((uint32_t)MPU_Init->IsBufferable            << MPU_RASR_B_Pos)    |
-                ((uint32_t)MPU_Init->SubRegionDisable        << MPU_RASR_SRD_Pos)  |
-                ((uint32_t)MPU_Init->Size                    << MPU_RASR_SIZE_Pos) |
-                ((uint32_t)MPU_Init->Enable                  << MPU_RASR_ENABLE_Pos);
-  }
-  else
-  {
-    MPU->RBAR = 0x00U;
-    MPU->RASR = 0x00U;
-  }
+  /* Apply configuration */
+  MPU->RBAR = MPU_Init->BaseAddress;
+  MPU->RASR = ((uint32_t)MPU_Init->DisableExec             << MPU_RASR_XN_Pos)   |
+              ((uint32_t)MPU_Init->AccessPermission        << MPU_RASR_AP_Pos)   |
+              ((uint32_t)MPU_Init->TypeExtField            << MPU_RASR_TEX_Pos)  |
+              ((uint32_t)MPU_Init->IsShareable             << MPU_RASR_S_Pos)    |
+              ((uint32_t)MPU_Init->IsCacheable             << MPU_RASR_C_Pos)    |
+              ((uint32_t)MPU_Init->IsBufferable            << MPU_RASR_B_Pos)    |
+              ((uint32_t)MPU_Init->SubRegionDisable        << MPU_RASR_SRD_Pos)  |
+              ((uint32_t)MPU_Init->Size                    << MPU_RASR_SIZE_Pos) |
+              ((uint32_t)MPU_Init->Enable                  << MPU_RASR_ENABLE_Pos);
 }
 #endif /* __MPU_PRESENT */
 
@@ -478,5 +503,3 @@ void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_crc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_crc.c
@@ -9,6 +9,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
  ===============================================================================
                      ##### How to use this driver #####
@@ -28,17 +39,6 @@
              (default or non-default) to initiate CRC calculation
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -62,8 +62,8 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /** @defgroup CRC_Private_Functions CRC Private Functions
- * @{
- */
+  * @{
+  */
 static uint32_t CRC_Handle_8(CRC_HandleTypeDef *hcrc, uint8_t pBuffer[], uint32_t BufferLength);
 static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint32_t BufferLength);
 /**
@@ -77,8 +77,8 @@ static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint3
   */
 
 /** @defgroup CRC_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions.
- *
+  *  @brief    Initialization and Configuration functions.
+  *
 @verbatim
  ===============================================================================
             ##### Initialization and de-initialization functions #####
@@ -200,7 +200,7 @@ HAL_StatusTypeDef HAL_CRC_DeInit(CRC_HandleTypeDef *hcrc)
   __HAL_CRC_DR_RESET(hcrc);
 
   /* Reset IDR register content */
-  CLEAR_BIT(hcrc->Instance->IDR, CRC_IDR_IDR);
+  CLEAR_REG(hcrc->Instance->IDR);
 
   /* DeInit the low level hardware */
   HAL_CRC_MspDeInit(hcrc);
@@ -250,8 +250,8 @@ __weak void HAL_CRC_MspDeInit(CRC_HandleTypeDef *hcrc)
   */
 
 /** @defgroup CRC_Exported_Functions_Group2 Peripheral Control functions
- *  @brief    management functions.
- *
+  *  @brief    management functions.
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral Control functions #####
@@ -385,8 +385,8 @@ uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t
   */
 
 /** @defgroup CRC_Exported_Functions_Group3 Peripheral State functions
- *  @brief    Peripheral State functions.
- *
+  *  @brief    Peripheral State functions.
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral State functions #####
@@ -403,7 +403,7 @@ uint32_t HAL_CRC_Calculate(CRC_HandleTypeDef *hcrc, uint32_t pBuffer[], uint32_t
   * @param  hcrc CRC handle
   * @retval HAL state
   */
-HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc)
+HAL_CRC_StateTypeDef HAL_CRC_GetState(const CRC_HandleTypeDef *hcrc)
 {
   /* Return CRC handle state */
   return hcrc->State;
@@ -418,8 +418,8 @@ HAL_CRC_StateTypeDef HAL_CRC_GetState(CRC_HandleTypeDef *hcrc)
   */
 
 /** @addtogroup CRC_Private_Functions
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  Enter 8-bit input data to the CRC calculator.
@@ -514,5 +514,3 @@ static uint32_t CRC_Handle_16(CRC_HandleTypeDef *hcrc, uint16_t pBuffer[], uint3
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_crc_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_crc_ex.c
@@ -6,26 +6,26 @@
   *          This file provides firmware functions to manage the extended
   *          functionalities of the CRC peripheral.
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
 ================================================================================
             ##### How to use this driver #####
 ================================================================================
     [..]
-         (+) Set user-defined generating polynomial thru HAL_CRCEx_Polynomial_Set()
+         (+) Set user-defined generating polynomial through HAL_CRCEx_Polynomial_Set()
          (+) Configure Input or Output data inversion
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -94,44 +94,53 @@ HAL_StatusTypeDef HAL_CRCEx_Polynomial_Set(CRC_HandleTypeDef *hcrc, uint32_t Pol
   /* Check the parameters */
   assert_param(IS_CRC_POL_LENGTH(PolyLength));
 
-  /* check polynomial definition vs polynomial size:
-   * polynomial length must be aligned with polynomial
-   * definition. HAL_ERROR is reported if Pol degree is
-   * larger than that indicated by PolyLength.
-   * Look for MSB position: msb will contain the degree of
-   *  the second to the largest polynomial member. E.g., for
-   *  X^7 + X^6 + X^5 + X^2 + 1, msb = 6. */
-  while ((msb-- > 0U) && ((Pol & ((uint32_t)(0x1U) << (msb & 0x1FU))) == 0U))
+  /* Ensure that the generating polynomial is odd */
+  if ((Pol & (uint32_t)(0x1U)) ==  0U)
   {
+    status =  HAL_ERROR;
   }
-
-  switch (PolyLength)
+  else
   {
-    case CRC_POLYLENGTH_7B:
-      if (msb >= HAL_CRC_LENGTH_7B)
-      {
-        status =   HAL_ERROR;
-      }
-      break;
-    case CRC_POLYLENGTH_8B:
-      if (msb >= HAL_CRC_LENGTH_8B)
-      {
-        status =   HAL_ERROR;
-      }
-      break;
-    case CRC_POLYLENGTH_16B:
-      if (msb >= HAL_CRC_LENGTH_16B)
-      {
-        status =   HAL_ERROR;
-      }
-      break;
+    /* check polynomial definition vs polynomial size:
+     * polynomial length must be aligned with polynomial
+     * definition. HAL_ERROR is reported if Pol degree is
+     * larger than that indicated by PolyLength.
+     * Look for MSB position: msb will contain the degree of
+     *  the second to the largest polynomial member. E.g., for
+     *  X^7 + X^6 + X^5 + X^2 + 1, msb = 6. */
+    while ((msb-- > 0U) && ((Pol & ((uint32_t)(0x1U) << (msb & 0x1FU))) == 0U))
+    {
+    }
 
-    case CRC_POLYLENGTH_32B:
-      /* no polynomial definition vs. polynomial length issue possible */
-      break;
-    default:
-      status =  HAL_ERROR;
-      break;
+    switch (PolyLength)
+    {
+
+      case CRC_POLYLENGTH_7B:
+        if (msb >= HAL_CRC_LENGTH_7B)
+        {
+          status =   HAL_ERROR;
+        }
+        break;
+      case CRC_POLYLENGTH_8B:
+        if (msb >= HAL_CRC_LENGTH_8B)
+        {
+          status =   HAL_ERROR;
+        }
+        break;
+      case CRC_POLYLENGTH_16B:
+        if (msb >= HAL_CRC_LENGTH_16B)
+        {
+          status =   HAL_ERROR;
+        }
+        break;
+
+      case CRC_POLYLENGTH_32B:
+        /* no polynomial definition vs. polynomial length issue possible */
+        break;
+      default:
+        status =  HAL_ERROR;
+        break;
+    }
   }
   if (status == HAL_OK)
   {
@@ -201,8 +210,6 @@ HAL_StatusTypeDef HAL_CRCEx_Output_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_
 }
 
 
-
-
 /**
   * @}
   */
@@ -221,5 +228,3 @@ HAL_StatusTypeDef HAL_CRCEx_Output_Data_Reverse(CRC_HandleTypeDef *hcrc, uint32_
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_cryp.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_cryp.c
@@ -11,6 +11,17 @@
   *           + CRYP IRQ handler management
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -19,7 +30,8 @@
       The CRYP HAL driver can be used in CRYP or TinyAES peripheral as follows:
 
       (#)Initialize the CRYP low level resources by implementing the HAL_CRYP_MspInit():
-         (##) Enable the CRYP interface clock using __HAL_RCC_CRYP_CLK_ENABLE()or __HAL_RCC_AES_CLK_ENABLE for TinyAES peripheral
+         (##) Enable the CRYP interface clock using __HAL_RCC_CRYP_CLK_ENABLE()
+              or __HAL_RCC_AES_CLK_ENABLE for TinyAES peripheral
          (##) In case of using interrupts (e.g. HAL_CRYP_Encrypt_IT())
              (+++) Configure the CRYP interrupt priority using HAL_NVIC_SetPriority()
              (+++) Enable the CRYP IRQ handler using HAL_NVIC_EnableIRQ()
@@ -47,8 +59,10 @@
          (##) The DataWidthUnit field. It specifies whether the data length (or the payload length for authentication
                algorithms) is in words or bytes.
          (##) The Header used only in AES GCM and CCM Algorithm for authentication.
-         (##) The HeaderSize providing the size of the header buffer in words or bytes, depending upon HeaderWidthUnit field.
-         (##) The HeaderWidthUnit field. It specifies whether the header length (for authentication algorithms) is in words or bytes.
+         (##) The HeaderSize providing the size of the header buffer in words or bytes,
+              depending upon HeaderWidthUnit field.
+         (##) The HeaderWidthUnit field. It specifies whether the header length (for authentication algorithms)
+              is in words or bytes.
          (##) The B0 block is the first authentication block used only in AES CCM mode.
          (##) The KeyIVConfigSkip used to process several messages in a row (please see more information below).
 
@@ -67,7 +81,7 @@
          the CRYP peripheral is configured and processes the buffer in input.
          At second call, no need to Initialize the CRYP, user have to get current configuration via
          HAL_CRYP_GetConfig() API, then only  HAL_CRYP_SetConfig() is requested to set
-         new parametres, finally user can  start encryption/decryption.
+         new parameters, finally user can  start encryption/decryption.
 
        (#)Call HAL_CRYP_DeInit() to deinitialize the CRYP peripheral.
 
@@ -189,7 +203,7 @@
          (##) To perform message payload encryption or decryption AES is configured in CTR mode.
          (##) For authentication two phases are performed :
           - Header phase: peripheral processes the Additional Authenticated Data (AAD) first, then the cleartext message
-          only cleartext payload (not the ciphertext payload) is used and no outpout.
+          only cleartext payload (not the ciphertext payload) is used and no output.
          (##) Final phase: peripheral generates the authenticated tag (T) using the last block of data.
 
   *** Callback registration ***
@@ -283,17 +297,6 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -316,7 +319,8 @@
   * @{
   */
 #define CRYP_TIMEOUT_KEYPREPARATION      82U         /* The latency of key preparation operation is 82 clock cycles.*/
-#define CRYP_TIMEOUT_GCMCCMINITPHASE     299U        /* The latency of  GCM/CCM init phase to prepare hash subkey is 299 clock cycles.*/
+#define CRYP_TIMEOUT_GCMCCMINITPHASE     299U        /* The latency of  GCM/CCM init phase to prepare hash subkey
+                                                        is 299 clock cycles.*/
 #define CRYP_TIMEOUT_GCMCCMHEADERPHASE   290U        /* The latency of  GCM/CCM header phase is 290 clock cycles.*/
 
 #define CRYP_PHASE_READY                 0x00000001U /*!< CRYP peripheral is ready for initialization. */
@@ -350,7 +354,8 @@
   * @{
   */
 
-#define CRYP_SET_PHASE(__HANDLE__, __PHASE__)   MODIFY_REG((__HANDLE__)->Instance->CR, AES_CR_GCMPH, (uint32_t)(__PHASE__))
+#define CRYP_SET_PHASE(__HANDLE__, __PHASE__)   MODIFY_REG((__HANDLE__)->Instance->CR,\
+                                                           AES_CR_GCMPH, (uint32_t)(__PHASE__))
 
 /**
   * @}
@@ -390,12 +395,12 @@ static HAL_StatusTypeDef CRYP_AES_Decrypt_DMA(CRYP_HandleTypeDef *hcryp);
 static HAL_StatusTypeDef CRYP_WaitOnCCFlag(CRYP_HandleTypeDef *hcryp, uint32_t Timeout);
 static void CRYP_ClearCCFlagWhenHigh(CRYP_HandleTypeDef *hcryp, uint32_t Timeout);
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
-static void CRYP_Read_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output);
-static void CRYP_Write_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input);
-static void CRYP_Read_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output);
-static void CRYP_Write_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input);
-static void CRYP_Read_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output, uint32_t KeySize);
-static void CRYP_Write_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input, uint32_t KeySize);
+static void CRYP_Read_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Output);
+static void CRYP_Write_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Input);
+static void CRYP_Read_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Output);
+static void CRYP_Write_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Input);
+static void CRYP_Read_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Output, uint32_t KeySize);
+static void CRYP_Write_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint32_t KeySize);
 static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp);
 #endif /* USE_HAL_CRYP_SUSPEND_RESUME */
 
@@ -488,7 +493,8 @@ HAL_StatusTypeDef HAL_CRYP_Init(CRYP_HandleTypeDef *hcryp)
 #endif /* (USE_HAL_CRYP_REGISTER_CALLBACKS) */
 
   /* Set the key size (This bit field is do not care in the DES or TDES modes), data type and Algorithm */
-  MODIFY_REG(hcryp->Instance->CR, AES_CR_DATATYPE | AES_CR_KEYSIZE | AES_CR_CHMOD, hcryp->Init.DataType | hcryp->Init.KeySize | hcryp->Init.Algorithm);
+  MODIFY_REG(hcryp->Instance->CR, AES_CR_DATATYPE | AES_CR_KEYSIZE | AES_CR_CHMOD,
+             hcryp->Init.DataType | hcryp->Init.KeySize | hcryp->Init.Algorithm);
 
   /* Reset Error Code field */
   hcryp->ErrorCode = HAL_CRYP_ERROR_NONE;
@@ -511,7 +517,7 @@ HAL_StatusTypeDef HAL_CRYP_Init(CRYP_HandleTypeDef *hcryp)
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
   *         the configuration information for CRYP module
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_CRYP_DeInit(CRYP_HandleTypeDef *hcryp)
 {
   /* Check the CRYP handle allocation */
@@ -587,18 +593,21 @@ HAL_StatusTypeDef HAL_CRYP_SetConfig(CRYP_HandleTypeDef *hcryp, CRYP_ConfigTypeD
     __HAL_LOCK(hcryp);
 
     /* Set  CRYP parameters  */
-    hcryp->Init.DataType   = pConf->DataType;
-    hcryp->Init.pKey       = pConf->pKey;
-    hcryp->Init.Algorithm  = pConf->Algorithm;
-    hcryp->Init.KeySize    = pConf->KeySize;
-    hcryp->Init.pInitVect  = pConf->pInitVect;
-    hcryp->Init.Header     = pConf->Header;
-    hcryp->Init.HeaderSize = pConf->HeaderSize;
-    hcryp->Init.B0         = pConf->B0;
-    hcryp->Init.DataWidthUnit = pConf->DataWidthUnit;
+    hcryp->Init.DataType        = pConf->DataType;
+    hcryp->Init.pKey            = pConf->pKey;
+    hcryp->Init.Algorithm       = pConf->Algorithm;
+    hcryp->Init.KeySize         = pConf->KeySize;
+    hcryp->Init.pInitVect       = pConf->pInitVect;
+    hcryp->Init.Header          = pConf->Header;
+    hcryp->Init.HeaderSize      = pConf->HeaderSize;
+    hcryp->Init.B0              = pConf->B0;
+    hcryp->Init.DataWidthUnit   = pConf->DataWidthUnit;
+    hcryp->Init.HeaderWidthUnit = pConf->HeaderWidthUnit;
+    hcryp->Init.KeyIVConfigSkip = pConf->KeyIVConfigSkip;
 
     /* Set the key size (This bit field is do not care in the DES or TDES modes), data type and operating mode*/
-    MODIFY_REG(hcryp->Instance->CR, AES_CR_DATATYPE | AES_CR_KEYSIZE | AES_CR_CHMOD, hcryp->Init.DataType | hcryp->Init.KeySize | hcryp->Init.Algorithm);
+    MODIFY_REG(hcryp->Instance->CR, AES_CR_DATATYPE | AES_CR_KEYSIZE | AES_CR_CHMOD,
+               hcryp->Init.DataType | hcryp->Init.KeySize | hcryp->Init.Algorithm);
 
     /*clear error flags*/
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_ERR_CLEAR);
@@ -661,7 +670,9 @@ HAL_StatusTypeDef HAL_CRYP_GetConfig(CRYP_HandleTypeDef *hcryp, CRYP_ConfigTypeD
     pConf->Header          = hcryp->Init.Header ;
     pConf->HeaderSize      = hcryp->Init.HeaderSize;
     pConf->B0              = hcryp->Init.B0;
-    pConf->DataWidthUnit    = hcryp->Init.DataWidthUnit;
+    pConf->DataWidthUnit   = hcryp->Init.DataWidthUnit;
+    pConf->HeaderWidthUnit = hcryp->Init.HeaderWidthUnit;
+    pConf->KeyIVConfigSkip = hcryp->Init.KeyIVConfigSkip;
 
     /* Process Unlocked */
     __HAL_UNLOCK(hcryp);
@@ -693,8 +704,8 @@ __weak void HAL_CRYP_MspInit(CRYP_HandleTypeDef *hcryp)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hcryp);
 
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_CRYP_MspInit could be implemented in the user file
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_CRYP_MspInit can be implemented in the user file
    */
 }
 
@@ -709,8 +720,8 @@ __weak void HAL_CRYP_MspDeInit(CRYP_HandleTypeDef *hcryp)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hcryp);
 
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_CRYP_MspDeInit could be implemented in the user file
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_CRYP_MspDeInit can be implemented in the user file
    */
 }
 
@@ -729,7 +740,8 @@ __weak void HAL_CRYP_MspDeInit(CRYP_HandleTypeDef *hcryp)
   * @param pCallback pointer to the Callback function
   * @retval status
   */
-HAL_StatusTypeDef HAL_CRYP_RegisterCallback(CRYP_HandleTypeDef *hcryp, HAL_CRYP_CallbackIDTypeDef CallbackID, pCRYP_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_CRYP_RegisterCallback(CRYP_HandleTypeDef *hcryp, HAL_CRYP_CallbackIDTypeDef CallbackID,
+                                            pCRYP_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -916,8 +928,6 @@ void HAL_CRYP_ProcessSuspend(CRYP_HandleTypeDef *hcryp)
   hcryp->SuspendRequest = HAL_CRYP_SUSPEND;
 }
 
-
-
 /**
   * @brief  CRYP processing suspension and peripheral internal parameters storage.
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure that contains
@@ -950,14 +960,14 @@ HAL_StatusTypeDef HAL_CRYP_Suspend(CRYP_HandleTypeDef *hcryp)
     /* If authentication algorithms on-going, carry out first saving steps
        before disable the peripheral */
     if ((hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC) || \
-         (hcryp->Init.Algorithm == CRYP_AES_CCM))
+        (hcryp->Init.Algorithm == CRYP_AES_CCM))
     {
-        /* Save Suspension registers */
-        CRYP_Read_SuspendRegisters(hcryp, hcryp->SUSPxR_saved);
-        /* Save Key */
-        CRYP_Read_KeyRegisters(hcryp, hcryp->Key_saved, hcryp->Init.KeySize);
-        /* Save IV */
-        CRYP_Read_IVRegisters(hcryp, hcryp->IV_saved);
+      /* Save Suspension registers */
+      CRYP_Read_SuspendRegisters(hcryp, hcryp->SUSPxR_saved);
+      /* Save Key */
+      CRYP_Read_KeyRegisters(hcryp, hcryp->Key_saved, hcryp->Init.KeySize);
+      /* Save IV */
+      CRYP_Read_IVRegisters(hcryp, hcryp->IV_saved);
     }
     /* Disable AES */
     __HAL_CRYP_DISABLE(hcryp);
@@ -970,7 +980,8 @@ HAL_StatusTypeDef HAL_CRYP_Suspend(CRYP_HandleTypeDef *hcryp)
     hcryp->CrypOutCount_saved      = hcryp->CrypOutCount;
     hcryp->Phase_saved             = hcryp->Phase;
     hcryp->State_saved             = hcryp->State;
-    hcryp->Size_saved              = ( (hcryp->Init.DataWidthUnit == CRYP_DATAWIDTHUNIT_WORD) ? (hcryp->Size /4U) : hcryp->Size);
+    hcryp->Size_saved              = ((hcryp->Init.DataWidthUnit == CRYP_DATAWIDTHUNIT_WORD) ? \
+                                      (hcryp->Size / 4U) : hcryp->Size);
     hcryp->SizesSum_saved          = hcryp->SizesSum;
     hcryp->AutoKeyDerivation_saved = hcryp->AutoKeyDerivation;
     hcryp->CrypHeaderCount_saved   = hcryp->CrypHeaderCount;
@@ -1028,7 +1039,7 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
       hcryp->AutoKeyDerivation = hcryp->AutoKeyDerivation_saved;
 
       if ((hcryp->Init.Algorithm == CRYP_AES_CBC) || \
-        (hcryp->Init.Algorithm == CRYP_AES_CTR))
+          (hcryp->Init.Algorithm == CRYP_AES_CTR))
       {
         hcryp->Init.pInitVect     = hcryp->IV_saved;
       }
@@ -1061,14 +1072,16 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
     hcryp->ResumingFlag = 1U;
     if (READ_BIT(hcryp->CR_saved, AES_CR_MODE) == CRYP_OPERATINGMODE_ENCRYPT)
     {
-      if (HAL_CRYP_Encrypt_IT(hcryp, hcryp->pCrypInBuffPtr_saved, hcryp->Size_saved, hcryp->pCrypOutBuffPtr_saved) != HAL_OK)
+      if (HAL_CRYP_Encrypt_IT(hcryp, hcryp->pCrypInBuffPtr_saved, hcryp->Size_saved, \
+                              hcryp->pCrypOutBuffPtr_saved) != HAL_OK)
       {
         return HAL_ERROR;
       }
     }
     else
     {
-      if (HAL_CRYP_Decrypt_IT(hcryp, hcryp->pCrypInBuffPtr_saved, hcryp->Size_saved, hcryp->pCrypOutBuffPtr_saved) != HAL_OK)
+      if (HAL_CRYP_Decrypt_IT(hcryp, hcryp->pCrypInBuffPtr_saved, hcryp->Size_saved, \
+                              hcryp->pCrypOutBuffPtr_saved) != HAL_OK)
       {
         return HAL_ERROR;
       }
@@ -1196,7 +1209,8 @@ HAL_StatusTypeDef HAL_CRYP_Resume(CRYP_HandleTypeDef *hcryp)
   * @param  Timeout Specify Timeout value
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output, uint32_t Timeout)
+HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output,
+                                   uint32_t Timeout)
 {
   uint32_t algo;
   HAL_StatusTypeDef status;
@@ -1205,7 +1219,7 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
 
   /* Check input buffer size */
   assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
-#endif
+#endif /* USE_FULL_ASSERT */
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1296,7 +1310,8 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
   * @param  Timeout Specify Timeout value
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output, uint32_t Timeout)
+HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint16_t Size, uint32_t *Output,
+                                   uint32_t Timeout)
 {
   HAL_StatusTypeDef status;
   uint32_t algo;
@@ -1305,7 +1320,7 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t *Input, u
 
   /* Check input buffer size */
   assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
-#endif
+#endif /* USE_FULL_ASSERT */
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1404,7 +1419,7 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
 
   /* Check input buffer size */
   assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
-#endif
+#endif /* USE_FULL_ASSERT */
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1416,26 +1431,26 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
 
     /*  Reset CrypInCount, CrypOutCount and Initialize pCrypInBuffPtr and pCrypOutBuffPtr parameters*/
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
-   if (hcryp->ResumingFlag == 1U)
-   {
-     hcryp->ResumingFlag = 0U;
-     if (hcryp->Phase != CRYP_PHASE_HEADER_SUSPENDED)
-     {
-       hcryp->CrypInCount = (uint16_t) hcryp->CrypInCount_saved;
-       hcryp->CrypOutCount = (uint16_t) hcryp->CrypOutCount_saved;
-     }
-     else
-     {
-    hcryp->CrypInCount = 0U;
-    hcryp->CrypOutCount = 0U;
-     }
-   }
-   else
+    if (hcryp->ResumingFlag == 1U)
+    {
+      hcryp->ResumingFlag = 0U;
+      if (hcryp->Phase != CRYP_PHASE_HEADER_SUSPENDED)
+      {
+        hcryp->CrypInCount = (uint16_t) hcryp->CrypInCount_saved;
+        hcryp->CrypOutCount = (uint16_t) hcryp->CrypOutCount_saved;
+      }
+      else
+      {
+        hcryp->CrypInCount = 0U;
+        hcryp->CrypOutCount = 0U;
+      }
+    }
+    else
 #endif  /* USE_HAL_CRYP_SUSPEND_RESUME */
-   {
-    hcryp->CrypInCount = 0U;
-    hcryp->CrypOutCount = 0U;
-   }
+    {
+      hcryp->CrypInCount = 0U;
+      hcryp->CrypOutCount = 0U;
+    }
 
     hcryp->pCrypInBuffPtr = Input;
     hcryp->pCrypOutBuffPtr = Output;
@@ -1514,7 +1529,7 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
 
   /* Check input buffer size */
   assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
-#endif
+#endif /* USE_FULL_ASSERT */
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1526,26 +1541,26 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_IT(CRYP_HandleTypeDef *hcryp, uint32_t *Input
 
     /*  Reset CrypInCount, CrypOutCount and Initialize pCrypInBuffPtr and pCrypOutBuffPtr parameters*/
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
-   if (hcryp->ResumingFlag == 1U)
-   {
-     hcryp->ResumingFlag = 0U;
-     if (hcryp->Phase != CRYP_PHASE_HEADER_SUSPENDED)
-     {
-       hcryp->CrypInCount = (uint16_t) hcryp->CrypInCount_saved;
-       hcryp->CrypOutCount = (uint16_t) hcryp->CrypOutCount_saved;
-     }
-     else
-     {
-    hcryp->CrypInCount = 0U;
-    hcryp->CrypOutCount = 0U;
-     }
-   }
-   else
+    if (hcryp->ResumingFlag == 1U)
+    {
+      hcryp->ResumingFlag = 0U;
+      if (hcryp->Phase != CRYP_PHASE_HEADER_SUSPENDED)
+      {
+        hcryp->CrypInCount = (uint16_t) hcryp->CrypInCount_saved;
+        hcryp->CrypOutCount = (uint16_t) hcryp->CrypOutCount_saved;
+      }
+      else
+      {
+        hcryp->CrypInCount = 0U;
+        hcryp->CrypOutCount = 0U;
+      }
+    }
+    else
 #endif  /* USE_HAL_CRYP_SUSPEND_RESUME */
-   {
-     hcryp->CrypInCount = 0U;
-     hcryp->CrypOutCount = 0U;
-   }
+    {
+      hcryp->CrypInCount = 0U;
+      hcryp->CrypOutCount = 0U;
+    }
     hcryp->pCrypInBuffPtr = Input;
     hcryp->pCrypOutBuffPtr = Output;
 
@@ -1624,7 +1639,7 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
 
   /* Check input buffer size */
   assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
-#endif
+#endif /* USE_FULL_ASSERT */
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1699,7 +1714,8 @@ HAL_StatusTypeDef HAL_CRYP_Encrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
         hcryp->Phase = CRYP_PHASE_PROCESS;
 
         /* Start DMA process transfer for AES */
-        CRYP_SetDMAConfig(hcryp, (uint32_t)(hcryp->pCrypInBuffPtr), (hcryp->Size / 4U), (uint32_t)(hcryp->pCrypOutBuffPtr));
+        CRYP_SetDMAConfig(hcryp, (uint32_t)(hcryp->pCrypInBuffPtr), (hcryp->Size / 4U), \
+                          (uint32_t)(hcryp->pCrypOutBuffPtr));
         status = HAL_OK;
         break;
 
@@ -1750,7 +1766,7 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
 
   /* Check input buffer size */
   assert_param(IS_CRYP_BUFFERSIZE(algo_assert, hcryp->Init.DataWidthUnit, Size));
-#endif
+#endif /* USE_FULL_ASSERT */
 
   if (hcryp->State == HAL_CRYP_STATE_READY)
   {
@@ -1852,48 +1868,50 @@ HAL_StatusTypeDef HAL_CRYP_Decrypt_DMA(CRYP_HandleTypeDef *hcryp, uint32_t *Inpu
   */
 void HAL_CRYP_IRQHandler(CRYP_HandleTypeDef *hcryp)
 {
+  uint32_t itsource = hcryp->Instance->CR;
+  uint32_t itflag   = hcryp->Instance->SR;
 
   /* Check if error occurred */
-  if (__HAL_CRYP_GET_IT_SOURCE(hcryp,CRYP_IT_ERRIE) != RESET)
+  if ((itsource & CRYP_IT_ERRIE) == CRYP_IT_ERRIE)
   {
     /* If write Error occurred */
-    if (__HAL_CRYP_GET_FLAG(hcryp,CRYP_IT_WRERR) != RESET)
+    if ((itflag & CRYP_IT_WRERR) == CRYP_IT_WRERR)
     {
       hcryp->ErrorCode |= HAL_CRYP_ERROR_WRITE;
     }
     /* If read Error occurred */
-    if (__HAL_CRYP_GET_FLAG(hcryp,CRYP_IT_RDERR) != RESET)
+    if ((itflag & CRYP_IT_RDERR) == CRYP_IT_RDERR)
     {
       hcryp->ErrorCode |= HAL_CRYP_ERROR_READ;
     }
   }
 
-  if (__HAL_CRYP_GET_FLAG(hcryp, CRYP_IT_CCF) != RESET)
+  if ((itflag & CRYP_IT_CCF) == CRYP_IT_CCF)
   {
-    if(__HAL_CRYP_GET_IT_SOURCE(hcryp, CRYP_IT_CCFIE) != RESET)
-  {
-    /* Clear computation complete flag */
-    __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
-
-    if ((hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC) || (hcryp->Init.Algorithm == CRYP_AES_CCM))
+    if ((itsource & CRYP_IT_CCFIE) == CRYP_IT_CCFIE)
     {
+      /* Clear computation complete flag */
+      __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
 
-      /* if header phase */
-      if ((hcryp->Instance->CR & CRYP_PHASE_HEADER) == CRYP_PHASE_HEADER)
+      if ((hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC) || (hcryp->Init.Algorithm == CRYP_AES_CCM))
       {
-        CRYP_GCMCCM_SetHeaderPhase_IT(hcryp);
+
+        /* if header phase */
+        if ((hcryp->Instance->CR & CRYP_PHASE_HEADER) == CRYP_PHASE_HEADER)
+        {
+          CRYP_GCMCCM_SetHeaderPhase_IT(hcryp);
+        }
+        else  /* if payload phase */
+        {
+          CRYP_GCMCCM_SetPayloadPhase_IT(hcryp);
+        }
       }
-      else  /* if payload phase */
+      else  /* AES Algorithm ECB,CBC or CTR*/
       {
-        CRYP_GCMCCM_SetPayloadPhase_IT(hcryp);
+        CRYP_AES_IT(hcryp);
       }
-    }
-    else  /* AES Algorithm ECB,CBC or CTR*/
-    {
-      CRYP_AES_IT(hcryp);
     }
   }
-}
 }
 
 /**
@@ -1929,8 +1947,8 @@ __weak void HAL_CRYP_InCpltCallback(CRYP_HandleTypeDef *hcryp)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hcryp);
 
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_CRYP_InCpltCallback could be implemented in the user file
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_CRYP_InCpltCallback can be implemented in the user file
    */
 }
 
@@ -1945,8 +1963,8 @@ __weak void HAL_CRYP_OutCpltCallback(CRYP_HandleTypeDef *hcryp)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hcryp);
 
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_CRYP_OutCpltCallback could be implemented in the user file
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_CRYP_OutCpltCallback can be implemented in the user file
    */
 }
 
@@ -1961,8 +1979,8 @@ __weak void HAL_CRYP_ErrorCallback(CRYP_HandleTypeDef *hcryp)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hcryp);
 
-  /* NOTE : This function Should not be modified, when the callback is needed,
-            the HAL_CRYP_ErrorCallback could be implemented in the user file
+  /* NOTE : This function should not be modified; when the callback is needed,
+            the HAL_CRYP_ErrorCallback can be implemented in the user file
    */
 }
 /**
@@ -2102,15 +2120,17 @@ static HAL_StatusTypeDef CRYP_AES_Encrypt_IT(CRYP_HandleTypeDef *hcryp)
     /* Enable CRYP */
     __HAL_CRYP_ENABLE(hcryp);
 
-    /* Write the input block in the IN FIFO */
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    /* Increment the pointer before writing the input block in the IN FIFO to make sure that
+       when Computation Completed IRQ fires, the hcryp->CrypInCount has always a consistent value
+       and it is ready for the next operation. */
     hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
     hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
     hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
     hcryp->CrypInCount++;
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
   }
   else
   {
@@ -2130,7 +2150,7 @@ static HAL_StatusTypeDef CRYP_AES_Encrypt_IT(CRYP_HandleTypeDef *hcryp)
   * @param  hcryp pointer to a CRYP_HandleTypeDef structure
   * @param  Timeout Specify Timeout value
   * @retval HAL status
-*/
+  */
 static HAL_StatusTypeDef CRYP_AES_Decrypt(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
 {
   uint16_t incount;  /* Temporary CrypInCount Value */
@@ -2303,8 +2323,7 @@ static HAL_StatusTypeDef CRYP_AES_Decrypt_IT(CRYP_HandleTypeDef *hcryp)
             __HAL_UNLOCK(hcryp);
             return HAL_ERROR;
           }
-        }
-        while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+        } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
         /* Clear CCF Flag */
         __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -2348,15 +2367,17 @@ static HAL_StatusTypeDef CRYP_AES_Decrypt_IT(CRYP_HandleTypeDef *hcryp)
     /* Enable CRYP */
     __HAL_CRYP_ENABLE(hcryp);
 
-    /* Write the input block in the IN FIFO */
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    /* Increment the pointer before writing the input block in the IN FIFO to make sure that
+       when Computation Completed IRQ fires, the hcryp->CrypInCount has always a consistent value
+       and it is ready for the next operation. */
     hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
     hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
     hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
     hcryp->CrypInCount++;
+    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
   }
   else
   {
@@ -2432,8 +2453,7 @@ static HAL_StatusTypeDef CRYP_AES_Decrypt_DMA(CRYP_HandleTypeDef *hcryp)
             __HAL_UNLOCK(hcryp);
             return HAL_ERROR;
           }
-        }
-        while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+        } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
         /* Clear CCF Flag */
         __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -2499,9 +2519,10 @@ static void CRYP_DMAInCplt(DMA_HandleTypeDef *hdma)
   uint32_t loopcounter;
   uint32_t headersize_in_bytes;
   uint32_t tmp;
-  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
-                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
-                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+  static const uint32_t mask[12U] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                                     0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                                     0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU
+                                    }; /*  8-bit data type */
 
   /* Stop the DMA transfers to the IN FIFO by clearing to "0" the DMAINEN */
   CLEAR_BIT(hcryp->Instance->CR, AES_CR_DMAINEN);
@@ -2570,15 +2591,31 @@ static void CRYP_DMAInCplt(DMA_HandleTypeDef *hdma)
     /* Initiate payload DMA IN and processed data DMA OUT transfers */
     (void)CRYP_GCMCCM_SetPayloadPhase_DMA(hcryp);
   }
+  else
+  {
+    uint32_t algo;
+    /* ECB, CBC or CTR end of input data feeding
+       or
+       end of GCM/CCM payload data feeding through DMA */
+    algo = hcryp->Instance->CR & AES_CR_CHMOD;
 
-  /* Call input data transfer complete callback */
+    /* Don't call input data transfer complete callback only if
+       it remains some input data to write to the peripheral.
+       This case can only occur for GCM and CCM with a payload length
+       not a multiple of 16 bytes */
+    if (!(((algo == CRYP_AES_GCM_GMAC) || (algo == CRYP_AES_CCM)) && \
+          (((hcryp->Size) % 16U) != 0U)))
+    {
+      /* Call input data transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-  /*Call registered Input complete callback*/
-  hcryp->InCpltCallback(hcryp);
+      /*Call registered Input complete callback*/
+      hcryp->InCpltCallback(hcryp);
 #else
-  /*Call legacy weak Input complete callback*/
-  HAL_CRYP_InCpltCallback(hcryp);
+      /*Call legacy weak Input complete callback*/
+      HAL_CRYP_InCpltCallback(hcryp);
 #endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
+    }
+  } /* if (hcryp->Phase == CRYP_PHASE_HEADER_DMA_FEED) */
 }
 
 /**
@@ -2642,6 +2679,14 @@ static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma)
       hcryp->Instance->DINR = 0x0U;
       count++;
     }
+    /* Call input data transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+    /*Call registered Input complete callback*/
+    hcryp->InCpltCallback(hcryp);
+#else
+    /*Call legacy weak Input complete callback*/
+    HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
 
     /*Wait on CCF flag*/
     CRYP_ClearCCFlagWhenHigh(hcryp, CRYP_TIMEOUT_GCMCCMHEADERPHASE);
@@ -2649,12 +2694,13 @@ static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma)
     /*Read the output block from the output FIFO */
     for (count = 0U; count < 4U; count++)
     {
-      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
+      /* Read the output block from the output FIFO and put them in temporary buffer
+         then get CrypOutBuff from temporary buffer */
       temp[count] = hcryp->Instance->DOUTR;
     }
 
     count = 0U;
-    while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (count<4U))
+    while ((hcryp->CrypOutCount < ((hcryp->Size + 3U) / 4U)) && (count < 4U))
     {
       *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[count];
       hcryp->CrypOutCount++;
@@ -2662,7 +2708,8 @@ static void CRYP_DMAOutCplt(DMA_HandleTypeDef *hdma)
     }
   }
 
-  if (((hcryp->Init.Algorithm & CRYP_AES_GCM_GMAC) != CRYP_AES_GCM_GMAC) && ((hcryp->Init.Algorithm & CRYP_AES_CCM) != CRYP_AES_CCM))
+  if (((hcryp->Init.Algorithm & CRYP_AES_GCM_GMAC) != CRYP_AES_GCM_GMAC)
+      && ((hcryp->Init.Algorithm & CRYP_AES_CCM) != CRYP_AES_CCM))
   {
     /* Disable CRYP (not allowed in  GCM)*/
     __HAL_CRYP_DISABLE(hcryp);
@@ -2859,13 +2906,14 @@ static void CRYP_AES_ProcessData(CRYP_HandleTypeDef *hcryp, uint32_t Timeout)
   /* Clear CCF Flag */
   __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
 
-  /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer*/
+  /* Read the output block from the output FIFO and put them in temporary buffer
+     then get CrypOutBuff from temporary buffer*/
   for (i = 0U; i < 4U; i++)
   {
     temp[i] = hcryp->Instance->DOUTR;
   }
-  i= 0U;
-  while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (i<4U))
+  i = 0U;
+  while ((hcryp->CrypOutCount < ((hcryp->Size + 3U) / 4U)) && (i < 4U))
   {
     *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[i];
     hcryp->CrypOutCount++;
@@ -2888,19 +2936,20 @@ static void CRYP_AES_IT(CRYP_HandleTypeDef *hcryp)
 
   if (hcryp->State == HAL_CRYP_STATE_BUSY)
   {
-    /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer*/
+    /* Read the output block from the output FIFO and put them in temporary buffer
+       then get CrypOutBuff from temporary buffer*/
     for (i = 0U; i < 4U; i++)
     {
       temp[i] = hcryp->Instance->DOUTR;
     }
-    i= 0U;
-    while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (i<4U))
+    i = 0U;
+    while ((hcryp->CrypOutCount < ((hcryp->Size + 3U) / 4U)) && (i < 4U))
     {
       *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[i];
       hcryp->CrypOutCount++;
       i++;
     }
-    if (hcryp->CrypOutCount ==  (hcryp->Size / 4U))
+    if (hcryp->CrypOutCount == (hcryp->Size / 4U))
     {
       /* Disable Computation Complete flag and errors interrupts */
       __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
@@ -2936,13 +2985,13 @@ static void CRYP_AES_IT(CRYP_HandleTypeDef *hcryp)
         /* reset SuspendRequest */
         hcryp->SuspendRequest = HAL_CRYP_SUSPEND_NONE;
         /* Disable Computation Complete Flag and Errors Interrupts */
-        __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE|CRYP_IT_ERRIE);
+        __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
         /* Change the CRYP state */
         hcryp->State = HAL_CRYP_STATE_SUSPENDED;
         /* Mark that the payload phase is suspended */
         hcryp->Phase = CRYP_PHASE_PAYLOAD_SUSPENDED;
 
-       /* Process Unlocked */
+        /* Process Unlocked */
         __HAL_UNLOCK(hcryp);
       }
       else
@@ -2958,7 +3007,7 @@ static void CRYP_AES_IT(CRYP_HandleTypeDef *hcryp)
         hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
 
-        if (hcryp->CrypInCount ==  (hcryp->Size / 4U))
+        if (hcryp->CrypInCount == (hcryp->Size / 4U))
         {
           /* Call Input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -3214,7 +3263,8 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
     /*Read the output block from the output FIFO */
     for (index = 0U; index < 4U; index++)
     {
-      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
+      /* Read the output block from the output FIFO and put them in temporary buffer
+         then get CrypOutBuff from temporary buffer */
       temp[index] = hcryp->Instance->DOUTR;
     }
     for (index = 0U; index < lastwordsize; index++)
@@ -3243,9 +3293,10 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
   uint32_t headersize_in_bytes;
   uint32_t tmp;
-  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
-                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
-                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+  static const uint32_t mask[12U] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                                     0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                                     0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU
+                                    }; /*  8-bit data type */
 
 
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
@@ -3330,8 +3381,7 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         __HAL_UNLOCK(hcryp);
         return HAL_ERROR;
       }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+    } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
     /* Clear CCF flag */
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -3380,7 +3430,7 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         hcryp->CrypInCount++;
         hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
-        if (hcryp->CrypInCount ==  (hcryp->Size / 4U))
+        if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
         {
           /* Call Input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -3431,6 +3481,14 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
           hcryp->Instance->DINR = 0x0U;
           loopcounter++;
         }
+        /* Call Input transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+        /*Call registered Input complete callback*/
+        hcryp->InCpltCallback(hcryp);
+#else
+        /*Call legacy weak Input complete callback*/
+        HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
       }
     }
     /* Enter header data */
@@ -3463,22 +3521,13 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         loopcounter++;
         hcryp->CrypHeaderCount++ ;
         /* Pad the data with zeros to have a complete block */
-      while (loopcounter < 4U)
-      {
-        hcryp->Instance->DINR = 0x0U;
-        loopcounter++;
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
           hcryp->CrypHeaderCount++;
         }
       }
-
-      /* Call Input transfer complete callback */
-#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-      /*Call registered Input complete callback*/
-      hcryp->InCpltCallback(hcryp);
-#else
-      /*Call legacy weak Input complete callback*/
-      HAL_CRYP_InCpltCallback(hcryp);
-#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
     }
     else
     {
@@ -3499,10 +3548,6 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
           header has already been processed;
           only process here message payload */
   {
-
-    /* Enable computation complete flag and error interrupts */
-    __HAL_CRYP_ENABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
-
     /* Set to 0 the number of non-valid bytes using NPBLB register*/
     MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
 
@@ -3528,7 +3573,7 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
       hcryp->CrypInCount++;
       hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
       hcryp->CrypInCount++;
-      if (hcryp->CrypInCount ==  (hcryp->Size / 4U))
+      if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
       {
         /* Call Input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -3539,6 +3584,9 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         HAL_CRYP_InCpltCallback(hcryp);
 #endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
       }
+
+      /* Enable computation complete flag and error interrupts */
+      __HAL_CRYP_ENABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
     }
     else /* Size < 16Bytes  : first block is the last block*/
     {
@@ -3579,6 +3627,17 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         hcryp->Instance->DINR = 0x0U;
         loopcounter++;
       }
+      /* Call Input transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+      /*Call registered Input complete callback*/
+      hcryp->InCpltCallback(hcryp);
+#else
+      /*Call legacy weak Input complete callback*/
+      HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
+
+      /* Enable computation complete flag and error interrupts */
+      __HAL_CRYP_ENABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
     }
   }
 
@@ -3661,8 +3720,7 @@ static HAL_StatusTypeDef CRYP_AESGCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
         __HAL_UNLOCK(hcryp);
         return HAL_ERROR;
       }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+    } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
     /* Clear CCF flag */
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -3807,7 +3865,7 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
     /* Check for the Timeout */
     if (Timeout != HAL_MAX_DELAY)
     {
-      if (((HAL_GetTick() - tickstart) > Timeout) ||(Timeout == 0U))
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
       {
         /* Disable the CRYP peripheral clock */
         __HAL_CRYP_DISABLE(hcryp);
@@ -3875,10 +3933,11 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process(CRYP_HandleTypeDef *hcryp, uint32_t
 
     for (loopcounter = 0U; loopcounter < 4U; loopcounter++)
     {
-      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
+      /* Read the output block from the output FIFO and put them in temporary buffer
+         then get CrypOutBuff from temporary buffer */
       temp[loopcounter] = hcryp->Instance->DOUTR;
     }
-    for (loopcounter = 0U; loopcounter<lastwordsize; loopcounter++)
+    for (loopcounter = 0U; loopcounter < lastwordsize; loopcounter++)
     {
       *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[loopcounter];
       hcryp->CrypOutCount++;
@@ -3904,6 +3963,12 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
   uint32_t npblb;
   uint32_t mode;
   uint32_t DoKeyIVConfig = 1U; /* By default, carry out peripheral Key and IV configuration */
+  uint32_t headersize_in_bytes;
+  uint32_t tmp;
+  static const uint32_t mask[12U] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                                     0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                                     0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU
+                                    }; /*  8-bit data type */
 
 #if (USE_HAL_CRYP_SUSPEND_RESUME == 1U)
   if ((hcryp->Phase == CRYP_PHASE_HEADER_SUSPENDED) || (hcryp->Phase == CRYP_PHASE_PAYLOAD_SUSPENDED))
@@ -3976,8 +4041,7 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         __HAL_UNLOCK(hcryp);
         return HAL_ERROR;
       }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+    } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
     /* Clear CCF flag */
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -3993,7 +4057,16 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
     /* Enable the CRYP peripheral */
     __HAL_CRYP_ENABLE(hcryp);
 
-    if (hcryp->Init.HeaderSize ==   0U) /*header phase is  skipped*/
+    if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
+    {
+      headersize_in_bytes = hcryp->Init.HeaderSize * 4U;
+    }
+    else
+    {
+      headersize_in_bytes = hcryp->Init.HeaderSize;
+    }
+
+    if (headersize_in_bytes == 0U) /* Header phase is  skipped */
     {
       /* Set the phase */
       hcryp->Phase = CRYP_PHASE_PROCESS;
@@ -4021,16 +4094,16 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
       }
       else if (hcryp->Size >= 16U)
       {
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
         hcryp->CrypInCount++;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
         hcryp->CrypInCount++;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
         hcryp->CrypInCount++;
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
 
-        if ((hcryp->CrypInCount ==  (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
+        if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
         {
           /* Call Input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -4077,37 +4150,73 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
           hcryp->Instance->DINR = 0x0U;
           loopcounter++;
         }
+        /* Call Input transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+        /*Call registered Input complete callback*/
+        hcryp->InCpltCallback(hcryp);
+#else
+        /*Call legacy weak Input complete callback*/
+        HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
       }
     }
-    else if ((hcryp->Init.HeaderSize) < 4U) /*HeaderSize < 4 */
+    /* Enter header data */
+    /* Check first whether header length is small enough to enter the full header in one shot */
+    else if (headersize_in_bytes <= 16U)
     {
-      /*  Last block optionally pad the data with zeros*/
-      for (loopcounter = 0U; loopcounter < (hcryp->Init.HeaderSize % 4U); loopcounter++)
+      for (loopcounter = 0U; (loopcounter < (headersize_in_bytes / 4U)); loopcounter++)
       {
         hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
         hcryp->CrypHeaderCount++ ;
       }
-      while (loopcounter < 4U)
+      /* If the header size is a multiple of words */
+      if ((headersize_in_bytes % 4U) == 0U)
       {
-        /* pad the data with zeros to have a complete block */
-        hcryp->Instance->DINR = 0x0U;
-        loopcounter++;
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
       }
+      else
+      {
+        /* Enter last bytes, padded with zeros */
+        tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        tmp &= mask[(hcryp->Init.DataType * 2U) + (headersize_in_bytes % 4U)];
+        hcryp->Instance->DINR = tmp;
+        hcryp->CrypHeaderCount++;
+        loopcounter++;
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
+      }
+      /* Call Input transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+      /*Call registered Input complete callback*/
+      hcryp->InCpltCallback(hcryp);
+#else
+      /*Call legacy weak Input complete callback*/
+      HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
     }
     else
     {
-      /* Write the input block in the IN FIFO */
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      /* Write the first input header block in the Input FIFO,
+         the following header data will be fed after interrupt occurrence */
       hcryp->CrypHeaderCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount - 1U);
       hcryp->CrypHeaderCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount - 1U);
       hcryp->CrypHeaderCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount - 1U);
       hcryp->CrypHeaderCount++;
-    }
-
-  } /* end of if (DoKeyIVConfig == 1U) */
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount - 1U);
+    }/* if (hcryp->Init.HeaderSize == 0U) */ /* Header phase is  skipped*/
+  } /* end of if (dokeyivconfig == 1U) */
   else  /* Key and IV have already been configured,
           header has already been processed;
           only process here message payload */
@@ -4126,16 +4235,16 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
     }
     else if (hcryp->Size >= 16U)
     {
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
       hcryp->CrypInCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
       hcryp->CrypInCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
       hcryp->CrypInCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
       hcryp->CrypInCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + (hcryp->CrypInCount - 1U));
 
-      if ((hcryp->CrypInCount ==  (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
+      if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
       {
         /* Call Input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -4182,6 +4291,14 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_IT(CRYP_HandleTypeDef *hcryp)
         hcryp->Instance->DINR = 0x0U;
         loopcounter++;
       }
+      /* Call Input transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+      /*Call registered Input complete callback*/
+      hcryp->InCpltCallback(hcryp);
+#else
+      /*Call legacy weak Input complete callback*/
+      HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
     }
   }
 
@@ -4265,8 +4382,7 @@ static HAL_StatusTypeDef CRYP_AESCCM_Process_DMA(CRYP_HandleTypeDef *hcryp)
         __HAL_UNLOCK(hcryp);
         return HAL_ERROR;
       }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+    } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
     /* Clear CCF flag */
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -4312,13 +4428,14 @@ static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
 
   /***************************** Payload phase *******************************/
 
-  /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer*/
+  /* Read the output block from the output FIFO and put them in temporary buffer
+     then get CrypOutBuff from temporary buffer*/
   for (i = 0U; i < 4U; i++)
   {
     temp[i] = hcryp->Instance->DOUTR;
   }
-  i= 0U;
-  while((hcryp->CrypOutCount < ((hcryp->Size + 3U)/4U)) && (i<4U))
+  i = 0U;
+  while ((hcryp->CrypOutCount < ((hcryp->Size + 3U) / 4U)) && (i < 4U))
   {
     *(uint32_t *)(hcryp->pCrypOutBuffPtr + hcryp->CrypOutCount) = temp[i];
     hcryp->CrypOutCount++;
@@ -4326,15 +4443,15 @@ static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
   }
   incount = hcryp->CrypInCount;
   outcount = hcryp->CrypOutCount;
-  if ((outcount >=  (hcryp->Size / 4U)) && ((incount * 4U) >=  hcryp->Size))
+  if ((outcount >= (hcryp->Size / 4U)) && ((incount * 4U) >=  hcryp->Size))
   {
 
-     /* When in CCM with Key and IV configuration skipped, don't disable interruptions */
-     if (!((hcryp->Init.Algorithm == CRYP_AES_CCM) && (hcryp->KeyIVConfig == 1U)))
-     {
+    /* When in CCM with Key and IV configuration skipped, don't disable interruptions */
+    if (!((hcryp->Init.Algorithm == CRYP_AES_CCM) && (hcryp->KeyIVConfig == 1U)))
+    {
       /* Disable computation complete flag and errors interrupts */
       __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
-     }
+    }
 
     /* Change the CRYP state */
     hcryp->State = HAL_CRYP_STATE_READY;
@@ -4366,39 +4483,39 @@ static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
       /* reset SuspendRequest */
       hcryp->SuspendRequest = HAL_CRYP_SUSPEND_NONE;
       /* Disable Computation Complete Flag and Errors Interrupts */
-      __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE|CRYP_IT_ERRIE);
+      __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
       /* Change the CRYP state */
       hcryp->State = HAL_CRYP_STATE_SUSPENDED;
       /* Mark that the payload phase is suspended */
       hcryp->Phase = CRYP_PHASE_PAYLOAD_SUSPENDED;
 
-     /* Process Unlocked */
+      /* Process Unlocked */
       __HAL_UNLOCK(hcryp);
     }
     else
 #endif /* USE_HAL_CRYP_SUSPEND_RESUME */
     {
-    /* Write the input block in the IN FIFO */
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
-    hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
-    hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
-    hcryp->CrypInCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
-    hcryp->CrypInCount++;
-    if ((hcryp->CrypInCount ==  hcryp->Size) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC))
-    {
-      /* Call output transfer complete callback */
+      /* Write the input block in the IN FIFO */
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->CrypInCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->CrypInCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->CrypInCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
+      hcryp->CrypInCount++;
+      if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
+      {
+        /* Call input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-      /*Call registered Input complete callback*/
-      hcryp->InCpltCallback(hcryp);
+        /*Call registered Input complete callback*/
+        hcryp->InCpltCallback(hcryp);
 #else
-      /*Call legacy weak Input complete callback*/
-      HAL_CRYP_InCpltCallback(hcryp);
+        /*Call legacy weak Input complete callback*/
+        HAL_CRYP_InCpltCallback(hcryp);
 #endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
+      }
     }
-  }
   }
   else /* Last block of payload < 128bit*/
   {
@@ -4435,6 +4552,14 @@ static void CRYP_GCMCCM_SetPayloadPhase_IT(CRYP_HandleTypeDef *hcryp)
       hcryp->Instance->DINR = 0x0U;
       loopcounter++;
     }
+    /* Call input transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+    /*Call registered Input complete callback*/
+    hcryp->InCpltCallback(hcryp);
+#else
+    /*Call legacy weak Input complete callback*/
+    HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
   }
 }
 
@@ -4478,9 +4603,9 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcr
     npblb = 16U - (uint32_t)hcryp->Size;
 
     /* Set Npblb in case of AES GCM payload encryption or AES CCM payload decryption to get right tag*/
-    reg = hcryp->Instance->CR & (AES_CR_CHMOD|AES_CR_MODE);
-    if ((reg == (CRYP_AES_GCM_GMAC|CRYP_OPERATINGMODE_ENCRYPT)) ||\
-        (reg == (CRYP_AES_CCM|CRYP_OPERATINGMODE_DECRYPT)))
+    reg = hcryp->Instance->CR & (AES_CR_CHMOD | AES_CR_MODE);
+    if ((reg == (CRYP_AES_GCM_GMAC | CRYP_OPERATINGMODE_ENCRYPT)) || \
+        (reg == (CRYP_AES_CCM | CRYP_OPERATINGMODE_DECRYPT)))
     {
       /* Specify the number of non-valid bytes using NPBLB register*/
       MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, npblb << 20U);
@@ -4509,6 +4634,14 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcr
       hcryp->Instance->DINR  = 0U;
       index++;
     }
+    /* Call the input data transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+    /*Call registered Input complete callback*/
+    hcryp->InCpltCallback(hcryp);
+#else
+    /*Call legacy weak Input complete callback*/
+    HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
     /* Wait for CCF flag to be raised */
     count = CRYP_TIMEOUT_GCMCCMHEADERPHASE;
     do
@@ -4527,8 +4660,7 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcr
         __HAL_UNLOCK(hcryp);
         return HAL_ERROR;
       }
-    }
-    while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+    } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
     /* Clear CCF Flag */
     __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -4536,7 +4668,8 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcr
     /*Read the output block from the output FIFO */
     for (index = 0U; index < 4U; index++)
     {
-      /* Read the output block from the output FIFO and put them in temporary buffer then get CrypOutBuff from temporary buffer */
+      /* Read the output block from the output FIFO and put them in temporary buffer
+         then get CrypOutBuff from temporary buffer */
       temp[index] = hcryp->Instance->DOUTR;
     }
     for (index = 0U; index < lastwordsize; index++)
@@ -4550,6 +4683,15 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetPayloadPhase_DMA(CRYP_HandleTypeDef *hcr
 
     /* Process unlocked */
     __HAL_UNLOCK(hcryp);
+
+    /* Call Output transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+    /*Call registered Output complete callback*/
+    hcryp->OutCpltCallback(hcryp);
+#else
+    /*Call legacy weak Output complete callback*/
+    HAL_CRYP_OutCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
   }
 
   return HAL_OK;
@@ -4567,9 +4709,10 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
   uint32_t loopcounter;
   uint32_t size_in_bytes;
   uint32_t tmp;
-  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
-                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
-                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+  static const uint32_t mask[12U] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                                     0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                                     0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU
+                                    }; /*  8-bit data type */
 
   /***************************** Header phase for GCM/GMAC or CCM *********************************/
   if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
@@ -4671,17 +4814,17 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase(CRYP_HandleTypeDef *hcryp, u
       }
       else
       {
-         /* Enter last bytes, padded with zeros */
-         tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-         tmp &= mask[(hcryp->Init.DataType * 2U) + (size_in_bytes % 4U)];
-         hcryp->Instance->DINR = tmp;
-         loopcounter++;
-         /* Pad the data with zeros to have a complete block */
-         while (loopcounter < 4U)
-         {
-           hcryp->Instance->DINR = 0x0U;
-           loopcounter++;
-         }
+        /* Enter last bytes, padded with zeros */
+        tmp =  *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        tmp &= mask[(hcryp->Init.DataType * 2U) + (size_in_bytes % 4U)];
+        hcryp->Instance->DINR = tmp;
+        loopcounter++;
+        /* Pad the data with zeros to have a complete block */
+        while (loopcounter < 4U)
+        {
+          hcryp->Instance->DINR = 0x0U;
+          loopcounter++;
+        }
       }
 
       if (CRYP_WaitOnCCFlag(hcryp, Timeout) != HAL_OK)
@@ -4727,9 +4870,10 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase_DMA(CRYP_HandleTypeDef *hcry
   uint32_t loopcounter;
   uint32_t headersize_in_bytes;
   uint32_t tmp;
-  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
-                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
-                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+  static const uint32_t mask[12U] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                                     0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                                     0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU
+                                    }; /*  8-bit data type */
 
   /***************************** Header phase for GCM/GMAC or CCM *********************************/
   if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
@@ -4756,7 +4900,8 @@ static HAL_StatusTypeDef CRYP_GCMCCM_SetHeaderPhase_DMA(CRYP_HandleTypeDef *hcry
   if (headersize_in_bytes >= 16U)
   {
     /* Initiate header DMA transfer */
-    if (CRYP_SetHeaderDMAConfig(hcryp, (uint32_t)(hcryp->Init.Header), (uint16_t)((headersize_in_bytes / 16U) * 4U)) != HAL_OK)
+    if (CRYP_SetHeaderDMAConfig(hcryp, (uint32_t)(hcryp->Init.Header),
+                                (uint16_t)((headersize_in_bytes / 16U) * 4U)) != HAL_OK)
     {
       return HAL_ERROR;
     }
@@ -4848,9 +4993,10 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
   uint32_t mode;
   uint32_t headersize_in_bytes;
   uint32_t tmp;
-  uint32_t mask[12] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
-                       0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
-                       0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU}; /*  8-bit data type */
+  static const uint32_t mask[12U] = {0x0U, 0xFF000000U, 0xFFFF0000U, 0xFFFFFF00U,  /* 32-bit data type */
+                                     0x0U, 0x0000FF00U, 0x0000FFFFU, 0xFF00FFFFU,  /* 16-bit data type */
+                                     0x0U, 0x000000FFU, 0x0000FFFFU, 0x00FFFFFFU
+                                    }; /*  8-bit data type */
 
   if (hcryp->Init.HeaderWidthUnit == CRYP_HEADERWIDTHUNIT_WORD)
   {
@@ -4901,7 +5047,7 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
       hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
       hcryp->CrypInCount++;
 
-      if ((hcryp->CrypInCount ==  (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
+      if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
       {
         /* Call the input data transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
@@ -4947,6 +5093,14 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
         hcryp->Instance->DINR = 0x0U;
         loopcounter++;
       }
+      /* Call the input data transfer complete callback */
+#if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
+      /*Call registered Input complete callback*/
+      hcryp->InCpltCallback(hcryp);
+#else
+      /*Call legacy weak Input complete callback*/
+      HAL_CRYP_InCpltCallback(hcryp);
+#endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
     }
   }
   else if ((((headersize_in_bytes / 4U) - (hcryp->CrypHeaderCount)) >= 4U))
@@ -4963,28 +5117,28 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
       /* reset SuspendRequest */
       hcryp->SuspendRequest = HAL_CRYP_SUSPEND_NONE;
       /* Disable Computation Complete Flag and Errors Interrupts */
-      __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE|CRYP_IT_ERRIE);
+      __HAL_CRYP_DISABLE_IT(hcryp, CRYP_IT_CCFIE | CRYP_IT_ERRIE);
       /* Change the CRYP state */
       hcryp->State = HAL_CRYP_STATE_SUSPENDED;
       /* Mark that the payload phase is suspended */
       hcryp->Phase = CRYP_PHASE_HEADER_SUSPENDED;
 
-     /* Process Unlocked */
+      /* Process Unlocked */
       __HAL_UNLOCK(hcryp);
     }
     else
 #endif /* USE_HAL_CRYP_SUSPEND_RESUME */
     {
-    /* Write the input block in the IN FIFO */
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-    hcryp->CrypHeaderCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-    hcryp->CrypHeaderCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-    hcryp->CrypHeaderCount++;
-    hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
-    hcryp->CrypHeaderCount++;
-  }
+      /* Write the input block in the IN FIFO */
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->CrypHeaderCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->CrypHeaderCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->CrypHeaderCount++;
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+      hcryp->CrypHeaderCount++;
+    }
   }
   else /* Write last header block (4 words), padded with zeros if needed */
   {
@@ -5014,10 +5168,10 @@ static void CRYP_GCMCCM_SetHeaderPhase_IT(CRYP_HandleTypeDef *hcryp)
       loopcounter++;
       hcryp->CrypHeaderCount++;
       /* Pad the data with zeros to have a complete block */
-    while (loopcounter < 4U)
-    {
-      hcryp->Instance->DINR = 0x0U;
-      loopcounter++;
+      while (loopcounter < 4U)
+      {
+        hcryp->Instance->DINR = 0x0U;
+        loopcounter++;
         hcryp->CrypHeaderCount++;
       }
     }
@@ -5081,15 +5235,14 @@ static void CRYP_ClearCCFlagWhenHigh(CRYP_HandleTypeDef *hcryp, uint32_t Timeout
       hcryp->State = HAL_CRYP_STATE_READY;
 
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1U)
-    /*Call registered error callback*/
-    hcryp->ErrorCallback(hcryp);
+      /*Call registered error callback*/
+      hcryp->ErrorCallback(hcryp);
 #else
-    /*Call legacy weak error callback*/
-    HAL_CRYP_ErrorCallback(hcryp);
+      /*Call legacy weak error callback*/
+      HAL_CRYP_ErrorCallback(hcryp);
 #endif /* USE_HAL_CRYP_REGISTER_CALLBACKS */
     }
-  }
-  while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
+  } while (HAL_IS_BIT_CLR(hcryp->Instance->SR, AES_SR_CCF));
 
   /* Clear CCF flag */
   __HAL_CRYP_CLEAR_FLAG(hcryp, CRYP_CCF_CLEAR);
@@ -5105,17 +5258,17 @@ static void CRYP_ClearCCFlagWhenHigh(CRYP_HandleTypeDef *hcryp, uint32_t Timeout
   *         as soon as the suspended processing has to be resumed.
   * @retval None
   */
-static void CRYP_Read_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output)
+static void CRYP_Read_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Output)
 {
   uint32_t outputaddr = (uint32_t)Output;
 
-  *(uint32_t*)(outputaddr) = hcryp->Instance->IVR3;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->IVR2;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->IVR1;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->IVR0;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->IVR3;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->IVR2;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->IVR1;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->IVR0;
 }
 
 /**
@@ -5128,17 +5281,17 @@ static void CRYP_Read_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output)
   * @note   AES must be disabled when reconfiguring the IV values.
   * @retval None
   */
-static void CRYP_Write_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input)
+static void CRYP_Write_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Input)
 {
   uint32_t ivaddr = (uint32_t)Input;
 
-  hcryp->Instance->IVR3 = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->IVR2 = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->IVR1 = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->IVR0 = *(uint32_t*)(ivaddr);
+  hcryp->Instance->IVR3 = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->IVR2 = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->IVR1 = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->IVR0 = *(uint32_t *)(ivaddr);
 }
 
 /**
@@ -5151,52 +5304,52 @@ static void CRYP_Write_IVRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input)
   *         as soon as the suspended processing has to be resumed.
   * @retval None
   */
-static void CRYP_Read_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output)
+static void CRYP_Read_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Output)
 {
   uint32_t outputaddr = (uint32_t)Output;
   __IO uint32_t count = 0U;
 
   /* In case of GCM payload phase encryption, check that suspension can be carried out */
-  if (READ_BIT(hcryp->Instance->CR, (AES_CR_CHMOD|AES_CR_GCMPH|AES_CR_MODE)) == (CRYP_AES_GCM_GMAC|AES_CR_GCMPH_1|0x0U))
+  if (READ_BIT(hcryp->Instance->CR,
+               (AES_CR_CHMOD | AES_CR_GCMPH | AES_CR_MODE)) == (CRYP_AES_GCM_GMAC | AES_CR_GCMPH_1 | 0x0U))
   {
 
-      /* Wait for BUSY flag to be cleared */
-      count = 0xFFF;
-      do
+    /* Wait for BUSY flag to be cleared */
+    count = 0xFFF;
+    do
+    {
+      count-- ;
+      if (count == 0U)
       {
-        count-- ;
-        if(count == 0U)
-        {
-          /* Change state */
-          hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
-          hcryp->State = HAL_CRYP_STATE_READY;
+        /* Change state */
+        hcryp->ErrorCode |= HAL_CRYP_ERROR_TIMEOUT;
+        hcryp->State = HAL_CRYP_STATE_READY;
 
-          /* Process unlocked */
-          __HAL_UNLOCK(hcryp);
-          HAL_CRYP_ErrorCallback(hcryp);
-          return;
-        }
+        /* Process unlocked */
+        __HAL_UNLOCK(hcryp);
+        HAL_CRYP_ErrorCallback(hcryp);
+        return;
       }
-      while(HAL_IS_BIT_SET(hcryp->Instance->SR, AES_SR_BUSY));
+    } while (HAL_IS_BIT_SET(hcryp->Instance->SR, AES_SR_BUSY));
 
   }
 
 
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP7R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP6R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP5R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP4R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP3R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP2R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP1R;
-  outputaddr+=4U;
-  *(uint32_t*)(outputaddr) = hcryp->Instance->SUSP0R;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP7R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP6R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP5R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP4R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP3R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP2R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP1R;
+  outputaddr += 4U;
+  *(uint32_t *)(outputaddr) = hcryp->Instance->SUSP0R;
 }
 
 /**
@@ -5209,25 +5362,25 @@ static void CRYP_Read_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Outp
   * @note   AES must be disabled when reconfiguring the suspend registers.
   * @retval None
   */
-static void CRYP_Write_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input)
+static void CRYP_Write_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Input)
 {
   uint32_t ivaddr = (uint32_t)Input;
 
-  hcryp->Instance->SUSP7R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP6R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP5R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP4R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP3R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP2R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP1R = *(uint32_t*)(ivaddr);
-  ivaddr+=4U;
-  hcryp->Instance->SUSP0R = *(uint32_t*)(ivaddr);
+  hcryp->Instance->SUSP7R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP6R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP5R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP4R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP3R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP2R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP1R = *(uint32_t *)(ivaddr);
+  ivaddr += 4U;
+  hcryp->Instance->SUSP0R = *(uint32_t *)(ivaddr);
 }
 
 /**
@@ -5240,37 +5393,37 @@ static void CRYP_Write_SuspendRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Inp
   *         as soon as the suspended processing has to be resumed.
   * @retval None
   */
-static void CRYP_Read_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output, uint32_t KeySize)
+static void CRYP_Read_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Output, uint32_t KeySize)
 {
   uint32_t keyaddr = (uint32_t)Output;
 
   switch (KeySize)
   {
     case CRYP_KEYSIZE_256B:
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 1U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 2U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 3U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 4U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 5U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 6U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 7U);
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 1U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 2U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 3U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 4U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 5U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 6U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 7U);
       break;
     case CRYP_KEYSIZE_128B:
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 1U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 2U);
-      keyaddr+=4U;
-      *(uint32_t*)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 3U);
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 1U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 2U);
+      keyaddr += 4U;
+      *(uint32_t *)(keyaddr) = *(uint32_t *)(hcryp->Init.pKey + 3U);
       break;
     default:
       break;
@@ -5288,29 +5441,29 @@ static void CRYP_Read_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Output, 
   * @note   AES must be disabled when reconfiguring the Key registers.
   * @retval None
   */
-static void CRYP_Write_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t* Input, uint32_t KeySize)
+static void CRYP_Write_KeyRegisters(CRYP_HandleTypeDef *hcryp, uint32_t *Input, uint32_t KeySize)
 {
   uint32_t keyaddr = (uint32_t)Input;
 
   if (KeySize == CRYP_KEYSIZE_256B)
   {
-    hcryp->Instance->KEYR7 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
-    hcryp->Instance->KEYR6 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
-    hcryp->Instance->KEYR5 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
-    hcryp->Instance->KEYR4 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
+    hcryp->Instance->KEYR7 = *(uint32_t *)(keyaddr);
+    keyaddr += 4U;
+    hcryp->Instance->KEYR6 = *(uint32_t *)(keyaddr);
+    keyaddr += 4U;
+    hcryp->Instance->KEYR5 = *(uint32_t *)(keyaddr);
+    keyaddr += 4U;
+    hcryp->Instance->KEYR4 = *(uint32_t *)(keyaddr);
+    keyaddr += 4U;
   }
 
-    hcryp->Instance->KEYR3 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
-    hcryp->Instance->KEYR2 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
-    hcryp->Instance->KEYR1 = *(uint32_t*)(keyaddr);
-    keyaddr+=4U;
-    hcryp->Instance->KEYR0 = *(uint32_t*)(keyaddr);
+  hcryp->Instance->KEYR3 = *(uint32_t *)(keyaddr);
+  keyaddr += 4U;
+  hcryp->Instance->KEYR2 = *(uint32_t *)(keyaddr);
+  keyaddr += 4U;
+  hcryp->Instance->KEYR1 = *(uint32_t *)(keyaddr);
+  keyaddr += 4U;
+  hcryp->Instance->KEYR0 = *(uint32_t *)(keyaddr);
 }
 
 /**
@@ -5338,7 +5491,7 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
   /* Case of header phase resumption =================================================*/
   if (hcryp->Phase == CRYP_PHASE_HEADER_SUSPENDED)
   {
-      /* Set the phase */
+    /* Set the phase */
     hcryp->Phase = CRYP_PHASE_PROCESS;
 
     /* Select header phase */
@@ -5347,24 +5500,24 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
     if ((((hcryp->Init.HeaderSize) - (hcryp->CrypHeaderCount)) >= 4U))
     {
       /* Write the input block in the IN FIFO */
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount );
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
       hcryp->CrypHeaderCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount );
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
       hcryp->CrypHeaderCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount );
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
       hcryp->CrypHeaderCount++;
-      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount );
+      hcryp->Instance->DINR  = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
       hcryp->CrypHeaderCount++;
     }
     else /*HeaderSize < 4 or HeaderSize >4 & HeaderSize %4 != 0*/
     {
       /*  Last block optionally pad the data with zeros*/
-      for(loopcounter = 0U; loopcounter < (hcryp->Init.HeaderSize %4U ); loopcounter++)
+      for (loopcounter = 0U; loopcounter < (hcryp->Init.HeaderSize % 4U); loopcounter++)
       {
-        hcryp->Instance->DINR = *(uint32_t*)(hcryp->Init.Header + hcryp->CrypHeaderCount);
+        hcryp->Instance->DINR = *(uint32_t *)(hcryp->Init.Header + hcryp->CrypHeaderCount);
         hcryp->CrypHeaderCount++ ;
       }
-      while(loopcounter <4U )
+      while (loopcounter < 4U)
       {
         /* pad the data with zeros to have a complete block */
         hcryp->Instance->DINR = 0x0U;
@@ -5387,20 +5540,20 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
       /* Set to 0 the number of non-valid bytes using NPBLB register*/
       MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, 0U);
 
-      if (((hcryp->Size/4U) - (hcryp->CrypInCount)) >= 4U)
+      if (((hcryp->Size / 4U) - (hcryp->CrypInCount)) >= 4U)
       {
         /* Write the input block in the IN FIFO */
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
-        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+        hcryp->Instance->DINR  = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
         hcryp->CrypInCount++;
-        if((hcryp->CrypInCount ==  hcryp->Size) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC))
+        if ((hcryp->CrypInCount == (hcryp->Size / 4U)) && ((hcryp->Size % 16U) == 0U))
         {
-          /* Call output transfer complete callback */
+          /* Call input transfer complete callback */
 #if (USE_HAL_CRYP_REGISTER_CALLBACKS == 1)
           /*Call registered Input complete callback*/
           hcryp->InCpltCallback(hcryp);
@@ -5413,32 +5566,32 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
       else /* Last block of payload < 128bit*/
       {
         /* Compute the number of padding bytes in last block of payload */
-        npblb = (((hcryp->Size/16U)+1U)*16U) - (hcryp->Size);
+        npblb = (((hcryp->Size / 16U) + 1U) * 16U) - (hcryp->Size);
         cr_temp = hcryp->Instance->CR;
-        if((((cr_temp & AES_CR_MODE) == CRYP_OPERATINGMODE_ENCRYPT) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC)) ||
-           (((cr_temp& AES_CR_MODE) == CRYP_OPERATINGMODE_DECRYPT) && (hcryp->Init.Algorithm == CRYP_AES_CCM)))
+        if ((((cr_temp & AES_CR_MODE) == CRYP_OPERATINGMODE_ENCRYPT) && (hcryp->Init.Algorithm == CRYP_AES_GCM_GMAC)) ||
+            (((cr_temp & AES_CR_MODE) == CRYP_OPERATINGMODE_DECRYPT) && (hcryp->Init.Algorithm == CRYP_AES_CCM)))
         {
           /* Specify the number of non-valid bytes using NPBLB register*/
-            MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, ((uint32_t)npblb)<< 20U);
+          MODIFY_REG(hcryp->Instance->CR, AES_CR_NPBLB, ((uint32_t)npblb) << 20U);
         }
 
         /* Number of valid words (lastwordsize) in last block */
-        if ((npblb % 4U) ==0U)
+        if ((npblb % 4U) == 0U)
         {
-          lastwordsize = (16U-npblb)/4U;
+          lastwordsize = (16U - npblb) / 4U;
         }
         else
         {
-          lastwordsize = ((16U-npblb)/4U) +1U;
+          lastwordsize = ((16U - npblb) / 4U) + 1U;
         }
 
         /*  Last block optionally pad the data with zeros*/
-        for(loopcounter = 0U; loopcounter < lastwordsize; loopcounter++)
+        for (loopcounter = 0U; loopcounter < lastwordsize; loopcounter++)
         {
-          hcryp->Instance->DINR = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount );
+          hcryp->Instance->DINR = *(uint32_t *)(hcryp->pCrypInBuffPtr + hcryp->CrypInCount);
           hcryp->CrypInCount++;
         }
-        while(loopcounter < 4U )
+        while (loopcounter < 4U)
         {
           /* pad the data with zeros to have a complete block */
           hcryp->Instance->DINR = 0x0U;
@@ -5462,6 +5615,5 @@ static void CRYP_PhaseProcessingResume(CRYP_HandleTypeDef *hcryp)
   */
 
 /**
- * @}
- */
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+  * @}
+  */

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_cryp_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_cryp_ex.c
@@ -9,13 +9,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -72,8 +71,8 @@
   */
 
 /** @defgroup CRYPEx_Exported_Functions_Group1 Extended AES processing functions
- *  @brief   Extended processing functions.
- *
+  *  @brief   Extended processing functions.
+  *
 @verbatim
   ==============================================================================
               ##### Extended AES processing functions #####
@@ -162,7 +161,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESGCM_GenerateAuthTAG(CRYP_HandleTypeDef *hcryp, u
       /* Check for the Timeout */
       if (Timeout != HAL_MAX_DELAY)
       {
-        if (((HAL_GetTick() - tickstart) > Timeout)||(Timeout == 0U))
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
         {
           /* Disable the CRYP peripheral clock */
           __HAL_CRYP_DISABLE(hcryp);
@@ -268,7 +267,7 @@ HAL_StatusTypeDef HAL_CRYPEx_AESCCM_GenerateAuthTAG(CRYP_HandleTypeDef *hcryp, u
       /* Check for the Timeout */
       if (Timeout != HAL_MAX_DELAY)
       {
-        if (((HAL_GetTick() - tickstart) > Timeout) ||(Timeout == 0U))
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
         {
           /* Disable the CRYP peripheral Clock */
           __HAL_CRYP_DISABLE(hcryp);
@@ -385,5 +384,3 @@ void  HAL_CRYPEx_DisableAutoKeyDerivation(CRYP_HandleTypeDef *hcryp)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_dma.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_dma.c
@@ -8,6 +8,17 @@
   *           + Initialization and de-initialization functions
   *           + IO operation functions
   *           + Peripheral State and errors functions
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -73,17 +84,6 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -123,8 +123,8 @@ static void DMA_CalcDMAMUXRequestGenBaseAndMask(DMA_HandleTypeDef *hdma);
   */
 
 /** @defgroup DMA_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief   Initialization and de-initialization functions
- *
+  *  @brief   Initialization and de-initialization functions
+  *
 @verbatim
  ===============================================================================
              ##### Initialization and de-initialization functions  #####
@@ -188,7 +188,7 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
   /* DMA1 */
   hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA1_Channel1) / ((uint32_t)DMA1_Channel2 - (uint32_t)DMA1_Channel1)) << 2U;
   hdma->DmaBaseAddress = DMA1;
-#endif
+#endif /* DMA2 */
 
   /* Change DMA peripheral state */
   hdma->State = HAL_DMA_STATE_BUSY;
@@ -298,7 +298,7 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
   /* DMA1 */
   hdma->ChannelIndex = (((uint32_t)hdma->Instance - (uint32_t)DMA1_Channel1) / ((uint32_t)DMA1_Channel2 - (uint32_t)DMA1_Channel1)) << 2U;
   hdma->DmaBaseAddress = DMA1;
-#endif
+#endif /* DMA2 */
 
   /* Reset DMA Channel control register */
   hdma->Instance->CCR  = 0U;
@@ -359,8 +359,8 @@ HAL_StatusTypeDef HAL_DMA_DeInit(DMA_HandleTypeDef *hdma)
   */
 
 /** @defgroup DMA_Exported_Functions_Group2 Input and Output operation functions
- *  @brief   Input and Output operation functions
- *
+  *  @brief   Input and Output operation functions
+  *
 @verbatim
  ===============================================================================
                       #####  IO operation functions  #####
@@ -429,7 +429,8 @@ HAL_StatusTypeDef HAL_DMA_Start(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, ui
   * @param DataLength The length of data to be transferred from source to destination
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress, uint32_t DataLength)
+HAL_StatusTypeDef HAL_DMA_Start_IT(DMA_HandleTypeDef *hdma, uint32_t SrcAddress, uint32_t DstAddress,
+                                   uint32_t DataLength)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -508,7 +509,7 @@ HAL_StatusTypeDef HAL_DMA_Abort(DMA_HandleTypeDef *hdma)
   }
 
   /* Check the DMA peripheral state */
-  if(hdma->State != HAL_DMA_STATE_BUSY)
+  if (hdma->State != HAL_DMA_STATE_BUSY)
   {
     hdma->ErrorCode = HAL_DMA_ERROR_NO_XFER;
 
@@ -621,7 +622,8 @@ HAL_StatusTypeDef HAL_DMA_Abort_IT(DMA_HandleTypeDef *hdma)
   * @param Timeout Timeout duration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_LevelCompleteTypeDef CompleteLevel, uint32_t Timeout)
+HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_LevelCompleteTypeDef CompleteLevel,
+                                          uint32_t Timeout)
 {
   uint32_t temp;
   uint32_t tickstart;
@@ -656,9 +658,9 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
   /* Get tick */
   tickstart = HAL_GetTick();
 
-  while((hdma->DmaBaseAddress->ISR & temp) == 0U)
+  while ((hdma->DmaBaseAddress->ISR & temp) == 0U)
   {
-    if((hdma->DmaBaseAddress->ISR & (DMA_FLAG_TE1 << (hdma->ChannelIndex& 0x1CU))) != 0U)
+    if ((hdma->DmaBaseAddress->ISR & (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1CU))) != 0U)
     {
       /* When a DMA transfer error occurs */
       /* A hardware clear of its EN bits is performed */
@@ -679,7 +681,7 @@ HAL_StatusTypeDef HAL_DMA_PollForTransfer(DMA_HandleTypeDef *hdma, HAL_DMA_Level
     /* Check for the Timeout */
     if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
       {
         /* Update error code */
         hdma->ErrorCode = HAL_DMA_ERROR_TIMEOUT;
@@ -801,7 +803,7 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
   }
 
   /* Transfer Error Interrupt management **************************************/
-  else if (((flag_it & (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1cU)))!= 0U) && ((source_it & DMA_IT_TE) != 0U))
+  else if (((flag_it & (DMA_FLAG_TE1 << (hdma->ChannelIndex & 0x1cU))) != 0U) && ((source_it & DMA_IT_TE) != 0U))
   {
     /* When a DMA transfer error occurs */
     /* A hardware clear of its EN bits is performed */
@@ -837,9 +839,9 @@ void HAL_DMA_IRQHandler(DMA_HandleTypeDef *hdma)
   * @brief  Register callbacks
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
   *                               the configuration information for the specified DMA Channel.
-  * @param CallbackID User Callback identifer
+  * @param CallbackID User Callback identifier
   *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
-  * @param pCallback Pointer to private callbacsk function which has pointer to
+  * @param pCallback Pointer to private callback function which has pointer to
   *                               a DMA_HandleTypeDef structure as parameter.
   * @retval HAL status
   */
@@ -890,7 +892,7 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
   * @brief  UnRegister callbacks
   * @param hdma Pointer to a DMA_HandleTypeDef structure that contains
   *                               the configuration information for the specified DMA Channel.
-  * @param CallbackID User Callback identifer
+  * @param CallbackID User Callback identifier
   *                               a HAL_DMA_CallbackIDTypeDef ENUM as parameter.
   * @retval HAL status
   */
@@ -951,8 +953,8 @@ HAL_StatusTypeDef HAL_DMA_UnRegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Ca
 
 
 /** @defgroup DMA_Exported_Functions_Group3 Peripheral State and Errors functions
- *  @brief    Peripheral State and Errors functions
- *
+  *  @brief    Peripheral State and Errors functions
+  *
 @verbatim
  ===============================================================================
             ##### Peripheral State and Errors functions #####
@@ -1072,7 +1074,7 @@ static void DMA_CalcDMAMUXChannelBaseAndMask(DMA_HandleTypeDef *hdma)
 #else
   /* DMA1 */
   hdma->DMAmuxChannel = (DMAMUX1_Channel0 + (hdma->ChannelIndex >> 2U));
-#endif
+#endif /* DMA2 */
   channel_number = (((uint32_t)hdma->Instance & 0xFFU) - 8U) / 20U;
   hdma->DMAmuxChannelStatus = DMAMUX1_ChannelStatus;
 
@@ -1116,5 +1118,3 @@ static void DMA_CalcDMAMUXRequestGenBaseAndMask(DMA_HandleTypeDef *hdma)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_dma_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_dma_ex.c
@@ -7,6 +7,17 @@
   *         functionalities of the DMA Extension peripheral:
   *           + Extended features functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -26,17 +37,6 @@
       (exception done if a given DMA is not using the DMAMUX SYNC block neither a request generator)
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -68,8 +68,8 @@
   */
 
 /** @defgroup DMAEx_Exported_Functions_Group1 DMAEx Extended features functions
- *  @brief   Extended features functions
- *
+  *  @brief   Extended features functions
+  *
 @verbatim
  ===============================================================================
                 #####  Extended features functions  #####
@@ -134,12 +134,13 @@ HAL_StatusTypeDef HAL_DMAEx_ConfigMuxSync(DMA_HandleTypeDef *hdma, HAL_DMA_MuxSy
   * @brief  Configure the DMAMUX request generator block used by the given DMA channel (instance).
   * @param  hdma Pointer to a DMA_HandleTypeDef structure that contains
   *                     the configuration information for the specified DMA channel.
-* @param  pRequestGeneratorConfig Pointer to HAL_DMA_MuxRequestGeneratorConfigTypeDef :
+  * @param  pRequestGeneratorConfig Pointer to HAL_DMA_MuxRequestGeneratorConfigTypeDef :
   *         contains the request generator parameters.
   *
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_DMAEx_ConfigMuxRequestGenerator(DMA_HandleTypeDef *hdma, HAL_DMA_MuxRequestGeneratorConfigTypeDef *pRequestGeneratorConfig)
+HAL_StatusTypeDef HAL_DMAEx_ConfigMuxRequestGenerator(DMA_HandleTypeDef *hdma,
+                                                      HAL_DMA_MuxRequestGeneratorConfigTypeDef *pRequestGeneratorConfig)
 {
   /* Check the parameters */
   assert_param(IS_DMA_ALL_INSTANCE(hdma->Instance));
@@ -292,5 +293,3 @@ void HAL_DMAEx_MUX_IRQHandler(DMA_HandleTypeDef *hdma)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_exti.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_exti.c
@@ -7,7 +7,17 @@
   *          functionalities of the General Purpose Input/Output (EXTI) peripheral:
   *           + Initialization and de-initialization functions
   *           + IO operation functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                     ##### EXTI Peripheral features #####
@@ -30,7 +40,7 @@
         (++) Trigger request occurred
 
     (+) Exti lines 0 to 15 are linked to gpio pin number 0 to 15. Gpio port can
-        be selected throught multiplexer.
+        be selected through multiplexer.
 
                      ##### How to use this driver #####
   ==============================================================================
@@ -68,17 +78,6 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -106,8 +105,8 @@
 /** @defgroup EXTI_Private_Constants EXTI Private Constants
   * @{
   */
-#define EXTI_MODE_OFFSET                    0x04u   /* 0x10: offset between CPU IMR/EMR registers */
-#define EXTI_CONFIG_OFFSET                  0x08u   /* 0x20: offset between CPU Rising/Falling configuration registers */
+#define EXTI_MODE_OFFSET                    0x04u  /* 0x10: offset between CPU IMR/EMR registers */
+#define EXTI_CONFIG_OFFSET                  0x08u  /* 0x20: offset between CPU Rising/Falling configuration registers */
 /**
   * @}
   */
@@ -122,8 +121,8 @@
   */
 
 /** @addtogroup EXTI_Exported_Functions_Group1
- *  @brief    Configuration functions
- *
+  *  @brief    Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Configuration functions #####
@@ -281,7 +280,7 @@ HAL_StatusTypeDef HAL_EXTI_GetConfigLine(EXTI_HandleTypeDef *hexti, EXTI_ConfigT
   /* Check the parameter */
   assert_param(IS_EXTI_LINE(hexti->Line));
 
-  /* Store handle line number to configiguration structure */
+  /* Store handle line number to configuration structure */
   pExtiConfig->Line = hexti->Line;
 
   /* compute line register offset and line mask */
@@ -313,6 +312,10 @@ HAL_StatusTypeDef HAL_EXTI_GetConfigLine(EXTI_HandleTypeDef *hexti, EXTI_ConfigT
     pExtiConfig->Mode |= EXTI_MODE_EVENT;
   }
 
+  /* Get default Trigger and GPIOSel configuration */
+  pExtiConfig->Trigger = EXTI_TRIGGER_NONE;
+  pExtiConfig->GPIOSel = 0x00u;
+
   /* 2] Get trigger for configurable lines : rising */
   if ((pExtiConfig->Line & EXTI_CONFIG) != 0x00u)
   {
@@ -323,10 +326,6 @@ HAL_StatusTypeDef HAL_EXTI_GetConfigLine(EXTI_HandleTypeDef *hexti, EXTI_ConfigT
     if ((regval & maskline) != 0x00u)
     {
       pExtiConfig->Trigger = EXTI_TRIGGER_RISING;
-    }
-    else
-    {
-      pExtiConfig->Trigger = EXTI_TRIGGER_NONE;
     }
 
     /* Get falling configuration */
@@ -345,17 +344,8 @@ HAL_StatusTypeDef HAL_EXTI_GetConfigLine(EXTI_HandleTypeDef *hexti, EXTI_ConfigT
       assert_param(IS_EXTI_GPIO_PIN(linepos));
 
       regval = SYSCFG->EXTICR[linepos >> 2u];
-      pExtiConfig->GPIOSel = ((regval << (SYSCFG_EXTICR1_EXTI1_Pos * (3uL - (linepos & 0x03u)))) >> 24);
+      pExtiConfig->GPIOSel = (regval >> (SYSCFG_EXTICR1_EXTI1_Pos * (linepos & 0x03u))) & SYSCFG_EXTICR1_EXTI0;
     }
-    else
-    {
-      pExtiConfig->GPIOSel = 0x00u;
-    }
-  }
-  else
-  {
-    pExtiConfig->Trigger = EXTI_TRIGGER_NONE;
-    pExtiConfig->GPIOSel = 0x00u;
   }
 
   return HAL_OK;
@@ -433,7 +423,8 @@ HAL_StatusTypeDef HAL_EXTI_ClearConfigLine(EXTI_HandleTypeDef *hexti)
   * @param  pPendingCbfn function pointer to be stored as callback.
   * @retval HAL Status.
   */
-HAL_StatusTypeDef HAL_EXTI_RegisterCallback(EXTI_HandleTypeDef *hexti, EXTI_CallbackIDTypeDef CallbackID, void (*pPendingCbfn)(void))
+HAL_StatusTypeDef HAL_EXTI_RegisterCallback(EXTI_HandleTypeDef *hexti, EXTI_CallbackIDTypeDef CallbackID,
+                                            void (*pPendingCbfn)(void))
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -484,8 +475,8 @@ HAL_StatusTypeDef HAL_EXTI_GetHandle(EXTI_HandleTypeDef *hexti, uint32_t ExtiLin
   */
 
 /** @addtogroup EXTI_Exported_Functions_Group2
- *  @brief EXTI IO functions.
- *
+  *  @brief EXTI IO functions.
+  *
 @verbatim
  ===============================================================================
                        ##### IO operation functions #####
@@ -540,6 +531,9 @@ void HAL_EXTI_IRQHandler(EXTI_HandleTypeDef *hexti)
   */
 uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
 {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Edge);
+
   __IO uint32_t *regaddr;
   uint32_t regval;
   uint32_t linepos;
@@ -549,7 +543,6 @@ uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   /* Check parameters */
   assert_param(IS_EXTI_LINE(hexti->Line));
   assert_param(IS_EXTI_CONFIG_LINE(hexti->Line));
-  assert_param(IS_EXTI_PENDING_EDGE(Edge));
 
   /* compute line register offset and line mask */
   offset = ((hexti->Line & EXTI_REG_MASK) >> EXTI_REG_SHIFT);
@@ -576,6 +569,9 @@ uint32_t HAL_EXTI_GetPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   */
 void HAL_EXTI_ClearPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
 {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Edge);
+
   __IO uint32_t *regaddr;
   uint32_t maskline;
   uint32_t offset;
@@ -583,7 +579,6 @@ void HAL_EXTI_ClearPending(EXTI_HandleTypeDef *hexti, uint32_t Edge)
   /* Check parameters */
   assert_param(IS_EXTI_LINE(hexti->Line));
   assert_param(IS_EXTI_CONFIG_LINE(hexti->Line));
-  assert_param(IS_EXTI_PENDING_EDGE(Edge));
 
   /* compute line register offset and line mask */
   offset = ((hexti->Line & EXTI_REG_MASK) >> EXTI_REG_SHIFT);
@@ -637,5 +632,3 @@ void HAL_EXTI_GenerateSWI(EXTI_HandleTypeDef *hexti)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash.c
@@ -8,7 +8,17 @@
   *           + Program operations functions
   *           + Memory Control functions
   *           + Peripheral Errors functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
  @verbatim
   ==============================================================================
                         ##### FLASH peripheral features #####
@@ -76,17 +86,6 @@
 
  @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -116,8 +115,8 @@
 /* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /** @defgroup FLASH_Private_Variables FLASH Private Variables
- * @{
- */
+  * @{
+  */
 /**
   * @brief  Variable used for Program/Erase sectors under interruption
   */
@@ -134,8 +133,8 @@ FLASH_ProcessTypeDef pFlash = {.Lock = HAL_UNLOCKED, \
 
 /* Private function prototypes -----------------------------------------------*/
 /** @defgroup FLASH_Private_Functions FLASH Private Functions
- * @{
- */
+  * @{
+  */
 static void          FLASH_Program_DoubleWord(uint32_t Address, uint64_t Data);
 static void          FLASH_Program_Fast(uint32_t Address, uint32_t DataAddress);
 /**
@@ -148,8 +147,8 @@ static void          FLASH_Program_Fast(uint32_t Address, uint32_t DataAddress);
   */
 
 /** @defgroup FLASH_Exported_Functions_Group1 Programming operation functions
- *  @brief   Programming operation functions
- *
+  *  @brief   Programming operation functions
+  *
 @verbatim
  ===============================================================================
                   ##### Programming operation functions #####
@@ -312,7 +311,7 @@ void HAL_FLASH_IRQHandler(void)
   /* check operation was a program or erase */
   if ((pFlash.ProcedureOnGoing & (FLASH_TYPEPROGRAM_DOUBLEWORD | FLASH_TYPEPROGRAM_FAST)) != 0U)
   {
-    /* return adress being programmed */
+    /* return address being programmed */
     param = pFlash.Address;
   }
   else if ((pFlash.ProcedureOnGoing & (FLASH_TYPEERASE_PAGES)) != 0U)
@@ -425,8 +424,8 @@ __weak void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue)
   */
 
 /** @defgroup FLASH_Exported_Functions_Group2 Peripheral Control functions
- *  @brief   Management functions
- *
+  *  @brief   Management functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral Control functions #####
@@ -550,8 +549,8 @@ HAL_StatusTypeDef HAL_FLASH_OB_Launch(void)
   */
 
 /** @defgroup FLASH_Exported_Functions_Group3 Peripheral State and Errors functions
- *  @brief   Peripheral Errors functions
- *
+  *  @brief   Peripheral Errors functions
+  *
 @verbatim
  ===============================================================================
                 ##### Peripheral Errors functions #####
@@ -626,6 +625,19 @@ HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
   {
     /* Clear FLASH End of Operation pending bit */
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP);
+  }
+
+  /* Workaround for BZ 70309 :
+     - OPTVERR is always set at power-up due to failure of engi bytes checking
+     - FLASH_WaitForLastOperation() is called at the beginning of erase or program
+       operations, so the bit will be clear when performing first operation */
+  if ((error & FLASH_FLAG_OPTVERR) != 0U)
+  {
+    /* Clear FLASH OPTVERR bit */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPTVERR);
+
+    /* Clear OPTVERR bit in "error" variable to not treat it as error */
+    error &= ~FLASH_FLAG_OPTVERR;
   }
 
   /* Now update error variable to only error value */
@@ -703,8 +715,7 @@ static __RAM_FUNC void FLASH_Program_Fast(uint32_t Address, uint32_t DataAddress
     dest_addr++;
     src_addr++;
     row_index--;
-  }
-  while (row_index != 0U);
+  } while (row_index != 0U);
 
   /* wait for BSY in order to be sure that flash operation is ended before
      allowing prefetch in flash. Timeout does not return status, as it will
@@ -730,5 +741,3 @@ static __RAM_FUNC void FLASH_Program_Fast(uint32_t Address, uint32_t DataAddress
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash_ex.c
@@ -6,7 +6,17 @@
   *          This file provides firmware functions to manage the following
   *          functionalities of the FLASH extended peripheral:
   *           + Extended programming operations functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
  @verbatim
  ==============================================================================
                    ##### Flash Extended features #####
@@ -63,17 +73,6 @@
 
  @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -96,22 +95,25 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /** @defgroup FLASHEx_Private_Functions FLASHEx Private Functions
- * @{
- */
+  * @{
+  */
 static void              FLASH_AcknowledgePageErase(void);
 static void              FLASH_FlushCaches(void);
 static void              FLASH_OB_WRPConfig(uint32_t WRPArea, uint32_t WRPStartOffset, uint32_t WRDPEndOffset);
 static void              FLASH_OB_OptrConfig(uint32_t UserType, uint32_t UserConfig, uint32_t RDPLevel);
-static void              FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAddr, uint32_t PCROP1AEndAddr);
+static void              FLASH_OB_PCROP1AConfig(uint32_t PCROPConfig, uint32_t PCROP1AStartAddr,
+                                                uint32_t PCROP1AEndAddr);
 static void              FLASH_OB_PCROP1BConfig(uint32_t PCROP1BStartAddr, uint32_t PCROP1BEndAddr);
 static void              FLASH_OB_IPCCBufferAddrConfig(uint32_t IPCCDataBufAddr);
 static void              FLASH_OB_SecureConfig(FLASH_OBProgramInitTypeDef *pOBParam);
 static void              FLASH_OB_GetWRP(uint32_t WRPArea, uint32_t *WRPStartOffset, uint32_t *WRDPEndOffset);
 static uint32_t          FLASH_OB_GetRDP(void);
 static uint32_t          FLASH_OB_GetUser(void);
-static void              FLASH_OB_GetPCROP(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr, uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr);
+static void              FLASH_OB_GetPCROP(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr,
+                                           uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr);
 static uint32_t          FLASH_OB_GetIPCCBufferAddr(void);
-static void              FLASH_OB_GetSecureMemoryConfig(uint32_t *SecureFlashStartAddr, uint32_t *SecureRAM2aStartAddr, uint32_t *SecureRAM2bStartAddr, uint32_t *SecureMode);
+static void              FLASH_OB_GetSecureMemoryConfig(uint32_t *SecureFlashStartAddr, uint32_t *SecureRAM2aStartAddr,
+                                                        uint32_t *SecureRAM2bStartAddr, uint32_t *SecureMode);
 static void              FLASH_OB_GetC2BootResetConfig(uint32_t *C2BootResetVectAddr, uint32_t *C2BootResetRegion);
 static HAL_StatusTypeDef FLASH_OB_ProceedWriteOperation(void);
 /**
@@ -124,8 +126,8 @@ static HAL_StatusTypeDef FLASH_OB_ProceedWriteOperation(void);
   */
 
 /** @defgroup FLASHEx_Exported_Functions_Group1 Extended IO operation functions
- *  @brief   Extended IO operation functions
- *
+  *  @brief   Extended IO operation functions
+  *
 @verbatim
  ===============================================================================
                 ##### Extended programming operation functions #####
@@ -289,7 +291,7 @@ HAL_StatusTypeDef HAL_FLASHEx_OBProgram(FLASH_OBProgramInitTypeDef *pOBInit)
   /* Option register */
   if ((pOBInit->OptionType & (OPTIONBYTE_RDP | OPTIONBYTE_USER)) == (OPTIONBYTE_RDP | OPTIONBYTE_USER))
   {
-    /* Fully modify OPTR register with RDP & user datas */
+    /* Fully modify OPTR register with RDP & user data */
     FLASH_OB_OptrConfig(pOBInit->UserType, pOBInit->UserConfig, pOBInit->RDPLevel);
   }
   else if ((pOBInit->OptionType & OPTIONBYTE_RDP) != 0U)
@@ -385,14 +387,16 @@ void HAL_FLASHEx_OBGetConfig(FLASH_OBProgramInitTypeDef *pOBInit)
   pOBInit->UserType = OB_USER_ALL;
 
   /* Get the Zone 1A and 1B Proprietary code readout protection */
-  FLASH_OB_GetPCROP(&(pOBInit->PCROPConfig), &(pOBInit->PCROP1AStartAddr), &(pOBInit->PCROP1AEndAddr), &(pOBInit->PCROP1BStartAddr), &(pOBInit->PCROP1BEndAddr));
+  FLASH_OB_GetPCROP(&(pOBInit->PCROPConfig), &(pOBInit->PCROP1AStartAddr), &(pOBInit->PCROP1AEndAddr),
+                    &(pOBInit->PCROP1BStartAddr), &(pOBInit->PCROP1BEndAddr));
   pOBInit->PCROPConfig |= (OB_PCROP_ZONE_A | OB_PCROP_ZONE_B);
 
   /* Get the IPCC start Address */
   pOBInit->IPCCdataBufAddr = FLASH_OB_GetIPCCBufferAddr();
 
   /* Get the Secure Flash start address, Secure Backup RAM2a start address, Secure non-Backup RAM2b start address and the Security Mode, */
-  FLASH_OB_GetSecureMemoryConfig(&(pOBInit->SecureFlashStartAddr), &(pOBInit->SecureRAM2aStartAddr), &(pOBInit->SecureRAM2bStartAddr), &(pOBInit->SecureMode));
+  FLASH_OB_GetSecureMemoryConfig(&(pOBInit->SecureFlashStartAddr), &(pOBInit->SecureRAM2aStartAddr),
+                                 &(pOBInit->SecureRAM2bStartAddr), &(pOBInit->SecureMode));
 
   /* Get the M0+ Secure Boot reset vector and Secure Boot memory selection */
   FLASH_OB_GetC2BootResetConfig(&(pOBInit->C2SecureBootVectAddr), &(pOBInit->C2BootRegion));
@@ -778,7 +782,7 @@ static void FLASH_OB_SecureConfig(FLASH_OBProgramInitTypeDef *pOBParam)
     MODIFY_REG(srrvr_reg_val, (FLASH_SRRVR_SBRSA | FLASH_SRRVR_SNBRSA), \
                (((((pOBParam->SecureRAM2aStartAddr - SRAM2A_BASE) >> SRAM_SECURE_PAGE_GRANULARITY_OFFSET) << FLASH_SRRVR_SBRSA_Pos)) | \
                 ((((pOBParam->SecureRAM2bStartAddr - SRAM2B_BASE) >> SRAM_SECURE_PAGE_GRANULARITY_OFFSET) << FLASH_SRRVR_SNBRSA_Pos))));
-#endif
+#endif /* FLASH_SRRVR_SBRSA_A */
 
     /* If Full System Secure mode is requested, clear all the corresponding bit */
     /* Else set the corresponding bit */
@@ -789,7 +793,7 @@ static void FLASH_OB_SecureConfig(FLASH_OBProgramInitTypeDef *pOBParam)
       CLEAR_BIT(srrvr_reg_val, (FLASH_SRRVR_BRSD_A | FLASH_SRRVR_BRSD_B));
 #else
       CLEAR_BIT(srrvr_reg_val, (FLASH_SRRVR_BRSD | FLASH_SRRVR_NBRSD));
-#endif
+#endif /* FLASH_SRRVR_BRSD_A */
     }
     else
     {
@@ -798,7 +802,7 @@ static void FLASH_OB_SecureConfig(FLASH_OBProgramInitTypeDef *pOBParam)
       SET_BIT(srrvr_reg_val, (FLASH_SRRVR_BRSD_A | FLASH_SRRVR_BRSD_B));
 #else
       SET_BIT(srrvr_reg_val, (FLASH_SRRVR_BRSD | FLASH_SRRVR_NBRSD));
-#endif
+#endif /* FLASH_SRRVR_BRSD_A */
     }
 
     /* Update Flash registers */
@@ -815,11 +819,13 @@ static void FLASH_OB_SecureConfig(FLASH_OBProgramInitTypeDef *pOBParam)
     /* Set the boot vector */
     if (pOBParam->C2BootRegion == OB_C2_BOOT_FROM_FLASH)
     {
-      MODIFY_REG(srrvr_reg_val, (FLASH_SRRVR_SBRV | FLASH_SRRVR_C2OPT), (((pOBParam->C2SecureBootVectAddr - FLASH_BASE) >> 2) | pOBParam->C2BootRegion));
+      MODIFY_REG(srrvr_reg_val, (FLASH_SRRVR_SBRV | FLASH_SRRVR_C2OPT),
+                 (((pOBParam->C2SecureBootVectAddr - FLASH_BASE) >> 2) | pOBParam->C2BootRegion));
     }
     else
     {
-      MODIFY_REG(srrvr_reg_val, (FLASH_SRRVR_SBRV | FLASH_SRRVR_C2OPT), (((pOBParam->C2SecureBootVectAddr - SRAM1_BASE) >> 2) | pOBParam->C2BootRegion));
+      MODIFY_REG(srrvr_reg_val, (FLASH_SRRVR_SBRV | FLASH_SRRVR_C2OPT),
+                 (((pOBParam->C2SecureBootVectAddr - SRAM1_BASE) >> 2) | pOBParam->C2BootRegion));
     }
   }
 
@@ -920,7 +926,8 @@ static uint32_t FLASH_OB_GetUser(void)
   *                       the Zone 1B Proprietary code readout protection
   * @retval None
   */
-static void FLASH_OB_GetPCROP(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr, uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr)
+static void FLASH_OB_GetPCROP(uint32_t *PCROPConfig, uint32_t *PCROP1AStartAddr, uint32_t *PCROP1AEndAddr,
+                              uint32_t *PCROP1BStartAddr, uint32_t *PCROP1BEndAddr)
 {
   uint32_t pcrop;
 
@@ -959,7 +966,8 @@ static uint32_t FLASH_OB_GetIPCCBufferAddr(void)
   *                              @arg @ref SYSTEM_NOT_IN_SECURE_MODE : Security disabled
   * @retval None
   */
-static void FLASH_OB_GetSecureMemoryConfig(uint32_t *SecureFlashStartAddr, uint32_t *SecureRAM2aStartAddr, uint32_t *SecureRAM2bStartAddr, uint32_t *SecureMode)
+static void FLASH_OB_GetSecureMemoryConfig(uint32_t *SecureFlashStartAddr, uint32_t *SecureRAM2aStartAddr,
+                                           uint32_t *SecureRAM2bStartAddr, uint32_t *SecureMode)
 {
   uint32_t sfr_reg_val = READ_REG(FLASH->SFR);
   uint32_t srrvr_reg_val = READ_REG(FLASH->SRRVR);
@@ -974,7 +982,7 @@ static void FLASH_OB_GetSecureMemoryConfig(uint32_t *SecureFlashStartAddr, uint3
   user_config = (READ_BIT(srrvr_reg_val, FLASH_SRRVR_SBRSA_A) >> FLASH_SRRVR_SBRSA_A_Pos);
 #else
   user_config = (READ_BIT(srrvr_reg_val, FLASH_SRRVR_SBRSA) >> FLASH_SRRVR_SBRSA_Pos);
-#endif
+#endif /* FLASH_SRRVR_SBRSA_A */
 
   *SecureRAM2aStartAddr = ((user_config << SRAM_SECURE_PAGE_GRANULARITY_OFFSET) + SRAM2A_BASE);
 
@@ -983,7 +991,7 @@ static void FLASH_OB_GetSecureMemoryConfig(uint32_t *SecureFlashStartAddr, uint3
   user_config = (READ_BIT(srrvr_reg_val, FLASH_SRRVR_SBRSA_B) >> FLASH_SRRVR_SBRSA_B_Pos);
 #else
   user_config = (READ_BIT(srrvr_reg_val, FLASH_SRRVR_SNBRSA) >> FLASH_SRRVR_SNBRSA_Pos);
-#endif
+#endif /* FLASH_SRRVR_SBRSA_B */
 
   *SecureRAM2bStartAddr = ((user_config << SRAM_SECURE_PAGE_GRANULARITY_OFFSET) + SRAM2B_BASE);
 
@@ -1051,5 +1059,3 @@ static HAL_StatusTypeDef FLASH_OB_ProceedWriteOperation(void)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_gpio.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_gpio.c
@@ -7,7 +7,17 @@
   *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
   *           + Initialization and de-initialization functions
   *           + IO operation functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                     ##### GPIO Peripheral features #####
@@ -73,6 +83,9 @@
     (#) To set/reset the level of a pin configured in output mode use
         HAL_GPIO_WritePin()/HAL_GPIO_TogglePin().
 
+    (#) To set the level of several pins and reset level of several other pins in
+        same cycle, use HAL_GPIO_WriteMultipleStatePin().
+
    (#) To lock pin configuration until next reset use HAL_GPIO_LockPin().
 
     (#) During and just after reset, the alternate functions are not
@@ -88,17 +101,6 @@
         The HSE has priority over the GPIO function.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -123,17 +125,9 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private defines ------------------------------------------------------------*/
-/** @defgroup GPIO_Private_Constants GPIO Private Constants
+/** @addtogroup GPIO_Private_Constants GPIO Private Constants
   * @{
   */
-#define GPIO_MODE             (0x00000003u)
-#define EXTI_MODE             (0x10000000u)
-#define GPIO_MODE_IT          (0x00010000u)
-#define GPIO_MODE_EVT         (0x00020000u)
-#define RISING_EDGE           (0x00100000u)
-#define FALLING_EDGE          (0x00200000u)
-#define GPIO_OUTPUT_TYPE      (0x00000010u)
-
 #define GPIO_NUMBER           (16u)
 /**
   * @}
@@ -149,8 +143,8 @@
   */
 
 /** @addtogroup GPIO_Exported_Functions_Group1
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
@@ -189,8 +183,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
     {
       /*--------------------- GPIO Mode Configuration ------------------------*/
       /* In case of Output or Alternate function mode selection */
-      if((GPIO_Init->Mode == GPIO_MODE_OUTPUT_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_PP) ||
-         (GPIO_Init->Mode == GPIO_MODE_OUTPUT_OD) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      if (((GPIO_Init->Mode & GPIO_MODE) == MODE_OUTPUT) || ((GPIO_Init->Mode & GPIO_MODE) == MODE_AF))
       {
         /* Check the Speed parameter */
         assert_param(IS_GPIO_SPEED(GPIO_Init->Speed));
@@ -203,18 +196,21 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         /* Configure the IO Output Type */
         temp = GPIOx->OTYPER;
         temp &= ~(GPIO_OTYPER_OT0 << position) ;
-        temp |= (((GPIO_Init->Mode & GPIO_OUTPUT_TYPE) >> 4u) << position);
+        temp |= (((GPIO_Init->Mode & OUTPUT_TYPE) >> OUTPUT_TYPE_Pos) << position);
         GPIOx->OTYPER = temp;
       }
 
       /* Activate the Pull-up or Pull down resistor for the current IO */
-      temp = GPIOx->PUPDR;
-      temp &= ~(GPIO_PUPDR_PUPD0 << (position * 2u));
-      temp |= ((GPIO_Init->Pull) << (position * 2u));
-      GPIOx->PUPDR = temp;
+      if ((GPIO_Init->Mode & GPIO_MODE) != MODE_ANALOG)
+      {
+        temp = GPIOx->PUPDR;
+        temp &= ~(GPIO_PUPDR_PUPD0 << (position * 2U));
+        temp |= ((GPIO_Init->Pull) << (position * 2U));
+        GPIOx->PUPDR = temp;
+      }
 
       /* In case of Alternate function mode selection */
-      if((GPIO_Init->Mode == GPIO_MODE_AF_PP) || (GPIO_Init->Mode == GPIO_MODE_AF_OD))
+      if ((GPIO_Init->Mode & GPIO_MODE) == MODE_AF)
       {
         /* Check the Alternate function parameters */
         assert_param(IS_GPIO_AF_INSTANCE(GPIOx));
@@ -235,34 +231,17 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
 
       /*--------------------- EXTI Mode Configuration ------------------------*/
       /* Configure the External Interrupt or event for the current IO */
-      if((GPIO_Init->Mode & EXTI_MODE) == EXTI_MODE)
+      if ((GPIO_Init->Mode & EXTI_MODE) != 0x00u)
       {
         temp = SYSCFG->EXTICR[position >> 2u];
         temp &= ~(0x0FuL << (4u * (position & 0x03u)));
         temp |= (GPIO_GET_INDEX(GPIOx) << (4u * (position & 0x03u)));
         SYSCFG->EXTICR[position >> 2u] = temp;
 
-        /* Clear EXTI line configuration */
-        temp = EXTI->IMR1;
-        temp &= ~(iocurrent);
-        if((GPIO_Init->Mode & GPIO_MODE_IT) == GPIO_MODE_IT)
-        {
-          temp |= iocurrent;
-        }
-        EXTI->IMR1 = temp;
-
-        temp = EXTI->EMR1;
-        temp &= ~(iocurrent);
-        if((GPIO_Init->Mode & GPIO_MODE_EVT) == GPIO_MODE_EVT)
-        {
-          temp |= iocurrent;
-        }
-        EXTI->EMR1 = temp;
-
         /* Clear Rising Falling edge configuration */
         temp = EXTI->RTSR1;
         temp &= ~(iocurrent);
-        if((GPIO_Init->Mode & RISING_EDGE) == RISING_EDGE)
+        if ((GPIO_Init->Mode & TRIGGER_RISING) != 0x00u)
         {
           temp |= iocurrent;
         }
@@ -270,11 +249,28 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
 
         temp = EXTI->FTSR1;
         temp &= ~(iocurrent);
-        if((GPIO_Init->Mode & FALLING_EDGE) == FALLING_EDGE)
+        if ((GPIO_Init->Mode & TRIGGER_FALLING) != 0x00u)
         {
           temp |= iocurrent;
         }
         EXTI->FTSR1 = temp;
+
+        /* Clear EXTI line configuration */
+        temp = EXTI->IMR1;
+        temp &= ~(iocurrent);
+        if ((GPIO_Init->Mode & EXTI_IT) != 0x00u)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->IMR1 = temp;
+
+        temp = EXTI->EMR1;
+        temp &= ~(iocurrent);
+        if ((GPIO_Init->Mode & EXTI_EVT) != 0x00u)
+        {
+          temp |= iocurrent;
+        }
+        EXTI->EMR1 = temp;
       }
     }
 
@@ -352,8 +348,8 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   */
 
 /** @addtogroup GPIO_Exported_Functions_Group2
- *  @brief GPIO Read, Write, Toggle, Lock and EXTI management functions.
- *
+  *  @brief GPIO Read, Write, Toggle, Lock and EXTI management functions.
+  *
 @verbatim
  ===============================================================================
                        ##### IO operation functions #####
@@ -370,7 +366,7 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   *         This parameter can be GPIO_PIN_x where x can be (0..15).
   * @retval The input port pin value.
   */
-GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
   GPIO_PinState bitstatus;
 
@@ -390,11 +386,9 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 
 /**
   * @brief  Set or clear the selected data port bit.
-  *
   * @note   This function uses GPIOx_BSRR and GPIOx_BRR registers to allow atomic read/modify
   *         accesses. In this way, there is no risk of an IRQ occurring between
   *         the read and the modify access.
-  *
   * @param GPIOx where x can be (A..F) to select the GPIO peripheral for STM32WBxx family
   * @param GPIO_Pin specifies the port bit to be written.
   *         This parameter can be one of GPIO_PIN_x where x can be (0..15).
@@ -404,13 +398,13 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   *            @arg GPIO_PIN_SET: to set the port pin
   * @retval None
   */
-void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
+void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
 {
   /* Check the parameters */
   assert_param(IS_GPIO_PIN(GPIO_Pin));
   assert_param(IS_GPIO_PIN_ACTION(PinState));
 
-  if(PinState != GPIO_PIN_RESET)
+  if (PinState != GPIO_PIN_RESET)
   {
     GPIOx->BSRR = (uint32_t)GPIO_Pin;
   }
@@ -421,19 +415,46 @@ void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState Pin
 }
 
 /**
+  * @brief  Set and clear several pins of a dedicated port in same cycle.
+  * @note   This function uses GPIOx_BSRR and GPIOx_BRR registers to allow atomic read/modify
+  *         accesses.
+  * @param  GPIOx where x can be (A..F) to select the GPIO peripheral for STM32WLxx family
+  * @param  PinReset specifies the port bits to be reset
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15) or zero.
+  * @param  PinSet specifies the port bits to be set
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15) or zero.
+  * @note   Both PinReset and PinSet combinations shall not get any common bit, else
+  *         assert would be triggered.
+  * @note   At least one of the two parameters used to set or reset shall be different from zero.
+  * @retval None
+  */
+void HAL_GPIO_WriteMultipleStatePin(GPIO_TypeDef *GPIOx, uint16_t PinReset, uint16_t PinSet)
+{
+  uint32_t tmp;
+
+  /* Check the parameters */
+  /* Make sure at least one parameter is different from zero and that there is no common pin */
+  assert_param(IS_GPIO_PIN((uint32_t)PinReset | (uint32_t)PinSet));
+  assert_param(IS_GPIO_COMMON_PIN(PinReset, PinSet));
+
+  tmp = (((uint32_t)PinReset << 16) | PinSet);
+  GPIOx->BSRR = tmp;
+}
+
+/**
   * @brief  Toggle the specified GPIO pin.
   * @param GPIOx where x can be (A..H) to select the GPIO peripheral for STM32WBxx family
   * @param GPIO_Pin specifies the pin to be toggled.
   * @retval None
   */
-void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+void HAL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
   uint32_t odr;
 
   /* Check the parameters */
   assert_param(IS_GPIO_PIN(GPIO_Pin));
 
-  /* get current Ouput Data Register value */
+  /* get current Output Data Register value */
   odr = GPIOx->ODR;
 
   /* Set selected pins that were at low level, and reset ones that were high */
@@ -441,17 +462,17 @@ void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 }
 
 /**
-* @brief  Lock GPIO Pins configuration registers.
+  * @brief  Lock GPIO Pins configuration registers.
   * @note   The locked registers are GPIOx_MODER, GPIOx_OTYPER, GPIOx_OSPEEDR,
   *         GPIOx_PUPDR, GPIOx_AFRL and GPIOx_AFRH.
   * @note   The configuration of the locked GPIO pins can no longer be modified
   *         until the next reset.
   * @param GPIOx where x can be (A..H) to select the GPIO peripheral for STM32WBxx family
   * @param GPIO_Pin specifies the port bits to be locked.
-  *         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval None
   */
-HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
   __IO uint32_t tmp = GPIO_LCKR_LCKK;
 
@@ -489,7 +510,7 @@ HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin)
 {
   /* EXTI line interrupt detected */
-  if(__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != 0x00u)
+  if (__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != 0x00u)
   {
     __HAL_GPIO_EXTI_CLEAR_IT(GPIO_Pin);
     HAL_GPIO_EXTI_Callback(GPIO_Pin);
@@ -528,5 +549,3 @@ __weak void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_hsem.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_hsem.c
@@ -14,6 +14,17 @@
   *           + IRQ handler management
   *
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -70,17 +81,6 @@
       (+) __HAL_HSEM_CLEAR_FLAG: Clear the semaphores status release flags.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -367,5 +367,3 @@ __weak void HAL_HSEM_FreeCallback(uint32_t SemMask)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c.c
@@ -9,6 +9,17 @@
   *           + IO operation functions
   *           + Peripheral State and Errors functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -19,7 +30,7 @@
     (#) Declare a I2C_HandleTypeDef handle structure, for example:
         I2C_HandleTypeDef  hi2c;
 
-    (#)Initialize the I2C low level resources by implementing the @ref HAL_I2C_MspInit() API:
+    (#)Initialize the I2C low level resources by implementing the HAL_I2C_MspInit() API:
         (##) Enable the I2Cx interface clock
         (##) I2C pins configuration
             (+++) Enable the clock for the I2C GPIOs
@@ -28,7 +39,8 @@
             (+++) Configure the I2Cx interrupt priority
             (+++) Enable the NVIC I2C IRQ Channel
         (##) DMA Configuration if you need to use DMA process
-            (+++) Declare a DMA_HandleTypeDef handle structure for the transmit or receive channel
+            (+++) Declare a DMA_HandleTypeDef handle structure for
+                  the transmit or receive channel
             (+++) Enable the DMAx interface clock using
             (+++) Configure the DMA handle parameters
             (+++) Configure the DMA Tx or Rx channel
@@ -39,49 +51,49 @@
     (#) Configure the Communication Clock Timing, Own Address1, Master Addressing mode, Dual Addressing mode,
         Own Address2, Own Address2 Mask, General call and Nostretch mode in the hi2c Init structure.
 
-    (#) Initialize the I2C registers by calling the @ref HAL_I2C_Init(), configures also the low level Hardware
-        (GPIO, CLOCK, NVIC...etc) by calling the customized @ref HAL_I2C_MspInit(&hi2c) API.
+    (#) Initialize the I2C registers by calling the HAL_I2C_Init(), configures also the low level Hardware
+        (GPIO, CLOCK, NVIC...etc) by calling the customized HAL_I2C_MspInit(&hi2c) API.
 
-    (#) To check if target device is ready for communication, use the function @ref HAL_I2C_IsDeviceReady()
+    (#) To check if target device is ready for communication, use the function HAL_I2C_IsDeviceReady()
 
     (#) For I2C IO and IO MEM operations, three operation modes are available within this driver :
 
     *** Polling mode IO operation ***
     =================================
     [..]
-      (+) Transmit in master mode an amount of data in blocking mode using @ref HAL_I2C_Master_Transmit()
-      (+) Receive in master mode an amount of data in blocking mode using @ref HAL_I2C_Master_Receive()
-      (+) Transmit in slave mode an amount of data in blocking mode using @ref HAL_I2C_Slave_Transmit()
-      (+) Receive in slave mode an amount of data in blocking mode using @ref HAL_I2C_Slave_Receive()
+      (+) Transmit in master mode an amount of data in blocking mode using HAL_I2C_Master_Transmit()
+      (+) Receive in master mode an amount of data in blocking mode using HAL_I2C_Master_Receive()
+      (+) Transmit in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Transmit()
+      (+) Receive in slave mode an amount of data in blocking mode using HAL_I2C_Slave_Receive()
 
     *** Polling mode IO MEM operation ***
     =====================================
     [..]
-      (+) Write an amount of data in blocking mode to a specific memory address using @ref HAL_I2C_Mem_Write()
-      (+) Read an amount of data in blocking mode from a specific memory address using @ref HAL_I2C_Mem_Read()
+      (+) Write an amount of data in blocking mode to a specific memory address using HAL_I2C_Mem_Write()
+      (+) Read an amount of data in blocking mode from a specific memory address using HAL_I2C_Mem_Read()
 
 
     *** Interrupt mode IO operation ***
     ===================================
     [..]
-      (+) Transmit in master mode an amount of data in non-blocking mode using @ref HAL_I2C_Master_Transmit_IT()
-      (+) At transmission end of transfer, @ref HAL_I2C_MasterTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MasterTxCpltCallback()
-      (+) Receive in master mode an amount of data in non-blocking mode using @ref HAL_I2C_Master_Receive_IT()
-      (+) At reception end of transfer, @ref HAL_I2C_MasterRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MasterRxCpltCallback()
-      (+) Transmit in slave mode an amount of data in non-blocking mode using @ref HAL_I2C_Slave_Transmit_IT()
-      (+) At transmission end of transfer, @ref HAL_I2C_SlaveTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_SlaveTxCpltCallback()
-      (+) Receive in slave mode an amount of data in non-blocking mode using @ref HAL_I2C_Slave_Receive_IT()
-      (+) At reception end of transfer, @ref HAL_I2C_SlaveRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_SlaveRxCpltCallback()
-      (+) In case of transfer Error, @ref HAL_I2C_ErrorCallback() function is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_ErrorCallback()
-      (+) Abort a master I2C process communication with Interrupt using @ref HAL_I2C_Master_Abort_IT()
-      (+) End of abort process, @ref HAL_I2C_AbortCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_AbortCpltCallback()
-      (+) Discard a slave I2C process communication using @ref __HAL_I2C_GENERATE_NACK() macro.
+      (+) Transmit in master mode an amount of data in non-blocking mode using HAL_I2C_Master_Transmit_IT()
+      (+) At transmission end of transfer, HAL_I2C_MasterTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MasterTxCpltCallback()
+      (+) Receive in master mode an amount of data in non-blocking mode using HAL_I2C_Master_Receive_IT()
+      (+) At reception end of transfer, HAL_I2C_MasterRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
+      (+) Transmit in slave mode an amount of data in non-blocking mode using HAL_I2C_Slave_Transmit_IT()
+      (+) At transmission end of transfer, HAL_I2C_SlaveTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback()
+      (+) Receive in slave mode an amount of data in non-blocking mode using HAL_I2C_Slave_Receive_IT()
+      (+) At reception end of transfer, HAL_I2C_SlaveRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
+           add their own code by customization of function pointer HAL_I2C_ErrorCallback()
+      (+) Abort a master or memory I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
+      (+) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
            This action will inform Master to generate a Stop condition to discard the communication.
 
 
@@ -92,120 +104,135 @@
           when a direction change during transfer
     [..]
       (+) A specific option field manage the different steps of a sequential transfer
-      (+) Option field values are defined through @ref I2C_XFEROPTIONS and are listed below:
-      (++) I2C_FIRST_AND_LAST_FRAME: No sequential usage, functional is same as associated interfaces in no sequential mode
+      (+) Option field values are defined through I2C_XFEROPTIONS and are listed below:
+      (++) I2C_FIRST_AND_LAST_FRAME: No sequential usage, functional is same as associated interfaces in
+           no sequential mode
       (++) I2C_FIRST_FRAME: Sequential usage, this option allow to manage a sequence with start condition, address
                             and data to transfer without a final stop condition
-      (++) I2C_FIRST_AND_NEXT_FRAME: Sequential usage (Master only), this option allow to manage a sequence with start condition, address
-                            and data to transfer without a final stop condition, an then permit a call the same master sequential interface
-                            several times (like @ref HAL_I2C_Master_Seq_Transmit_IT() then @ref HAL_I2C_Master_Seq_Transmit_IT()
-                            or @ref HAL_I2C_Master_Seq_Transmit_DMA() then @ref HAL_I2C_Master_Seq_Transmit_DMA())
+      (++) I2C_FIRST_AND_NEXT_FRAME: Sequential usage (Master only), this option allow to manage a sequence with
+                            start condition, address and data to transfer without a final stop condition,
+                            an then permit a call the same master sequential interface several times
+                            (like HAL_I2C_Master_Seq_Transmit_IT() then HAL_I2C_Master_Seq_Transmit_IT()
+                            or HAL_I2C_Master_Seq_Transmit_DMA() then HAL_I2C_Master_Seq_Transmit_DMA())
       (++) I2C_NEXT_FRAME: Sequential usage, this option allow to manage a sequence with a restart condition, address
-                            and with new data to transfer if the direction change or manage only the new data to transfer
+                            and with new data to transfer if the direction change or manage only the new data to
+                            transfer
                             if no direction change and without a final stop condition in both cases
       (++) I2C_LAST_FRAME: Sequential usage, this option allow to manage a sequance with a restart condition, address
-                            and with new data to transfer if the direction change or manage only the new data to transfer
+                            and with new data to transfer if the direction change or manage only the new data to
+                            transfer
                             if no direction change and with a final stop condition in both cases
-      (++) I2C_LAST_FRAME_NO_STOP: Sequential usage (Master only), this option allow to manage a restart condition after several call of the same master sequential
-                            interface several times (link with option I2C_FIRST_AND_NEXT_FRAME).
-                            Usage can, transfer several bytes one by one using HAL_I2C_Master_Seq_Transmit_IT(option I2C_FIRST_AND_NEXT_FRAME then I2C_NEXT_FRAME)
-                              or HAL_I2C_Master_Seq_Receive_IT(option I2C_FIRST_AND_NEXT_FRAME then I2C_NEXT_FRAME)
-                              or HAL_I2C_Master_Seq_Transmit_DMA(option I2C_FIRST_AND_NEXT_FRAME then I2C_NEXT_FRAME)
-                              or HAL_I2C_Master_Seq_Receive_DMA(option I2C_FIRST_AND_NEXT_FRAME then I2C_NEXT_FRAME).
-                            Then usage of this option I2C_LAST_FRAME_NO_STOP at the last Transmit or Receive sequence permit to call the opposite interface Receive or Transmit
+      (++) I2C_LAST_FRAME_NO_STOP: Sequential usage (Master only), this option allow to manage a restart condition
+                            after several call of the same master sequential interface several times
+                            (link with option I2C_FIRST_AND_NEXT_FRAME).
+                            Usage can, transfer several bytes one by one using
+                              HAL_I2C_Master_Seq_Transmit_IT
+                              or HAL_I2C_Master_Seq_Receive_IT
+                              or HAL_I2C_Master_Seq_Transmit_DMA
+                              or HAL_I2C_Master_Seq_Receive_DMA
+                              with option I2C_FIRST_AND_NEXT_FRAME then I2C_NEXT_FRAME.
+                             Then usage of this option I2C_LAST_FRAME_NO_STOP at the last Transmit or
+                              Receive sequence permit to call the opposite interface Receive or Transmit
                               without stopping the communication and so generate a restart condition.
-      (++) I2C_OTHER_FRAME: Sequential usage (Master only), this option allow to manage a restart condition after each call of the same master sequential
+      (++) I2C_OTHER_FRAME: Sequential usage (Master only), this option allow to manage a restart condition after
+                            each call of the same master sequential
                             interface.
-                            Usage can, transfer several bytes one by one with a restart with slave address between each bytes using HAL_I2C_Master_Seq_Transmit_IT(option I2C_FIRST_FRAME then I2C_OTHER_FRAME)
-                              or HAL_I2C_Master_Seq_Receive_IT(option I2C_FIRST_FRAME then I2C_OTHER_FRAME)
-                              or HAL_I2C_Master_Seq_Transmit_DMA(option I2C_FIRST_FRAME then I2C_OTHER_FRAME)
-                              or HAL_I2C_Master_Seq_Receive_DMA(option I2C_FIRST_FRAME then I2C_OTHER_FRAME).
-                            Then usage of this option I2C_OTHER_AND_LAST_FRAME at the last frame to help automatic generation of STOP condition.
+                            Usage can, transfer several bytes one by one with a restart with slave address between
+                            each bytes using
+                              HAL_I2C_Master_Seq_Transmit_IT
+                              or HAL_I2C_Master_Seq_Receive_IT
+                              or HAL_I2C_Master_Seq_Transmit_DMA
+                              or HAL_I2C_Master_Seq_Receive_DMA
+                              with option I2C_FIRST_FRAME then I2C_OTHER_FRAME.
+                            Then usage of this option I2C_OTHER_AND_LAST_FRAME at the last frame to help automatic
+                            generation of STOP condition.
 
       (+) Different sequential I2C interfaces are listed below:
-      (++) Sequential transmit in master I2C mode an amount of data in non-blocking mode using @ref HAL_I2C_Master_Seq_Transmit_IT()
-            or using @ref HAL_I2C_Master_Seq_Transmit_DMA()
-      (+++) At transmission end of current frame transfer, @ref HAL_I2C_MasterTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MasterTxCpltCallback()
-      (++) Sequential receive in master I2C mode an amount of data in non-blocking mode using @ref HAL_I2C_Master_Seq_Receive_IT()
-            or using @ref HAL_I2C_Master_Seq_Receive_DMA()
-      (+++) At reception end of current frame transfer, @ref HAL_I2C_MasterRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MasterRxCpltCallback()
-      (++) Abort a master IT or DMA I2C process communication with Interrupt using @ref HAL_I2C_Master_Abort_IT()
-      (+++) End of abort process, @ref HAL_I2C_AbortCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_AbortCpltCallback()
-      (++) Enable/disable the Address listen mode in slave I2C mode using @ref HAL_I2C_EnableListen_IT() @ref HAL_I2C_DisableListen_IT()
-      (+++) When address slave I2C match, @ref HAL_I2C_AddrCallback() is executed and user can
-           add his own code to check the Address Match Code and the transmission direction request by master (Write/Read).
-      (+++) At Listen mode end @ref HAL_I2C_ListenCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_ListenCpltCallback()
-      (++) Sequential transmit in slave I2C mode an amount of data in non-blocking mode using @ref HAL_I2C_Slave_Seq_Transmit_IT()
-            or using @ref HAL_I2C_Slave_Seq_Transmit_DMA()
-      (+++) At transmission end of current frame transfer, @ref HAL_I2C_SlaveTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_SlaveTxCpltCallback()
-      (++) Sequential receive in slave I2C mode an amount of data in non-blocking mode using @ref HAL_I2C_Slave_Seq_Receive_IT()
-            or using @ref HAL_I2C_Slave_Seq_Receive_DMA()
-      (+++) At reception end of current frame transfer, @ref HAL_I2C_SlaveRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_SlaveRxCpltCallback()
-      (++) In case of transfer Error, @ref HAL_I2C_ErrorCallback() function is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_ErrorCallback()
-      (++) Discard a slave I2C process communication using @ref __HAL_I2C_GENERATE_NACK() macro.
+      (++) Sequential transmit in master I2C mode an amount of data in non-blocking mode using
+            HAL_I2C_Master_Seq_Transmit_IT() or using HAL_I2C_Master_Seq_Transmit_DMA()
+      (+++) At transmission end of current frame transfer, HAL_I2C_MasterTxCpltCallback() is executed and
+            users can add their own code by customization of function pointer HAL_I2C_MasterTxCpltCallback()
+      (++) Sequential receive in master I2C mode an amount of data in non-blocking mode using
+            HAL_I2C_Master_Seq_Receive_IT() or using HAL_I2C_Master_Seq_Receive_DMA()
+      (+++) At reception end of current frame transfer, HAL_I2C_MasterRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
+      (++) Abort a master or memory IT or DMA I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+++) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
+      (++) Enable/disable the Address listen mode in slave I2C mode using HAL_I2C_EnableListen_IT()
+            HAL_I2C_DisableListen_IT()
+      (+++) When address slave I2C match, HAL_I2C_AddrCallback() is executed and users can
+           add their own code to check the Address Match Code and the transmission direction request by master
+           (Write/Read).
+      (+++) At Listen mode end HAL_I2C_ListenCpltCallback() is executed and users can
+          add their own code by customization of function pointer HAL_I2C_ListenCpltCallback()
+      (++) Sequential transmit in slave I2C mode an amount of data in non-blocking mode using
+            HAL_I2C_Slave_Seq_Transmit_IT() or using HAL_I2C_Slave_Seq_Transmit_DMA()
+      (+++) At transmission end of current frame transfer, HAL_I2C_SlaveTxCpltCallback() is executed and
+            users can add their own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback()
+      (++) Sequential receive in slave I2C mode an amount of data in non-blocking mode using
+            HAL_I2C_Slave_Seq_Receive_IT() or using HAL_I2C_Slave_Seq_Receive_DMA()
+      (+++) At reception end of current frame transfer, HAL_I2C_SlaveRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
+      (++) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
+           add their own code by customization of function pointer HAL_I2C_ErrorCallback()
+      (++) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
            This action will inform Master to generate a Stop condition to discard the communication.
 
     *** Interrupt mode IO MEM operation ***
     =======================================
     [..]
       (+) Write an amount of data in non-blocking mode with Interrupt to a specific memory address using
-          @ref HAL_I2C_Mem_Write_IT()
-      (+) At Memory end of write transfer, @ref HAL_I2C_MemTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MemTxCpltCallback()
+          HAL_I2C_Mem_Write_IT()
+      (+) At Memory end of write transfer, HAL_I2C_MemTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MemTxCpltCallback()
       (+) Read an amount of data in non-blocking mode with Interrupt from a specific memory address using
-          @ref HAL_I2C_Mem_Read_IT()
-      (+) At Memory end of read transfer, @ref HAL_I2C_MemRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MemRxCpltCallback()
-      (+) In case of transfer Error, @ref HAL_I2C_ErrorCallback() function is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_ErrorCallback()
+          HAL_I2C_Mem_Read_IT()
+      (+) At Memory end of read transfer, HAL_I2C_MemRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MemRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
+           add their own code by customization of function pointer HAL_I2C_ErrorCallback()
 
     *** DMA mode IO operation ***
     ==============================
     [..]
       (+) Transmit in master mode an amount of data in non-blocking mode (DMA) using
-          @ref HAL_I2C_Master_Transmit_DMA()
-      (+) At transmission end of transfer, @ref HAL_I2C_MasterTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MasterTxCpltCallback()
+          HAL_I2C_Master_Transmit_DMA()
+      (+) At transmission end of transfer, HAL_I2C_MasterTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MasterTxCpltCallback()
       (+) Receive in master mode an amount of data in non-blocking mode (DMA) using
-          @ref HAL_I2C_Master_Receive_DMA()
-      (+) At reception end of transfer, @ref HAL_I2C_MasterRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MasterRxCpltCallback()
+          HAL_I2C_Master_Receive_DMA()
+      (+) At reception end of transfer, HAL_I2C_MasterRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
       (+) Transmit in slave mode an amount of data in non-blocking mode (DMA) using
-          @ref HAL_I2C_Slave_Transmit_DMA()
-      (+) At transmission end of transfer, @ref HAL_I2C_SlaveTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_SlaveTxCpltCallback()
+          HAL_I2C_Slave_Transmit_DMA()
+      (+) At transmission end of transfer, HAL_I2C_SlaveTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_SlaveTxCpltCallback()
       (+) Receive in slave mode an amount of data in non-blocking mode (DMA) using
-          @ref HAL_I2C_Slave_Receive_DMA()
-      (+) At reception end of transfer, @ref HAL_I2C_SlaveRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_SlaveRxCpltCallback()
-      (+) In case of transfer Error, @ref HAL_I2C_ErrorCallback() function is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_ErrorCallback()
-      (+) Abort a master I2C process communication with Interrupt using @ref HAL_I2C_Master_Abort_IT()
-      (+) End of abort process, @ref HAL_I2C_AbortCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_AbortCpltCallback()
-      (+) Discard a slave I2C process communication using @ref __HAL_I2C_GENERATE_NACK() macro.
+          HAL_I2C_Slave_Receive_DMA()
+      (+) At reception end of transfer, HAL_I2C_SlaveRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
+           add their own code by customization of function pointer HAL_I2C_ErrorCallback()
+      (+) Abort a master or memory I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
+      (+) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
            This action will inform Master to generate a Stop condition to discard the communication.
 
     *** DMA mode IO MEM operation ***
     =================================
     [..]
       (+) Write an amount of data in non-blocking mode with DMA to a specific memory address using
-          @ref HAL_I2C_Mem_Write_DMA()
-      (+) At Memory end of write transfer, @ref HAL_I2C_MemTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MemTxCpltCallback()
+          HAL_I2C_Mem_Write_DMA()
+      (+) At Memory end of write transfer, HAL_I2C_MemTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MemTxCpltCallback()
       (+) Read an amount of data in non-blocking mode with DMA from a specific memory address using
-          @ref HAL_I2C_Mem_Read_DMA()
-      (+) At Memory end of read transfer, @ref HAL_I2C_MemRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_MemRxCpltCallback()
-      (+) In case of transfer Error, @ref HAL_I2C_ErrorCallback() function is executed and user can
-           add his own code by customization of function pointer @ref HAL_I2C_ErrorCallback()
+          HAL_I2C_Mem_Read_DMA()
+      (+) At Memory end of read transfer, HAL_I2C_MemRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_I2C_MemRxCpltCallback()
+      (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
+           add their own code by customization of function pointer HAL_I2C_ErrorCallback()
 
 
      *** I2C HAL driver macros list ***
@@ -213,23 +240,23 @@
      [..]
        Below the list of most used macros in I2C HAL driver.
 
-      (+) @ref __HAL_I2C_ENABLE: Enable the I2C peripheral
-      (+) @ref __HAL_I2C_DISABLE: Disable the I2C peripheral
-      (+) @ref __HAL_I2C_GENERATE_NACK: Generate a Non-Acknowledge I2C peripheral in Slave mode
-      (+) @ref __HAL_I2C_GET_FLAG: Check whether the specified I2C flag is set or not
-      (+) @ref __HAL_I2C_CLEAR_FLAG: Clear the specified I2C pending flag
-      (+) @ref __HAL_I2C_ENABLE_IT: Enable the specified I2C interrupt
-      (+) @ref __HAL_I2C_DISABLE_IT: Disable the specified I2C interrupt
+      (+) __HAL_I2C_ENABLE: Enable the I2C peripheral
+      (+) __HAL_I2C_DISABLE: Disable the I2C peripheral
+      (+) __HAL_I2C_GENERATE_NACK: Generate a Non-Acknowledge I2C peripheral in Slave mode
+      (+) __HAL_I2C_GET_FLAG: Check whether the specified I2C flag is set or not
+      (+) __HAL_I2C_CLEAR_FLAG: Clear the specified I2C pending flag
+      (+) __HAL_I2C_ENABLE_IT: Enable the specified I2C interrupt
+      (+) __HAL_I2C_DISABLE_IT: Disable the specified I2C interrupt
 
      *** Callback registration ***
      =============================================
     [..]
      The compilation flag USE_HAL_I2C_REGISTER_CALLBACKS when set to 1
      allows the user to configure dynamically the driver callbacks.
-     Use Functions @ref HAL_I2C_RegisterCallback() or @ref HAL_I2C_RegisterAddrCallback()
+     Use Functions HAL_I2C_RegisterCallback() or HAL_I2C_RegisterAddrCallback()
      to register an interrupt callback.
     [..]
-     Function @ref HAL_I2C_RegisterCallback() allows to register following callbacks:
+     Function HAL_I2C_RegisterCallback() allows to register following callbacks:
        (+) MasterTxCpltCallback : callback for Master transmission end of transfer.
        (+) MasterRxCpltCallback : callback for Master reception end of transfer.
        (+) SlaveTxCpltCallback  : callback for Slave transmission end of transfer.
@@ -244,11 +271,11 @@
      This function takes as parameters the HAL peripheral handle, the Callback ID
      and a pointer to the user callback function.
     [..]
-     For specific callback AddrCallback use dedicated register callbacks : @ref HAL_I2C_RegisterAddrCallback().
+     For specific callback AddrCallback use dedicated register callbacks : HAL_I2C_RegisterAddrCallback().
     [..]
-     Use function @ref HAL_I2C_UnRegisterCallback to reset a callback to the default
+     Use function HAL_I2C_UnRegisterCallback to reset a callback to the default
      weak function.
-     @ref HAL_I2C_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     HAL_I2C_UnRegisterCallback takes as parameters the HAL peripheral handle,
      and the Callback ID.
      This function allows to reset following callbacks:
        (+) MasterTxCpltCallback : callback for Master transmission end of transfer.
@@ -263,24 +290,24 @@
        (+) MspInitCallback      : callback for Msp Init.
        (+) MspDeInitCallback    : callback for Msp DeInit.
     [..]
-     For callback AddrCallback use dedicated register callbacks : @ref HAL_I2C_UnRegisterAddrCallback().
+     For callback AddrCallback use dedicated register callbacks : HAL_I2C_UnRegisterAddrCallback().
     [..]
-     By default, after the @ref HAL_I2C_Init() and when the state is @ref HAL_I2C_STATE_RESET
+     By default, after the HAL_I2C_Init() and when the state is HAL_I2C_STATE_RESET
      all callbacks are set to the corresponding weak functions:
-     examples @ref HAL_I2C_MasterTxCpltCallback(), @ref HAL_I2C_MasterRxCpltCallback().
+     examples HAL_I2C_MasterTxCpltCallback(), HAL_I2C_MasterRxCpltCallback().
      Exception done for MspInit and MspDeInit functions that are
-     reset to the legacy weak functions in the @ref HAL_I2C_Init()/ @ref HAL_I2C_DeInit() only when
+     reset to the legacy weak functions in the HAL_I2C_Init()/ HAL_I2C_DeInit() only when
      these callbacks are null (not registered beforehand).
-     If MspInit or MspDeInit are not null, the @ref HAL_I2C_Init()/ @ref HAL_I2C_DeInit()
+     If MspInit or MspDeInit are not null, the HAL_I2C_Init()/ HAL_I2C_DeInit()
      keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
     [..]
-     Callbacks can be registered/unregistered in @ref HAL_I2C_STATE_READY state only.
+     Callbacks can be registered/unregistered in HAL_I2C_STATE_READY state only.
      Exception done MspInit/MspDeInit functions that can be registered/unregistered
-     in @ref HAL_I2C_STATE_READY or @ref HAL_I2C_STATE_RESET state,
+     in HAL_I2C_STATE_READY or HAL_I2C_STATE_RESET state,
      thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
      Then, the user first registers the MspInit/MspDeInit user callbacks
-     using @ref HAL_I2C_RegisterCallback() before calling @ref HAL_I2C_DeInit()
-     or @ref HAL_I2C_Init() function.
+     using HAL_I2C_RegisterCallback() before calling HAL_I2C_DeInit()
+     or HAL_I2C_Init() function.
     [..]
      When the compilation flag USE_HAL_I2C_REGISTER_CALLBACKS is set to 0 or
      not defined, the callback registration feature is not available and all callbacks
@@ -290,18 +317,6 @@
        (@) You can refer to the I2C HAL driver header file for more useful macros
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -336,28 +351,48 @@
 #define I2C_TIMEOUT_FLAG    (25U)          /*!< 25 ms */
 
 #define MAX_NBYTE_SIZE      255U
-#define SlaveAddr_SHIFT     7U
-#define SlaveAddr_MSK       0x06U
+#define SLAVE_ADDR_SHIFT     7U
+#define SLAVE_ADDR_MSK       0x06U
 
 /* Private define for @ref PreviousState usage */
-#define I2C_STATE_MSK             ((uint32_t)((uint32_t)((uint32_t)HAL_I2C_STATE_BUSY_TX | (uint32_t)HAL_I2C_STATE_BUSY_RX) & (uint32_t)(~((uint32_t)HAL_I2C_STATE_READY)))) /*!< Mask State define, keep only RX and TX bits            */
-#define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))                                                        /*!< Default Value                                          */
-#define I2C_STATE_MASTER_BUSY_TX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MASTER))            /*!< Master Busy TX, combinaison of State LSB and Mode enum */
-#define I2C_STATE_MASTER_BUSY_RX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MASTER))            /*!< Master Busy RX, combinaison of State LSB and Mode enum */
-#define I2C_STATE_SLAVE_BUSY_TX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_SLAVE))             /*!< Slave Busy TX, combinaison of State LSB and Mode enum  */
-#define I2C_STATE_SLAVE_BUSY_RX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_SLAVE))             /*!< Slave Busy RX, combinaison of State LSB and Mode enum  */
-#define I2C_STATE_MEM_BUSY_TX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MEM))               /*!< Memory Busy TX, combinaison of State LSB and Mode enum */
-#define I2C_STATE_MEM_BUSY_RX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | (uint32_t)HAL_I2C_MODE_MEM))               /*!< Memory Busy RX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MSK             ((uint32_t)((uint32_t)((uint32_t)HAL_I2C_STATE_BUSY_TX | \
+                                                         (uint32_t)HAL_I2C_STATE_BUSY_RX) & \
+                                              (uint32_t)(~((uint32_t)HAL_I2C_STATE_READY))))
+/*!< Mask State define, keep only RX and TX bits */
+#define I2C_STATE_NONE            ((uint32_t)(HAL_I2C_MODE_NONE))
+/*!< Default Value */
+#define I2C_STATE_MASTER_BUSY_TX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | \
+                                              (uint32_t)HAL_I2C_MODE_MASTER))
+/*!< Master Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MASTER_BUSY_RX  ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | \
+                                              (uint32_t)HAL_I2C_MODE_MASTER))
+/*!< Master Busy RX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_SLAVE_BUSY_TX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | \
+                                              (uint32_t)HAL_I2C_MODE_SLAVE))
+/*!< Slave Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_SLAVE_BUSY_RX   ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | \
+                                              (uint32_t)HAL_I2C_MODE_SLAVE))
+/*!< Slave Busy RX, combinaison of State LSB and Mode enum  */
+#define I2C_STATE_MEM_BUSY_TX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_TX & I2C_STATE_MSK) | \
+                                              (uint32_t)HAL_I2C_MODE_MEM))
+/*!< Memory Busy TX, combinaison of State LSB and Mode enum */
+#define I2C_STATE_MEM_BUSY_RX     ((uint32_t)(((uint32_t)HAL_I2C_STATE_BUSY_RX & I2C_STATE_MSK) | \
+                                              (uint32_t)HAL_I2C_MODE_MEM))
+/*!< Memory Busy RX, combinaison of State LSB and Mode enum */
 
 
 /* Private define to centralize the enable/disable of Interrupts */
-#define I2C_XFER_TX_IT          (uint16_t)(0x0001U)   /* Bit field can be combinated with @ref I2C_XFER_LISTEN_IT */
-#define I2C_XFER_RX_IT          (uint16_t)(0x0002U)   /* Bit field can be combinated with @ref I2C_XFER_LISTEN_IT */
-#define I2C_XFER_LISTEN_IT      (uint16_t)(0x8000U)   /* Bit field can be combinated with @ref I2C_XFER_TX_IT and @ref I2C_XFER_RX_IT */
+#define I2C_XFER_TX_IT          (uint16_t)(0x0001U)   /*!< Bit field can be combinated with
+                                                         @ref I2C_XFER_LISTEN_IT */
+#define I2C_XFER_RX_IT          (uint16_t)(0x0002U)   /*!< Bit field can be combinated with
+                                                         @ref I2C_XFER_LISTEN_IT */
+#define I2C_XFER_LISTEN_IT      (uint16_t)(0x8000U)   /*!< Bit field can be combinated with @ref I2C_XFER_TX_IT
+                                                         and @ref I2C_XFER_RX_IT */
 
-#define I2C_XFER_ERROR_IT       (uint16_t)(0x0010U)   /* Bit definition to manage addition of global Error and NACK treatment */
-#define I2C_XFER_CPLT_IT        (uint16_t)(0x0020U)   /* Bit definition to manage only STOP evenement */
-#define I2C_XFER_RELOAD_IT      (uint16_t)(0x0040U)   /* Bit definition to manage only Reload of NBYTE */
+#define I2C_XFER_ERROR_IT       (uint16_t)(0x0010U)   /*!< Bit definition to manage addition of global Error
+                                                         and NACK treatment */
+#define I2C_XFER_CPLT_IT        (uint16_t)(0x0020U)   /*!< Bit definition to manage only STOP evenement */
+#define I2C_XFER_RELOAD_IT      (uint16_t)(0x0040U)   /*!< Bit definition to manage only Reload of NBYTE */
 
 /* Private define Sequential Transfer Options default/reset value */
 #define I2C_NO_OPTION_FRAME     (0xFFFF0000U)
@@ -365,13 +400,25 @@
   * @}
   */
 
-/* Private macro -------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup I2C_Private_Macro
+  * @{
+  */
+#if defined(HAL_DMA_MODULE_ENABLED)
+/* Macro to get remaining data to transfer on DMA side */
+#define I2C_GET_DMA_REMAIN_DATA(__HANDLE__)     __HAL_DMA_GET_COUNTER(__HANDLE__)
+#endif /* HAL_DMA_MODULE_ENABLED */
+/**
+  * @}
+  */
+
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 
 /** @defgroup I2C_Private_Functions I2C Private Functions
   * @{
   */
+#if defined(HAL_DMA_MODULE_ENABLED)
 /* Private functions to handle DMA transfer */
 static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma);
@@ -379,6 +426,8 @@ static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMAError(DMA_HandleTypeDef *hdma);
 static void I2C_DMAAbort(DMA_HandleTypeDef *hdma);
+
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /* Private functions to handle IT transfer */
 static void I2C_ITAddrCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags);
@@ -390,21 +439,40 @@ static void I2C_ITListenCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags);
 static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode);
 
 /* Private functions to handle IT transfer */
-static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart);
-static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
+                                                uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout,
+                                                uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
+                                               uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout,
+                                               uint32_t Tickstart);
 
 /* Private functions for I2C transfer IRQ handler */
-static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources);
-static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources);
-static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources);
-static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources);
+static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                           uint32_t ITSources);
+static HAL_StatusTypeDef I2C_Mem_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                        uint32_t ITSources);
+static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                          uint32_t ITSources);
+#if defined(HAL_DMA_MODULE_ENABLED)
+static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                            uint32_t ITSources);
+static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                         uint32_t ITSources);
+static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                           uint32_t ITSources);
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /* Private functions to handle flags during polling transfer */
-static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout, uint32_t Tickstart);
-static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
-static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
-static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
-static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status,
+                                                    uint32_t Timeout, uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                                        uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                                        uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                                        uint32_t Tickstart);
+static HAL_StatusTypeDef I2C_IsErrorOccurred(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                             uint32_t Tickstart);
 
 /* Private functions to centralize the enable/disable of Interrupts */
 static void I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest);
@@ -417,7 +485,8 @@ static void I2C_TreatErrorCallback(I2C_HandleTypeDef *hi2c);
 static void I2C_Flush_TXDR(I2C_HandleTypeDef *hi2c);
 
 /* Private function to handle  start, restart or stop a transfer */
-static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t Size, uint32_t Mode,
+                               uint32_t Request);
 
 /* Private function to Convert Specific options */
 static void I2C_ConvertOtherXferOptions(I2C_HandleTypeDef *hi2c);
@@ -432,8 +501,8 @@ static void I2C_ConvertOtherXferOptions(I2C_HandleTypeDef *hi2c);
   */
 
 /** @defgroup I2C_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
@@ -545,7 +614,12 @@ HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
   /* Configure I2Cx: Addressing Master mode */
   if (hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
   {
-    hi2c->Instance->CR2 = (I2C_CR2_ADD10);
+    SET_BIT(hi2c->Instance->CR2, I2C_CR2_ADD10);
+  }
+  else
+  {
+    /* Clear the I2C ADD10 bit */
+    CLEAR_BIT(hi2c->Instance->CR2, I2C_CR2_ADD10);
   }
   /* Enable the AUTOEND by default, and enable NACK (should be disable only during Slave process */
   hi2c->Instance->CR2 |= (I2C_CR2_AUTOEND | I2C_CR2_NACK);
@@ -555,7 +629,8 @@ HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
   hi2c->Instance->OAR2 &= ~I2C_DUALADDRESS_ENABLE;
 
   /* Configure I2Cx: Dual mode and Own Address2 */
-  hi2c->Instance->OAR2 = (hi2c->Init.DualAddressMode | hi2c->Init.OwnAddress2 | (hi2c->Init.OwnAddress2Masks << 8));
+  hi2c->Instance->OAR2 = (hi2c->Init.DualAddressMode | hi2c->Init.OwnAddress2 | \
+                          (hi2c->Init.OwnAddress2Masks << 8));
 
   /*---------------------------- I2Cx CR1 Configuration ----------------------*/
   /* Configure I2Cx: Generalcall and NoStretch mode */
@@ -654,6 +729,8 @@ __weak void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
 /**
   * @brief  Register a User I2C Callback
   *         To be used instead of the weak predefined callback
+  * @note   The HAL_I2C_RegisterCallback() may be called before HAL_I2C_Init() in HAL_I2C_STATE_RESET
+  *         to register callbacks for HAL_I2C_MSPINIT_CB_ID and HAL_I2C_MSPDEINIT_CB_ID.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  CallbackID ID of the callback to be registered
@@ -672,7 +749,8 @@ __weak void HAL_I2C_MspDeInit(I2C_HandleTypeDef *hi2c)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_CallbackIDTypeDef CallbackID, pI2C_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_CallbackIDTypeDef CallbackID,
+                                           pI2C_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -683,8 +761,6 @@ HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_Call
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hi2c);
 
   if (HAL_I2C_STATE_READY == hi2c->State)
   {
@@ -773,14 +849,14 @@ HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_Call
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hi2c);
   return status;
 }
 
 /**
   * @brief  Unregister an I2C Callback
   *         I2C callback is redirected to the weak predefined callback
+  * @note   The HAL_I2C_UnRegisterCallback() may be called before HAL_I2C_Init() in HAL_I2C_STATE_RESET
+  *         to un-register callbacks for HAL_I2C_MSPINIT_CB_ID and HAL_I2C_MSPDEINIT_CB_ID.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  CallbackID ID of the callback to be unregistered
@@ -802,9 +878,6 @@ HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_Call
 HAL_StatusTypeDef HAL_I2C_UnRegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
-
-  /* Process locked */
-  __HAL_LOCK(hi2c);
 
   if (HAL_I2C_STATE_READY == hi2c->State)
   {
@@ -893,8 +966,6 @@ HAL_StatusTypeDef HAL_I2C_UnRegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_Ca
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hi2c);
   return status;
 }
 
@@ -917,8 +988,6 @@ HAL_StatusTypeDef HAL_I2C_RegisterAddrCallback(I2C_HandleTypeDef *hi2c, pI2C_Add
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hi2c);
 
   if (HAL_I2C_STATE_READY == hi2c->State)
   {
@@ -933,8 +1002,6 @@ HAL_StatusTypeDef HAL_I2C_RegisterAddrCallback(I2C_HandleTypeDef *hi2c, pI2C_Add
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hi2c);
   return status;
 }
 
@@ -949,9 +1016,6 @@ HAL_StatusTypeDef HAL_I2C_UnRegisterAddrCallback(I2C_HandleTypeDef *hi2c)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(hi2c);
-
   if (HAL_I2C_STATE_READY == hi2c->State)
   {
     hi2c->AddrCallback = HAL_I2C_AddrCallback; /* Legacy weak AddrCallback  */
@@ -965,8 +1029,6 @@ HAL_StatusTypeDef HAL_I2C_UnRegisterAddrCallback(I2C_HandleTypeDef *hi2c)
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hi2c);
   return status;
 }
 
@@ -977,8 +1039,8 @@ HAL_StatusTypeDef HAL_I2C_UnRegisterAddrCallback(I2C_HandleTypeDef *hi2c)
   */
 
 /** @defgroup I2C_Exported_Functions_Group2 Input and Output operation functions
- *  @brief   Data transfers functions
- *
+  *  @brief   Data transfers functions
+  *
 @verbatim
  ===============================================================================
                       ##### IO operation functions #####
@@ -1060,9 +1122,11 @@ HAL_StatusTypeDef HAL_I2C_UnRegisterAddrCallback(I2C_HandleTypeDef *hi2c)
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                          uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
+  uint32_t xfermode;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1086,17 +1150,40 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
     hi2c->XferCount = Size;
     hi2c->XferISR   = NULL;
 
-    /* Send Slave Address */
-    /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
       hi2c->XferSize = MAX_NBYTE_SIZE;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
+      xfermode = I2C_RELOAD_MODE;
     }
     else
     {
       hi2c->XferSize = hi2c->XferCount;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+      xfermode = I2C_AUTOEND_MODE;
+    }
+
+    if (hi2c->XferSize > 0U)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)(hi2c->XferSize + 1U), xfermode,
+                         I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode,
+                         I2C_GENERATE_START_WRITE);
     }
 
     while (hi2c->XferCount > 0U)
@@ -1126,12 +1213,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
         if (hi2c->XferCount > MAX_NBYTE_SIZE)
         {
           hi2c->XferSize = MAX_NBYTE_SIZE;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
+                             I2C_NO_STARTSTOP);
         }
         else
         {
           hi2c->XferSize = hi2c->XferCount;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                             I2C_NO_STARTSTOP);
         }
       }
     }
@@ -1174,7 +1263,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                         uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
 
@@ -1205,12 +1295,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAd
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
       hi2c->XferSize = MAX_NBYTE_SIZE;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
+                         I2C_GENERATE_START_READ);
     }
     else
     {
       hi2c->XferSize = hi2c->XferCount;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                         I2C_GENERATE_START_READ);
     }
 
     while (hi2c->XferCount > 0U)
@@ -1241,12 +1333,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAd
         if (hi2c->XferCount > MAX_NBYTE_SIZE)
         {
           hi2c->XferSize = MAX_NBYTE_SIZE;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
+                             I2C_NO_STARTSTOP);
         }
         else
         {
           hi2c->XferSize = hi2c->XferCount;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                             I2C_NO_STARTSTOP);
         }
       }
     }
@@ -1287,9 +1381,12 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAd
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                         uint32_t Timeout)
 {
   uint32_t tickstart;
+  uint16_t tmpXferCount;
+  HAL_StatusTypeDef error;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1316,11 +1413,28 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     /* Enable Address Acknowledge */
     hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
 
+    /* Preload TX data if no stretch enable */
+    if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+    }
+
     /* Wait until ADDR flag is set */
     if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
     {
       /* Disable Address Acknowledge */
       hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
+
       return HAL_ERROR;
     }
 
@@ -1335,6 +1449,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
       {
         /* Disable Address Acknowledge */
         hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        /* Flush TX register */
+        I2C_Flush_TXDR(hi2c);
+
         return HAL_ERROR;
       }
 
@@ -1347,6 +1465,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     {
       /* Disable Address Acknowledge */
       hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
+
       return HAL_ERROR;
     }
 
@@ -1369,26 +1491,48 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
       hi2c->XferCount--;
     }
 
-    /* Wait until STOP flag is set */
-    if (I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
-    {
-      /* Disable Address Acknowledge */
-      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+    /* Wait until AF flag is set */
+    error = I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_AF, RESET, Timeout, tickstart);
 
-      if (hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+    if (error != HAL_OK)
+    {
+      /* Check that I2C transfer finished */
+      /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+      /* Mean XferCount == 0 */
+
+      tmpXferCount = hi2c->XferCount;
+      if ((hi2c->ErrorCode == HAL_I2C_ERROR_AF) && (tmpXferCount == 0U))
       {
-        /* Normal use case for Transmitter mode */
-        /* A NACK is generated to confirm the end of transfer */
+        /* Reset ErrorCode to NONE */
         hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
       }
       else
       {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
         return HAL_ERROR;
       }
     }
+    else
+    {
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
 
-    /* Clear STOP flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      /* Clear AF flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Wait until STOP flag is set */
+      if (I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        return HAL_ERROR;
+      }
+
+      /* Clear STOP flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+    }
 
     /* Wait until BUSY flag is reset */
     if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout, tickstart) != HAL_OK)
@@ -1424,7 +1568,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                        uint32_t Timeout)
 {
   uint32_t tickstart;
 
@@ -1448,6 +1593,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
     /* Prepare transfer parameters */
     hi2c->pBuffPtr  = pData;
     hi2c->XferCount = Size;
+    hi2c->XferSize = hi2c->XferCount;
     hi2c->XferISR   = NULL;
 
     /* Enable Address Acknowledge */
@@ -1490,6 +1636,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
           hi2c->pBuffPtr++;
 
           hi2c->XferCount--;
+          hi2c->XferSize--;
         }
 
         return HAL_ERROR;
@@ -1502,6 +1649,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
       hi2c->pBuffPtr++;
 
       hi2c->XferCount--;
+      hi2c->XferSize--;
     }
 
     /* Wait until STOP flag is set */
@@ -1550,7 +1698,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive(I2C_HandleTypeDef *hi2c, uint8_t *pData,
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                             uint16_t Size)
 {
   uint32_t xfermode;
 
@@ -1587,7 +1736,26 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t D
 
     /* Send Slave Address */
     /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE */
-    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_GENERATE_START_WRITE);
+    if (hi2c->XferSize > 0U)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)(hi2c->XferSize + 1U), xfermode,
+                         I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode,
+                         I2C_GENERATE_START_WRITE);
+    }
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -1598,7 +1766,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t D
 
     /* Enable ERR, TC, STOP, NACK, TXI interrupt */
     /* possible to enable all of these */
-    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+      I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
     I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
 
     return HAL_OK;
@@ -1619,7 +1788,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t D
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                            uint16_t Size)
 {
   uint32_t xfermode;
 
@@ -1667,7 +1837,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t De
 
     /* Enable ERR, TC, STOP, NACK, RXI interrupt */
     /* possible to enable all of these */
-    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+      I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
     I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
 
     return HAL_OK;
@@ -1707,6 +1878,20 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pD
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
     hi2c->XferISR     = I2C_Slave_ISR_IT;
 
+    /* Preload TX data if no stretch enable */
+    if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
+
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
 
@@ -1716,7 +1901,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pD
 
     /* Enable ERR, TC, STOP, NACK, TXI interrupt */
     /* possible to enable all of these */
-    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+      I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
     I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT | I2C_XFER_LISTEN_IT);
 
     return HAL_OK;
@@ -1765,7 +1951,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
 
     /* Enable ERR, TC, STOP, NACK, RXI interrupt */
     /* possible to enable all of these */
-    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+      I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
     I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT | I2C_XFER_LISTEN_IT);
 
     return HAL_OK;
@@ -1776,6 +1963,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
   }
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Transmit in master mode an amount of data in non-blocking mode with DMA
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -1786,10 +1974,12 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pDa
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                              uint16_t Size)
 {
   uint32_t xfermode;
   HAL_StatusTypeDef dmaxferstatus;
+  uint32_t sizetoxfer = 0U;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1824,6 +2014,20 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 
     if (hi2c->XferSize > 0U)
     {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      sizetoxfer = hi2c->XferSize;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
+
+    if (hi2c->XferSize > 0U)
+    {
       if (hi2c->hdmatx != NULL)
       {
         /* Set the I2C DMA transfer complete callback */
@@ -1837,7 +2041,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
         hi2c->hdmatx->XferAbortCallback = NULL;
 
         /* Enable the DMA channel */
-        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr,
+                                         (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
       }
       else
       {
@@ -1858,7 +2063,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
       {
         /* Send Slave Address */
         /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
-        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_GENERATE_START_WRITE);
+        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)(hi2c->XferSize + 1U),
+                           xfermode, I2C_GENERATE_START_WRITE);
 
         /* Update XferCount value */
         hi2c->XferCount -= hi2c->XferSize;
@@ -1897,7 +2103,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 
       /* Send Slave Address */
       /* Set NBYTES to write and generate START condition */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, I2C_AUTOEND_MODE,
+                         I2C_GENERATE_START_WRITE);
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -1907,7 +2114,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
                 process unlock */
       /* Enable ERR, TC, STOP, NACK, TXI interrupt */
       /* possible to enable all of these */
-      /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+      /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+        I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
       I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
     }
 
@@ -1929,7 +2137,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                             uint16_t Size)
 {
   uint32_t xfermode;
   HAL_StatusTypeDef dmaxferstatus;
@@ -1980,7 +2189,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
         hi2c->hdmarx->XferAbortCallback = NULL;
 
         /* Enable the DMA channel */
-        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData,
+                                         hi2c->XferSize);
       }
       else
       {
@@ -2040,7 +2250,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
 
       /* Send Slave Address */
       /* Set NBYTES to read and generate START condition */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                         I2C_GENERATE_START_READ);
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -2048,10 +2259,11 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
       /* Note : The I2C interrupts must be enabled after unlocking current process
                 to avoid the risk of I2C interrupt handle execution before current
                 process unlock */
-      /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+      /* Enable ERR, TC, STOP, NACK, RXI interrupt */
       /* possible to enable all of these */
-      /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
-      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+      /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+        I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+      I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
     }
 
     return HAL_OK;
@@ -2095,37 +2307,87 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
     hi2c->XferISR     = I2C_Slave_ISR_DMA;
 
-    if (hi2c->hdmatx != NULL)
+    /* Preload TX data if no stretch enable */
+    if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
     {
-      /* Set the I2C DMA transfer complete callback */
-      hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
 
-      /* Set the DMA error callback */
-      hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
 
-      /* Set the unused DMA callbacks to NULL */
-      hi2c->hdmatx->XferHalfCpltCallback = NULL;
-      hi2c->hdmatx->XferAbortCallback = NULL;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
 
-      /* Enable the DMA channel */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+    if (hi2c->XferCount != 0U)
+    {
+      if (hi2c->hdmatx != NULL)
+      {
+        /* Set the I2C DMA transfer complete callback */
+        hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+
+        /* Set the DMA error callback */
+        hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+        /* Set the unused DMA callbacks to NULL */
+        hi2c->hdmatx->XferHalfCpltCallback = NULL;
+        hi2c->hdmatx->XferAbortCallback = NULL;
+
+        /* Enable the DMA channel */
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx,
+                                         (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR,
+                                         hi2c->XferSize);
+      }
+      else
+      {
+        /* Update I2C state */
+        hi2c->State     = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode      = HAL_I2C_MODE_NONE;
+
+        /* Update I2C error code */
+        hi2c->ErrorCode |= HAL_I2C_ERROR_DMA_PARAM;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_ERROR;
+      }
+
+      if (dmaxferstatus == HAL_OK)
+      {
+        /* Enable Address Acknowledge */
+        hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Note : The I2C interrupts must be enabled after unlocking current process
+                  to avoid the risk of I2C interrupt handle execution before current
+                  process unlock */
+        /* Enable ERR, STOP, NACK, ADDR interrupts */
+        I2C_Enable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
+
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+      else
+      {
+        /* Update I2C state */
+        hi2c->State     = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode      = HAL_I2C_MODE_NONE;
+
+        /* Update I2C error code */
+        hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_ERROR;
+      }
     }
     else
-    {
-      /* Update I2C state */
-      hi2c->State     = HAL_I2C_STATE_LISTEN;
-      hi2c->Mode      = HAL_I2C_MODE_NONE;
-
-      /* Update I2C error code */
-      hi2c->ErrorCode |= HAL_I2C_ERROR_DMA_PARAM;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
-      return HAL_ERROR;
-    }
-
-    if (dmaxferstatus == HAL_OK)
     {
       /* Enable Address Acknowledge */
       hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
@@ -2134,27 +2396,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
       __HAL_UNLOCK(hi2c);
 
       /* Note : The I2C interrupts must be enabled after unlocking current process
-                to avoid the risk of I2C interrupt handle execution before current
-                process unlock */
+      to avoid the risk of I2C interrupt handle execution before current
+      process unlock */
       /* Enable ERR, STOP, NACK, ADDR interrupts */
       I2C_Enable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
-
-      /* Enable DMA Request */
-      hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
-    }
-    else
-    {
-      /* Update I2C state */
-      hi2c->State     = HAL_I2C_STATE_LISTEN;
-      hi2c->Mode      = HAL_I2C_MODE_NONE;
-
-      /* Update I2C error code */
-      hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
-      return HAL_ERROR;
     }
 
     return HAL_OK;
@@ -2211,7 +2456,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
       hi2c->hdmarx->XferAbortCallback = NULL;
 
       /* Enable the DMA channel */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData,
+                                       hi2c->XferSize);
     }
     else
     {
@@ -2267,6 +2513,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
     return HAL_BUSY;
   }
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
+
 /**
   * @brief  Write an amount of data in blocking mode to a specific memory address
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -2280,7 +2528,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                    uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
 
@@ -2363,17 +2612,18 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress
         if (hi2c->XferCount > MAX_NBYTE_SIZE)
         {
           hi2c->XferSize = MAX_NBYTE_SIZE;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
+                             I2C_NO_STARTSTOP);
         }
         else
         {
           hi2c->XferSize = hi2c->XferCount;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                             I2C_NO_STARTSTOP);
         }
       }
 
-    }
-    while (hi2c->XferCount > 0U);
+    } while (hi2c->XferCount > 0U);
 
     /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
     /* Wait until STOPF flag is reset */
@@ -2415,7 +2665,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write(I2C_HandleTypeDef *hi2c, uint16_t DevAddress
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                   uint16_t MemAddSize, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
 
@@ -2463,12 +2714,14 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
       hi2c->XferSize = MAX_NBYTE_SIZE;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_GENERATE_START_READ);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
+                         I2C_GENERATE_START_READ);
     }
     else
     {
       hi2c->XferSize = hi2c->XferCount;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                         I2C_GENERATE_START_READ);
     }
 
     do
@@ -2499,16 +2752,17 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
         if (hi2c->XferCount > MAX_NBYTE_SIZE)
         {
           hi2c->XferSize = MAX_NBYTE_SIZE;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t) hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t) hi2c->XferSize, I2C_RELOAD_MODE,
+                             I2C_NO_STARTSTOP);
         }
         else
         {
           hi2c->XferSize = hi2c->XferCount;
-          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                             I2C_NO_STARTSTOP);
         }
       }
-    }
-    while (hi2c->XferCount > 0U);
+    } while (hi2c->XferCount > 0U);
 
     /* No need to Check TC flag, with AUTOEND mode the stop is automatically generated */
     /* Wait until STOPF flag is reset */
@@ -2548,11 +2802,9 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                       uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
 {
-  uint32_t tickstart;
-  uint32_t xfermode;
-
   /* Check the parameters */
   assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
 
@@ -2572,40 +2824,38 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
     /* Process Locked */
     __HAL_LOCK(hi2c);
 
-    /* Init tickstart for timeout management*/
-    tickstart = HAL_GetTick();
-
     hi2c->State       = HAL_I2C_STATE_BUSY_TX;
     hi2c->Mode        = HAL_I2C_MODE_MEM;
     hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
 
     /* Prepare transfer parameters */
+    hi2c->XferSize    = 0U;
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
-    hi2c->XferISR     = I2C_Master_ISR_IT;
+    hi2c->XferISR     = I2C_Mem_ISR_IT;
+    hi2c->Devaddress  = DevAddress;
 
-    if (hi2c->XferCount > MAX_NBYTE_SIZE)
+    /* If Memory address size is 8Bit */
+    if (MemAddSize == I2C_MEMADD_SIZE_8BIT)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
-      xfermode = I2C_RELOAD_MODE;
+      /* Prefetch Memory Address */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+
+      /* Reset Memaddress content */
+      hi2c->Memaddress = 0xFFFFFFFFU;
     }
+    /* If Memory address size is 16Bit */
     else
     {
-      hi2c->XferSize = hi2c->XferCount;
-      xfermode = I2C_AUTOEND_MODE;
-    }
+      /* Prefetch Memory Address (MSB part, LSB will be manage through interrupt) */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
 
+      /* Prepare Memaddress buffer for LSB part */
+      hi2c->Memaddress = I2C_MEM_ADD_LSB(MemAddress);
+    }
     /* Send Slave Address and Memory Address */
-    if (I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
-    {
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-      return HAL_ERROR;
-    }
-
-    /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
-    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_NO_STARTSTOP);
+    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)MemAddSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -2616,7 +2866,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
 
     /* Enable ERR, TC, STOP, NACK, TXI interrupt */
     /* possible to enable all of these */
-    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+      I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
     I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
 
     return HAL_OK;
@@ -2639,11 +2890,9 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                      uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
 {
-  uint32_t tickstart;
-  uint32_t xfermode;
-
   /* Check the parameters */
   assert_param(IS_I2C_MEMADD_SIZE(MemAddSize));
 
@@ -2663,9 +2912,6 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
     /* Process Locked */
     __HAL_LOCK(hi2c);
 
-    /* Init tickstart for timeout management*/
-    tickstart = HAL_GetTick();
-
     hi2c->State       = HAL_I2C_STATE_BUSY_RX;
     hi2c->Mode        = HAL_I2C_MODE_MEM;
     hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
@@ -2674,29 +2920,29 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
-    hi2c->XferISR     = I2C_Master_ISR_IT;
+    hi2c->XferISR     = I2C_Mem_ISR_IT;
+    hi2c->Devaddress  = DevAddress;
 
-    if (hi2c->XferCount > MAX_NBYTE_SIZE)
+    /* If Memory address size is 8Bit */
+    if (MemAddSize == I2C_MEMADD_SIZE_8BIT)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
-      xfermode = I2C_RELOAD_MODE;
+      /* Prefetch Memory Address */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+
+      /* Reset Memaddress content */
+      hi2c->Memaddress = 0xFFFFFFFFU;
     }
+    /* If Memory address size is 16Bit */
     else
     {
-      hi2c->XferSize = hi2c->XferCount;
-      xfermode = I2C_AUTOEND_MODE;
-    }
+      /* Prefetch Memory Address (MSB part, LSB will be manage through interrupt) */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
 
+      /* Prepare Memaddress buffer for LSB part */
+      hi2c->Memaddress = I2C_MEM_ADD_LSB(MemAddress);
+    }
     /* Send Slave Address and Memory Address */
-    if (I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
-    {
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-      return HAL_ERROR;
-    }
-
-    /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
-    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_GENERATE_START_READ);
+    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)MemAddSize, I2C_SOFTEND_MODE, I2C_GENERATE_START_WRITE);
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -2705,10 +2951,11 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
               to avoid the risk of I2C interrupt handle execution before current
               process unlock */
 
-    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
     /* possible to enable all of these */
-    /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
-    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+      I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
 
     return HAL_OK;
   }
@@ -2717,6 +2964,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
     return HAL_BUSY;
   }
 }
+
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Write an amount of data in non-blocking mode with DMA to a specific memory address
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -2729,10 +2978,9 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
   * @param  Size Amount of data to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                        uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
 {
-  uint32_t tickstart;
-  uint32_t xfermode;
   HAL_StatusTypeDef dmaxferstatus;
 
   /* Check the parameters */
@@ -2754,9 +3002,6 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
     /* Process Locked */
     __HAL_LOCK(hi2c);
 
-    /* Init tickstart for timeout management*/
-    tickstart = HAL_GetTick();
-
     hi2c->State       = HAL_I2C_STATE_BUSY_TX;
     hi2c->Mode        = HAL_I2C_MODE_MEM;
     hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
@@ -2765,27 +3010,36 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
-    hi2c->XferISR     = I2C_Master_ISR_DMA;
+    hi2c->XferISR     = I2C_Mem_ISR_DMA;
+    hi2c->Devaddress  = DevAddress;
 
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
       hi2c->XferSize = MAX_NBYTE_SIZE;
-      xfermode = I2C_RELOAD_MODE;
     }
     else
     {
       hi2c->XferSize = hi2c->XferCount;
-      xfermode = I2C_AUTOEND_MODE;
     }
 
-    /* Send Slave Address and Memory Address */
-    if (I2C_RequestMemoryWrite(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
+    /* If Memory address size is 8Bit */
+    if (MemAddSize == I2C_MEMADD_SIZE_8BIT)
     {
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-      return HAL_ERROR;
-    }
+      /* Prefetch Memory Address */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
 
+      /* Reset Memaddress content */
+      hi2c->Memaddress = 0xFFFFFFFFU;
+    }
+    /* If Memory address size is 16Bit */
+    else
+    {
+      /* Prefetch Memory Address (MSB part, LSB will be manage through interrupt) */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
+
+      /* Prepare Memaddress buffer for LSB part */
+      hi2c->Memaddress = I2C_MEM_ADD_LSB(MemAddress);
+    }
 
     if (hi2c->hdmatx != NULL)
     {
@@ -2800,7 +3054,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
       hi2c->hdmatx->XferAbortCallback = NULL;
 
       /* Enable the DMA channel */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR,
+                                       hi2c->XferSize);
     }
     else
     {
@@ -2819,12 +3074,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
 
     if (dmaxferstatus == HAL_OK)
     {
-      /* Send Slave Address */
-      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_NO_STARTSTOP);
-
-      /* Update XferCount value */
-      hi2c->XferCount -= hi2c->XferSize;
+      /* Send Slave Address and Memory Address */
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)MemAddSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -2832,11 +3083,11 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
       /* Note : The I2C interrupts must be enabled after unlocking current process
                 to avoid the risk of I2C interrupt handle execution before current
                 process unlock */
-      /* Enable ERR and NACK interrupts */
-      I2C_Enable_IRQ(hi2c, I2C_XFER_ERROR_IT);
-
-      /* Enable DMA Request */
-      hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+      /* possible to enable all of these */
+      /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+        I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
     }
     else
     {
@@ -2873,10 +3124,9 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
   * @param  Size Amount of data to be read
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress,
+                                       uint16_t MemAddSize, uint8_t *pData, uint16_t Size)
 {
-  uint32_t tickstart;
-  uint32_t xfermode;
   HAL_StatusTypeDef dmaxferstatus;
 
   /* Check the parameters */
@@ -2898,9 +3148,6 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
     /* Process Locked */
     __HAL_LOCK(hi2c);
 
-    /* Init tickstart for timeout management*/
-    tickstart = HAL_GetTick();
-
     hi2c->State       = HAL_I2C_STATE_BUSY_RX;
     hi2c->Mode        = HAL_I2C_MODE_MEM;
     hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
@@ -2909,25 +3156,35 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
-    hi2c->XferISR     = I2C_Master_ISR_DMA;
+    hi2c->XferISR     = I2C_Mem_ISR_DMA;
+    hi2c->Devaddress  = DevAddress;
 
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
       hi2c->XferSize = MAX_NBYTE_SIZE;
-      xfermode = I2C_RELOAD_MODE;
     }
     else
     {
       hi2c->XferSize = hi2c->XferCount;
-      xfermode = I2C_AUTOEND_MODE;
     }
 
-    /* Send Slave Address and Memory Address */
-    if (I2C_RequestMemoryRead(hi2c, DevAddress, MemAddress, MemAddSize, I2C_TIMEOUT_FLAG, tickstart) != HAL_OK)
+    /* If Memory address size is 8Bit */
+    if (MemAddSize == I2C_MEMADD_SIZE_8BIT)
     {
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-      return HAL_ERROR;
+      /* Prefetch Memory Address */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_LSB(MemAddress);
+
+      /* Reset Memaddress content */
+      hi2c->Memaddress = 0xFFFFFFFFU;
+    }
+    /* If Memory address size is 16Bit */
+    else
+    {
+      /* Prefetch Memory Address (MSB part, LSB will be manage through interrupt) */
+      hi2c->Instance->TXDR = I2C_MEM_ADD_MSB(MemAddress);
+
+      /* Prepare Memaddress buffer for LSB part */
+      hi2c->Memaddress = I2C_MEM_ADD_LSB(MemAddress);
     }
 
     if (hi2c->hdmarx != NULL)
@@ -2943,7 +3200,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
       hi2c->hdmarx->XferAbortCallback = NULL;
 
       /* Enable the DMA channel */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData,
+                                       hi2c->XferSize);
     }
     else
     {
@@ -2962,11 +3220,8 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
 
     if (dmaxferstatus == HAL_OK)
     {
-      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_GENERATE_START_READ);
-
-      /* Update XferCount value */
-      hi2c->XferCount -= hi2c->XferSize;
+      /* Send Slave Address and Memory Address */
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)MemAddSize, I2C_SOFTEND_MODE, I2C_GENERATE_START_WRITE);
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -2974,11 +3229,11 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
       /* Note : The I2C interrupts must be enabled after unlocking current process
                 to avoid the risk of I2C interrupt handle execution before current
                 process unlock */
-      /* Enable ERR and NACK interrupts */
-      I2C_Enable_IRQ(hi2c, I2C_XFER_ERROR_IT);
-
-      /* Enable DMA Request */
-      hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+      /* possible to enable all of these */
+      /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+        I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
     }
     else
     {
@@ -3002,6 +3257,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
     return HAL_BUSY;
   }
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /**
   * @brief  Checks if target device is ready for communication.
@@ -3014,11 +3270,14 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
+HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint32_t Trials,
+                                        uint32_t Timeout)
 {
   uint32_t tickstart;
 
   __IO uint32_t I2C_Trials = 0UL;
+
+  HAL_StatusTypeDef status = HAL_OK;
 
   FlagStatus tmp1;
   FlagStatus tmp2;
@@ -3077,55 +3336,65 @@ HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
         /* Wait until STOPF flag is reset */
         if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
         {
-          return HAL_ERROR;
+          /* A non acknowledge appear during STOP Flag waiting process, a new trial must be performed */
+          if (hi2c->ErrorCode == HAL_I2C_ERROR_AF)
+          {
+            /* Clear STOP Flag */
+            __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+
+            /* Reset the error code for next trial */
+            hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+          }
+          else
+          {
+            status = HAL_ERROR;
+          }
         }
+        else
+        {
+          /* A acknowledge appear during STOP Flag waiting process, this mean that device respond to its address */
 
-        /* Clear STOP Flag */
-        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+          /* Clear STOP Flag */
+          __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
 
-        /* Device is ready */
-        hi2c->State = HAL_I2C_STATE_READY;
+          /* Device is ready */
+          hi2c->State = HAL_I2C_STATE_READY;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hi2c);
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
 
-        return HAL_OK;
+          return HAL_OK;
+        }
       }
       else
       {
-        /* Wait until STOPF flag is reset */
-        if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
-        {
-          return HAL_ERROR;
-        }
+        /* A non acknowledge is detected, this mean that device not respond to its address,
+           a new trial must be performed */
 
         /* Clear NACK Flag */
         __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
 
-        /* Clear STOP Flag, auto generated with autoend*/
-        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
-      }
-
-      /* Check if the maximum allowed number of trials has been reached */
-      if (I2C_Trials == Trials)
-      {
-        /* Generate Stop */
-        hi2c->Instance->CR2 |= I2C_CR2_STOP;
-
         /* Wait until STOPF flag is reset */
         if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
         {
-          return HAL_ERROR;
+          status = HAL_ERROR;
         }
-
-        /* Clear STOP Flag */
-        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+        else
+        {
+          /* Clear STOP Flag, auto generated with autoend*/
+          __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+        }
       }
 
       /* Increment Trials */
       I2C_Trials++;
-    }
-    while (I2C_Trials < Trials);
+
+      if ((I2C_Trials < Trials) && (status == HAL_ERROR))
+      {
+        status = HAL_OK;
+      }
+
+    } while (I2C_Trials < Trials);
 
     /* Update I2C state */
     hi2c->State = HAL_I2C_STATE_READY;
@@ -3156,10 +3425,12 @@ HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                 uint16_t Size, uint32_t XferOptions)
 {
   uint32_t xfermode;
   uint32_t xferrequest = I2C_GENERATE_START_WRITE;
+  uint32_t sizetoxfer = 0U;
 
   /* Check the parameters */
   assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -3191,9 +3462,26 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
       xfermode = hi2c->XferOptions;
     }
 
-    /* If transfer direction not change and there is no request to start another frame, do not generate Restart Condition */
+    if ((hi2c->XferSize > 0U) && ((XferOptions == I2C_FIRST_FRAME) || \
+                                  (XferOptions == I2C_FIRST_AND_LAST_FRAME)))
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      sizetoxfer = hi2c->XferSize;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
+
+    /* If transfer direction not change and there is no request to start another frame,
+       do not generate Restart Condition */
     /* Mean Previous state is same as current state */
-    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) && (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
+    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) && \
+        (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
     {
       xferrequest = I2C_NO_STARTSTOP;
     }
@@ -3210,7 +3498,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
     }
 
     /* Send Slave Address and set NBYTES to write */
-    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+    if ((XferOptions == I2C_FIRST_FRAME) || (XferOptions == I2C_FIRST_AND_LAST_FRAME))
+    {
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, xfermode, xferrequest);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+    }
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -3218,6 +3513,10 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
     /* Note : The I2C interrupts must be enabled after unlocking current process
               to avoid the risk of I2C interrupt handle execution before current
               process unlock */
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+    /* possible to enable all of these */
+    /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+       I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
     I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
 
     return HAL_OK;
@@ -3228,6 +3527,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
   }
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Sequential transmit in master I2C mode an amount of data in non-blocking mode with DMA.
   * @note   This interface allow to manage repeated start condition when a direction change during transfer
@@ -3240,11 +3540,13 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                  uint16_t Size, uint32_t XferOptions)
 {
   uint32_t xfermode;
   uint32_t xferrequest = I2C_GENERATE_START_WRITE;
   HAL_StatusTypeDef dmaxferstatus;
+  uint32_t sizetoxfer = 0U;
 
   /* Check the parameters */
   assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -3276,9 +3578,26 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
       xfermode = hi2c->XferOptions;
     }
 
-    /* If transfer direction not change and there is no request to start another frame, do not generate Restart Condition */
+    if ((hi2c->XferSize > 0U) && ((XferOptions == I2C_FIRST_FRAME) || \
+                                  (XferOptions == I2C_FIRST_AND_LAST_FRAME)))
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      sizetoxfer = hi2c->XferSize;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
+
+    /* If transfer direction not change and there is no request to start another frame,
+       do not generate Restart Condition */
     /* Mean Previous state is same as current state */
-    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) && (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
+    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) && \
+        (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
     {
       xferrequest = I2C_NO_STARTSTOP;
     }
@@ -3309,7 +3628,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
         hi2c->hdmatx->XferAbortCallback = NULL;
 
         /* Enable the DMA channel */
-        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr,
+                                         (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
       }
       else
       {
@@ -3329,7 +3649,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
       if (dmaxferstatus == HAL_OK)
       {
         /* Send Slave Address and set NBYTES to write */
-        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+        if ((XferOptions == I2C_FIRST_FRAME) || (XferOptions == I2C_FIRST_AND_LAST_FRAME))
+        {
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, xfermode, xferrequest);
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+        }
 
         /* Update XferCount value */
         hi2c->XferCount -= hi2c->XferSize;
@@ -3368,7 +3695,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
 
       /* Send Slave Address */
       /* Set NBYTES to write and generate START condition */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_WRITE);
+      if ((XferOptions == I2C_FIRST_FRAME) || (XferOptions == I2C_FIRST_AND_LAST_FRAME))
+      {
+        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, xfermode, xferrequest);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+      }
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -3378,7 +3712,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
                 process unlock */
       /* Enable ERR, TC, STOP, NACK, TXI interrupt */
       /* possible to enable all of these */
-      /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+      /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+        I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
       I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
     }
 
@@ -3389,6 +3724,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
     return HAL_BUSY;
   }
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /**
   * @brief  Sequential receive in master I2C mode an amount of data in non-blocking mode with Interrupt
@@ -3402,7 +3738,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                uint16_t Size, uint32_t XferOptions)
 {
   uint32_t xfermode;
   uint32_t xferrequest = I2C_GENERATE_START_READ;
@@ -3437,9 +3774,11 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_
       xfermode = hi2c->XferOptions;
     }
 
-    /* If transfer direction not change and there is no request to start another frame, do not generate Restart Condition */
+    /* If transfer direction not change and there is no request to start another frame,
+       do not generate Restart Condition */
     /* Mean Previous state is same as current state */
-    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX) && (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
+    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX) && \
+        (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
     {
       xferrequest = I2C_NO_STARTSTOP;
     }
@@ -3474,6 +3813,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_
   }
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Sequential receive in master I2C mode an amount of data in non-blocking mode with DMA
   * @note   This interface allow to manage repeated start condition when a direction change during transfer
@@ -3486,7 +3826,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *pData,
+                                                 uint16_t Size, uint32_t XferOptions)
 {
   uint32_t xfermode;
   uint32_t xferrequest = I2C_GENERATE_START_READ;
@@ -3522,9 +3863,11 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
       xfermode = hi2c->XferOptions;
     }
 
-    /* If transfer direction not change and there is no request to start another frame, do not generate Restart Condition */
+    /* If transfer direction not change and there is no request to start another frame,
+       do not generate Restart Condition */
     /* Mean Previous state is same as current state */
-    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX) && (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
+    if ((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_RX) && \
+        (IS_I2C_TRANSFER_OTHER_OPTIONS_REQUEST(XferOptions) == 0))
     {
       xferrequest = I2C_NO_STARTSTOP;
     }
@@ -3555,7 +3898,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
         hi2c->hdmarx->XferAbortCallback = NULL;
 
         /* Enable the DMA channel */
-        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData,
+                                         hi2c->XferSize);
       }
       else
       {
@@ -3614,7 +3958,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
 
       /* Send Slave Address */
       /* Set NBYTES to read and generate START condition */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_GENERATE_START_READ);
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+                         I2C_GENERATE_START_READ);
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -3622,10 +3967,11 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
       /* Note : The I2C interrupts must be enabled after unlocking current process
                 to avoid the risk of I2C interrupt handle execution before current
                 process unlock */
-      /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+      /* Enable ERR, TC, STOP, NACK, RXI interrupt */
       /* possible to enable all of these */
-      /* I2C_IT_ERRI | I2C_IT_TCI| I2C_IT_STOPI| I2C_IT_NACKI | I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
-      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+      /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
+        I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
+      I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
     }
 
     return HAL_OK;
@@ -3635,6 +3981,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
     return HAL_BUSY;
   }
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /**
   * @brief  Sequential transmit in slave/device I2C mode an amount of data in non-blocking mode with Interrupt
@@ -3646,8 +3993,12 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                                uint32_t XferOptions)
 {
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  FlagStatus tmp;
+
   /* Check the parameters */
   assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
 
@@ -3672,6 +4023,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t
       /* Disable associated Interrupts */
       I2C_Disable_IRQ(hi2c, I2C_XFER_RX_IT);
 
+#if defined(HAL_DMA_MODULE_ENABLED)
       /* Abort DMA Xfer if any */
       if ((hi2c->Instance->CR1 & I2C_CR1_RXDMAEN) == I2C_CR1_RXDMAEN)
       {
@@ -3691,6 +4043,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t
           }
         }
       }
+#endif /* HAL_DMA_MODULE_ENABLED */
     }
 
     hi2c->State     = HAL_I2C_STATE_BUSY_TX_LISTEN;
@@ -3707,7 +4060,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t
     hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Slave_ISR_IT;
 
-    if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+    tmp = __HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR);
+    if ((I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE) && (tmp != RESET))
     {
       /* Clear ADDR flag after prepare the transfer parameters */
       /* This action will generate an acknowledge to the Master */
@@ -3731,6 +4085,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t
   }
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Sequential transmit in slave/device I2C mode an amount of data in non-blocking mode with DMA
   * @note   This interface allow to manage repeated start condition when a direction change during transfer
@@ -3741,8 +4096,11 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                                 uint32_t XferOptions)
 {
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  FlagStatus tmp;
   HAL_StatusTypeDef dmaxferstatus;
 
   /* Check the parameters */
@@ -3777,7 +4135,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
           hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
 
           /* Set the I2C DMA Abort callback :
-           will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
+          will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
           hi2c->hdmarx->XferAbortCallback = I2C_DMAAbort;
 
           /* Abort DMA RX */
@@ -3799,7 +4157,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
         if (hi2c->hdmatx != NULL)
         {
           /* Set the I2C DMA Abort callback :
-           will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
+          will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
           hi2c->hdmatx->XferAbortCallback = I2C_DMAAbort;
 
           /* Abort DMA TX */
@@ -3843,7 +4201,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
       hi2c->hdmatx->XferAbortCallback = NULL;
 
       /* Enable the DMA channel */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
+      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR,
+                                       hi2c->XferSize);
     }
     else
     {
@@ -3883,7 +4242,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
       return HAL_ERROR;
     }
 
-    if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+    tmp = __HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR);
+    if ((I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE) && (tmp != RESET))
     {
       /* Clear ADDR flag after prepare the transfer parameters */
       /* This action will generate an acknowledge to the Master */
@@ -3893,14 +4253,14 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
 
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+
     /* Note : The I2C interrupts must be enabled after unlocking current process
     to avoid the risk of I2C interrupt handle execution before current
     process unlock */
     /* Enable ERR, STOP, NACK, ADDR interrupts */
     I2C_Enable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
-
-    /* Enable DMA Request */
-    hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
 
     return HAL_OK;
   }
@@ -3909,6 +4269,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
     return HAL_ERROR;
   }
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /**
   * @brief  Sequential receive in slave/device I2C mode an amount of data in non-blocking mode with Interrupt
@@ -3920,8 +4281,12 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                               uint32_t XferOptions)
 {
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  FlagStatus tmp;
+
   /* Check the parameters */
   assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
 
@@ -3946,6 +4311,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t 
       /* Disable associated Interrupts */
       I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
 
+#if defined(HAL_DMA_MODULE_ENABLED)
       if ((hi2c->Instance->CR1 & I2C_CR1_TXDMAEN) == I2C_CR1_TXDMAEN)
       {
         hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
@@ -3965,6 +4331,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t 
           }
         }
       }
+#endif /* HAL_DMA_MODULE_ENABLED */
     }
 
     hi2c->State     = HAL_I2C_STATE_BUSY_RX_LISTEN;
@@ -3981,7 +4348,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t 
     hi2c->XferOptions = XferOptions;
     hi2c->XferISR     = I2C_Slave_ISR_IT;
 
-    if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_TRANSMIT)
+    tmp = __HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR);
+    if ((I2C_GET_DIR(hi2c) == I2C_DIRECTION_TRANSMIT) && (tmp != RESET))
     {
       /* Clear ADDR flag after prepare the transfer parameters */
       /* This action will generate an acknowledge to the Master */
@@ -4005,6 +4373,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t 
   }
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Sequential receive in slave/device I2C mode an amount of data in non-blocking mode with DMA
   * @note   This interface allow to manage repeated start condition when a direction change during transfer
@@ -4015,8 +4384,11 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_IT(I2C_HandleTypeDef *hi2c, uint8_t 
   * @param  XferOptions Options of Transfer, value of @ref I2C_XFEROPTIONS
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pData, uint16_t Size,
+                                                uint32_t XferOptions)
 {
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  FlagStatus tmp;
   HAL_StatusTypeDef dmaxferstatus;
 
   /* Check the parameters */
@@ -4117,7 +4489,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t
       hi2c->hdmarx->XferAbortCallback = NULL;
 
       /* Enable the DMA channel */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)pData, hi2c->XferSize);
+      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR,
+                                       (uint32_t)pData, hi2c->XferSize);
     }
     else
     {
@@ -4157,7 +4530,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t
       return HAL_ERROR;
     }
 
-    if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_TRANSMIT)
+    tmp = __HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_ADDR);
+    if ((I2C_GET_DIR(hi2c) == I2C_DIRECTION_TRANSMIT) && (tmp != RESET))
     {
       /* Clear ADDR flag after prepare the transfer parameters */
       /* This action will generate an acknowledge to the Master */
@@ -4167,14 +4541,14 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
 
+    /* Enable DMA Request */
+    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+
     /* Note : The I2C interrupts must be enabled after unlocking current process
     to avoid the risk of I2C interrupt handle execution before current
     process unlock */
     /* REnable ADDR interrupt */
     I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT | I2C_XFER_LISTEN_IT);
-
-    /* Enable DMA Request */
-    hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
 
     return HAL_OK;
   }
@@ -4183,6 +4557,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t
     return HAL_ERROR;
   }
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /**
   * @brief  Enable the Address listen mode with Interrupt.
@@ -4240,7 +4615,7 @@ HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
 }
 
 /**
-  * @brief  Abort a master I2C IT or DMA process communication with Interrupt.
+  * @brief  Abort a master or memory I2C IT or DMA process communication with Interrupt.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  DevAddress Target device address: The device 7 bits address value
@@ -4249,7 +4624,9 @@ HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
   */
 HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
-  if (hi2c->Mode == HAL_I2C_MODE_MASTER)
+  HAL_I2C_ModeTypeDef tmp_mode = hi2c->Mode;
+
+  if ((tmp_mode == HAL_I2C_MODE_MASTER) || (tmp_mode == HAL_I2C_MODE_MEM))
   {
     /* Process Locked */
     __HAL_LOCK(hi2c);
@@ -4300,8 +4677,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevA
   */
 
 /** @defgroup I2C_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  This function handles I2C event interrupt request.
@@ -4309,7 +4686,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevA
   *                the configuration information for the specified I2C.
   * @retval None
   */
-void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c)
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c) /* Derogation MISRAC2012-Rule-8.13 */
 {
   /* Get current IT Flags and IT sources value */
   uint32_t itflags   = READ_REG(hi2c->Instance->ISR);
@@ -4335,7 +4712,8 @@ void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
   uint32_t tmperror;
 
   /* I2C Bus error interrupt occurred ------------------------------------*/
-  if ((I2C_CHECK_FLAG(itflags, I2C_FLAG_BERR) != RESET) && (I2C_CHECK_IT_SOURCE(itsources, I2C_IT_ERRI) != RESET))
+  if ((I2C_CHECK_FLAG(itflags, I2C_FLAG_BERR) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(itsources, I2C_IT_ERRI) != RESET))
   {
     hi2c->ErrorCode |= HAL_I2C_ERROR_BERR;
 
@@ -4344,7 +4722,8 @@ void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
   }
 
   /* I2C Over-Run/Under-Run interrupt occurred ----------------------------------------*/
-  if ((I2C_CHECK_FLAG(itflags, I2C_FLAG_OVR) != RESET) && (I2C_CHECK_IT_SOURCE(itsources, I2C_IT_ERRI) != RESET))
+  if ((I2C_CHECK_FLAG(itflags, I2C_FLAG_OVR) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(itsources, I2C_IT_ERRI) != RESET))
   {
     hi2c->ErrorCode |= HAL_I2C_ERROR_OVR;
 
@@ -4353,7 +4732,8 @@ void HAL_I2C_ER_IRQHandler(I2C_HandleTypeDef *hi2c)
   }
 
   /* I2C Arbitration Loss error interrupt occurred -------------------------------------*/
-  if ((I2C_CHECK_FLAG(itflags, I2C_FLAG_ARLO) != RESET) && (I2C_CHECK_IT_SOURCE(itsources, I2C_IT_ERRI) != RESET))
+  if ((I2C_CHECK_FLAG(itflags, I2C_FLAG_ARLO) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(itsources, I2C_IT_ERRI) != RESET))
   {
     hi2c->ErrorCode |= HAL_I2C_ERROR_ARLO;
 
@@ -4539,8 +4919,8 @@ __weak void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c)
   */
 
 /** @defgroup I2C_Exported_Functions_Group3 Peripheral State, Mode and Error functions
- *  @brief   Peripheral State, Mode and Error functions
- *
+  *  @brief   Peripheral State, Mode and Error functions
+  *
 @verbatim
  ===============================================================================
             ##### Peripheral State, Mode and Error functions #####
@@ -4559,7 +4939,7 @@ __weak void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c)
   *                the configuration information for the specified I2C.
   * @retval HAL state
   */
-HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
+HAL_I2C_StateTypeDef HAL_I2C_GetState(const I2C_HandleTypeDef *hi2c)
 {
   /* Return I2C handle state */
   return hi2c->State;
@@ -4571,18 +4951,18 @@ HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
   *         the configuration information for I2C module
   * @retval HAL mode
   */
-HAL_I2C_ModeTypeDef HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c)
+HAL_I2C_ModeTypeDef HAL_I2C_GetMode(const I2C_HandleTypeDef *hi2c)
 {
   return hi2c->Mode;
 }
 
 /**
-* @brief  Return the I2C error code.
+  * @brief  Return the I2C error code.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *              the configuration information for the specified I2C.
-* @retval I2C Error Code
-*/
-uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
+  * @retval I2C Error Code
+  */
+uint32_t HAL_I2C_GetError(const I2C_HandleTypeDef *hi2c)
 {
   return hi2c->ErrorCode;
 }
@@ -4607,7 +4987,8 @@ uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
   * @param  ITSources Interrupt sources enabled.
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources)
+static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                           uint32_t ITSources)
 {
   uint16_t devaddress;
   uint32_t tmpITFlags = ITFlags;
@@ -4615,7 +4996,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
   /* Process Locked */
   __HAL_LOCK(hi2c);
 
-  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Clear NACK Flag */
     __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
@@ -4628,7 +5010,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
     /* Flush TX register */
     I2C_Flush_TXDR(hi2c);
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_RXNE) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_RXI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_RXNE) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_RXI) != RESET))
   {
     /* Remove RXNE flag on temporary variable as read done */
     tmpITFlags &= ~I2C_FLAG_RXNE;
@@ -4642,18 +5025,25 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
     hi2c->XferSize--;
     hi2c->XferCount--;
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TC) == RESET) && \
+           ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && \
+            (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET)))
   {
     /* Write data to TXDR */
-    hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+    if (hi2c->XferCount != 0U)
+    {
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
 
-    /* Increment Buffer pointer */
-    hi2c->pBuffPtr++;
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
 
-    hi2c->XferSize--;
-    hi2c->XferCount--;
+      hi2c->XferSize--;
+      hi2c->XferCount--;
+    }
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TCR) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TCR) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
     if ((hi2c->XferCount != 0U) && (hi2c->XferSize == 0U))
     {
@@ -4669,11 +5059,13 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
         hi2c->XferSize = hi2c->XferCount;
         if (hi2c->XferOptions != I2C_NO_OPTION_FRAME)
         {
-          I2C_TransferConfig(hi2c, devaddress, (uint8_t)hi2c->XferSize, hi2c->XferOptions, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, devaddress, (uint8_t)hi2c->XferSize,
+                             hi2c->XferOptions, I2C_NO_STARTSTOP);
         }
         else
         {
-          I2C_TransferConfig(hi2c, devaddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+          I2C_TransferConfig(hi2c, devaddress, (uint8_t)hi2c->XferSize,
+                             I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
         }
       }
     }
@@ -4693,7 +5085,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
       }
     }
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TC) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TC) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
     if (hi2c->XferCount == 0U)
     {
@@ -4724,7 +5117,151 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
     /* Nothing to do */
   }
 
-  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_STOPF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_STOPF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
+  {
+    /* Call I2C Master complete process */
+    I2C_ITMasterCplt(hi2c, tmpITFlags);
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Memory Mode with Interrupt.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  ITFlags Interrupt flags to handle.
+  * @param  ITSources Interrupt sources enabled.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_Mem_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                        uint32_t ITSources)
+{
+  uint32_t direction = I2C_GENERATE_START_WRITE;
+  uint32_t tmpITFlags = ITFlags;
+
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Set corresponding Error Code */
+    /* No need to generate STOP, it is automatically done */
+    /* Error callback will be send during stop flag treatment */
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+    /* Flush TX register */
+    I2C_Flush_TXDR(hi2c);
+  }
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_RXNE) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_RXI) != RESET))
+  {
+    /* Remove RXNE flag on temporary variable as read done */
+    tmpITFlags &= ~I2C_FLAG_RXNE;
+
+    /* Read data from RXDR */
+    *hi2c->pBuffPtr = (uint8_t)hi2c->Instance->RXDR;
+
+    /* Increment Buffer pointer */
+    hi2c->pBuffPtr++;
+
+    hi2c->XferSize--;
+    hi2c->XferCount--;
+  }
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET))
+  {
+    if (hi2c->Memaddress == 0xFFFFFFFFU)
+    {
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferSize--;
+      hi2c->XferCount--;
+    }
+    else
+    {
+      /* Write LSB part of Memory Address */
+      hi2c->Instance->TXDR = hi2c->Memaddress;
+
+      /* Reset Memaddress content */
+      hi2c->Memaddress = 0xFFFFFFFFU;
+    }
+  }
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TCR) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  {
+    if ((hi2c->XferCount != 0U) && (hi2c->XferSize == 0U))
+    {
+      if (hi2c->XferCount > MAX_NBYTE_SIZE)
+      {
+        hi2c->XferSize = MAX_NBYTE_SIZE;
+        I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                           I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+        I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                           I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+    }
+    else
+    {
+      /* Wrong size Status regarding TCR flag event */
+      /* Call the corresponding callback to inform upper layer of End of Transfer */
+      I2C_ITError(hi2c, HAL_I2C_ERROR_SIZE);
+    }
+  }
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TC) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  {
+    /* Disable Interrupt related to address step */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    /* Enable ERR, TC, STOP, NACK and RXI interrupts */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+
+    if (hi2c->State == HAL_I2C_STATE_BUSY_RX)
+    {
+      direction = I2C_GENERATE_START_READ;
+    }
+
+    if (hi2c->XferCount > MAX_NBYTE_SIZE)
+    {
+      hi2c->XferSize = MAX_NBYTE_SIZE;
+
+      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
+      I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                         I2C_RELOAD_MODE, direction);
+    }
+    else
+    {
+      hi2c->XferSize = hi2c->XferCount;
+
+      /* Set NBYTES to write and generate RESTART */
+      I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                         I2C_AUTOEND_MODE, direction);
+    }
+  }
+  else
+  {
+    /* Nothing to do */
+  }
+
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_STOPF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
   {
     /* Call I2C Master complete process */
     I2C_ITMasterCplt(hi2c, tmpITFlags);
@@ -4744,7 +5281,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
   * @param  ITSources Interrupt sources enabled.
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources)
+static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                          uint32_t ITSources)
 {
   uint32_t tmpoptions = hi2c->XferOptions;
   uint32_t tmpITFlags = ITFlags;
@@ -4753,13 +5291,14 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
   __HAL_LOCK(hi2c);
 
   /* Check if STOPF is set */
-  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_STOPF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_STOPF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
   {
     /* Call I2C Slave complete process */
     I2C_ITSlaveCplt(hi2c, tmpITFlags);
   }
-
-  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Check that I2C transfer finished */
     /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
@@ -4767,7 +5306,9 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
     /* So clear Flag NACKF only */
     if (hi2c->XferCount == 0U)
     {
-      if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME)) /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for Warning[Pa134]: left and right operands are identical */
+      if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME))
+        /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for
+           Warning[Pa134]: left and right operands are identical */
       {
         /* Call I2C Listen complete process */
         I2C_ITListenCplt(hi2c, tmpITFlags);
@@ -4806,7 +5347,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
       }
     }
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_RXNE) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_RXI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_RXNE) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_RXI) != RESET))
   {
     if (hi2c->XferCount > 0U)
     {
@@ -4827,15 +5369,17 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
       I2C_ITSlaveSeqCplt(hi2c);
     }
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_ADDR) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_ADDRI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_ADDR) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_ADDRI) != RESET))
   {
     I2C_ITAddrCplt(hi2c, tmpITFlags);
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET))
   {
     /* Write data to TXDR only if XferCount not reach "0" */
     /* A TXIS flag can be set, during STOP treatment      */
-    /* Check if all data have already been sent */
+    /* Check if all Data have already been sent */
     /* If it is the case, this last write in TXDR is not sent, correspond to a dummy TXIS event */
     if (hi2c->XferCount > 0U)
     {
@@ -4869,6 +5413,7 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
   return HAL_OK;
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Master Mode with DMA.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -4877,7 +5422,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
   * @param  ITSources Interrupt sources enabled.
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources)
+static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                            uint32_t ITSources)
 {
   uint16_t devaddress;
   uint32_t xfermode;
@@ -4885,7 +5431,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
   /* Process Locked */
   __HAL_LOCK(hi2c);
 
-  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Clear NACK Flag */
     __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
@@ -4901,7 +5448,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
     /* Flush TX register */
     I2C_Flush_TXDR(hi2c);
   }
-  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TCR) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TCR) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
     /* Disable TC interrupt */
     __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_TCI);
@@ -4962,7 +5510,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
       }
     }
   }
-  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TC) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TC) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
     if (hi2c->XferCount == 0U)
     {
@@ -4988,7 +5537,156 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
       I2C_ITError(hi2c, HAL_I2C_ERROR_SIZE);
     }
   }
-  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_STOPF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_STOPF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
+  {
+    /* Call I2C Master complete process */
+    I2C_ITMasterCplt(hi2c, ITFlags);
+  }
+  else
+  {
+    /* Nothing to do */
+  }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hi2c);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Interrupt Sub-Routine which handle the Interrupt Flags Memory Mode with DMA.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  ITFlags Interrupt flags to handle.
+  * @param  ITSources Interrupt sources enabled.
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                         uint32_t ITSources)
+{
+  uint32_t direction = I2C_GENERATE_START_WRITE;
+
+  /* Process Locked */
+  __HAL_LOCK(hi2c);
+
+  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  {
+    /* Clear NACK Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Set corresponding Error Code */
+    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+    /* No need to generate STOP, it is automatically done */
+    /* But enable STOP interrupt, to treat it */
+    /* Error callback will be send during stop flag treatment */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_CPLT_IT);
+
+    /* Flush TX register */
+    I2C_Flush_TXDR(hi2c);
+  }
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TXIS) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET))
+  {
+    /* Write LSB part of Memory Address */
+    hi2c->Instance->TXDR = hi2c->Memaddress;
+
+    /* Reset Memaddress content */
+    hi2c->Memaddress = 0xFFFFFFFFU;
+  }
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TCR) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  {
+    /* Disable Interrupt related to address step */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    /* Enable only Error interrupt */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_ERROR_IT);
+
+    if (hi2c->XferCount != 0U)
+    {
+      /* Prepare the new XferSize to transfer */
+      if (hi2c->XferCount > MAX_NBYTE_SIZE)
+      {
+        hi2c->XferSize = MAX_NBYTE_SIZE;
+        I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                           I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
+      }
+      else
+      {
+        hi2c->XferSize = hi2c->XferCount;
+        I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                           I2C_AUTOEND_MODE, I2C_NO_STARTSTOP);
+      }
+
+      /* Update XferCount value */
+      hi2c->XferCount -= hi2c->XferSize;
+
+      /* Enable DMA Request */
+      if (hi2c->State == HAL_I2C_STATE_BUSY_RX)
+      {
+        hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+      }
+      else
+      {
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+    }
+    else
+    {
+      /* Wrong size Status regarding TCR flag event */
+      /* Call the corresponding callback to inform upper layer of End of Transfer */
+      I2C_ITError(hi2c, HAL_I2C_ERROR_SIZE);
+    }
+  }
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TC) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
+  {
+    /* Disable Interrupt related to address step */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    /* Enable only Error and NACK interrupt for data transfer */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_ERROR_IT);
+
+    if (hi2c->State == HAL_I2C_STATE_BUSY_RX)
+    {
+      direction = I2C_GENERATE_START_READ;
+    }
+
+    if (hi2c->XferCount > MAX_NBYTE_SIZE)
+    {
+      hi2c->XferSize = MAX_NBYTE_SIZE;
+
+      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
+      I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                         I2C_RELOAD_MODE, direction);
+    }
+    else
+    {
+      hi2c->XferSize = hi2c->XferCount;
+
+      /* Set NBYTES to write and generate RESTART */
+      I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
+                         I2C_AUTOEND_MODE, direction);
+    }
+
+    /* Update XferCount value */
+    hi2c->XferCount -= hi2c->XferSize;
+
+    /* Enable DMA Request */
+    if (hi2c->State == HAL_I2C_STATE_BUSY_RX)
+    {
+      hi2c->Instance->CR1 |= I2C_CR1_RXDMAEN;
+    }
+    else
+    {
+      hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+    }
+  }
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_STOPF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
   {
     /* Call I2C Master complete process */
     I2C_ITMasterCplt(hi2c, ITFlags);
@@ -5012,7 +5710,8 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
   * @param  ITSources Interrupt sources enabled.
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags, uint32_t ITSources)
+static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
+                                           uint32_t ITSources)
 {
   uint32_t tmpoptions = hi2c->XferOptions;
   uint32_t treatdmanack = 0U;
@@ -5022,13 +5721,14 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
   __HAL_LOCK(hi2c);
 
   /* Check if STOPF is set */
-  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_STOPF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
+  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_STOPF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_STOPI) != RESET))
   {
     /* Call I2C Slave complete process */
     I2C_ITSlaveCplt(hi2c, ITFlags);
   }
-
-  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Check that I2C transfer finished */
     /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
@@ -5042,7 +5742,7 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
       {
         if (I2C_CHECK_IT_SOURCE(ITSources, I2C_CR1_RXDMAEN) != RESET)
         {
-          if (__HAL_DMA_GET_COUNTER(hi2c->hdmarx) == 0U)
+          if (I2C_GET_DMA_REMAIN_DATA(hi2c->hdmarx) == 0U)
           {
             treatdmanack = 1U;
           }
@@ -5054,7 +5754,7 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
       {
         if (I2C_CHECK_IT_SOURCE(ITSources, I2C_CR1_TXDMAEN) != RESET)
         {
-          if (__HAL_DMA_GET_COUNTER(hi2c->hdmatx) == 0U)
+          if (I2C_GET_DMA_REMAIN_DATA(hi2c->hdmatx) == 0U)
           {
             treatdmanack = 1U;
           }
@@ -5063,7 +5763,9 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
 
       if (treatdmanack == 1U)
       {
-        if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME)) /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for Warning[Pa134]: left and right operands are identical */
+        if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME))
+          /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for
+             Warning[Pa134]: left and right operands are identical */
         {
           /* Call I2C Listen complete process */
           I2C_ITListenCplt(hi2c, ITFlags);
@@ -5124,7 +5826,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
       __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
     }
   }
-  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_ADDR) != RESET) && (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_ADDRI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_ADDR) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_ADDRI) != RESET))
   {
     I2C_ITAddrCplt(hi2c, ITFlags);
   }
@@ -5138,6 +5841,7 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
 
   return HAL_OK;
 }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 /**
   * @brief  Master sends target device address followed by internal memory address for write request.
@@ -5151,7 +5855,9 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
   * @param  Tickstart Tick start value
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart)
+static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
+                                                uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout,
+                                                uint32_t Tickstart)
 {
   I2C_TransferConfig(hi2c, DevAddress, (uint8_t)MemAddSize, I2C_RELOAD_MODE, I2C_GENERATE_START_WRITE);
 
@@ -5204,7 +5910,9 @@ static HAL_StatusTypeDef I2C_RequestMemoryWrite(I2C_HandleTypeDef *hi2c, uint16_
   * @param  Tickstart Tick start value
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout, uint32_t Tickstart)
+static HAL_StatusTypeDef I2C_RequestMemoryRead(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
+                                               uint16_t MemAddress, uint16_t MemAddSize, uint32_t Timeout,
+                                               uint32_t Tickstart)
 {
   I2C_TransferConfig(hi2c, DevAddress, (uint8_t)MemAddSize, I2C_SOFTEND_MODE, I2C_GENERATE_START_WRITE);
 
@@ -5272,7 +5980,7 @@ static void I2C_ITAddrCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
     /* If 10bits addressing mode is selected */
     if (hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
     {
-      if ((slaveaddrcode & SlaveAddr_MSK) == ((ownadd1code >> SlaveAddr_SHIFT) & SlaveAddr_MSK))
+      if ((slaveaddrcode & SLAVE_ADDR_MSK) == ((ownadd1code >> SLAVE_ADDR_SHIFT) & SLAVE_ADDR_MSK))
       {
         slaveaddrcode = ownadd1code;
         hi2c->AddrEventCount++;
@@ -5406,6 +6114,7 @@ static void I2C_ITSlaveSeqCplt(I2C_HandleTypeDef *hi2c)
   /* Reset I2C handle mode */
   hi2c->Mode = HAL_I2C_MODE_NONE;
 
+#if defined(HAL_DMA_MODULE_ENABLED)
   /* If a DMA is ongoing, Update handle size context */
   if (I2C_CHECK_IT_SOURCE(tmpcr1value, I2C_CR1_TXDMAEN) != RESET)
   {
@@ -5421,6 +6130,7 @@ static void I2C_ITSlaveSeqCplt(I2C_HandleTypeDef *hi2c)
   {
     /* Do nothing */
   }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
   if (hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN)
   {
@@ -5620,6 +6330,7 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 {
   uint32_t tmpcr1value = READ_REG(hi2c->Instance->CR1);
   uint32_t tmpITFlags = ITFlags;
+  uint32_t tmpoptions = hi2c->XferOptions;
   HAL_I2C_StateTypeDef tmpstate = hi2c->State;
 
   /* Clear STOP Flag */
@@ -5636,6 +6347,11 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
     I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_RX_IT);
     hi2c->PreviousState = I2C_STATE_SLAVE_BUSY_RX;
   }
+  else if (tmpstate == HAL_I2C_STATE_LISTEN)
+  {
+    I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_TX_IT | I2C_XFER_RX_IT);
+    hi2c->PreviousState = I2C_STATE_NONE;
+  }
   else
   {
     /* Do nothing */
@@ -5650,6 +6366,7 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
   /* Flush TX register */
   I2C_Flush_TXDR(hi2c);
 
+#if defined(HAL_DMA_MODULE_ENABLED)
   /* If a DMA is ongoing, Update handle size context */
   if (I2C_CHECK_IT_SOURCE(tmpcr1value, I2C_CR1_TXDMAEN) != RESET)
   {
@@ -5658,7 +6375,7 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 
     if (hi2c->hdmatx != NULL)
     {
-      hi2c->XferCount = (uint16_t)__HAL_DMA_GET_COUNTER(hi2c->hdmatx);
+      hi2c->XferCount = (uint16_t)I2C_GET_DMA_REMAIN_DATA(hi2c->hdmatx);
     }
   }
   else if (I2C_CHECK_IT_SOURCE(tmpcr1value, I2C_CR1_RXDMAEN) != RESET)
@@ -5668,13 +6385,14 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 
     if (hi2c->hdmarx != NULL)
     {
-      hi2c->XferCount = (uint16_t)__HAL_DMA_GET_COUNTER(hi2c->hdmarx);
+      hi2c->XferCount = (uint16_t)I2C_GET_DMA_REMAIN_DATA(hi2c->hdmarx);
     }
   }
   else
   {
     /* Do nothing */
   }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
   /* Store Last receive data if any */
   if (I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_RXNE) != RESET)
@@ -5688,7 +6406,7 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
     /* Increment Buffer pointer */
     hi2c->pBuffPtr++;
 
-    if ((hi2c->XferSize > 0U))
+    if (hi2c->XferSize > 0U)
     {
       hi2c->XferSize--;
       hi2c->XferCount--;
@@ -5700,6 +6418,57 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
   {
     /* Set ErrorCode corresponding to a Non-Acknowledge */
     hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+  }
+
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(tmpcr1value, I2C_IT_NACKI) != RESET))
+  {
+    /* Check that I2C transfer finished */
+    /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if (hi2c->XferCount == 0U)
+    {
+      if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME))
+        /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for
+           Warning[Pa134]: left and right operands are identical */
+      {
+        /* Call I2C Listen complete process */
+        I2C_ITListenCplt(hi2c, tmpITFlags);
+      }
+      else if ((hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN) && (tmpoptions != I2C_NO_OPTION_FRAME))
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Flush TX register */
+        I2C_Flush_TXDR(hi2c);
+
+        /* Last Byte is Transmitted */
+        /* Call I2C Slave Sequential complete process */
+        I2C_ITSlaveSeqCplt(hi2c);
+      }
+      else
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+      }
+    }
+    else
+    {
+      /* if no, error use case, a Non-Acknowledge of last Data is generated by the MASTER*/
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+      if ((tmpoptions == I2C_FIRST_FRAME) || (tmpoptions == I2C_NEXT_FRAME))
+      {
+        /* Call the corresponding callback to inform upper layer of End of Transfer */
+        I2C_ITError(hi2c, hi2c->ErrorCode);
+      }
+    }
   }
 
   hi2c->Mode = HAL_I2C_MODE_NONE;
@@ -5793,7 +6562,7 @@ static void I2C_ITListenCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
     /* Increment Buffer pointer */
     hi2c->pBuffPtr++;
 
-    if ((hi2c->XferSize > 0U))
+    if (hi2c->XferSize > 0U)
     {
       hi2c->XferSize--;
       hi2c->XferCount--;
@@ -5829,7 +6598,10 @@ static void I2C_ITListenCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode)
 {
   HAL_I2C_StateTypeDef tmpstate = hi2c->State;
+
+#if defined(HAL_DMA_MODULE_ENABLED)
   uint32_t tmppreviousstate;
+#endif /* HAL_DMA_MODULE_ENABLED */
 
   /* Reset handle parameters */
   hi2c->Mode          = HAL_I2C_MODE_NONE;
@@ -5856,19 +6628,39 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode)
     /* Disable all interrupts */
     I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_RX_IT | I2C_XFER_TX_IT);
 
+    /* Flush TX register */
+    I2C_Flush_TXDR(hi2c);
+
     /* If state is an abort treatment on going, don't change state */
     /* This change will be do later */
     if (hi2c->State != HAL_I2C_STATE_ABORT)
     {
       /* Set HAL_I2C_STATE_READY */
       hi2c->State         = HAL_I2C_STATE_READY;
+
+      /* Check if a STOPF is detected */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+      {
+        if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+        {
+          __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+
     }
     hi2c->XferISR       = NULL;
   }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
   /* Abort DMA TX transfer if any */
   tmppreviousstate = hi2c->PreviousState;
-  if ((hi2c->hdmatx != NULL) && ((tmppreviousstate == I2C_STATE_MASTER_BUSY_TX) || (tmppreviousstate == I2C_STATE_SLAVE_BUSY_TX)))
+
+  if ((hi2c->hdmatx != NULL) && ((tmppreviousstate == I2C_STATE_MASTER_BUSY_TX) || \
+                                 (tmppreviousstate == I2C_STATE_SLAVE_BUSY_TX)))
   {
     if ((hi2c->Instance->CR1 & I2C_CR1_TXDMAEN) == I2C_CR1_TXDMAEN)
     {
@@ -5897,7 +6689,8 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode)
     }
   }
   /* Abort DMA RX transfer if any */
-  else if ((hi2c->hdmarx != NULL) && ((tmppreviousstate == I2C_STATE_MASTER_BUSY_RX) || (tmppreviousstate == I2C_STATE_SLAVE_BUSY_RX)))
+  else if ((hi2c->hdmarx != NULL) && ((tmppreviousstate == I2C_STATE_MASTER_BUSY_RX) || \
+                                      (tmppreviousstate == I2C_STATE_SLAVE_BUSY_RX)))
   {
     if ((hi2c->Instance->CR1 & I2C_CR1_RXDMAEN) == I2C_CR1_RXDMAEN)
     {
@@ -5926,6 +6719,7 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode)
     }
   }
   else
+#endif /* HAL_DMA_MODULE_ENABLED */
   {
     I2C_TreatErrorCallback(hi2c);
   }
@@ -5990,6 +6784,7 @@ static void I2C_Flush_TXDR(I2C_HandleTypeDef *hi2c)
   }
 }
 
+#if defined(HAL_DMA_MODULE_ENABLED)
 /**
   * @brief  DMA I2C master transmit process complete callback.
   * @param  hdma DMA handle
@@ -5997,7 +6792,8 @@ static void I2C_Flush_TXDR(I2C_HandleTypeDef *hi2c)
   */
 static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
 {
-  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  /* Derogation MISRAC2012-Rule-11.5 */
+  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Disable DMA Request */
   hi2c->Instance->CR1 &= ~I2C_CR1_TXDMAEN;
@@ -6025,7 +6821,8 @@ static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
     }
 
     /* Enable the DMA channel */
-    if (HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize) != HAL_OK)
+    if (HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR,
+                         hi2c->XferSize) != HAL_OK)
     {
       /* Call the corresponding callback to inform upper layer of End of Transfer */
       I2C_ITError(hi2c, HAL_I2C_ERROR_DMA);
@@ -6038,6 +6835,7 @@ static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
   }
 }
 
+
 /**
   * @brief  DMA I2C slave transmit process complete callback.
   * @param  hdma DMA handle
@@ -6045,7 +6843,8 @@ static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
   */
 static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma)
 {
-  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  /* Derogation MISRAC2012-Rule-11.5 */
+  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
   uint32_t tmpoptions = hi2c->XferOptions;
 
   if ((tmpoptions == I2C_NEXT_FRAME) || (tmpoptions == I2C_FIRST_FRAME))
@@ -6065,6 +6864,7 @@ static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma)
   }
 }
 
+
 /**
   * @brief DMA I2C master receive process complete callback.
   * @param  hdma DMA handle
@@ -6072,7 +6872,8 @@ static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma)
   */
 static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  /* Derogation MISRAC2012-Rule-11.5 */
+  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Disable DMA Request */
   hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
@@ -6100,7 +6901,8 @@ static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
     }
 
     /* Enable the DMA channel */
-    if (HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr, hi2c->XferSize) != HAL_OK)
+    if (HAL_DMA_Start_IT(hi2c->hdmarx, (uint32_t)&hi2c->Instance->RXDR, (uint32_t)hi2c->pBuffPtr,
+                         hi2c->XferSize) != HAL_OK)
     {
       /* Call the corresponding callback to inform upper layer of End of Transfer */
       I2C_ITError(hi2c, HAL_I2C_ERROR_DMA);
@@ -6113,6 +6915,7 @@ static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
   }
 }
 
+
 /**
   * @brief  DMA I2C slave receive process complete callback.
   * @param  hdma DMA handle
@@ -6120,10 +6923,11 @@ static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  /* Derogation MISRAC2012-Rule-11.5 */
+  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
   uint32_t tmpoptions = hi2c->XferOptions;
 
-  if ((__HAL_DMA_GET_COUNTER(hi2c->hdmarx) == 0U) && \
+  if ((I2C_GET_DMA_REMAIN_DATA(hi2c->hdmarx) == 0U) && \
       (tmpoptions != I2C_NO_OPTION_FRAME))
   {
     /* Disable DMA Request */
@@ -6140,6 +6944,7 @@ static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma)
   }
 }
 
+
 /**
   * @brief  DMA I2C communication error callback.
   * @param hdma DMA handle
@@ -6147,7 +6952,8 @@ static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void I2C_DMAError(DMA_HandleTypeDef *hdma)
 {
-  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  /* Derogation MISRAC2012-Rule-11.5 */
+  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Disable Acknowledge */
   hi2c->Instance->CR2 |= I2C_CR2_NACK;
@@ -6155,6 +6961,7 @@ static void I2C_DMAError(DMA_HandleTypeDef *hdma)
   /* Call the corresponding callback to inform upper layer of End of Transfer */
   I2C_ITError(hi2c, HAL_I2C_ERROR_DMA);
 }
+
 
 /**
   * @brief DMA I2C communication abort callback
@@ -6164,7 +6971,8 @@ static void I2C_DMAError(DMA_HandleTypeDef *hdma)
   */
 static void I2C_DMAAbort(DMA_HandleTypeDef *hdma)
 {
-  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  /* Derogation MISRAC2012-Rule-11.5 */
+  I2C_HandleTypeDef *hi2c = (I2C_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Reset AbortCpltCallback */
   if (hi2c->hdmatx != NULL)
@@ -6179,32 +6987,45 @@ static void I2C_DMAAbort(DMA_HandleTypeDef *hdma)
   I2C_TreatErrorCallback(hi2c);
 }
 
+#endif /* HAL_DMA_MODULE_ENABLED */
+
 /**
-  * @brief  This function handles I2C Communication Timeout.
+  * @brief  This function handles I2C Communication Timeout. It waits
+  *                until a flag is no longer in the specified status.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  Flag Specifies the I2C flag to check.
-  * @param  Status The new Flag status (SET or RESET).
+  * @param  Status The actual Flag status (SET or RESET).
   * @param  Timeout Timeout duration
   * @param  Tickstart Tick start value
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status, uint32_t Timeout, uint32_t Tickstart)
+static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Flag, FlagStatus Status,
+                                                    uint32_t Timeout, uint32_t Tickstart)
 {
   while (__HAL_I2C_GET_FLAG(hi2c, Flag) == Status)
   {
+    /* Check if an error is detected */
+    if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
     /* Check for the Timeout */
     if (Timeout != HAL_MAX_DELAY)
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-        hi2c->State = HAL_I2C_STATE_READY;
-        hi2c->Mode = HAL_I2C_MODE_NONE;
+        if (__HAL_I2C_GET_FLAG(hi2c, Flag) == Status)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hi2c);
-        return HAL_ERROR;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_ERROR;
+        }
       }
     }
   }
@@ -6219,12 +7040,13 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
   * @param  Tickstart Tick start value
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                                        uint32_t Tickstart)
 {
   while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET)
   {
-    /* Check if a NACK is detected */
-    if (I2C_IsAcknowledgeFailed(hi2c, Timeout, Tickstart) != HAL_OK)
+    /* Check if an error is detected */
+    if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
     {
       return HAL_ERROR;
     }
@@ -6233,6 +7055,47 @@ static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
     if (Timeout != HAL_MAX_DELAY)
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
+      {
+        if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET)
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  This function handles I2C Communication Timeout for specific usage of STOP flag.
+  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
+  *                the configuration information for the specified I2C.
+  * @param  Timeout Timeout duration
+  * @param  Tickstart Tick start value
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                                        uint32_t Tickstart)
+{
+  while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+  {
+    /* Check if an error is detected */
+    if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
+    /* Check for the Timeout */
+    if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
+    {
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
       {
         hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
         hi2c->State = HAL_I2C_STATE_READY;
@@ -6249,40 +7112,6 @@ static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
 }
 
 /**
-  * @brief  This function handles I2C Communication Timeout for specific usage of STOP flag.
-  * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
-  *                the configuration information for the specified I2C.
-  * @param  Timeout Timeout duration
-  * @param  Tickstart Tick start value
-  * @retval HAL status
-  */
-static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
-{
-  while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
-  {
-    /* Check if a NACK is detected */
-    if (I2C_IsAcknowledgeFailed(hi2c, Timeout, Tickstart) != HAL_OK)
-    {
-      return HAL_ERROR;
-    }
-
-    /* Check for the Timeout */
-    if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
-    {
-      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-      hi2c->State = HAL_I2C_STATE_READY;
-      hi2c->Mode = HAL_I2C_MODE_NONE;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
-      return HAL_ERROR;
-    }
-  }
-  return HAL_OK;
-}
-
-/**
   * @brief  This function handles I2C Communication Timeout for specific usage of RXNE flag.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
@@ -6290,18 +7119,21 @@ static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
   * @param  Tickstart Tick start value
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
+                                                        uint32_t Tickstart)
 {
-  while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+  HAL_StatusTypeDef status = HAL_OK;
+
+  while ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET) && (status == HAL_OK))
   {
-    /* Check if a NACK is detected */
-    if (I2C_IsAcknowledgeFailed(hi2c, Timeout, Tickstart) != HAL_OK)
+    /* Check if an error is detected */
+    if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
     {
-      return HAL_ERROR;
+      status = HAL_ERROR;
     }
 
     /* Check if a STOPF is detected */
-    if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+    if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) && (status == HAL_OK))
     {
       /* Check if an RXNE is pending */
       /* Store Last receive data if any */
@@ -6309,97 +7141,181 @@ static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
       {
         /* Return HAL_OK */
         /* The Reading of data from RXDR will be done in caller function */
-        return HAL_OK;
+        status = HAL_OK;
       }
-      else
+
+      /* Check a no-acknowledge have been detected */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
       {
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+        hi2c->ErrorCode = HAL_I2C_ERROR_AF;
+
         /* Clear STOP Flag */
         __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
 
         /* Clear Configuration Register 2 */
         I2C_RESET_CR2(hi2c);
 
-        hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
         hi2c->State = HAL_I2C_STATE_READY;
         hi2c->Mode = HAL_I2C_MODE_NONE;
 
         /* Process Unlocked */
         __HAL_UNLOCK(hi2c);
 
-        return HAL_ERROR;
+        status = HAL_ERROR;
+      }
+      else
+      {
+        hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
       }
     }
 
     /* Check for the Timeout */
-    if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
+    if ((((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U)) && (status == HAL_OK))
     {
-      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-      hi2c->State = HAL_I2C_STATE_READY;
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c->State = HAL_I2C_STATE_READY;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
 
-      return HAL_ERROR;
+        status = HAL_ERROR;
+      }
     }
   }
-  return HAL_OK;
+  return status;
 }
 
 /**
-  * @brief  This function handles Acknowledge failed detection during an I2C Communication.
+  * @brief  This function handles errors detection during an I2C Communication.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  Timeout Timeout duration
   * @param  Tickstart Tick start value
   * @retval HAL status
   */
-static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
+static HAL_StatusTypeDef I2C_IsErrorOccurred(I2C_HandleTypeDef *hi2c, uint32_t Timeout, uint32_t Tickstart)
 {
-  if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t itflag   = hi2c->Instance->ISR;
+  uint32_t error_code = 0;
+  uint32_t tickstart = Tickstart;
+  uint32_t tmp1;
+  HAL_I2C_ModeTypeDef tmp2;
+
+  if (HAL_IS_BIT_SET(itflag, I2C_FLAG_AF))
   {
-    /* Wait until STOP Flag is reset */
+    /* Clear NACKF Flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+    /* Wait until STOP Flag is set or timeout occurred */
     /* AutoEnd should be initiate after AF */
-    while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+    while ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET) && (status == HAL_OK))
     {
       /* Check for the Timeout */
       if (Timeout != HAL_MAX_DELAY)
       {
-        if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
         {
-          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-          hi2c->State = HAL_I2C_STATE_READY;
-          hi2c->Mode = HAL_I2C_MODE_NONE;
+          tmp1 = (uint32_t)(hi2c->Instance->CR2 & I2C_CR2_STOP);
+          tmp2 = hi2c->Mode;
 
-          /* Process Unlocked */
-          __HAL_UNLOCK(hi2c);
+          /* In case of I2C still busy, try to regenerate a STOP manually */
+          if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_BUSY) != RESET) && \
+              (tmp1 != I2C_CR2_STOP) && \
+              (tmp2 != HAL_I2C_MODE_SLAVE))
+          {
+            /* Generate Stop */
+            hi2c->Instance->CR2 |= I2C_CR2_STOP;
 
-          return HAL_ERROR;
+            /* Update Tick with new reference */
+            tickstart = HAL_GetTick();
+          }
+
+          while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
+          {
+            /* Check for the Timeout */
+            if ((HAL_GetTick() - tickstart) > I2C_TIMEOUT_STOPF)
+            {
+              error_code |= HAL_I2C_ERROR_TIMEOUT;
+
+              status = HAL_ERROR;
+
+              break;
+            }
+          }
         }
       }
     }
 
-    /* Clear NACKF Flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+    /* In case STOP Flag is detected, clear it */
+    if (status == HAL_OK)
+    {
+      /* Clear STOP Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+    }
 
-    /* Clear STOP Flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+    error_code |= HAL_I2C_ERROR_AF;
 
+    status = HAL_ERROR;
+  }
+
+  /* Refresh Content of Status register */
+  itflag = hi2c->Instance->ISR;
+
+  /* Then verify if an additional errors occurs */
+  /* Check if a Bus error occurred */
+  if (HAL_IS_BIT_SET(itflag, I2C_FLAG_BERR))
+  {
+    error_code |= HAL_I2C_ERROR_BERR;
+
+    /* Clear BERR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_BERR);
+
+    status = HAL_ERROR;
+  }
+
+  /* Check if an Over-Run/Under-Run error occurred */
+  if (HAL_IS_BIT_SET(itflag, I2C_FLAG_OVR))
+  {
+    error_code |= HAL_I2C_ERROR_OVR;
+
+    /* Clear OVR flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_OVR);
+
+    status = HAL_ERROR;
+  }
+
+  /* Check if an Arbitration Loss error occurred */
+  if (HAL_IS_BIT_SET(itflag, I2C_FLAG_ARLO))
+  {
+    error_code |= HAL_I2C_ERROR_ARLO;
+
+    /* Clear ARLO flag */
+    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_ARLO);
+
+    status = HAL_ERROR;
+  }
+
+  if (status != HAL_OK)
+  {
     /* Flush TX register */
     I2C_Flush_TXDR(hi2c);
 
     /* Clear Configuration Register 2 */
     I2C_RESET_CR2(hi2c);
 
-    hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+    hi2c->ErrorCode |= error_code;
     hi2c->State = HAL_I2C_STATE_READY;
     hi2c->Mode = HAL_I2C_MODE_NONE;
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
-
-    return HAL_ERROR;
   }
-  return HAL_OK;
+
+  return status;
 }
 
 /**
@@ -6421,16 +7337,26 @@ static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32
   *     @arg @ref I2C_GENERATE_START_WRITE Generate Restart for write request.
   * @retval None
   */
-static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+static void I2C_TransferConfig(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t Size, uint32_t Mode,
+                               uint32_t Request)
 {
+  uint32_t tmp;
+
   /* Check the parameters */
   assert_param(IS_I2C_ALL_INSTANCE(hi2c->Instance));
   assert_param(IS_TRANSFER_MODE(Mode));
   assert_param(IS_TRANSFER_REQUEST(Request));
 
+  /* Declaration of tmp to prevent undefined behavior of volatile usage */
+  tmp = ((uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | \
+                    (((uint32_t)Size << I2C_CR2_NBYTES_Pos) & I2C_CR2_NBYTES) | \
+                    (uint32_t)Mode | (uint32_t)Request) & (~0x80000000U));
+
   /* update CR2 register */
-  MODIFY_REG(hi2c->Instance->CR2, ((I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31U - I2C_CR2_RD_WRN_Pos))) | I2C_CR2_START | I2C_CR2_STOP)), \
-             (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << I2C_CR2_NBYTES_Pos) & I2C_CR2_NBYTES) | (uint32_t)Mode | (uint32_t)Request));
+  MODIFY_REG(hi2c->Instance->CR2, \
+             ((I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | \
+               (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31U - I2C_CR2_RD_WRN_Pos))) | \
+               I2C_CR2_START | I2C_CR2_STOP)), tmp);
 }
 
 /**
@@ -6444,13 +7370,62 @@ static void I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest)
 {
   uint32_t tmpisr = 0U;
 
-  if ((hi2c->XferISR == I2C_Master_ISR_DMA) || \
-      (hi2c->XferISR == I2C_Slave_ISR_DMA))
+#if defined(HAL_DMA_MODULE_ENABLED)
+  if ((hi2c->XferISR != I2C_Master_ISR_DMA) && \
+      (hi2c->XferISR != I2C_Slave_ISR_DMA) && \
+      (hi2c->XferISR != I2C_Mem_ISR_DMA))
+#endif /* HAL_DMA_MODULE_ENABLED */
   {
     if ((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
     {
       /* Enable ERR, STOP, NACK and ADDR interrupts */
       tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and TXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and RXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
+    }
+
+    if (InterruptRequest == I2C_XFER_ERROR_IT)
+    {
+      /* Enable ERR and NACK interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_NACKI;
+    }
+
+    if (InterruptRequest == I2C_XFER_CPLT_IT)
+    {
+      /* Enable STOP interrupts */
+      tmpisr |= I2C_IT_STOPI;
+    }
+  }
+
+#if defined(HAL_DMA_MODULE_ENABLED)
+  else
+  {
+    if ((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
+    {
+      /* Enable ERR, STOP, NACK and ADDR interrupts */
+      tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and TXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and RXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
     }
 
     if (InterruptRequest == I2C_XFER_ERROR_IT)
@@ -6471,32 +7446,7 @@ static void I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest)
       tmpisr |= I2C_IT_TCI;
     }
   }
-  else
-  {
-    if ((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
-    {
-      /* Enable ERR, STOP, NACK, and ADDR interrupts */
-      tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
-    }
-
-    if ((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
-    {
-      /* Enable ERR, TC, STOP, NACK and RXI interrupts */
-      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
-    }
-
-    if ((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
-    {
-      /* Enable ERR, TC, STOP, NACK and TXI interrupts */
-      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
-    }
-
-    if (InterruptRequest == I2C_XFER_CPLT_IT)
-    {
-      /* Enable STOP interrupts */
-      tmpisr |= I2C_IT_STOPI;
-    }
-  }
+#endif /* HAL_DMA_MODULE_ENABLED */
 
   /* Enable interrupts only at the end */
   /* to avoid the risk of I2C interrupt handle execution before */
@@ -6609,5 +7559,3 @@ static void I2C_ConvertOtherXferOptions(I2C_HandleTypeDef *hi2c)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_i2c_ex.c
@@ -5,8 +5,21 @@
   * @brief   I2C Extended HAL module driver.
   *          This file provides firmware functions to manage the following
   *          functionalities of I2C Extended peripheral:
-  *           + Extended features functions
+  *           + Filter Mode Functions
+  *           + WakeUp Mode Functions
+  *           + FastModePlus Functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                ##### I2C peripheral Extended features  #####
@@ -32,18 +45,6 @@
           (++) HAL_I2CEx_EnableFastModePlus()
           (++) HAL_I2CEx_DisableFastModePlus()
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -71,17 +72,15 @@
   * @{
   */
 
-/** @defgroup I2CEx_Exported_Functions_Group1 Extended features functions
-  * @brief    Extended features functions
- *
+/** @defgroup I2CEx_Exported_Functions_Group1 Filter Mode Functions
+  * @brief    Filter Mode Functions
+  *
 @verbatim
  ===============================================================================
-                      ##### Extended features functions #####
+                      ##### Filter Mode Functions #####
  ===============================================================================
     [..] This section provides functions allowing to:
       (+) Configure Noise Filters
-      (+) Configure Wake Up Feature
-      (+) Configure Fast Mode Plus
 
 @endverbatim
   * @{
@@ -182,6 +181,23 @@ HAL_StatusTypeDef HAL_I2CEx_ConfigDigitalFilter(I2C_HandleTypeDef *hi2c, uint32_
     return HAL_BUSY;
   }
 }
+/**
+  * @}
+  */
+
+/** @defgroup I2CEx_Exported_Functions_Group2 WakeUp Mode Functions
+  * @brief    WakeUp Mode Functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### WakeUp Mode Functions #####
+ ===============================================================================
+    [..] This section provides functions allowing to:
+      (+) Configure Wake Up Feature
+
+@endverbatim
+  * @{
+  */
 
 /**
   * @brief  Enable I2C wakeup from Stop mode(s).
@@ -260,6 +276,23 @@ HAL_StatusTypeDef HAL_I2CEx_DisableWakeUp(I2C_HandleTypeDef *hi2c)
     return HAL_BUSY;
   }
 }
+/**
+  * @}
+  */
+
+/** @defgroup I2CEx_Exported_Functions_Group3 Fast Mode Plus Functions
+  * @brief    Fast Mode Plus Functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Fast Mode Plus Functions #####
+ ===============================================================================
+    [..] This section provides functions allowing to:
+      (+) Configure Fast Mode Plus
+
+@endverbatim
+  * @{
+  */
 
 /**
   * @brief Enable the I2C fast mode plus driving capability.
@@ -304,11 +337,9 @@ void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus)
   /* Disable fast mode plus driving capability for selected pin */
   CLEAR_BIT(SYSCFG->CFGR1, (uint32_t)ConfigFastModePlus);
 }
-
 /**
   * @}
   */
-
 /**
   * @}
   */
@@ -321,5 +352,3 @@ void HAL_I2CEx_DisableFastModePlus(uint32_t ConfigFastModePlus)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_ipcc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_ipcc.c
@@ -9,6 +9,17 @@
   *           + Initialization and de-initialization functions
   *           + Configuration, notification and interrupts handling
   *           + Peripheral State and Error functions
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -39,17 +50,6 @@
 
 @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -73,7 +73,7 @@
   */
 #define IPCC_ALL_RX_BUF 0x0000003FU /*!< Mask for all RX buffers. */
 #define IPCC_ALL_TX_BUF 0x003F0000U /*!< Mask for all TX buffers. */
-#define CHANNEL_INDEX_Msk 0x0000000FU /*!< Mask the channel index to avoid overflow */
+#define CHANNEL_INDEX_MASK 0x0000000FU /*!< Mask the channel index to avoid overflow */
 /**
   * @}
   */
@@ -97,8 +97,8 @@ void IPCC_Reset_Register(IPCC_CommonTypeDef *Instance);
   */
 
 /** @addtogroup IPCC_Exported_Functions_Group1
- *  @brief    Initialization and de-initialization functions
- *
+  *  @brief    Initialization and de-initialization functions
+  *
 @verbatim
  ===============================================================================
              ##### Initialization and de-initialization functions  #####
@@ -239,8 +239,8 @@ __weak void HAL_IPCC_MspDeInit(IPCC_HandleTypeDef *hipcc)
 
 
 /** @addtogroup IPCC_Exported_Functions_Group2
- *  @brief    Configuration, notification and Irq handling functions.
- *
+  *  @brief    Configuration, notification and Irq handling functions.
+  *
 @verbatim
  ===============================================================================
               ##### IO operation functions #####
@@ -301,7 +301,9 @@ __weak void HAL_IPCC_MspDeInit(IPCC_HandleTypeDef *hipcc)
   * @param  cb Interrupt callback
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IPCC_ActivateNotification(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir, ChannelCb cb)
+HAL_StatusTypeDef HAL_IPCC_ActivateNotification(IPCC_HandleTypeDef *hipcc,
+                                                uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir,
+                                                ChannelCb cb)
 {
   HAL_StatusTypeDef err = HAL_OK;
 
@@ -318,12 +320,12 @@ HAL_StatusTypeDef HAL_IPCC_ActivateNotification(IPCC_HandleTypeDef *hipcc, uint3
       if (ChannelDir == IPCC_CHANNEL_DIR_TX)
       {
         hipcc->ChannelCallbackTx[ChannelIndex] = cb;
-        hipcc->callbackRequest |= (IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+        hipcc->callbackRequest |= (IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
       }
       else
       {
         hipcc->ChannelCallbackRx[ChannelIndex] = cb;
-        hipcc->callbackRequest |= (IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+        hipcc->callbackRequest |= (IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
       }
 
       /* Unmask only the channels in reception (Transmission channel mask/unmask is done in HAL_IPCC_NotifyCPU) */
@@ -358,7 +360,8 @@ HAL_StatusTypeDef HAL_IPCC_ActivateNotification(IPCC_HandleTypeDef *hipcc, uint3
   * @param  ChannelDir Channel direction
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IPCC_DeActivateNotification(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir)
+HAL_StatusTypeDef HAL_IPCC_DeActivateNotification(IPCC_HandleTypeDef *hipcc,
+                                                  uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir)
 {
   HAL_StatusTypeDef err = HAL_OK;
 
@@ -375,12 +378,12 @@ HAL_StatusTypeDef HAL_IPCC_DeActivateNotification(IPCC_HandleTypeDef *hipcc, uin
       if (ChannelDir == IPCC_CHANNEL_DIR_TX)
       {
         hipcc->ChannelCallbackTx[ChannelIndex] = HAL_IPCC_TxCallback;
-        hipcc->callbackRequest &= ~(IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+        hipcc->callbackRequest &= ~(IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
       }
       else
       {
         hipcc->ChannelCallbackRx[ChannelIndex] = HAL_IPCC_RxCallback;
-        hipcc->callbackRequest &= ~(IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+        hipcc->callbackRequest &= ~(IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
       }
 
       /* Mask the interrupt */
@@ -412,7 +415,8 @@ HAL_StatusTypeDef HAL_IPCC_DeActivateNotification(IPCC_HandleTypeDef *hipcc, uin
   * @param  ChannelDir Channel direction
   * @retval Channel status
   */
-IPCC_CHANNELStatusTypeDef HAL_IPCC_GetChannelStatus(IPCC_HandleTypeDef const *const hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir)
+IPCC_CHANNELStatusTypeDef HAL_IPCC_GetChannelStatus(IPCC_HandleTypeDef const *const hipcc,
+                                                    uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir)
 {
   uint32_t channel_state;
   IPCC_CommonTypeDef *currentInstance = IPCC_C1;
@@ -424,11 +428,11 @@ IPCC_CHANNELStatusTypeDef HAL_IPCC_GetChannelStatus(IPCC_HandleTypeDef const *co
   /* Read corresponding channel depending of the MCU and the direction */
   if (ChannelDir == IPCC_CHANNEL_DIR_TX)
   {
-    channel_state = (currentInstance->SR) & (IPCC_SR_CH1F_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+    channel_state = (currentInstance->SR) & (IPCC_SR_CH1F_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
   }
   else
   {
-    channel_state = (otherInstance->SR) & (IPCC_SR_CH1F_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+    channel_state = (otherInstance->SR) & (IPCC_SR_CH1F_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
   }
 
   return (channel_state == 0UL) ? IPCC_CHANNEL_STATUS_FREE : IPCC_CHANNEL_STATUS_OCCUPIED ;
@@ -448,7 +452,8 @@ IPCC_CHANNELStatusTypeDef HAL_IPCC_GetChannelStatus(IPCC_HandleTypeDef const *co
   * @param  ChannelDir Channel direction
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IPCC_NotifyCPU(IPCC_HandleTypeDef const *const hipcc, uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir)
+HAL_StatusTypeDef HAL_IPCC_NotifyCPU(IPCC_HandleTypeDef const *const hipcc,
+                                     uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir)
 {
   HAL_StatusTypeDef err = HAL_OK;
   uint32_t mask;
@@ -457,14 +462,17 @@ HAL_StatusTypeDef HAL_IPCC_NotifyCPU(IPCC_HandleTypeDef const *const hipcc, uint
   /* Check the parameters */
   assert_param(IS_IPCC_ALL_INSTANCE(hipcc->Instance));
 
-  /* Check if IPCC is initiliased */
+  /* Check if IPCC is initialized */
   if (hipcc->State == HAL_IPCC_STATE_READY)
   {
     /* For IPCC_CHANNEL_DIR_TX, set the status. For IPCC_CHANNEL_DIR_RX, clear the status */
-    currentInstance->SCR |= ((ChannelDir == IPCC_CHANNEL_DIR_TX) ? IPCC_SCR_CH1S : IPCC_SCR_CH1C) << (ChannelIndex & CHANNEL_INDEX_Msk) ;
+    currentInstance->SCR |= ((ChannelDir == IPCC_CHANNEL_DIR_TX) ? IPCC_SCR_CH1S :
+                             IPCC_SCR_CH1C)
+                            << (ChannelIndex & CHANNEL_INDEX_MASK);
 
     /* Unmask interrupt if the callback is requested */
-    mask = ((ChannelDir == IPCC_CHANNEL_DIR_TX) ? IPCC_MR_CH1FM_Msk : IPCC_MR_CH1OM_Msk) << (ChannelIndex & CHANNEL_INDEX_Msk) ;
+    mask = ((ChannelDir == IPCC_CHANNEL_DIR_TX) ? IPCC_MR_CH1FM_Msk :
+            IPCC_MR_CH1OM_Msk) << (ChannelIndex & CHANNEL_INDEX_MASK);
     if ((hipcc->callbackRequest & mask) == mask)
     {
       IPCC_UnmaskInterrupt(ChannelIndex, ChannelDir);
@@ -483,8 +491,8 @@ HAL_StatusTypeDef HAL_IPCC_NotifyCPU(IPCC_HandleTypeDef const *const hipcc, uint
   */
 
 /** @addtogroup IPCC_IRQ_Handler_and_Callbacks
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  This function handles IPCC Tx Free interrupt request.
@@ -504,7 +512,7 @@ void HAL_IPCC_TX_IRQHandler(IPCC_HandleTypeDef *const hipcc)
 
   while (irqmask != 0UL)  /* if several bits are set, it loops to serve all of them */
   {
-    bit_pos = 1UL << (IPCC_MR_CH1FM_Pos + (ch_count & CHANNEL_INDEX_Msk));
+    bit_pos = 1UL << (IPCC_MR_CH1FM_Pos + (ch_count & CHANNEL_INDEX_MASK));
 
     if ((irqmask & bit_pos) != 0U)
     {
@@ -539,7 +547,7 @@ void HAL_IPCC_RX_IRQHandler(IPCC_HandleTypeDef *const hipcc)
 
   while (irqmask != 0UL)  /* if several bits are set, it loops to serve all of them */
   {
-    bit_pos = 1UL << (ch_count & CHANNEL_INDEX_Msk);
+    bit_pos = 1UL << (ch_count & CHANNEL_INDEX_MASK);
 
     if ((irqmask & bit_pos) != 0U)
     {
@@ -610,8 +618,8 @@ __weak void HAL_IPCC_TxCallback(IPCC_HandleTypeDef *hipcc, uint32_t ChannelIndex
   */
 
 /** @addtogroup IPCC_Exported_Functions_Group3
- *  @brief   IPCC Peripheral State and Error functions
- *
+  *  @brief   IPCC Peripheral State and Error functions
+  *
 @verbatim
   ==============================================================================
             ##### Peripheral State and Error functions #####
@@ -664,12 +672,12 @@ void IPCC_MaskInterrupt(uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelDir
   if (ChannelDir == IPCC_CHANNEL_DIR_TX)
   {
     /* Mask interrupt */
-    currentInstance->MR |= (IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+    currentInstance->MR |= (IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
   }
   else
   {
     /* Mask interrupt */
-    currentInstance->MR |= (IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+    currentInstance->MR |= (IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
   }
 }
 /**
@@ -690,12 +698,12 @@ void IPCC_UnmaskInterrupt(uint32_t ChannelIndex, IPCC_CHANNELDirTypeDef ChannelD
   if (ChannelDir == IPCC_CHANNEL_DIR_TX)
   {
     /* Unmask interrupt */
-    currentInstance->MR &= ~(IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+    currentInstance->MR &= ~(IPCC_MR_CH1FM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
   }
   else
   {
     /* Unmask interrupt */
-    currentInstance->MR &= ~(IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_Msk));
+    currentInstance->MR &= ~(IPCC_MR_CH1OM_Msk << (ChannelIndex & CHANNEL_INDEX_MASK));
   }
 }
 
@@ -744,4 +752,4 @@ void IPCC_Reset_Register(IPCC_CommonTypeDef *Instance)
   * @}
   */
 #endif /* IPCC */
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_irda.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_irda.c
@@ -11,6 +11,17 @@
   *           + Peripheral State and Errors functions
   *           + Peripheral Control functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -40,7 +51,8 @@
             (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
             (+++) Configure the DMA Tx/Rx channel.
             (+++) Associate the initialized DMA handle to the IRDA DMA Tx/Rx handle.
-            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+            (+++) Configure the priority and enable the NVIC for the transfer
+                  complete interrupt on the DMA Tx/Rx channel.
 
     (#) Program the Baud Rate, Word Length and Parity and Mode(Receiver/Transmitter),
         the normal or low power mode and the clock prescaler in the hirda handle Init structure.
@@ -130,7 +142,7 @@
 
     [..]
     Use function HAL_IRDA_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
+    weak function.
     HAL_IRDA_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the Callback ID.
     This function allows to reset following callbacks:
@@ -147,10 +159,10 @@
 
     [..]
     By default, after the HAL_IRDA_Init() and when the state is HAL_IRDA_STATE_RESET
-    all callbacks are set to the corresponding weak (surcharged) functions:
+    all callbacks are set to the corresponding weak functions:
     examples HAL_IRDA_TxCpltCallback(), HAL_IRDA_RxHalfCpltCallback().
     Exception done for MspInit and MspDeInit functions that are respectively
-    reset to the legacy weak (surcharged) functions in the HAL_IRDA_Init()
+    reset to the legacy weak functions in the HAL_IRDA_Init()
     and HAL_IRDA_DeInit() only when these callbacks are null (not registered beforehand).
     If not, MspInit or MspDeInit are not null, the HAL_IRDA_Init() and HAL_IRDA_DeInit()
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
@@ -167,21 +179,9 @@
     [..]
     When The compilation define USE_HAL_IRDA_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registration feature is not available
-    and weak (surcharged) callbacks are used.
-
+    and weak callbacks are used.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -207,7 +207,7 @@
 #define IRDA_TEACK_REACK_TIMEOUT            1000U                                   /*!< IRDA TX or RX enable acknowledge time-out value  */
 
 #define IRDA_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE \
-                                   | USART_CR1_PS | USART_CR1_TE | USART_CR1_RE))  /*!< UART or USART CR1 fields of parameters set by IRDA_SetConfig API */
+                                     | USART_CR1_PS | USART_CR1_TE | USART_CR1_RE))  /*!< UART or USART CR1 fields of parameters set by IRDA_SetConfig API */
 
 #define USART_BRR_MIN    0x10U        /*!< USART BRR minimum authorized value */
 
@@ -226,7 +226,8 @@
   * @param  __PRESCALER__ IRDA clock prescaler value.
   * @retval Division result
   */
-#define IRDA_DIV_SAMPLING16(__PCLK__, __BAUD__, __PRESCALER__)  ((((__PCLK__)/IRDAPrescTable[(__PRESCALER__)]) + ((__BAUD__)/2U)) / (__BAUD__))
+#define IRDA_DIV_SAMPLING16(__PCLK__, __BAUD__, __PRESCALER__)  ((((__PCLK__)/IRDAPrescTable[(__PRESCALER__)])\
+                                                                  + ((__BAUD__)/2U)) / (__BAUD__))
 /**
   * @}
   */
@@ -241,7 +242,8 @@ void IRDA_InitCallbacksToDefault(IRDA_HandleTypeDef *hirda);
 #endif /* USE_HAL_IRDA_REGISTER_CALLBACKS */
 static HAL_StatusTypeDef IRDA_SetConfig(IRDA_HandleTypeDef *hirda);
 static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda);
-static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status, uint32_t Tickstart, uint32_t Timeout);
+static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status,
+                                                     uint32_t Tickstart, uint32_t Timeout);
 static void IRDA_EndTxTransfer(IRDA_HandleTypeDef *hirda);
 static void IRDA_EndRxTransfer(IRDA_HandleTypeDef *hirda);
 static void IRDA_DMATransmitCplt(DMA_HandleTypeDef *hdma);
@@ -460,7 +462,9 @@ __weak void HAL_IRDA_MspDeInit(IRDA_HandleTypeDef *hirda)
 #if (USE_HAL_IRDA_REGISTER_CALLBACKS == 1)
 /**
   * @brief  Register a User IRDA Callback
-  *         To be used instead of the weak predefined callback
+  *         To be used to override the weak predefined callback
+  * @note   The HAL_IRDA_RegisterCallback() may be called before HAL_IRDA_Init() in HAL_IRDA_STATE_RESET
+  *         to register callbacks for HAL_IRDA_MSPINIT_CB_ID and HAL_IRDA_MSPDEINIT_CB_ID
   * @param  hirda irda handle
   * @param  CallbackID ID of the callback to be registered
   *         This parameter can be one of the following values:
@@ -477,7 +481,8 @@ __weak void HAL_IRDA_MspDeInit(IRDA_HandleTypeDef *hirda)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IRDA_RegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_CallbackIDTypeDef CallbackID, pIRDA_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_IRDA_RegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_CallbackIDTypeDef CallbackID,
+                                            pIRDA_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -488,8 +493,6 @@ HAL_StatusTypeDef HAL_IRDA_RegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hirda);
 
   if (hirda->gState == HAL_IRDA_STATE_READY)
   {
@@ -574,15 +577,14 @@ HAL_StatusTypeDef HAL_IRDA_RegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRDA_
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hirda);
-
   return status;
 }
 
 /**
   * @brief  Unregister an IRDA callback
   *         IRDA callback is redirected to the weak predefined callback
+  * @note   The HAL_IRDA_UnRegisterCallback() may be called before HAL_IRDA_Init() in HAL_IRDA_STATE_RESET
+  *         to un-register callbacks for HAL_IRDA_MSPINIT_CB_ID and HAL_IRDA_MSPDEINIT_CB_ID
   * @param  hirda irda handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
@@ -602,51 +604,50 @@ HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRD
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(hirda);
-
   if (HAL_IRDA_STATE_READY == hirda->gState)
   {
     switch (CallbackID)
     {
       case HAL_IRDA_TX_HALFCOMPLETE_CB_ID :
-        hirda->TxHalfCpltCallback = HAL_IRDA_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback       */
+        hirda->TxHalfCpltCallback = HAL_IRDA_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback    */
         break;
 
       case HAL_IRDA_TX_COMPLETE_CB_ID :
-        hirda->TxCpltCallback = HAL_IRDA_TxCpltCallback;                       /* Legacy weak TxCpltCallback            */
+        hirda->TxCpltCallback = HAL_IRDA_TxCpltCallback;                       /* Legacy weak TxCpltCallback         */
         break;
 
       case HAL_IRDA_RX_HALFCOMPLETE_CB_ID :
-        hirda->RxHalfCpltCallback = HAL_IRDA_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback        */
+        hirda->RxHalfCpltCallback = HAL_IRDA_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback     */
         break;
 
       case HAL_IRDA_RX_COMPLETE_CB_ID :
-        hirda->RxCpltCallback = HAL_IRDA_RxCpltCallback;                       /* Legacy weak RxCpltCallback            */
+        hirda->RxCpltCallback = HAL_IRDA_RxCpltCallback;                       /* Legacy weak RxCpltCallback         */
         break;
 
       case HAL_IRDA_ERROR_CB_ID :
-        hirda->ErrorCallback = HAL_IRDA_ErrorCallback;                         /* Legacy weak ErrorCallback             */
+        hirda->ErrorCallback = HAL_IRDA_ErrorCallback;                         /* Legacy weak ErrorCallback          */
         break;
 
       case HAL_IRDA_ABORT_COMPLETE_CB_ID :
-        hirda->AbortCpltCallback = HAL_IRDA_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback         */
+        hirda->AbortCpltCallback = HAL_IRDA_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback      */
         break;
 
       case HAL_IRDA_ABORT_TRANSMIT_COMPLETE_CB_ID :
-        hirda->AbortTransmitCpltCallback = HAL_IRDA_AbortTransmitCpltCallback; /* Legacy weak AbortTransmitCpltCallback */
+        hirda->AbortTransmitCpltCallback = HAL_IRDA_AbortTransmitCpltCallback; /* Legacy weak
+                                                                                  AbortTransmitCpltCallback          */
         break;
 
       case HAL_IRDA_ABORT_RECEIVE_COMPLETE_CB_ID :
-        hirda->AbortReceiveCpltCallback = HAL_IRDA_AbortReceiveCpltCallback;   /* Legacy weak AbortReceiveCpltCallback  */
+        hirda->AbortReceiveCpltCallback = HAL_IRDA_AbortReceiveCpltCallback;   /* Legacy weak
+                                                                                  AbortReceiveCpltCallback           */
         break;
 
       case HAL_IRDA_MSPINIT_CB_ID :
-        hirda->MspInitCallback = HAL_IRDA_MspInit;                             /* Legacy weak MspInitCallback           */
+        hirda->MspInitCallback = HAL_IRDA_MspInit;                             /* Legacy weak MspInitCallback        */
         break;
 
       case HAL_IRDA_MSPDEINIT_CB_ID :
-        hirda->MspDeInitCallback = HAL_IRDA_MspDeInit;                         /* Legacy weak MspDeInitCallback         */
+        hirda->MspDeInitCallback = HAL_IRDA_MspDeInit;                         /* Legacy weak MspDeInitCallback      */
         break;
 
       default :
@@ -688,9 +689,6 @@ HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRD
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hirda);
-
   return status;
 }
 #endif /* USE_HAL_IRDA_REGISTER_CALLBACKS */
@@ -716,6 +714,7 @@ HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRD
     While receiving data, transmission should be avoided as the data to be transmitted
     could be corrupted.
 
+  [..]
     (#) There are two modes of transfer:
         (++) Blocking mode: the communication is performed in polling mode.
              The HAL status of all data processing is returned by the same function
@@ -767,14 +766,17 @@ HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRD
 
     (#) In Non-Blocking mode transfers, possible errors are split into 2 categories.
         Errors are handled as follows :
-       (++) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
-            to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
-            Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
-            and HAL_IRDA_ErrorCallback() user callback is executed. Transfer is kept ongoing on IRDA side.
-            If user wants to abort it, Abort services should be called by user.
-       (++) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
-            This concerns Overrun Error In Interrupt mode reception and all errors in DMA mode.
-            Error code is set to allow user to identify error type, and HAL_IRDA_ErrorCallback() user callback is executed.
+        (++) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
+             to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error
+             in Interrupt mode reception .
+             Received character is then retrieved and stored in Rx buffer, Error code is set to allow user
+             to identify error type, and HAL_IRDA_ErrorCallback() user callback is executed.
+             Transfer is kept ongoing on IRDA side.
+             If user wants to abort it, Abort services should be called by user.
+        (++) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
+             This concerns Overrun Error In Interrupt mode reception and all errors in DMA mode.
+             Error code is set to allow user to identify error type, and
+             HAL_IRDA_ErrorCallback() user callback is executed.
 
 @endverbatim
   * @{
@@ -792,10 +794,10 @@ HAL_StatusTypeDef HAL_IRDA_UnRegisterCallback(IRDA_HandleTypeDef *hirda, HAL_IRD
   * @param Timeout Specify timeout value.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, const uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  uint8_t  *pdata8bits;
-  uint16_t *pdata16bits;
+  const uint8_t  *pdata8bits;
+  const uint16_t *pdata16bits;
   uint32_t tickstart;
 
   /* Check that a Tx process is not already ongoing */
@@ -812,7 +814,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, u
     hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
     hirda->gState = HAL_IRDA_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     hirda->TxXferSize = Size;
@@ -822,7 +824,7 @@ HAL_StatusTypeDef HAL_IRDA_Transmit(IRDA_HandleTypeDef *hirda, uint8_t *pData, u
     if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
     {
       pdata8bits  = NULL;
-      pdata16bits = (uint16_t *) pData; /* Derogation R.11.3 */
+      pdata16bits = (const uint16_t *) pData; /* Derogation R.11.3 */
     }
     else
     {
@@ -902,7 +904,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, ui
     hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
     hirda->RxState = HAL_IRDA_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     hirda->RxXferSize = Size;
@@ -971,7 +973,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive(IRDA_HandleTypeDef *hirda, uint8_t *pData, ui
   * @param Size Amount of data elements (u8 or u16) to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda, const uint8_t *pData, uint16_t Size)
 {
   /* Check that a Tx process is not already ongoing */
   if (hirda->gState == HAL_IRDA_STATE_READY)
@@ -1043,8 +1045,16 @@ HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData,
     /* Process Unlocked */
     __HAL_UNLOCK(hirda);
 
-    /* Enable the IRDA Parity Error and Data Register not empty Interrupts */
-    SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+    if (hirda->Init.Parity != IRDA_PARITY_NONE)
+    {
+      /* Enable the IRDA Parity Error and Data Register not empty Interrupts */
+      SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+    }
+    else
+    {
+      /* Enable the IRDA Data Register not empty Interrupts */
+      SET_BIT(hirda->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
+    }
 
     /* Enable the IRDA Error Interrupt: (Frame error, noise error, overrun error) */
     SET_BIT(hirda->Instance->CR3, USART_CR3_EIE);
@@ -1068,7 +1078,7 @@ HAL_StatusTypeDef HAL_IRDA_Receive_IT(IRDA_HandleTypeDef *hirda, uint8_t *pData,
   * @param Size Amount of data elements (u8 or u16) to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_IRDA_Transmit_DMA(IRDA_HandleTypeDef *hirda, const uint8_t *pData, uint16_t Size)
 {
   /* Check that a Tx process is not already ongoing */
   if (hirda->gState == HAL_IRDA_STATE_READY)
@@ -1185,8 +1195,11 @@ HAL_StatusTypeDef HAL_IRDA_Receive_DMA(IRDA_HandleTypeDef *hirda, uint8_t *pData
       /* Process Unlocked */
       __HAL_UNLOCK(hirda);
 
-      /* Enable the UART Parity Error Interrupt */
-      SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE);
+      if (hirda->Init.Parity != IRDA_PARITY_NONE)
+      {
+        /* Enable the UART Parity Error Interrupt */
+        SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE);
+      }
 
       /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
       SET_BIT(hirda->Instance->CR3, USART_CR3_EIE);
@@ -1277,8 +1290,11 @@ HAL_StatusTypeDef HAL_IRDA_DMAResume(IRDA_HandleTypeDef *hirda)
     /* Clear the Overrun flag before resuming the Rx transfer*/
     __HAL_IRDA_CLEAR_OREFLAG(hirda);
 
-    /* Reenable PE and ERR (Frame error, noise error, overrun error) interrupts */
-    SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE);
+    /* Re-enable PE and ERR (Frame error, noise error, overrun error) interrupts */
+    if (hirda->Init.Parity != IRDA_PARITY_NONE)
+    {
+      SET_BIT(hirda->Instance->CR1, USART_CR1_PEIE);
+    }
     SET_BIT(hirda->Instance->CR3, USART_CR3_EIE);
 
     /* Enable the IRDA DMA Rx request */
@@ -1373,11 +1389,12 @@ HAL_StatusTypeDef HAL_IRDA_DMAStop(IRDA_HandleTypeDef *hirda)
   *           - Set handle State to READY
   * @note   This procedure is executed in blocking mode : when exiting function, Abort is considered as completed.
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_IRDA_Abort(IRDA_HandleTypeDef *hirda)
 {
   /* Disable TXEIE, TCIE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(hirda->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  CLEAR_BIT(hirda->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | \
+                                   USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
   CLEAR_BIT(hirda->Instance->CR3, USART_CR3_EIE);
 
   /* Disable the IRDA DMA Tx request if enabled */
@@ -1459,7 +1476,7 @@ HAL_StatusTypeDef HAL_IRDA_Abort(IRDA_HandleTypeDef *hirda)
   *           - Set handle State to READY
   * @note   This procedure is executed in blocking mode : when exiting function, Abort is considered as completed.
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_IRDA_AbortTransmit(IRDA_HandleTypeDef *hirda)
 {
   /* Disable TXEIE and TCIE interrupts */
@@ -1511,7 +1528,7 @@ HAL_StatusTypeDef HAL_IRDA_AbortTransmit(IRDA_HandleTypeDef *hirda)
   *           - Set handle State to READY
   * @note   This procedure is executed in blocking mode : when exiting function, Abort is considered as completed.
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_IRDA_AbortReceive(IRDA_HandleTypeDef *hirda)
 {
   /* Disable RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts */
@@ -1569,13 +1586,14 @@ HAL_StatusTypeDef HAL_IRDA_AbortReceive(IRDA_HandleTypeDef *hirda)
   * @note   This procedure is executed in Interrupt mode, meaning that abort procedure could be
   *         considered as completed only when user abort complete callback is executed (not when exiting function).
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_IRDA_Abort_IT(IRDA_HandleTypeDef *hirda)
 {
   uint32_t abortcplt = 1U;
 
   /* Disable TXEIE, TCIE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(hirda->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  CLEAR_BIT(hirda->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | \
+                                   USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
   CLEAR_BIT(hirda->Instance->CR3, USART_CR3_EIE);
 
   /* If DMA Tx and/or DMA Rx Handles are associated to IRDA Handle, DMA Abort complete callbacks should be initialised
@@ -1701,7 +1719,7 @@ HAL_StatusTypeDef HAL_IRDA_Abort_IT(IRDA_HandleTypeDef *hirda)
   * @note   This procedure is executed in Interrupt mode, meaning that abort procedure could be
   *         considered as completed only when user abort complete callback is executed (not when exiting function).
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_IRDA_AbortTransmit_IT(IRDA_HandleTypeDef *hirda)
 {
   /* Disable TXEIE and TCIE interrupts */
@@ -1779,7 +1797,7 @@ HAL_StatusTypeDef HAL_IRDA_AbortTransmit_IT(IRDA_HandleTypeDef *hirda)
   * @note   This procedure is executed in Interrupt mode, meaning that abort procedure could be
   *         considered as completed only when user abort complete callback is executed (not when exiting function).
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_IRDA_AbortReceive_IT(IRDA_HandleTypeDef *hirda)
 {
   /* Disable RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts */
@@ -1862,6 +1880,7 @@ void HAL_IRDA_IRQHandler(IRDA_HandleTypeDef *hirda)
   uint32_t cr1its     = READ_REG(hirda->Instance->CR1);
   uint32_t cr3its;
   uint32_t errorflags;
+  uint32_t errorcode;
 
   /* If no error occurs */
   errorflags = (isrflags & (uint32_t)(USART_ISR_PE | USART_ISR_FE | USART_ISR_ORE | USART_ISR_NE));
@@ -1925,8 +1944,9 @@ void HAL_IRDA_IRQHandler(IRDA_HandleTypeDef *hirda)
 
       /* If Overrun error occurs, or if any error occurs in DMA mode reception,
          consider error as blocking */
+      errorcode = hirda->ErrorCode;
       if ((HAL_IS_BIT_SET(hirda->Instance->CR3, USART_CR3_DMAR)) ||
-          ((hirda->ErrorCode & HAL_IRDA_ERROR_ORE) != 0U))
+          ((errorcode & HAL_IRDA_ERROR_ORE) != 0U))
       {
         /* Blocking error : transfer is aborted
            Set the IRDA state ready to be able to start again the process,
@@ -2165,10 +2185,11 @@ __weak void HAL_IRDA_AbortReceiveCpltCallback(IRDA_HandleTypeDef *hirda)
   *                the configuration information for the specified IRDA module.
   * @retval HAL state
   */
-HAL_IRDA_StateTypeDef HAL_IRDA_GetState(IRDA_HandleTypeDef *hirda)
+HAL_IRDA_StateTypeDef HAL_IRDA_GetState(const IRDA_HandleTypeDef *hirda)
 {
   /* Return IRDA handle state */
-  uint32_t temp1, temp2;
+  uint32_t temp1;
+  uint32_t temp2;
   temp1 = (uint32_t)hirda->gState;
   temp2 = (uint32_t)hirda->RxState;
 
@@ -2181,7 +2202,7 @@ HAL_IRDA_StateTypeDef HAL_IRDA_GetState(IRDA_HandleTypeDef *hirda)
   *               the configuration information for the specified IRDA module.
   * @retval IRDA Error Code
   */
-uint32_t HAL_IRDA_GetError(IRDA_HandleTypeDef *hirda)
+uint32_t HAL_IRDA_GetError(const IRDA_HandleTypeDef *hirda)
 {
   return hirda->ErrorCode;
 }
@@ -2229,8 +2250,8 @@ static HAL_StatusTypeDef IRDA_SetConfig(IRDA_HandleTypeDef *hirda)
 {
   uint32_t tmpreg;
   IRDA_ClockSourceTypeDef clocksource;
-  HAL_StatusTypeDef ret               = HAL_OK;
-  const uint16_t IRDAPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
+  HAL_StatusTypeDef ret = HAL_OK;
+  static const uint16_t IRDAPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
   uint32_t pclk;
 
   /* Check the communication parameters */
@@ -2269,17 +2290,17 @@ static HAL_StatusTypeDef IRDA_SetConfig(IRDA_HandleTypeDef *hirda)
   {
     case IRDA_CLOCKSOURCE_PCLK2:
       pclk = HAL_RCC_GetPCLK2Freq();
-      tmpreg = (uint16_t)(IRDA_DIV_SAMPLING16(pclk, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
+      tmpreg = (uint32_t)(IRDA_DIV_SAMPLING16(pclk, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
       break;
     case IRDA_CLOCKSOURCE_HSI:
-      tmpreg = (uint16_t)(IRDA_DIV_SAMPLING16(HSI_VALUE, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
+      tmpreg = (uint32_t)(IRDA_DIV_SAMPLING16(HSI_VALUE, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
       break;
     case IRDA_CLOCKSOURCE_SYSCLK:
       pclk = HAL_RCC_GetSysClockFreq();
-      tmpreg = (uint16_t)(IRDA_DIV_SAMPLING16(pclk, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
+      tmpreg = (uint32_t)(IRDA_DIV_SAMPLING16(pclk, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
       break;
     case IRDA_CLOCKSOURCE_LSE:
-      tmpreg = (uint16_t)(IRDA_DIV_SAMPLING16((uint32_t)LSE_VALUE, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
+      tmpreg = (uint32_t)(IRDA_DIV_SAMPLING16((uint32_t)LSE_VALUE, hirda->Init.BaudRate, hirda->Init.ClockPrescaler));
       break;
     default:
       ret = HAL_ERROR;
@@ -2289,7 +2310,7 @@ static HAL_StatusTypeDef IRDA_SetConfig(IRDA_HandleTypeDef *hirda)
   /* USARTDIV must be greater than or equal to 0d16 */
   if ((tmpreg >= USART_BRR_MIN) && (tmpreg <= USART_BRR_MAX))
   {
-    hirda->Instance->BRR = tmpreg;
+    hirda->Instance->BRR = (uint16_t)tmpreg;
   }
   else
   {
@@ -2312,7 +2333,7 @@ static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda)
   /* Initialize the IRDA ErrorCode */
   hirda->ErrorCode = HAL_IRDA_ERROR_NONE;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Check if the Transmitter is enabled */
@@ -2347,16 +2368,18 @@ static HAL_StatusTypeDef IRDA_CheckIdleState(IRDA_HandleTypeDef *hirda)
 }
 
 /**
-  * @brief  Handle IRDA Communication Timeout.
+  * @brief  Handle IRDA Communication Timeout. It waits
+  *         until a flag is no longer in the specified status.
   * @param  hirda Pointer to a IRDA_HandleTypeDef structure that contains
   *               the configuration information for the specified IRDA module.
   * @param  Flag Specifies the IRDA flag to check.
-  * @param  Status Flag status (SET or RESET)
+  * @param  Status The actual Flag status (SET or RESET)
   * @param  Tickstart Tick start value
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status, uint32_t Tickstart, uint32_t Timeout)
+static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, uint32_t Flag, FlagStatus Status,
+                                                     uint32_t Tickstart, uint32_t Timeout)
 {
   /* Wait until flag is set */
   while ((__HAL_IRDA_GET_FLAG(hirda, Flag) ? SET : RESET) == Status)
@@ -2366,7 +2389,8 @@ static HAL_StatusTypeDef IRDA_WaitOnFlagUntilTimeout(IRDA_HandleTypeDef *hirda, 
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error)
+           interrupts for the interrupt process */
         CLEAR_BIT(hirda->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE));
         CLEAR_BIT(hirda->Instance->CR3, USART_CR3_EIE);
 
@@ -2397,7 +2421,6 @@ static void IRDA_EndTxTransfer(IRDA_HandleTypeDef *hirda)
   /* At end of Tx process, restore hirda->gState to Ready */
   hirda->gState = HAL_IRDA_STATE_READY;
 }
-
 
 /**
   * @brief  End ongoing Rx transfer on UART peripheral (following error detection or Reception completion).
@@ -2750,7 +2773,7 @@ static void IRDA_DMARxOnlyAbortCallback(DMA_HandleTypeDef *hdma)
   */
 static void IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda)
 {
-  uint16_t *tmp;
+  const uint16_t *tmp;
 
   /* Check that a Tx process is ongoing */
   if (hirda->gState == HAL_IRDA_STATE_BUSY_TX)
@@ -2767,7 +2790,7 @@ static void IRDA_Transmit_IT(IRDA_HandleTypeDef *hirda)
     {
       if ((hirda->Init.WordLength == IRDA_WORDLENGTH_9B) && (hirda->Init.Parity == IRDA_PARITY_NONE))
       {
-        tmp = (uint16_t *) hirda->pTxBuffPtr; /* Derogation R.11.3 */
+        tmp = (const uint16_t *) hirda->pTxBuffPtr; /* Derogation R.11.3 */
         hirda->Instance->TDR = (uint16_t)(*tmp & 0x01FFU);
         hirda->pTxBuffPtr += 2U;
       }
@@ -2875,4 +2898,4 @@ static void IRDA_Receive_IT(IRDA_HandleTypeDef *hirda)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_iwdg.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_iwdg.c
@@ -8,6 +8,17 @@
   *           + Initialization and Start functions
   *           + IO operation functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                     ##### IWDG Generic features #####
@@ -65,13 +76,13 @@
       (++) Configure the IWDG prescaler and counter reload value. This reload
            value will be loaded in the IWDG counter each time the watchdog is
            reloaded, then the IWDG will start counting down from this value.
-      (++) Wait for status flags to be reset.
       (++) Depending on window parameter:
         (+++) If Window Init parameter is same as Window register value,
              nothing more is done but reload counter value in order to exit
              function with exact time base.
         (+++) Else modify Window register. This will automatically reload
              watchdog counter.
+      (++) Wait for status flags to be reset.
 
     (#) Then the application program must refresh the IWDG counter at regular
         intervals during normal operation to prevent an MCU reset, using
@@ -86,18 +97,6 @@
           the reload register
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -121,11 +120,15 @@
 /* Status register needs up to 5 LSI clock periods divided by the clock
    prescaler to be updated. The number of LSI clock periods is upper-rounded to
    6 for the timeout value calculation.
-   The timeout value is also calculated using the highest prescaler (256) and
+   The timeout value is calculated using the highest prescaler (256) and
    the LSI_VALUE constant. The value of this constant can be changed by the user
    to take into account possible LSI clock period variations.
-   The timeout value is multiplied by 1000 to be converted in milliseconds. */
-#define HAL_IWDG_DEFAULT_TIMEOUT ((6UL * 256UL * 1000UL) / LSI_VALUE)
+   The timeout value is multiplied by 1000 to be converted in milliseconds.
+   LSI startup time is also considered here by adding LSI_STARTUP_TIME
+   converted in milliseconds. */
+#define HAL_IWDG_DEFAULT_TIMEOUT        (((6UL * 256UL * 1000UL) / (LSI_VALUE / 128U)) + \
+                                         ((LSI_STARTUP_TIME / 1000UL) + 1UL))
+#define IWDG_KERNEL_UPDATE_FLAGS        (IWDG_SR_WVU | IWDG_SR_RVU | IWDG_SR_PVU)
 /**
   * @}
   */
@@ -196,11 +199,14 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   tickstart = HAL_GetTick();
 
   /* Wait for register to be updated */
-  while (hiwdg->Instance->SR != 0x00u)
+  while ((hiwdg->Instance->SR & IWDG_KERNEL_UPDATE_FLAGS) != 0x00u)
   {
     if ((HAL_GetTick() - tickstart) > HAL_IWDG_DEFAULT_TIMEOUT)
     {
-      return HAL_TIMEOUT;
+      if ((hiwdg->Instance->SR & IWDG_KERNEL_UPDATE_FLAGS) != 0x00u)
+      {
+        return HAL_TIMEOUT;
+      }
     }
   }
 
@@ -223,6 +229,7 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   return HAL_OK;
 }
 
+
 /**
   * @}
   */
@@ -242,7 +249,6 @@ HAL_StatusTypeDef HAL_IWDG_Init(IWDG_HandleTypeDef *hiwdg)
   * @{
   */
 
-
 /**
   * @brief  Refresh the IWDG.
   * @param  hiwdg  pointer to a IWDG_HandleTypeDef structure that contains
@@ -257,6 +263,7 @@ HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
   /* Return function status */
   return HAL_OK;
 }
+
 
 /**
   * @}
@@ -274,5 +281,3 @@ HAL_StatusTypeDef HAL_IWDG_Refresh(IWDG_HandleTypeDef *hiwdg)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_lcd.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_lcd.c
@@ -9,6 +9,17 @@
   *           + I/O operation methods
   *           + Peripheral State methods
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -65,17 +76,6 @@
                STOP modes.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -611,6 +611,3 @@ HAL_StatusTypeDef LCD_WaitForSynchro(LCD_HandleTypeDef *hlcd)
 /**
   * @}
   */
-
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_lptim.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_lptim.c
@@ -11,6 +11,17 @@
   *           + Reading operation functions.
   *           + Peripheral State functions.
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -32,6 +43,9 @@
          (++) Clock: the counter clock.
              (+++) Source   : it can be either the ULPTIM input (IN1) or one of
                               the internal clock; (APB, LSE, LSI or MSI).
+                   CAUTION: if LSI2 is selected as LPTIM clock source, LSI1 has
+                            to be enabled as well (for further information please
+                            refer to errata sheet ES0394).
              (+++) Prescaler: select the clock divider.
          (++)  UltraLowPowerClock : To be used only if the ULPTIM is selected
                as counter clock source.
@@ -96,13 +110,13 @@
   The compilation define  USE_HAL_LPTIM_REGISTER_CALLBACKS when set to 1
   allows the user to configure dynamically the driver callbacks.
   [..]
-  Use Function @ref HAL_LPTIM_RegisterCallback() to register a callback.
-  @ref HAL_LPTIM_RegisterCallback() takes as parameters the HAL peripheral handle,
+  Use Function HAL_LPTIM_RegisterCallback() to register a callback.
+  HAL_LPTIM_RegisterCallback() takes as parameters the HAL peripheral handle,
   the Callback ID and a pointer to the user callback function.
   [..]
-  Use function @ref HAL_LPTIM_UnRegisterCallback() to reset a callback to the
+  Use function HAL_LPTIM_UnRegisterCallback() to reset a callback to the
   default weak function.
-  @ref HAL_LPTIM_UnRegisterCallback takes as parameters the HAL peripheral handle,
+  HAL_LPTIM_UnRegisterCallback takes as parameters the HAL peripheral handle,
   and the Callback ID.
   [..]
   These functions allow to register/unregister following callbacks:
@@ -120,7 +134,7 @@
   [..]
   By default, after the Init and when the state is HAL_LPTIM_STATE_RESET
   all interrupt callbacks are set to the corresponding weak functions:
-  examples @ref HAL_LPTIM_TriggerCallback(), @ref HAL_LPTIM_CompareMatchCallback().
+  examples HAL_LPTIM_TriggerCallback(), HAL_LPTIM_CompareMatchCallback().
 
   [..]
   Exception done for MspInit and MspDeInit functions that are reset to the legacy weak
@@ -134,7 +148,7 @@
   in HAL_LPTIM_STATE_READY or HAL_LPTIM_STATE_RESET state,
   thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
   In that case first register the MspInit/MspDeInit user callbacks
-  using @ref HAL_LPTIM_RegisterCallback() before calling DeInit or Init function.
+  using HAL_LPTIM_RegisterCallback() before calling DeInit or Init function.
 
   [..]
   When The compilation define USE_HAL_LPTIM_REGISTER_CALLBACKS is set to 0 or
@@ -142,17 +156,6 @@
   are set to the corresponding weak functions.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -188,10 +191,10 @@
   */
 #if defined(LPTIM2)
 #define __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(__INSTANCE__) \
-     (((__INSTANCE__) == LPTIM1) ? __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT() : __HAL_LPTIM_LPTIM2_EXTI_ENABLE_IT())
+  (((__INSTANCE__) == LPTIM1) ? __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT() : __HAL_LPTIM_LPTIM2_EXTI_ENABLE_IT())
 
 #define __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(__INSTANCE__) \
-     (((__INSTANCE__) == LPTIM1) ? __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT() : __HAL_LPTIM_LPTIM2_EXTI_DISABLE_IT())
+  (((__INSTANCE__) == LPTIM1) ? __HAL_LPTIM_LPTIM1_EXTI_DISABLE_IT() : __HAL_LPTIM_LPTIM2_EXTI_DISABLE_IT())
 #else
 #define __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(__INSTANCE__) __HAL_LPTIM_LPTIM1_EXTI_ENABLE_IT()
 
@@ -206,7 +209,7 @@
 #if (USE_HAL_LPTIM_REGISTER_CALLBACKS == 1)
 static void LPTIM_ResetCallback(LPTIM_HandleTypeDef *lptim);
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
-static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t flag);
+static HAL_StatusTypeDef LPTIM_WaitForFlag(const LPTIM_HandleTypeDef *hlptim, uint32_t flag);
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -215,8 +218,8 @@ static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t
   */
 
 /** @defgroup LPTIM_Exported_Functions_Group1 Initialization/de-initialization functions
- *  @brief    Initialization and Configuration functions.
- *
+  *  @brief    Initialization and Configuration functions.
+  *
 @verbatim
   ==============================================================================
               ##### Initialization and de-initialization functions #####
@@ -253,19 +256,17 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
 
   assert_param(IS_LPTIM_CLOCK_SOURCE(hlptim->Init.Clock.Source));
   assert_param(IS_LPTIM_CLOCK_PRESCALER(hlptim->Init.Clock.Prescaler));
-  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+  if ((hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+      || (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
     assert_param(IS_LPTIM_CLOCK_POLARITY(hlptim->Init.UltraLowPowerClock.Polarity));
+    assert_param(IS_LPTIM_CLOCK_SAMPLE_TIME(hlptim->Init.UltraLowPowerClock.SampleTime));
   }
   assert_param(IS_LPTIM_TRG_SOURCE(hlptim->Init.Trigger.Source));
   if (hlptim->Init.Trigger.Source != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     assert_param(IS_LPTIM_EXT_TRG_POLARITY(hlptim->Init.Trigger.ActiveEdge));
-  }
-  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC)
-  {
     assert_param(IS_LPTIM_TRIG_SAMPLE_TIME(hlptim->Init.Trigger.SampleTime));
-    assert_param(IS_LPTIM_CLOCK_SAMPLE_TIME(hlptim->Init.UltraLowPowerClock.SampleTime));
   }
   assert_param(IS_LPTIM_OUTPUT_POLARITY(hlptim->Init.OutputPolarity));
   assert_param(IS_LPTIM_UPDATE_MODE(hlptim->Init.UpdateMode));
@@ -299,21 +300,18 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
   /* Get the LPTIMx CFGR value */
   tmpcfgr = hlptim->Instance->CFGR;
 
-  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+  if ((hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+      || (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
-    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKPOL));
+    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKPOL | LPTIM_CFGR_CKFLT));
   }
   if (hlptim->Init.Trigger.Source != LPTIM_TRIGSOURCE_SOFTWARE)
   {
-    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_TRIGSEL));
-  }
-  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC)
-  {
-    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_TRGFLT | LPTIM_CFGR_CKFLT));
+    tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_TRGFLT | LPTIM_CFGR_TRIGSEL));
   }
 
-  /* Clear CKSEL, CKPOL, PRESC, TRIGEN, TRGFLT, WAVPOL, PRELOAD & COUNTMODE bits */
-  tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKSEL | LPTIM_CFGR_CKPOL | LPTIM_CFGR_TRIGEN | LPTIM_CFGR_PRELOAD |
+  /* Clear CKSEL, PRESC, TRIGEN, TRGFLT, WAVPOL, PRELOAD & COUNTMODE bits */
+  tmpcfgr &= (uint32_t)(~(LPTIM_CFGR_CKSEL | LPTIM_CFGR_TRIGEN | LPTIM_CFGR_PRELOAD |
                           LPTIM_CFGR_WAVPOL | LPTIM_CFGR_PRESC | LPTIM_CFGR_COUNTMODE));
 
   /* Set initialization parameters */
@@ -332,19 +330,21 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
                 hlptim->Init.UltraLowPowerClock.SampleTime);
   }
 
-  /* Configure the active edge or edges used by the counter only if LPTIM is
-   * clocked by an external clock source
-   */
-  if (hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+  /* Configure LPTIM external clock polarity and digital filter */
+  if ((hlptim->Init.Clock.Source == LPTIM_CLOCKSOURCE_ULPTIM)
+      || (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
-    tmpcfgr |= (hlptim->Init.UltraLowPowerClock.Polarity);
+    tmpcfgr |= (hlptim->Init.UltraLowPowerClock.Polarity |
+                hlptim->Init.UltraLowPowerClock.SampleTime);
   }
 
+  /* Configure LPTIM external trigger */
   if (hlptim->Init.Trigger.Source != LPTIM_TRIGSOURCE_SOFTWARE)
   {
     /* Enable External trigger and set the trigger source */
-    tmpcfgr |= (hlptim->Init.Trigger.Source |
-                hlptim->Init.Trigger.ActiveEdge);
+    tmpcfgr |= (hlptim->Init.Trigger.Source     |
+                hlptim->Init.Trigger.ActiveEdge |
+                hlptim->Init.Trigger.SampleTime);
   }
 
   /* Write to LPTIMx CFGR */
@@ -371,10 +371,10 @@ HAL_StatusTypeDef HAL_LPTIM_Init(LPTIM_HandleTypeDef *hlptim)
   }
   else
   {
-    /* Check LPTIM2 Input1 source */
+    /* Check LPTIM Input1 source */
     assert_param(IS_LPTIM_INPUT1_SOURCE(hlptim->Instance, hlptim->Init.Input1Source));
 
-    /* Configure LPTIM2 Input1 source */
+    /* Configure LPTIM Input1 source */
     hlptim->Instance->OR = hlptim->Init.Input1Source;
   }
 #endif /* LPTIM_OR_OR */
@@ -468,8 +468,8 @@ __weak void HAL_LPTIM_MspDeInit(LPTIM_HandleTypeDef *hlptim)
   */
 
 /** @defgroup LPTIM_Exported_Functions_Group2 LPTIM Start-Stop operation functions
- *  @brief   Start-Stop operation functions.
- *
+  *  @brief   Start-Stop operation functions.
+  *
 @verbatim
   ==============================================================================
                 ##### LPTIM Start Stop operation functions #####
@@ -497,7 +497,7 @@ __weak void HAL_LPTIM_MspDeInit(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the LPTIM PWM generation.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @param  Pulse Specifies the compare value.
   *         This parameter must be a value between 0x0000 and 0xFFFF.
   * @retval HAL status
@@ -545,7 +545,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Peri
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -562,7 +562,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop(LPTIM_HandleTypeDef *hlptim)
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
-  /* Set the LPTIM state */
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
@@ -573,7 +573,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop(LPTIM_HandleTypeDef *hlptim)
     return HAL_TIMEOUT;
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -584,7 +584,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the LPTIM PWM generation in interrupt mode.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF
+  *         This parameter must be a value between 0x0001 and 0xFFFF
   * @param  Pulse Specifies the compare value.
   *         This parameter must be a value between 0x0000 and 0xFFFF
   * @retval HAL status
@@ -662,7 +662,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t P
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -679,7 +679,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
-  /* Set the LPTIM state */
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
@@ -709,7 +709,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim)
     __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -720,7 +720,7 @@ HAL_StatusTypeDef HAL_LPTIM_PWM_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the LPTIM One pulse generation.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @param  Pulse Specifies the compare value.
   *         This parameter must be a value between 0x0000 and 0xFFFF.
   * @retval HAL status
@@ -768,7 +768,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start(LPTIM_HandleTypeDef *hlptim, uint32_t
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -796,7 +796,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop(LPTIM_HandleTypeDef *hlptim)
     return HAL_TIMEOUT;
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -807,7 +807,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the LPTIM One pulse generation in interrupt mode.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @param  Pulse Specifies the compare value.
   *         This parameter must be a value between 0x0000 and 0xFFFF.
   * @retval HAL status
@@ -885,7 +885,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Start_IT(LPTIM_HandleTypeDef *hlptim, uint3
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -904,6 +904,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim)
 
   /* Set the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_BUSY;
+
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
@@ -932,7 +933,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim)
     __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -943,7 +944,7 @@ HAL_StatusTypeDef HAL_LPTIM_OnePulse_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the LPTIM in Set once mode.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @param  Pulse Specifies the compare value.
   *         This parameter must be a value between 0x0000 and 0xFFFF.
   * @retval HAL status
@@ -991,7 +992,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1019,7 +1020,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop(LPTIM_HandleTypeDef *hlptim)
     return HAL_TIMEOUT;
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1108,7 +1109,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Start timer in single (one shot) mode */
   __HAL_LPTIM_START_SINGLE(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1155,7 +1156,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop_IT(LPTIM_HandleTypeDef *hlptim)
     __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_EXTTRIG);
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1166,7 +1167,7 @@ HAL_StatusTypeDef HAL_LPTIM_SetOnce_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the Encoder interface.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_LPTIM_Encoder_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
@@ -1216,7 +1217,7 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1247,7 +1248,7 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop(LPTIM_HandleTypeDef *hlptim)
   /* Reset ENC bit to disable the encoder interface */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_ENC;
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1326,7 +1327,7 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1363,7 +1364,7 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   /* Disable "switch to up direction" interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_UP);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1376,7 +1377,7 @@ HAL_StatusTypeDef HAL_LPTIM_Encoder_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   *         trigger event will reset the counter and the timer restarts.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @param  Timeout Specifies the TimeOut value to reset the counter.
   *         This parameter must be a value between 0x0000 and 0xFFFF.
   * @retval HAL status
@@ -1424,7 +1425,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1455,7 +1456,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop(LPTIM_HandleTypeDef *hlptim)
   /* Reset TIMOUT bit to enable the timeout function */
   hlptim->Instance->CFGR &= ~LPTIM_CFGR_TIMOUT;
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1468,7 +1469,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop(LPTIM_HandleTypeDef *hlptim)
   *         trigger event will reset the counter and the timer restarts.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @param  Timeout Specifies the TimeOut value to reset the counter.
   *         This parameter must be a value between 0x0000 and 0xFFFF.
   * @retval HAL status
@@ -1533,7 +1534,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1550,11 +1551,12 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
-  /* Set the LPTIM state */
-  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable EXTI Line interrupt on the LPTIM Wake-up Timer */
   __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(hlptim->Instance);
+
+  /* Set the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
@@ -1570,7 +1572,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   /* Disable Compare match interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_CMPM);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1581,7 +1583,7 @@ HAL_StatusTypeDef HAL_LPTIM_TimeOut_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the Counter mode.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
@@ -1594,7 +1596,8 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* If clock source is not ULPTIM clock and counter source is external, then it must not be prescaled */
-  if ((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
+  if ((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM)
+      && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
     /* Check if clock is prescaled */
     assert_param(IS_LPTIM_CLOCK_PRESCALERDIV1(hlptim->Init.Clock.Prescaler));
@@ -1620,7 +1623,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start(LPTIM_HandleTypeDef *hlptim, uint32_t 
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1648,7 +1651,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop(LPTIM_HandleTypeDef *hlptim)
     return HAL_TIMEOUT;
   }
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1659,7 +1662,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop(LPTIM_HandleTypeDef *hlptim)
   * @brief  Start the Counter mode in interrupt mode.
   * @param  hlptim LPTIM handle
   * @param  Period Specifies the Autoreload value.
-  *         This parameter must be a value between 0x0000 and 0xFFFF.
+  *         This parameter must be a value between 0x0001 and 0xFFFF.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32_t Period)
@@ -1675,7 +1678,8 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_IT(hlptim->Instance);
 
   /* If clock source is not ULPTIM clock and counter source is external, then it must not be prescaled */
-  if ((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM) && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
+  if ((hlptim->Init.Clock.Source != LPTIM_CLOCKSOURCE_ULPTIM)
+      && (hlptim->Init.CounterSource == LPTIM_COUNTERSOURCE_EXTERNAL))
   {
     /* Check if clock is prescaled */
     assert_param(IS_LPTIM_CLOCK_PRESCALERDIV1(hlptim->Init.Clock.Prescaler));
@@ -1718,7 +1722,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Start_IT(LPTIM_HandleTypeDef *hlptim, uint32
   /* Start timer in continuous mode */
   __HAL_LPTIM_START_CONTINUOUS(hlptim);
 
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1735,11 +1739,12 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
 
-  /* Set the LPTIM state */
-  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable EXTI Line interrupt on the LPTIM Wake-up Timer */
   __HAL_LPTIM_WAKEUPTIMER_EXTI_DISABLE_IT(hlptim->Instance);
+
+  /* Set the LPTIM state */
+  hlptim->State = HAL_LPTIM_STATE_BUSY;
 
   /* Disable the Peripheral */
   __HAL_LPTIM_DISABLE(hlptim);
@@ -1754,7 +1759,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
 
   /* Disable Autoreload match interrupt */
   __HAL_LPTIM_DISABLE_IT(hlptim, LPTIM_IT_ARRM);
-  /* Change the TIM state*/
+  /* Change the LPTIM state */
   hlptim->State = HAL_LPTIM_STATE_READY;
 
   /* Return function status */
@@ -1766,8 +1771,8 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   */
 
 /** @defgroup LPTIM_Exported_Functions_Group3 LPTIM Read operation functions
- *  @brief  Read operation functions.
- *
+  *  @brief  Read operation functions.
+  *
 @verbatim
   ==============================================================================
                   ##### LPTIM Read operation functions #####
@@ -1785,7 +1790,7 @@ HAL_StatusTypeDef HAL_LPTIM_Counter_Stop_IT(LPTIM_HandleTypeDef *hlptim)
   * @param  hlptim LPTIM handle
   * @retval Counter value.
   */
-uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim)
+uint32_t HAL_LPTIM_ReadCounter(const LPTIM_HandleTypeDef *hlptim)
 {
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
@@ -1798,7 +1803,7 @@ uint32_t HAL_LPTIM_ReadCounter(LPTIM_HandleTypeDef *hlptim)
   * @param  hlptim LPTIM handle
   * @retval Autoreload value.
   */
-uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim)
+uint32_t HAL_LPTIM_ReadAutoReload(const LPTIM_HandleTypeDef *hlptim)
 {
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
@@ -1811,7 +1816,7 @@ uint32_t HAL_LPTIM_ReadAutoReload(LPTIM_HandleTypeDef *hlptim)
   * @param  hlptim LPTIM handle
   * @retval Compare value.
   */
-uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim)
+uint32_t HAL_LPTIM_ReadCompare(const LPTIM_HandleTypeDef *hlptim)
 {
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(hlptim->Instance));
@@ -1824,8 +1829,8 @@ uint32_t HAL_LPTIM_ReadCompare(LPTIM_HandleTypeDef *hlptim)
   */
 
 /** @defgroup LPTIM_Exported_Functions_Group4 LPTIM IRQ handler and callbacks
- *  @brief  LPTIM  IRQ handler.
- *
+  *  @brief  LPTIM  IRQ handler.
+  *
 @verbatim
   ==============================================================================
                       ##### LPTIM IRQ handler and callbacks  #####
@@ -2106,9 +2111,6 @@ HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef        *hlptim,
     return HAL_ERROR;
   }
 
-  /* Process locked */
-  __HAL_LOCK(hlptim);
-
   if (hlptim->State == HAL_LPTIM_STATE_READY)
   {
     switch (CallbackID)
@@ -2179,9 +2181,6 @@ HAL_StatusTypeDef HAL_LPTIM_RegisterCallback(LPTIM_HandleTypeDef        *hlptim,
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hlptim);
-
   return status;
 }
 
@@ -2207,47 +2206,53 @@ HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef        *hlpti
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(hlptim);
-
   if (hlptim->State == HAL_LPTIM_STATE_READY)
   {
     switch (CallbackID)
     {
       case HAL_LPTIM_MSPINIT_CB_ID :
-        hlptim->MspInitCallback = HAL_LPTIM_MspInit;                          /* Legacy weak MspInit Callback */
+        /* Legacy weak MspInit Callback */
+        hlptim->MspInitCallback = HAL_LPTIM_MspInit;
         break;
 
       case HAL_LPTIM_MSPDEINIT_CB_ID :
-        hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;                       /* Legacy weak Msp DeInit Callback */
+        /* Legacy weak Msp DeInit Callback */
+        hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;
         break;
 
       case HAL_LPTIM_COMPARE_MATCH_CB_ID :
-        hlptim->CompareMatchCallback = HAL_LPTIM_CompareMatchCallback;         /* Legacy weak Compare match Callback */
+        /* Legacy weak Compare match Callback */
+        hlptim->CompareMatchCallback = HAL_LPTIM_CompareMatchCallback;
         break;
 
       case HAL_LPTIM_AUTORELOAD_MATCH_CB_ID :
-        hlptim->AutoReloadMatchCallback = HAL_LPTIM_AutoReloadMatchCallback;   /* Legacy weak Auto-reload match Callback */
+        /* Legacy weak Auto-reload match Callback */
+        hlptim->AutoReloadMatchCallback = HAL_LPTIM_AutoReloadMatchCallback;
         break;
 
       case HAL_LPTIM_TRIGGER_CB_ID :
-        hlptim->TriggerCallback = HAL_LPTIM_TriggerCallback;                   /* Legacy weak External trigger event detection Callback */
+        /* Legacy weak External trigger event detection Callback */
+        hlptim->TriggerCallback = HAL_LPTIM_TriggerCallback;
         break;
 
       case HAL_LPTIM_COMPARE_WRITE_CB_ID :
-        hlptim->CompareWriteCallback = HAL_LPTIM_CompareWriteCallback;         /* Legacy weak Compare register write complete Callback */
+        /* Legacy weak Compare register write complete Callback */
+        hlptim->CompareWriteCallback = HAL_LPTIM_CompareWriteCallback;
         break;
 
       case HAL_LPTIM_AUTORELOAD_WRITE_CB_ID :
-        hlptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback;   /* Legacy weak Auto-reload register write complete Callback */
+        /* Legacy weak Auto-reload register write complete Callback */
+        hlptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback;
         break;
 
       case HAL_LPTIM_DIRECTION_UP_CB_ID :
-        hlptim->DirectionUpCallback = HAL_LPTIM_DirectionUpCallback;           /* Legacy weak Up-counting direction change Callback */
+        /* Legacy weak Up-counting direction change Callback */
+        hlptim->DirectionUpCallback = HAL_LPTIM_DirectionUpCallback;
         break;
 
       case HAL_LPTIM_DIRECTION_DOWN_CB_ID :
-        hlptim->DirectionDownCallback = HAL_LPTIM_DirectionDownCallback;       /* Legacy weak Down-counting direction change Callback */
+        /* Legacy weak Down-counting direction change Callback */
+        hlptim->DirectionDownCallback = HAL_LPTIM_DirectionDownCallback;
         break;
 
       default :
@@ -2261,11 +2266,13 @@ HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef        *hlpti
     switch (CallbackID)
     {
       case HAL_LPTIM_MSPINIT_CB_ID :
-        hlptim->MspInitCallback = HAL_LPTIM_MspInit;                           /* Legacy weak MspInit Callback */
+        /* Legacy weak MspInit Callback */
+        hlptim->MspInitCallback = HAL_LPTIM_MspInit;
         break;
 
       case HAL_LPTIM_MSPDEINIT_CB_ID :
-        hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;                        /* Legacy weak Msp DeInit Callback */
+        /* Legacy weak Msp DeInit Callback */
+        hlptim->MspDeInitCallback = HAL_LPTIM_MspDeInit;
         break;
 
       default :
@@ -2280,9 +2287,6 @@ HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef        *hlpti
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hlptim);
-
   return status;
 }
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
@@ -2292,8 +2296,8 @@ HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef        *hlpti
   */
 
 /** @defgroup LPTIM_Group5 Peripheral State functions
- *  @brief   Peripheral State functions.
- *
+  *  @brief   Peripheral State functions.
+  *
 @verbatim
   ==============================================================================
                       ##### Peripheral State functions #####
@@ -2310,7 +2314,7 @@ HAL_StatusTypeDef HAL_LPTIM_UnRegisterCallback(LPTIM_HandleTypeDef        *hlpti
   * @param  hlptim LPTIM handle
   * @retval HAL state
   */
-HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim)
+HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(const LPTIM_HandleTypeDef *hlptim)
 {
   /* Return LPTIM handle state */
   return hlptim->State;
@@ -2340,13 +2344,13 @@ HAL_LPTIM_StateTypeDef HAL_LPTIM_GetState(LPTIM_HandleTypeDef *hlptim)
 static void LPTIM_ResetCallback(LPTIM_HandleTypeDef *lptim)
 {
   /* Reset the LPTIM callback to the legacy weak callbacks */
-  lptim->CompareMatchCallback    = HAL_LPTIM_CompareMatchCallback;    /* Compare match Callback                       */
-  lptim->AutoReloadMatchCallback = HAL_LPTIM_AutoReloadMatchCallback; /* Auto-reload match Callback                   */
-  lptim->TriggerCallback         = HAL_LPTIM_TriggerCallback;         /* External trigger event detection Callback    */
-  lptim->CompareWriteCallback    = HAL_LPTIM_CompareWriteCallback;    /* Compare register write complete Callback     */
-  lptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback; /* Auto-reload register write complete Callback */
-  lptim->DirectionUpCallback     = HAL_LPTIM_DirectionUpCallback;     /* Up-counting direction change Callback        */
-  lptim->DirectionDownCallback   = HAL_LPTIM_DirectionDownCallback;   /* Down-counting direction change Callback      */
+  lptim->CompareMatchCallback    = HAL_LPTIM_CompareMatchCallback;
+  lptim->AutoReloadMatchCallback = HAL_LPTIM_AutoReloadMatchCallback;
+  lptim->TriggerCallback         = HAL_LPTIM_TriggerCallback;
+  lptim->CompareWriteCallback    = HAL_LPTIM_CompareWriteCallback;
+  lptim->AutoReloadWriteCallback = HAL_LPTIM_AutoReloadWriteCallback;
+  lptim->DirectionUpCallback     = HAL_LPTIM_DirectionUpCallback;
+  lptim->DirectionDownCallback   = HAL_LPTIM_DirectionDownCallback;
 }
 #endif /* USE_HAL_LPTIM_REGISTER_CALLBACKS */
 
@@ -2357,7 +2361,7 @@ static void LPTIM_ResetCallback(LPTIM_HandleTypeDef *lptim)
   * @param  flag   The lptim flag
   * @retval HAL status
   */
-static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t flag)
+static HAL_StatusTypeDef LPTIM_WaitForFlag(const LPTIM_HandleTypeDef *hlptim, uint32_t flag)
 {
   HAL_StatusTypeDef result = HAL_OK;
   uint32_t count = TIMEOUT * (SystemCoreClock / 20UL / 1000UL);
@@ -2368,8 +2372,7 @@ static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t
     {
       result = HAL_TIMEOUT;
     }
-  }
-  while ((!(__HAL_LPTIM_GET_FLAG((hlptim), (flag)))) && (count != 0UL));
+  } while ((!(__HAL_LPTIM_GET_FLAG((hlptim), (flag)))) && (count != 0UL));
 
   return result;
 }
@@ -2385,34 +2388,20 @@ static HAL_StatusTypeDef LPTIM_WaitForFlag(LPTIM_HandleTypeDef *hlptim, uint32_t
   */
 void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim)
 {
-  uint32_t tmpclksource = 0;
   uint32_t tmpIER;
   uint32_t tmpCFGR;
   uint32_t tmpCMP;
   uint32_t tmpARR;
+  uint32_t primask_bit;
 #if defined(LPTIM_OR_OR)
   uint32_t tmpOR;
 #endif /* LPTIM_OR_OR */
 
-  __disable_irq();
+  /* Enter critical section */
+  primask_bit = __get_PRIMASK();
+  __set_PRIMASK(1) ;
 
   /*********** Save LPTIM Config ***********/
-  /* Save LPTIM source clock */
-  switch ((uint32_t)hlptim->Instance)
-  {
-    case LPTIM1_BASE:
-      tmpclksource = __HAL_RCC_GET_LPTIM1_SOURCE();
-      break;
-#if defined(LPTIM2)
-    case LPTIM2_BASE:
-      tmpclksource = __HAL_RCC_GET_LPTIM2_SOURCE();
-      break;
-#endif /* LPTIM2 */
-    default:
-      break;
-  }
-
-  /* Save LPTIM configuration registers */
   tmpIER = hlptim->Instance->IER;
   tmpCFGR = hlptim->Instance->CFGR;
   tmpCMP = hlptim->Instance->CMP;
@@ -2441,21 +2430,6 @@ void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim)
   /*********** Restore LPTIM Config ***********/
   if ((tmpCMP != 0UL) || (tmpARR != 0UL))
   {
-    /* Force LPTIM source kernel clock from APB */
-    switch ((uint32_t)hlptim->Instance)
-    {
-      case LPTIM1_BASE:
-        __HAL_RCC_LPTIM1_CONFIG(RCC_LPTIM1CLKSOURCE_PCLK1);
-        break;
-#if defined(LPTIM2)
-      case LPTIM2_BASE:
-        __HAL_RCC_LPTIM2_CONFIG(RCC_LPTIM2CLKSOURCE_PCLK1);
-        break;
-#endif /* LPTIM2 */
-      default:
-        break;
-    }
-
     if (tmpCMP != 0UL)
     {
       /* Restore CMP register (LPTIM should be enabled first) */
@@ -2484,21 +2458,6 @@ void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim)
 
       __HAL_LPTIM_CLEAR_FLAG(hlptim, LPTIM_FLAG_ARROK);
     }
-
-    /* Restore LPTIM source kernel clock */
-    switch ((uint32_t)hlptim->Instance)
-    {
-      case LPTIM1_BASE:
-        __HAL_RCC_LPTIM1_CONFIG(tmpclksource);
-        break;
-#if defined(LPTIM2)
-      case LPTIM2_BASE:
-        __HAL_RCC_LPTIM2_CONFIG(tmpclksource);
-        break;
-#endif /* LPTIM2 */
-      default:
-        break;
-    }
   }
 
   /* Restore configuration registers (LPTIM should be disabled first) */
@@ -2509,7 +2468,8 @@ void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim)
   hlptim->Instance->OR = tmpOR;
 #endif /* LPTIM_OR_OR */
 
-  __enable_irq();
+  /* Exit critical section: restore previous priority mask */
+  __set_PRIMASK(primask_bit);
 }
 /**
   * @}
@@ -2524,5 +2484,3 @@ void LPTIM_Disable(LPTIM_HandleTypeDef *hlptim)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_msp_template.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_msp_template.c
@@ -8,13 +8,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -97,5 +96,3 @@ void HAL_PPP_MspDeInit(void)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pcd.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pcd.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                     ##### How to use this driver #####
@@ -26,7 +37,7 @@
 
      (#) Initialize the PCD low level resources through the HAL_PCD_MspInit() API:
          (##) Enable the PCD/USB Low Level interface clock using
-              (+++) __HAL_RCC_USB_CLK_ENABLE(); For USB Device only FS peripheral
+              (+++) __HAL_RCC_USB_CLK_ENABLE(); For USB Device FS peripheral
 
          (##) Initialize the related GPIO clocks
          (##) Configure PCD pin-out
@@ -38,18 +49,10 @@
      (#)Enable PCD transmission and reception:
          (##) HAL_PCD_Start();
 
+     (#)NOTE: For applications not using double buffer mode, define the symbol
+               'USE_USB_DOUBLE_BUFFER' as 0 to reduce the driver's memory footprint.
+
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -88,6 +91,10 @@
   */
 
 static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd);
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+static HAL_StatusTypeDef HAL_PCD_EP_DB_Transmit(PCD_HandleTypeDef *hpcd, PCD_EPTypeDef *ep, uint16_t wEPVal);
+static uint16_t HAL_PCD_EP_DB_Receive(PCD_HandleTypeDef *hpcd, PCD_EPTypeDef *ep, uint16_t wEPVal);
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
 /**
   * @}
@@ -99,8 +106,8 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd);
   */
 
 /** @defgroup PCD_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
             ##### Initialization and de-initialization functions #####
@@ -174,7 +181,6 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
     /* Init ep structure */
     hpcd->IN_ep[i].is_in = 1U;
     hpcd->IN_ep[i].num = i;
-    hpcd->IN_ep[i].tx_fifo_num = i;
     /* Control until ep is activated */
     hpcd->IN_ep[i].type = EP_TYPE_CTRL;
     hpcd->IN_ep[i].maxpacket = 0U;
@@ -224,7 +230,10 @@ HAL_StatusTypeDef HAL_PCD_DeInit(PCD_HandleTypeDef *hpcd)
   hpcd->State = HAL_PCD_STATE_BUSY;
 
   /* Stop Device */
-  (void)HAL_PCD_Stop(hpcd);
+  if (USB_StopDevice(hpcd->Instance) != HAL_OK)
+  {
+    return HAL_ERROR;
+  }
 
 #if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
   if (hpcd->MspDeInitCallback == NULL)
@@ -287,13 +296,15 @@ __weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
   *          @arg @ref HAL_PCD_SUSPEND_CB_ID USB PCD Suspend callback ID
   *          @arg @ref HAL_PCD_RESUME_CB_ID USB PCD Resume callback ID
   *          @arg @ref HAL_PCD_CONNECT_CB_ID USB PCD Connect callback ID
-  *          @arg @ref HAL_PCD_DISCONNECT_CB_ID OTG PCD Disconnect callback ID
+  *          @arg @ref HAL_PCD_DISCONNECT_CB_ID USB PCD Disconnect callback ID
   *          @arg @ref HAL_PCD_MSPINIT_CB_ID MspDeInit callback ID
   *          @arg @ref HAL_PCD_MSPDEINIT_CB_ID MspDeInit callback ID
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_CallbackIDTypeDef CallbackID, pPCD_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd,
+                                           HAL_PCD_CallbackIDTypeDef CallbackID,
+                                           pPCD_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -389,7 +400,7 @@ HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_Call
 
 /**
   * @brief  Unregister an USB PCD Callback
-  *         USB PCD callabck is redirected to the weak predefined callback
+  *         USB PCD callback is redirected to the weak predefined callback
   * @param  hpcd USB PCD handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
@@ -399,7 +410,7 @@ HAL_StatusTypeDef HAL_PCD_RegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_Call
   *          @arg @ref HAL_PCD_SUSPEND_CB_ID USB PCD Suspend callback ID
   *          @arg @ref HAL_PCD_RESUME_CB_ID USB PCD Resume callback ID
   *          @arg @ref HAL_PCD_CONNECT_CB_ID USB PCD Connect callback ID
-  *          @arg @ref HAL_PCD_DISCONNECT_CB_ID OTG PCD Disconnect callback ID
+  *          @arg @ref HAL_PCD_DISCONNECT_CB_ID USB PCD Disconnect callback ID
   *          @arg @ref HAL_PCD_MSPINIT_CB_ID MspDeInit callback ID
   *          @arg @ref HAL_PCD_MSPDEINIT_CB_ID MspDeInit callback ID
   * @retval HAL status
@@ -503,7 +514,8 @@ HAL_StatusTypeDef HAL_PCD_UnRegisterCallback(PCD_HandleTypeDef *hpcd, HAL_PCD_Ca
   * @param  pCallback pointer to the USB PCD Data OUT Stage Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd, pPCD_DataOutStageCallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_DataOutStageCallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -538,7 +550,7 @@ HAL_StatusTypeDef HAL_PCD_RegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd, 
 }
 
 /**
-  * @brief  UnRegister the USB PCD Data OUT Stage Callback
+  * @brief  Unregister the USB PCD Data OUT Stage Callback
   *         USB PCD Data OUT Stage Callback is redirected to the weak HAL_PCD_DataOutStageCallback() predefined callback
   * @param  hpcd PCD handle
   * @retval HAL status
@@ -576,7 +588,8 @@ HAL_StatusTypeDef HAL_PCD_UnRegisterDataOutStageCallback(PCD_HandleTypeDef *hpcd
   * @param  pCallback pointer to the USB PCD Data IN Stage Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd, pPCD_DataInStageCallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_DataInStageCallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -611,7 +624,7 @@ HAL_StatusTypeDef HAL_PCD_RegisterDataInStageCallback(PCD_HandleTypeDef *hpcd, p
 }
 
 /**
-  * @brief  UnRegister the USB PCD Data IN Stage Callback
+  * @brief  Unregister the USB PCD Data IN Stage Callback
   *         USB PCD Data OUT Stage Callback is redirected to the weak HAL_PCD_DataInStageCallback() predefined callback
   * @param  hpcd PCD handle
   * @retval HAL status
@@ -649,7 +662,8 @@ HAL_StatusTypeDef HAL_PCD_UnRegisterDataInStageCallback(PCD_HandleTypeDef *hpcd)
   * @param  pCallback pointer to the USB PCD Iso OUT incomplete Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd, pPCD_IsoOutIncpltCallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                       pPCD_IsoOutIncpltCallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -684,8 +698,9 @@ HAL_StatusTypeDef HAL_PCD_RegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd, 
 }
 
 /**
-  * @brief  UnRegister the USB PCD Iso OUT incomplete Callback
-  *         USB PCD Iso OUT incomplete Callback is redirected to the weak HAL_PCD_ISOOUTIncompleteCallback() predefined callback
+  * @brief  Unregister the USB PCD Iso OUT incomplete Callback
+  *         USB PCD Iso OUT incomplete Callback is redirected
+  *         to the weak HAL_PCD_ISOOUTIncompleteCallback() predefined callback
   * @param  hpcd PCD handle
   * @retval HAL status
   */
@@ -722,7 +737,8 @@ HAL_StatusTypeDef HAL_PCD_UnRegisterIsoOutIncpltCallback(PCD_HandleTypeDef *hpcd
   * @param  pCallback pointer to the USB PCD Iso IN incomplete Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd, pPCD_IsoInIncpltCallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd,
+                                                      pPCD_IsoInIncpltCallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -757,8 +773,9 @@ HAL_StatusTypeDef HAL_PCD_RegisterIsoInIncpltCallback(PCD_HandleTypeDef *hpcd, p
 }
 
 /**
-  * @brief  UnRegister the USB PCD Iso IN incomplete Callback
-  *         USB PCD Iso IN incomplete Callback is redirected to the weak HAL_PCD_ISOINIncompleteCallback() predefined callback
+  * @brief  Unregister the USB PCD Iso IN incomplete Callback
+  *         USB PCD Iso IN incomplete Callback is redirected
+  *         to the weak HAL_PCD_ISOINIncompleteCallback() predefined callback
   * @param  hpcd PCD handle
   * @retval HAL status
   */
@@ -830,7 +847,7 @@ HAL_StatusTypeDef HAL_PCD_RegisterBcdCallback(PCD_HandleTypeDef *hpcd, pPCD_BcdC
 }
 
 /**
-  * @brief  UnRegister the USB PCD BCD Callback
+  * @brief  Unregister the USB PCD BCD Callback
   *         USB BCD Callback is redirected to the weak HAL_PCDEx_BCD_Callback() predefined callback
   * @param  hpcd PCD handle
   * @retval HAL status
@@ -903,7 +920,7 @@ HAL_StatusTypeDef HAL_PCD_RegisterLpmCallback(PCD_HandleTypeDef *hpcd, pPCD_LpmC
 }
 
 /**
-  * @brief  UnRegister the USB PCD LPM Callback
+  * @brief  Unregister the USB PCD LPM Callback
   *         USB LPM Callback is redirected to the weak HAL_PCDEx_LPM_Callback() predefined callback
   * @param  hpcd PCD handle
   * @retval HAL status
@@ -940,8 +957,8 @@ HAL_StatusTypeDef HAL_PCD_UnRegisterLpmCallback(PCD_HandleTypeDef *hpcd)
   */
 
 /** @defgroup PCD_Exported_Functions_Group2 Input and Output operation functions
- *  @brief   Data transfers functions
- *
+  *  @brief   Data transfers functions
+  *
 @verbatim
  ===============================================================================
                       ##### IO operation functions #####
@@ -962,9 +979,10 @@ HAL_StatusTypeDef HAL_PCD_UnRegisterLpmCallback(PCD_HandleTypeDef *hpcd)
 HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
 {
   __HAL_LOCK(hpcd);
-  (void)USB_DevConnect(hpcd->Instance);
   __HAL_PCD_ENABLE(hpcd);
+  (void)USB_DevConnect(hpcd->Instance);
   __HAL_UNLOCK(hpcd);
+
   return HAL_OK;
 }
 
@@ -977,9 +995,7 @@ HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
 {
   __HAL_LOCK(hpcd);
   __HAL_PCD_DISABLE(hpcd);
-
-  (void)USB_StopDevice(hpcd->Instance);
-
+  (void)USB_DevDisconnect(hpcd->Instance);
   __HAL_UNLOCK(hpcd);
 
   return HAL_OK;
@@ -993,14 +1009,18 @@ HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
   */
 void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 {
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_CTR))
+  uint32_t wIstr = USB_ReadInterrupts(hpcd->Instance);
+
+  if ((wIstr & USB_ISTR_CTR) == USB_ISTR_CTR)
   {
     /* servicing of the endpoint correct transfer interrupt */
     /* clear of the CTR flag into the sub */
     (void)PCD_EP_ISR_Handler(hpcd);
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_RESET))
+  if ((wIstr & USB_ISTR_RESET) == USB_ISTR_RESET)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_RESET);
 
@@ -1011,19 +1031,25 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
 
     (void)HAL_PCD_SetAddress(hpcd, 0U);
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_PMAOVR))
+  if ((wIstr & USB_ISTR_PMAOVR) == USB_ISTR_PMAOVR)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_PMAOVR);
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_ERR))
+  if ((wIstr & USB_ISTR_ERR) == USB_ISTR_ERR)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ERR);
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_WKUP))
+  if ((wIstr & USB_ISTR_WKUP) == USB_ISTR_WKUP)
   {
     hpcd->Instance->CNTR &= (uint16_t) ~(USB_CNTR_LPMODE);
     hpcd->Instance->CNTR &= (uint16_t) ~(USB_CNTR_FSUSP);
@@ -1045,9 +1071,11 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
 
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_WKUP);
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_SUSP))
+  if ((wIstr & USB_ISTR_SUSP) == USB_ISTR_SUSP)
   {
     /* Force low-power mode in the macrocell */
     hpcd->Instance->CNTR |= (uint16_t)USB_CNTR_FSUSP;
@@ -1062,10 +1090,12 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 #else
     HAL_PCD_SuspendCallback(hpcd);
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+    return;
   }
 
   /* Handle LPM Interrupt */
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_L1REQ))
+  if ((wIstr & USB_ISTR_L1REQ) == USB_ISTR_L1REQ)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_L1REQ);
     if (hpcd->LPM_State == LPM_L0)
@@ -1090,9 +1120,11 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
       HAL_PCD_SuspendCallback(hpcd);
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
     }
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_SOF))
+  if ((wIstr & USB_ISTR_SOF) == USB_ISTR_SOF)
   {
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_SOF);
 
@@ -1101,12 +1133,16 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
 #else
     HAL_PCD_SOFCallback(hpcd);
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+    return;
   }
 
-  if (__HAL_PCD_GET_FLAG(hpcd, USB_ISTR_ESOF))
+  if ((wIstr & USB_ISTR_ESOF) == USB_ISTR_ESOF)
   {
     /* clear ESOF flag in ISTR */
     __HAL_PCD_CLEAR_FLAG(hpcd, USB_ISTR_ESOF);
+
+    return;
   }
 }
 
@@ -1288,8 +1324,8 @@ __weak void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
   */
 
 /** @defgroup PCD_Exported_Functions_Group3 Peripheral Control functions
- *  @brief   management functions
- *
+  *  @brief   management functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral Control functions #####
@@ -1312,6 +1348,7 @@ HAL_StatusTypeDef HAL_PCD_DevConnect(PCD_HandleTypeDef *hpcd)
   __HAL_LOCK(hpcd);
   (void)USB_DevConnect(hpcd->Instance);
   __HAL_UNLOCK(hpcd);
+
   return HAL_OK;
 }
 
@@ -1325,6 +1362,7 @@ HAL_StatusTypeDef HAL_PCD_DevDisconnect(PCD_HandleTypeDef *hpcd)
   __HAL_LOCK(hpcd);
   (void)USB_DevDisconnect(hpcd->Instance);
   __HAL_UNLOCK(hpcd);
+
   return HAL_OK;
 }
 
@@ -1340,6 +1378,7 @@ HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address)
   hpcd->USB_Address = address;
   (void)USB_SetDevAddress(hpcd->Instance, address);
   __HAL_UNLOCK(hpcd);
+
   return HAL_OK;
 }
 /**
@@ -1350,9 +1389,10 @@ HAL_StatusTypeDef HAL_PCD_SetAddress(PCD_HandleTypeDef *hpcd, uint8_t address)
   * @param  ep_type endpoint type
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint16_t ep_mps, uint8_t ep_type)
+HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr,
+                                  uint16_t ep_mps, uint8_t ep_type)
 {
-  HAL_StatusTypeDef  ret = HAL_OK;
+  HAL_StatusTypeDef ret = HAL_OK;
   PCD_EPTypeDef *ep;
 
   if ((ep_addr & 0x80U) == 0x80U)
@@ -1367,14 +1407,9 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
   }
 
   ep->num = ep_addr & EP_ADDR_MSK;
-  ep->maxpacket = ep_mps;
+  ep->maxpacket = (uint32_t)ep_mps & 0x7FFU;
   ep->type = ep_type;
 
-  if (ep->is_in != 0U)
-  {
-    /* Assign a Tx FIFO */
-    ep->tx_fifo_num = ep->num;
-  }
   /* Set initial data PID. */
   if (ep_type == EP_TYPE_BULK)
   {
@@ -1408,7 +1443,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
     ep = &hpcd->OUT_ep[ep_addr & EP_ADDR_MSK];
     ep->is_in = 0U;
   }
-  ep->num   = ep_addr & EP_ADDR_MSK;
+  ep->num = ep_addr & EP_ADDR_MSK;
 
   __HAL_LOCK(hpcd);
   (void)USB_DeactivateEndpoint(hpcd->Instance, ep);
@@ -1438,14 +1473,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   ep->is_in = 0U;
   ep->num = ep_addr & EP_ADDR_MSK;
 
-  if ((ep_addr & EP_ADDR_MSK) == 0U)
-  {
-    (void)USB_EP0StartXfer(hpcd->Instance, ep);
-  }
-  else
-  {
-    (void)USB_EPStartXfer(hpcd->Instance, ep);
-  }
+  (void)USB_EPStartXfer(hpcd->Instance, ep);
 
   return HAL_OK;
 }
@@ -1456,7 +1484,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   * @param  ep_addr endpoint address
   * @retval Data Size
   */
-uint32_t HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+uint32_t HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef const *hpcd, uint8_t ep_addr)
 {
   return hpcd->OUT_ep[ep_addr & EP_ADDR_MSK].xfer_count;
 }
@@ -1477,18 +1505,13 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   /*setup and start the Xfer */
   ep->xfer_buff = pBuf;
   ep->xfer_len = len;
+  ep->xfer_fill_db = 1U;
+  ep->xfer_len_db = len;
   ep->xfer_count = 0U;
   ep->is_in = 1U;
   ep->num = ep_addr & EP_ADDR_MSK;
 
-  if ((ep_addr & EP_ADDR_MSK) == 0U)
-  {
-    (void)USB_EP0StartXfer(hpcd->Instance, ep);
-  }
-  else
-  {
-    (void)USB_EPStartXfer(hpcd->Instance, ep);
-  }
+  (void)USB_EPStartXfer(hpcd->Instance, ep);
 
   return HAL_OK;
 }
@@ -1525,10 +1548,7 @@ HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   __HAL_LOCK(hpcd);
 
   (void)USB_EPSetStall(hpcd->Instance, ep);
-  if ((ep_addr & EP_ADDR_MSK) == 0U)
-  {
-    (void)USB_EP0_OutStart(hpcd->Instance, (uint8_t *)hpcd->Setup);
-  }
+
   __HAL_UNLOCK(hpcd);
 
   return HAL_OK;
@@ -1571,6 +1591,32 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
 }
 
 /**
+   * @brief  Abort an USB EP transaction.
+   * @param  hpcd PCD handle
+   * @param  ep_addr endpoint address
+   * @retval HAL status
+   */
+HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  HAL_StatusTypeDef ret;
+  PCD_EPTypeDef *ep;
+
+  if ((0x80U & ep_addr) == 0x80U)
+  {
+    ep = &hpcd->IN_ep[ep_addr & EP_ADDR_MSK];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr & EP_ADDR_MSK];
+  }
+
+  /* Stop Xfer */
+  ret = USB_EPStopXfer(hpcd->Instance, ep);
+
+  return ret;
+}
+
+/**
   * @brief  Flush an endpoint
   * @param  hpcd PCD handle
   * @param  ep_addr endpoint address
@@ -1578,9 +1624,18 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   */
 HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
 {
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(hpcd);
-  UNUSED(ep_addr);
+  __HAL_LOCK(hpcd);
+
+  if ((ep_addr & 0x80U) == 0x80U)
+  {
+    (void)USB_FlushTxFifo(hpcd->Instance, (uint32_t)ep_addr & EP_ADDR_MSK);
+  }
+  else
+  {
+    (void)USB_FlushRxFifo(hpcd->Instance);
+  }
+
+  __HAL_UNLOCK(hpcd);
 
   return HAL_OK;
 }
@@ -1610,8 +1665,8 @@ HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
   */
 
 /** @defgroup PCD_Exported_Functions_Group4 Peripheral State functions
- *  @brief   Peripheral State functions
- *
+  *  @brief   Peripheral State functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral State functions #####
@@ -1629,7 +1684,7 @@ HAL_StatusTypeDef HAL_PCD_DeActivateRemoteWakeup(PCD_HandleTypeDef *hpcd)
   * @param  hpcd PCD handle
   * @retval HAL state
   */
-PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef *hpcd)
+PCD_StateTypeDef HAL_PCD_GetState(PCD_HandleTypeDef const *hpcd)
 {
   return hpcd->State;
 }
@@ -1659,12 +1714,18 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
   uint16_t count;
   uint16_t wIstr;
   uint16_t wEPVal;
+  uint16_t TxPctSize;
   uint8_t epindex;
+
+#if (USE_USB_DOUBLE_BUFFER != 1U)
+  count = 0U;
+#endif /* USE_USB_DOUBLE_BUFFER */
 
   /* stay in loop while pending interrupts */
   while ((hpcd->Instance->ISTR & USB_ISTR_CTR) != 0U)
   {
     wIstr = hpcd->Instance->ISTR;
+
     /* extract highest priority endpoint number */
     epindex = (uint8_t)(wIstr & USB_ISTR_EP_ID);
 
@@ -1712,6 +1773,18 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
           /* Get SETUP Packet */
           ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
 
+          if (ep->xfer_count != 8U)
+          {
+            /* Set Stall condition for EP0 IN/OUT */
+            PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_STALL);
+            PCD_SET_EP_TX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_TX_STALL);
+
+            /* SETUP bit kept frozen while CTR_RX = 1 */
+            PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
+
+            return HAL_OK;
+          }
+
           USB_ReadPMA(hpcd->Instance, (uint8_t *)hpcd->Setup,
                       ep->pmaadress, (uint16_t)ep->xfer_count);
 
@@ -1725,7 +1798,6 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
           HAL_PCD_SetupStageCallback(hpcd);
 #endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
         }
-
         else if ((wEPVal & USB_EP_CTR_RX) != 0U)
         {
           PCD_CLEAR_RX_EP_CTR(hpcd->Instance, PCD_ENDP0);
@@ -1733,74 +1805,92 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
           /* Get Control Data OUT Packet */
           ep->xfer_count = PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
 
-          if ((ep->xfer_count != 0U) && (ep->xfer_buff != 0U))
+          if (ep->xfer_count == 0U)
           {
-            USB_ReadPMA(hpcd->Instance, ep->xfer_buff,
-                        ep->pmaadress, (uint16_t)ep->xfer_count);
-
-            ep->xfer_buff += ep->xfer_count;
-
-            /* Process Control Data OUT Packet */
-#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
-            hpcd->DataOutStageCallback(hpcd, 0U);
-#else
-            HAL_PCD_DataOutStageCallback(hpcd, 0U);
-#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+            /* Status phase re-arm for next setup */
+            PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID);
           }
+          else
+          {
+            if (ep->xfer_buff != 0U)
+            {
+              USB_ReadPMA(hpcd->Instance, ep->xfer_buff,
+                          ep->pmaadress, (uint16_t)ep->xfer_count);  /* max 64bytes */
 
-          PCD_SET_EP_RX_CNT(hpcd->Instance, PCD_ENDP0, ep->maxpacket);
-          PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID);
+              ep->xfer_buff += ep->xfer_count;
+
+              /* Process Control Data OUT Packet */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+              hpcd->DataOutStageCallback(hpcd, 0U);
+#else
+              HAL_PCD_DataOutStageCallback(hpcd, 0U);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+            }
+          }
         }
       }
     }
     else
     {
       /* Decode and service non control endpoints interrupt */
-
       /* process related endpoint register */
       wEPVal = PCD_GET_ENDPOINT(hpcd->Instance, epindex);
+
       if ((wEPVal & USB_EP_CTR_RX) != 0U)
       {
         /* clear int flag */
         PCD_CLEAR_RX_EP_CTR(hpcd->Instance, epindex);
         ep = &hpcd->OUT_ep[epindex];
 
-        /* OUT double Buffering */
+        /* OUT Single Buffering */
         if (ep->doublebuffer == 0U)
         {
           count = (uint16_t)PCD_GET_EP_RX_CNT(hpcd->Instance, ep->num);
+
           if (count != 0U)
           {
             USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaadress, count);
           }
         }
+#if (USE_USB_DOUBLE_BUFFER == 1U)
         else
         {
-          /* free EP OUT Buffer */
-          PCD_FreeUserBuffer(hpcd->Instance, ep->num, 0U);
-
-          if ((PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_RX) != 0U)
+          /* manage double buffer bulk out */
+          if (ep->type == EP_TYPE_BULK)
           {
-            /* read from endpoint BUF0Addr buffer */
-            count = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
-            if (count != 0U)
-            {
-              USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, count);
-            }
+            count = HAL_PCD_EP_DB_Receive(hpcd, ep, wEPVal);
           }
-          else
+          else /* manage double buffer iso out */
           {
-            /* read from endpoint BUF1Addr buffer */
-            count = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
-            if (count != 0U)
+            /* free EP OUT Buffer */
+            PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 0U);
+
+            if ((PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_RX) != 0U)
             {
-              USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
+              /* read from endpoint BUF0Addr buffer */
+              count = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+
+              if (count != 0U)
+              {
+                USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, count);
+              }
+            }
+            else
+            {
+              /* read from endpoint BUF1Addr buffer */
+              count = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+
+              if (count != 0U)
+              {
+                USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
+              }
             }
           }
         }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
+
         /* multi-packet on the NON control OUT endpoint */
         ep->xfer_count += count;
-        ep->xfer_buff += count;
 
         if ((ep->xfer_len == 0U) || (count < ep->maxpacket))
         {
@@ -1813,10 +1903,10 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         }
         else
         {
-          (void)HAL_PCD_EP_Receive(hpcd, ep->num, ep->xfer_buff, ep->xfer_len);
+           ep->xfer_buff += count;
+          (void)USB_EPStartXfer(hpcd->Instance, ep);
         }
-
-      } /* if((wEPVal & EP_CTR_RX) */
+      }
 
       if ((wEPVal & USB_EP_CTR_TX) != 0U)
       {
@@ -1825,13 +1915,24 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         /* clear int flag */
         PCD_CLEAR_TX_EP_CTR(hpcd->Instance, epindex);
 
-        /* multi-packet on the NON control IN endpoint */
-        ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
-        ep->xfer_buff += ep->xfer_count;
-
-        /* Zero Length Packet? */
-        if (ep->xfer_len == 0U)
+        if (ep->type == EP_TYPE_ISOC)
         {
+          ep->xfer_len = 0U;
+
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+          if (ep->doublebuffer != 0U)
+          {
+            if ((wEPVal & USB_EP_DTOG_TX) != 0U)
+            {
+              PCD_SET_EP_DBUF0_CNT(hpcd->Instance, ep->num, ep->is_in, 0U);
+            }
+            else
+            {
+              PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, 0U);
+            }
+          }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
+
           /* TX COMPLETE */
 #if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
           hpcd->DataInStageCallback(hpcd, ep->num);
@@ -1841,13 +1942,320 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         }
         else
         {
-          (void)HAL_PCD_EP_Transmit(hpcd, ep->num, ep->xfer_buff, ep->xfer_len);
+          /* Manage Single Buffer Transaction */
+          if ((wEPVal & USB_EP_KIND) == 0U)
+          {
+            /* Multi-packet on the NON control IN endpoint */
+            TxPctSize = (uint16_t)PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
+
+            if (ep->xfer_len > TxPctSize)
+            {
+              ep->xfer_len -= TxPctSize;
+            }
+            else
+            {
+              ep->xfer_len = 0U;
+            }
+
+            /* Zero Length Packet? */
+            if (ep->xfer_len == 0U)
+            {
+              /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+              hpcd->DataInStageCallback(hpcd, ep->num);
+#else
+              HAL_PCD_DataInStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+            }
+            else
+            {
+              /* Transfer is not yet Done */
+              ep->xfer_buff += TxPctSize;
+              ep->xfer_count += TxPctSize;
+              (void)USB_EPStartXfer(hpcd->Instance, ep);
+            }
+          }
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+          /* Double Buffer bulk IN (bulk transfer Len > Ep_Mps) */
+          else
+          {
+            (void)HAL_PCD_EP_DB_Transmit(hpcd, ep, wEPVal);
+          }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
         }
       }
     }
   }
+
   return HAL_OK;
 }
+
+
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+/**
+  * @brief  Manage double buffer bulk out transaction from ISR
+  * @param  hpcd PCD handle
+  * @param  ep current endpoint handle
+  * @param  wEPVal Last snapshot of EPRx register value taken in ISR
+  * @retval HAL status
+  */
+static uint16_t HAL_PCD_EP_DB_Receive(PCD_HandleTypeDef *hpcd,
+                                      PCD_EPTypeDef *ep, uint16_t wEPVal)
+{
+  uint16_t count;
+
+  /* Manage Buffer0 OUT */
+  if ((wEPVal & USB_EP_DTOG_RX) != 0U)
+  {
+    /* Get count of received Data on buffer0 */
+    count = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len >= count)
+    {
+      ep->xfer_len -= count;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    if (ep->xfer_len == 0U)
+    {
+      /* Set NAK to OUT endpoint since double buffer is enabled */
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_NAK);
+    }
+
+    /* Check if Buffer1 is in blocked state which requires to toggle */
+    if ((wEPVal & USB_EP_DTOG_TX) != 0U)
+    {
+      PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 0U);
+    }
+
+    if (count != 0U)
+    {
+      USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr0, count);
+    }
+  }
+  /* Manage Buffer 1 DTOG_RX=0 */
+  else
+  {
+    /* Get count of received data */
+    count = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len >= count)
+    {
+      ep->xfer_len -= count;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    if (ep->xfer_len == 0U)
+    {
+      /* Set NAK on the current endpoint */
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_NAK);
+    }
+
+    /* Need to FreeUser Buffer */
+    if ((wEPVal & USB_EP_DTOG_TX) == 0U)
+    {
+      PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 0U);
+    }
+
+    if (count != 0U)
+    {
+      USB_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
+    }
+  }
+
+  return count;
+}
+
+
+/**
+  * @brief  Manage double buffer bulk IN transaction from ISR
+  * @param  hpcd PCD handle
+  * @param  ep current endpoint handle
+  * @param  wEPVal Last snapshot of EPRx register value taken in ISR
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef HAL_PCD_EP_DB_Transmit(PCD_HandleTypeDef *hpcd,
+                                                PCD_EPTypeDef *ep, uint16_t wEPVal)
+{
+  uint32_t len;
+  uint16_t TxPctSize;
+
+  /* Data Buffer0 ACK received */
+  if ((wEPVal & USB_EP_DTOG_TX) != 0U)
+  {
+    /* multi-packet on the NON control IN endpoint */
+    TxPctSize = (uint16_t)PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len > TxPctSize)
+    {
+      ep->xfer_len -= TxPctSize;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    /* Transfer is completed */
+    if (ep->xfer_len == 0U)
+    {
+      PCD_SET_EP_DBUF0_CNT(hpcd->Instance, ep->num, ep->is_in, 0U);
+      PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, 0U);
+
+      if (ep->type == EP_TYPE_BULK)
+      {
+        /* Set Bulk endpoint in NAK state */
+        PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_NAK);
+      }
+
+      /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->DataInStageCallback(hpcd, ep->num);
+#else
+      HAL_PCD_DataInStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+      if ((wEPVal & USB_EP_DTOG_RX) != 0U)
+      {
+        PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 1U);
+      }
+
+      return HAL_OK;
+    }
+    else /* Transfer is not yet Done */
+    {
+      /* Need to Free USB Buffer */
+      if ((wEPVal & USB_EP_DTOG_RX) != 0U)
+      {
+        PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 1U);
+      }
+
+      /* Still there is data to Fill in the next Buffer */
+      if (ep->xfer_fill_db == 1U)
+      {
+        ep->xfer_buff += TxPctSize;
+        ep->xfer_count += TxPctSize;
+
+        /* Calculate the len of the new buffer to fill */
+        if (ep->xfer_len_db >= ep->maxpacket)
+        {
+          len = ep->maxpacket;
+          ep->xfer_len_db -= len;
+        }
+        else if (ep->xfer_len_db == 0U)
+        {
+          len = TxPctSize;
+          ep->xfer_fill_db = 0U;
+        }
+        else
+        {
+          ep->xfer_fill_db = 0U;
+          len = ep->xfer_len_db;
+          ep->xfer_len_db = 0U;
+        }
+
+        /* Write remaining Data to Buffer */
+        /* Set the Double buffer counter for pma buffer0 */
+        PCD_SET_EP_DBUF0_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+
+        /* Copy user buffer to USB PMA */
+        USB_WritePMA(hpcd->Instance, ep->xfer_buff,  ep->pmaaddr0, (uint16_t)len);
+      }
+    }
+  }
+  else /* Data Buffer1 ACK received */
+  {
+    /* multi-packet on the NON control IN endpoint */
+    TxPctSize = (uint16_t)PCD_GET_EP_DBUF1_CNT(hpcd->Instance, ep->num);
+
+    if (ep->xfer_len >= TxPctSize)
+    {
+      ep->xfer_len -= TxPctSize;
+    }
+    else
+    {
+      ep->xfer_len = 0U;
+    }
+
+    /* Transfer is completed */
+    if (ep->xfer_len == 0U)
+    {
+      PCD_SET_EP_DBUF0_CNT(hpcd->Instance, ep->num, ep->is_in, 0U);
+      PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, 0U);
+
+      if (ep->type == EP_TYPE_BULK)
+      {
+        /* Set Bulk endpoint in NAK state */
+        PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_NAK);
+      }
+
+      /* TX COMPLETE */
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+      hpcd->DataInStageCallback(hpcd, ep->num);
+#else
+      HAL_PCD_DataInStageCallback(hpcd, ep->num);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+
+      /* need to Free USB Buff */
+      if ((wEPVal & USB_EP_DTOG_RX) == 0U)
+      {
+        PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 1U);
+      }
+
+      return HAL_OK;
+    }
+    else /* Transfer is not yet Done */
+    {
+      /* Need to Free USB Buffer */
+      if ((wEPVal & USB_EP_DTOG_RX) == 0U)
+      {
+        PCD_FREE_USER_BUFFER(hpcd->Instance, ep->num, 1U);
+      }
+
+      /* Still there is data to Fill in the next Buffer */
+      if (ep->xfer_fill_db == 1U)
+      {
+        ep->xfer_buff += TxPctSize;
+        ep->xfer_count += TxPctSize;
+
+        /* Calculate the len of the new buffer to fill */
+        if (ep->xfer_len_db >= ep->maxpacket)
+        {
+          len = ep->maxpacket;
+          ep->xfer_len_db -= len;
+        }
+        else if (ep->xfer_len_db == 0U)
+        {
+          len = TxPctSize;
+          ep->xfer_fill_db = 0U;
+        }
+        else
+        {
+          len = ep->xfer_len_db;
+          ep->xfer_len_db = 0U;
+          ep->xfer_fill_db = 0;
+        }
+
+        /* Set the Double buffer counter for pma buffer1 */
+        PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+
+        /* Copy the user buffer to USB PMA */
+        USB_WritePMA(hpcd->Instance, ep->xfer_buff,  ep->pmaaddr1, (uint16_t)len);
+      }
+    }
+  }
+
+  /* Enable endpoint IN */
+  PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID);
+
+  return HAL_OK;
+}
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
 
 /**
@@ -1855,7 +2263,6 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
   */
 #endif /* defined (USB) */
 #endif /* HAL_PCD_MODULE_ENABLED */
-
 /**
   * @}
   */
@@ -1863,5 +2270,3 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pcd_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pcd_ex.c
@@ -10,13 +10,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -49,7 +48,7 @@
 
 /** @defgroup PCDEx_Exported_Functions_Group1 Peripheral Control functions
   * @brief    PCDEx control functions
- *
+  *
 @verbatim
  ===============================================================================
                  ##### Extended features functions #####
@@ -78,10 +77,8 @@
   * @retval HAL status
   */
 
-HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd,
-                                       uint16_t ep_addr,
-                                       uint16_t ep_kind,
-                                       uint32_t pmaadress)
+HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd, uint16_t ep_addr,
+                                       uint16_t ep_kind, uint32_t pmaadress)
 {
   PCD_EPTypeDef *ep;
 
@@ -103,6 +100,7 @@ HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd,
     /* Configure the PMA */
     ep->pmaadress = (uint16_t)pmaadress;
   }
+#if (USE_USB_DOUBLE_BUFFER == 1U)
   else /* USB_DBL_BUF */
   {
     /* Double Buffer Endpoint */
@@ -111,6 +109,7 @@ HAL_StatusTypeDef  HAL_PCDEx_PMAConfig(PCD_HandleTypeDef *hpcd,
     ep->pmaaddr0 = (uint16_t)(pmaadress & 0xFFFFU);
     ep->pmaaddr1 = (uint16_t)((pmaadress & 0xFFFF0000U) >> 16);
   }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
   return HAL_OK;
 }
@@ -162,23 +161,8 @@ void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd)
   USB_TypeDef *USBx = hpcd->Instance;
   uint32_t tickstart = HAL_GetTick();
 
-  /* Wait Detect flag or a timeout is happen*/
-  while ((USBx->BCDR & USB_BCDR_DCDET) == 0U)
-  {
-    /* Check for the Timeout */
-    if ((HAL_GetTick() - tickstart) > 1000U)
-    {
-#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
-      hpcd->BCDCallback(hpcd, PCD_BCD_ERROR);
-#else
-      HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_ERROR);
-#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
-
-      return;
-    }
-  }
-
-  HAL_Delay(200U);
+  /* Wait for Min DCD Timeout */
+  HAL_Delay(300U);
 
   /* Data Pin Contact ? Check Detect flag */
   if ((USBx->BCDR & USB_BCDR_DCDET) == USB_BCDR_DCDET)
@@ -238,13 +222,25 @@ void HAL_PCDEx_BCD_VBUSDetect(PCD_HandleTypeDef *hpcd)
 
   /* Battery Charging capability discovery finished Start Enumeration */
   (void)HAL_PCDEx_DeActivateBCD(hpcd);
-#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
-  hpcd->BCDCallback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
-#else
-  HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
-#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
-}
 
+  /* Check for the Timeout, else start USB Device */
+  if ((HAL_GetTick() - tickstart) > 1000U)
+  {
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->BCDCallback(hpcd, PCD_BCD_ERROR);
+#else
+    HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_ERROR);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+  }
+  else
+  {
+#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
+    hpcd->BCDCallback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
+#else
+    HAL_PCDEx_BCD_Callback(hpcd, PCD_BCD_DISCOVERY_COMPLETED);
+#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
+  }
+}
 
 /**
   * @brief  Activate LPM feature.
@@ -280,7 +276,6 @@ HAL_StatusTypeDef HAL_PCDEx_DeActivateLPM(PCD_HandleTypeDef *hpcd)
 
   return HAL_OK;
 }
-
 
 
 /**
@@ -334,5 +329,3 @@ __weak void HAL_PCDEx_BCD_Callback(PCD_HandleTypeDef *hpcd, PCD_BCD_MsgTypeDef m
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pka.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pka.c
@@ -9,6 +9,17 @@
   *           + Start an operation
   *           + Retrieve the operation result
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -94,7 +105,7 @@
       (++) HAL_PKA_Arithmetic_GetResult() to retrieve the result of the operation.
             The resulting size can be the input parameter or the input parameter size + 1 (overflow).
 
-      (+) Arithmetic substraction using:
+      (+) Arithmetic subtraction using:
       (++) HAL_PKA_Sub().
       (++) HAL_PKA_Sub_IT().
       (++) HAL_PKA_Arithmetic_GetResult() to retrieve the result of the operation.
@@ -114,7 +125,7 @@
       (++) HAL_PKA_ModAdd_IT().
       (++) HAL_PKA_Arithmetic_GetResult() to retrieve the result of the operation.
 
-      (+) Modular substraction using:
+      (+) Modular subtraction using:
       (++) HAL_PKA_ModSub().
       (++) HAL_PKA_ModSub_IT().
       (++) HAL_PKA_Arithmetic_GetResult() to retrieve the result of the operation.
@@ -156,7 +167,7 @@
     [..]
       (+) Add HAL_PKA_IRQHandler to the IRQHandler of PKA.
       (+) Enable the IRQ using HAL_NVIC_EnableIRQ().
-      (+) When an operation is started in interrupt mode, the function returns immediatly.
+      (+) When an operation is started in interrupt mode, the function returns immediately.
       (+) When the operation is completed, the callback HAL_PKA_OperationCpltCallback is called.
       (+) When an error is encountered, the callback HAL_PKA_ErrorCallback is called.
       (+) To stop any operation in interrupt mode, use HAL_PKA_Abort().
@@ -174,11 +185,11 @@
 
      The compilation flag USE_HAL_PKA_REGISTER_CALLBACKS, when set to 1,
      allows the user to configure dynamically the driver callbacks.
-     Use Functions @ref HAL_PKA_RegisterCallback()
+     Use Functions HAL_PKA_RegisterCallback()
      to register an interrupt callback.
     [..]
 
-     Function @ref HAL_PKA_RegisterCallback() allows to register following callbacks:
+     Function HAL_PKA_RegisterCallback() allows to register following callbacks:
        (+) OperationCpltCallback : callback for End of operation.
        (+) ErrorCallback         : callback for error detection.
        (+) MspInitCallback       : callback for Msp Init.
@@ -187,11 +198,11 @@
      and a pointer to the user callback function.
     [..]
 
-     Use function @ref HAL_PKA_UnRegisterCallback to reset a callback to the default
+     Use function HAL_PKA_UnRegisterCallback to reset a callback to the default
      weak function.
     [..]
 
-     @ref HAL_PKA_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     HAL_PKA_UnRegisterCallback takes as parameters the HAL peripheral handle,
      and the Callback ID.
      This function allows to reset following callbacks:
        (+) OperationCpltCallback : callback for End of operation.
@@ -200,27 +211,27 @@
        (+) MspDeInitCallback     : callback for Msp DeInit.
      [..]
 
-     By default, after the @ref HAL_PKA_Init() and when the state is @ref HAL_PKA_STATE_RESET
+     By default, after the HAL_PKA_Init() and when the state is HAL_PKA_STATE_RESET
      all callbacks are set to the corresponding weak functions:
-     examples @ref HAL_PKA_OperationCpltCallback(), @ref HAL_PKA_ErrorCallback().
+     examples HAL_PKA_OperationCpltCallback(), HAL_PKA_ErrorCallback().
      Exception done for MspInit and MspDeInit functions that are
-     reset to the legacy weak functions in the @ref HAL_PKA_Init()/ @ref HAL_PKA_DeInit() only when
+     reset to the legacy weak functions in the HAL_PKA_Init()/ HAL_PKA_DeInit() only when
      these callbacks are null (not registered beforehand).
     [..]
 
-     If MspInit or MspDeInit are not null, the @ref HAL_PKA_Init()/ @ref HAL_PKA_DeInit()
+     If MspInit or MspDeInit are not null, the HAL_PKA_Init()/ HAL_PKA_DeInit()
      keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
      [..]
 
-     Callbacks can be registered/unregistered in @ref HAL_PKA_STATE_READY state only.
+     Callbacks can be registered/unregistered in HAL_PKA_STATE_READY state only.
      Exception done MspInit/MspDeInit functions that can be registered/unregistered
-     in @ref HAL_PKA_STATE_READY or @ref HAL_PKA_STATE_RESET state,
+     in HAL_PKA_STATE_READY or HAL_PKA_STATE_RESET state,
      thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
     [..]
 
      Then, the user first registers the MspInit/MspDeInit user callbacks
-     using @ref HAL_PKA_RegisterCallback() before calling @ref HAL_PKA_DeInit()
-     or @ref HAL_PKA_Init() function.
+     using HAL_PKA_RegisterCallback() before calling HAL_PKA_DeInit()
+     or HAL_PKA_Init() function.
      [..]
 
      When the compilation flag USE_HAL_PKA_REGISTER_CALLBACKS is set to 0 or
@@ -228,17 +239,6 @@
      are set to the corresponding weak functions.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -252,7 +252,7 @@
 #if defined(PKA) && defined(HAL_PKA_MODULE_ENABLED)
 
 /** @defgroup PKA PKA
-  * @brief PKA HAL module driver.
+  * @brief    PKA HAL module driver.
   * @{
   */
 
@@ -299,7 +299,8 @@ void PKA_ECCMulFastMode_Set(PKA_HandleTypeDef *hpka, PKA_ECCMulFastModeInTypeDef
 void PKA_ModRed_Set(PKA_HandleTypeDef *hpka, PKA_ModRedInTypeDef *in);
 void PKA_ModInv_Set(PKA_HandleTypeDef *hpka, PKA_ModInvInTypeDef *in);
 void PKA_MontgomeryParam_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint8_t *pOp1);
-void PKA_ARI_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint32_t *pOp1, const uint32_t *pOp2, const uint8_t *pOp3);
+void PKA_ARI_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint32_t *pOp1, const uint32_t *pOp2,
+                 const uint8_t *pOp3);
 /**
   * @}
   */
@@ -311,8 +312,8 @@ void PKA_ARI_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint32_t *p
   */
 
 /** @defgroup PKA_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief   Initialization and de-initialization functions
- *
+  * @brief    Initialization and de-initialization functions
+  *
 @verbatim
  ===============================================================================
              ##### Initialization and de-initialization functions  #####
@@ -411,7 +412,7 @@ HAL_StatusTypeDef HAL_PKA_DeInit(PKA_HandleTypeDef *hpka)
     hpka->State = HAL_PKA_STATE_BUSY;
 
     /* Reset the control register */
-    /* This abort any operation in progress (PKA RAM content is not guaranted in this case) */
+    /* This abort any operation in progress (PKA RAM content is not guaranteed in this case) */
     hpka->Instance->CR = 0;
 
     /* Reset any pending flag */
@@ -489,7 +490,8 @@ __weak void HAL_PKA_MspDeInit(PKA_HandleTypeDef *hpka)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_PKA_RegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_CallbackIDTypeDef CallbackID, pPKA_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_PKA_RegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_CallbackIDTypeDef CallbackID,
+                                           pPKA_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -649,8 +651,8 @@ HAL_StatusTypeDef HAL_PKA_UnRegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_Ca
   */
 
 /** @defgroup PKA_Exported_Functions_Group2 IO operation functions
- *  @brief   IO operation functions
- *
+  * @brief    IO operation functions
+  *
 @verbatim
  ===============================================================================
                       ##### IO operation functions #####
@@ -663,7 +665,7 @@ HAL_StatusTypeDef HAL_PKA_UnRegisterCallback(PKA_HandleTypeDef *hpka, HAL_PKA_Ca
        (++) Blocking mode : The operation is performed in the polling mode.
             These functions return when data operation is completed.
        (++) No-Blocking mode : The operation is performed using Interrupts.
-            These functions return immediatly.
+            These functions return immediately.
             The end of the operation is indicated by HAL_PKA_ErrorCallback in case of error.
             The end of the operation is indicated by HAL_PKA_OperationCpltCallback in case of success.
             To stop any operation in interrupt mode, use HAL_PKA_Abort().
@@ -864,7 +866,8 @@ HAL_StatusTypeDef HAL_PKA_ECDSASign_IT(PKA_HandleTypeDef *hpka, PKA_ECDSASignInT
   * @param  out Output information
   * @param  outExt Additional Output information (facultative)
   */
-void HAL_PKA_ECDSASign_GetResult(PKA_HandleTypeDef *hpka, PKA_ECDSASignOutTypeDef *out, PKA_ECDSASignOutExtParamTypeDef *outExt)
+void HAL_PKA_ECDSASign_GetResult(PKA_HandleTypeDef *hpka, PKA_ECDSASignOutTypeDef *out,
+                                 PKA_ECDSASignOutExtParamTypeDef *outExt)
 {
   uint32_t size;
 
@@ -902,7 +905,8 @@ HAL_StatusTypeDef HAL_PKA_ECDSAVerif(PKA_HandleTypeDef *hpka, PKA_ECDSAVerifInTy
 }
 
 /**
-  * @brief  Verify the validity of a signature using elliptic curves over prime fields in non-blocking mode with Interrupt.
+  * @brief  Verify the validity of a signature using elliptic curves
+  *         over prime fields in non-blocking mode with Interrupt.
   * @param  hpka PKA handle
   * @param  in Input information
   * @retval HAL status
@@ -1012,8 +1016,8 @@ HAL_StatusTypeDef HAL_PKA_PointCheck_IT(PKA_HandleTypeDef *hpka, PKA_PointCheckI
   */
 uint32_t HAL_PKA_PointCheck_IsOnCurve(PKA_HandleTypeDef const *const hpka)
 {
-  #define PKA_POINT_IS_ON_CURVE 0UL
-  /* Invert the value of the PKA RAM containig the result of the operation */
+#define PKA_POINT_IS_ON_CURVE 0UL
+  /* Invert the value of the PKA RAM containing the result of the operation */
   return (hpka->Instance->RAM[PKA_POINT_CHECK_OUT_ERROR] == PKA_POINT_IS_ON_CURVE) ? 1UL : 0UL;
 }
 
@@ -1131,7 +1135,7 @@ HAL_StatusTypeDef HAL_PKA_Add_IT(PKA_HandleTypeDef *hpka, PKA_AddInTypeDef *in)
 }
 
 /**
-  * @brief  Arithmetic substraction in blocking mode.
+  * @brief  Arithmetic subtraction in blocking mode.
   * @param  hpka PKA handle
   * @param  in Input information
   * @param  Timeout Timeout duration
@@ -1147,7 +1151,7 @@ HAL_StatusTypeDef HAL_PKA_Sub(PKA_HandleTypeDef *hpka, PKA_SubInTypeDef *in, uin
 }
 
 /**
-  * @brief  Arithmetic substraction in non-blocking mode with Interrupt.
+  * @brief  Arithmetic subtraction in non-blocking mode with Interrupt.
   * @param  hpka PKA handle
   * @param  in Input information
   * @retval HAL status
@@ -1286,7 +1290,7 @@ HAL_StatusTypeDef HAL_PKA_ModInv_IT(PKA_HandleTypeDef *hpka, PKA_ModInvInTypeDef
 }
 
 /**
-  * @brief  Modular substraction in blocking mode.
+  * @brief  Modular subtraction in blocking mode.
   * @param  hpka PKA handle
   * @param  in Input information
   * @param  Timeout Timeout duration
@@ -1302,7 +1306,7 @@ HAL_StatusTypeDef HAL_PKA_ModSub(PKA_HandleTypeDef *hpka, PKA_ModSubInTypeDef *i
 }
 
 /**
-  * @brief  Modular substraction in non-blocking mode with Interrupt.
+  * @brief  Modular subtraction in non-blocking mode with Interrupt.
   * @param  hpka PKA handle
   * @param  in Input information
   * @retval HAL status
@@ -1499,7 +1503,7 @@ HAL_StatusTypeDef HAL_PKA_Abort(PKA_HandleTypeDef *hpka)
   HAL_StatusTypeDef err = HAL_OK;
 
   /* Clear EN bit */
-  /* This abort any operation in progress (PKA RAM content is not guaranted in this case) */
+  /* This abort any operation in progress (PKA RAM content is not guaranteed in this case) */
   CLEAR_BIT(hpka->Instance->CR, PKA_CR_EN);
   SET_BIT(hpka->Instance->CR, PKA_CR_EN);
 
@@ -1633,8 +1637,8 @@ __weak void HAL_PKA_ErrorCallback(PKA_HandleTypeDef *hpka)
   */
 
 /** @defgroup PKA_Exported_Functions_Group3 Peripheral State and Error functions
- *  @brief   Peripheral State and Error functions
- *
+  * @brief    Peripheral State and Error functions
+  *
   @verbatim
  ===============================================================================
             ##### Peripheral State and Error functions #####
@@ -1661,7 +1665,7 @@ HAL_PKA_StateTypeDef HAL_PKA_GetState(PKA_HandleTypeDef *hpka)
   * @brief  Return the PKA error code.
   * @param  hpka PKA handle
   * @retval PKA error code
-*/
+  */
 uint32_t HAL_PKA_GetError(PKA_HandleTypeDef *hpka)
 {
   /* Return PKA handle error code */
@@ -1944,7 +1948,8 @@ HAL_StatusTypeDef PKA_Process(PKA_HandleTypeDef *hpka, uint32_t mode, uint32_t T
     tickstart = HAL_GetTick();
 
     /* Set the mode and deactivate the interrupts */
-    MODIFY_REG(hpka->Instance->CR, PKA_CR_MODE | PKA_CR_PROCENDIE | PKA_CR_RAMERRIE | PKA_CR_ADDRERRIE, mode << PKA_CR_MODE_Pos);
+    MODIFY_REG(hpka->Instance->CR, PKA_CR_MODE | PKA_CR_PROCENDIE | PKA_CR_RAMERRIE | PKA_CR_ADDRERRIE,
+               mode << PKA_CR_MODE_Pos);
 
     /* Start the computation */
     hpka->Instance->CR |= PKA_CR_START;
@@ -2002,7 +2007,8 @@ HAL_StatusTypeDef PKA_Process_IT(PKA_HandleTypeDef *hpka, uint32_t mode)
     hpka->ErrorCode = HAL_PKA_ERROR_NONE;
 
     /* Set the mode and activate interrupts */
-    MODIFY_REG(hpka->Instance->CR, PKA_CR_MODE | PKA_CR_PROCENDIE | PKA_CR_RAMERRIE | PKA_CR_ADDRERRIE, (mode << PKA_CR_MODE_Pos) | PKA_CR_PROCENDIE | PKA_CR_RAMERRIE | PKA_CR_ADDRERRIE);
+    MODIFY_REG(hpka->Instance->CR, PKA_CR_MODE | PKA_CR_PROCENDIE | PKA_CR_RAMERRIE | PKA_CR_ADDRERRIE,
+               (mode << PKA_CR_MODE_Pos) | PKA_CR_PROCENDIE | PKA_CR_RAMERRIE | PKA_CR_ADDRERRIE);
 
     /* Start the computation */
     hpka->Instance->CR |= PKA_CR_START;
@@ -2029,15 +2035,15 @@ void PKA_ModExp_Set(PKA_HandleTypeDef *hpka, PKA_ModExpInTypeDef *in)
 
   /* Move the input parameters pOp1 to PKA RAM */
   PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_MODULAR_EXP_IN_EXPONENT_BASE], in->pOp1, in->OpSize);
-  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_EXPONENT_BASE + (in->OpSize / 4UL));
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_EXPONENT_BASE + ((in->OpSize + 3UL) / 4UL));
 
   /* Move the exponent to PKA RAM */
   PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_MODULAR_EXP_IN_EXPONENT], in->pExp, in->expSize);
-  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_EXPONENT + (in->expSize / 4UL));
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_EXPONENT + ((in->expSize + 3UL) / 4UL));
 
   /* Move the modulus to PKA RAM */
   PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_MODULAR_EXP_IN_MODULUS], in->pMod, in->OpSize);
-  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_MODULUS + (in->OpSize / 4UL));
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_MODULUS + ((in->OpSize + 3UL) / 4UL));
 }
 
 /**
@@ -2066,8 +2072,9 @@ void PKA_ModExpFastMode_Set(PKA_HandleTypeDef *hpka, PKA_ModExpFastModeInTypeDef
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_MODULUS + (in->OpSize / 4UL));
 
   /* Move the Montgomery parameter to PKA RAM */
-  PKA_Memcpy_u32_to_u32(&hpka->Instance->RAM[PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM], in->pMontgomeryParam, in->expSize / 4UL);
-  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM + (in->expSize / 4UL));
+  PKA_Memcpy_u32_to_u32(&hpka->Instance->RAM[PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM], in->pMontgomeryParam,
+                        in->OpSize / 4UL);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_MODULAR_EXP_IN_MONTGOMERY_PARAM + (in->OpSize / 4UL));
 }
 
 
@@ -2153,11 +2160,13 @@ void PKA_ECDSAVerif_Set(PKA_HandleTypeDef *hpka, PKA_ECDSAVerifInTypeDef *in)
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECDSA_VERIF_IN_INITIAL_POINT_Y + ((in->modulusSize + 3UL) / 4UL));
 
   /* Move the input parameters public-key curve point Q coordinate xQ to PKA RAM */
-  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X], in->pPubKeyCurvePtX, in->modulusSize);
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X], in->pPubKeyCurvePtX,
+                       in->modulusSize);
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_X + ((in->modulusSize + 3UL) / 4UL));
 
   /* Move the input parameters public-key curve point Q coordinate xQ to PKA RAM */
-  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y], in->pPubKeyCurvePtY, in->modulusSize);
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y], in->pPubKeyCurvePtY,
+                       in->modulusSize);
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECDSA_VERIF_IN_PUBLIC_KEY_POINT_Y + ((in->modulusSize + 3UL) / 4UL));
 
   /* Move the input parameters signature part r to PKA RAM */
@@ -2276,12 +2285,12 @@ void PKA_ECCMul_Set(PKA_HandleTypeDef *hpka, PKA_ECCMulInTypeDef *in)
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_K + ((in->scalarMulSize + 3UL) / 4UL));
 
   /* Move the input parameters Point P coordinate x to PKA RAM */
-  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_POINT_CHECK_IN_INITIAL_POINT_X], in->pointX, in->modulusSize);
-  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_POINT_CHECK_IN_INITIAL_POINT_X + ((in->modulusSize + 3UL) / 4UL));
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X], in->pointX, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_X + ((in->modulusSize + 3UL) / 4UL));
 
   /* Move the input parameters Point P coordinate y to PKA RAM */
-  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_POINT_CHECK_IN_INITIAL_POINT_Y], in->pointY, in->modulusSize);
-  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_POINT_CHECK_IN_INITIAL_POINT_Y + ((in->modulusSize + 3UL) / 4UL));
+  PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y], in->pointY, in->modulusSize);
+  __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_INITIAL_POINT_Y + ((in->modulusSize + 3UL) / 4UL));
 
 }
 
@@ -2323,7 +2332,8 @@ void PKA_ECCMulFastMode_Set(PKA_HandleTypeDef *hpka, PKA_ECCMulFastModeInTypeDef
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_POINT_CHECK_IN_INITIAL_POINT_Y + ((in->modulusSize + 3UL) / 4UL));
 
   /* Move the Montgomery parameter to PKA RAM */
-  PKA_Memcpy_u32_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_MONTGOMERY_PARAM], in->pMontgomeryParam, (in->modulusSize + 3UL) / 4UL);
+  PKA_Memcpy_u32_to_u32(&hpka->Instance->RAM[PKA_ECC_SCALAR_MUL_IN_MONTGOMERY_PARAM], in->pMontgomeryParam,
+                        (in->modulusSize + 3UL) / 4UL);
   __PKA_RAM_PARAM_END(hpka->Instance->RAM, PKA_ECC_SCALAR_MUL_IN_MONTGOMERY_PARAM + ((in->modulusSize + 3UL) / 4UL));
 }
 /**
@@ -2375,10 +2385,22 @@ void PKA_ModRed_Set(PKA_HandleTypeDef *hpka, PKA_ModRedInTypeDef *in)
   */
 void PKA_MontgomeryParam_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint8_t *pOp1)
 {
+  uint32_t bytetoskip = 0UL;
+  uint32_t newSize;
+
   if (pOp1 != NULL)
   {
+    /* Count the number of zero bytes */
+    while ((bytetoskip < size) && (pOp1[bytetoskip] == 0UL))
+    {
+      bytetoskip++;
+    }
+
+    /* Get new size after skipping zero bytes */
+    newSize = size - bytetoskip;
+
     /* Get the number of bit per operand */
-    hpka->Instance->RAM[PKA_MONTGOMERY_PARAM_IN_MOD_NB_BITS] = PKA_GetOptBitSize_u8(size, *pOp1);
+    hpka->Instance->RAM[PKA_MONTGOMERY_PARAM_IN_MOD_NB_BITS] = PKA_GetOptBitSize_u8(newSize, pOp1[bytetoskip]);
 
     /* Move the input parameters pOp1 to PKA RAM */
     PKA_Memcpy_u8_to_u32(&hpka->Instance->RAM[PKA_MONTGOMERY_PARAM_IN_MODULUS], pOp1, size);
@@ -2394,7 +2416,8 @@ void PKA_MontgomeryParam_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const
   * @param  pOp2 Generic pointer to input data
   * @param  pOp3 Generic pointer to input data
   */
-void PKA_ARI_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint32_t *pOp1, const uint32_t *pOp2, const uint8_t *pOp3)
+void PKA_ARI_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint32_t *pOp1, const uint32_t *pOp2,
+                 const uint8_t *pOp3)
 {
   /* Get the number of bit per operand */
   hpka->Instance->RAM[PKA_ARITHMETIC_ALL_OPS_NB_BITS] = PKA_GetBitSize_u32(size);
@@ -2434,5 +2457,3 @@ void PKA_ARI_Set(PKA_HandleTypeDef *hpka, const uint32_t size, const uint32_t *p
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pwr.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pwr.c
@@ -11,13 +11,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -71,7 +70,7 @@
   * @}
   */
 
- /**
+/**
   * @}
   */
 
@@ -102,7 +101,7 @@ void HAL_PWR_DeInit(void)
 {
   /* Apply reset values to all PWR registers */
   /* Note: Update of each register required since PWR global reset is not     */
-  /*       available at RCC level on this STM32 serie.                        */
+  /*       available at RCC level on this STM32 series.                       */
   LL_PWR_WriteReg(CR1, PWR_CR1_RESET_VALUE);
   LL_PWR_WriteReg(CR2, PWR_CR2_RESET_VALUE);
   LL_PWR_WriteReg(CR3, PWR_CR3_RESET_VALUE);
@@ -117,7 +116,7 @@ void HAL_PWR_DeInit(void)
 #if defined(GPIOD)
   LL_PWR_WriteReg(PUCRD, PWR_PUCRD_RESET_VALUE);
   LL_PWR_WriteReg(PDCRD, PWR_PDCRD_RESET_VALUE);
-#endif
+#endif /* GPIOD */
   LL_PWR_WriteReg(PUCRE, PWR_PUCRE_RESET_VALUE);
   LL_PWR_WriteReg(PDCRE, PWR_PDCRE_RESET_VALUE);
   LL_PWR_WriteReg(PUCRH, PWR_PUCRH_RESET_VALUE);
@@ -126,24 +125,46 @@ void HAL_PWR_DeInit(void)
   LL_PWR_WriteReg(C2CR3, PWR_C2CR3_RESET_VALUE);
 
   /* Clear all flags */
+#if defined(PWR_CR3_E802A) && defined(PWR_CR5_SMPSEN)
   LL_PWR_WriteReg(SCR,
-                    LL_PWR_SCR_CC2HF
-                  | LL_PWR_SCR_CBLEAF
-                  | LL_PWR_SCR_CCRPEF
-#if defined(PWR_CR3_E802A)
-                  | LL_PWR_SCR_C802AF
-                  | LL_PWR_SCR_C802WUF
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_C802AF
+                | LL_PWR_SCR_C802WUF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CBORHF
+                | LL_PWR_SCR_CSMPSFBF
+                | LL_PWR_SCR_CWUF);
+#elif defined(PWR_CR3_E802A)
+  LL_PWR_WriteReg(SCR,
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_C802AF
+                | LL_PWR_SCR_C802WUF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CWUF);
+#elif defined(PWR_CR5_SMPSEN)
+  LL_PWR_WriteReg(SCR,
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CBORHF
+                | LL_PWR_SCR_CSMPSFBF
+                | LL_PWR_SCR_CWUF);
+#else
+  LL_PWR_WriteReg(SCR,
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CWUF);
 #endif
-                  | LL_PWR_SCR_CBLEWUF
-#if defined(PWR_CR5_SMPSEN)
-                  | LL_PWR_SCR_CBORHF
-                  | LL_PWR_SCR_CSMPSFBF
-#endif
-                  | LL_PWR_SCR_CWUF
-                 );
 
   LL_PWR_WriteReg(EXTSCR,
-                    LL_PWR_EXTSCR_CCRPF
+                  LL_PWR_EXTSCR_CCRPF
                   | LL_PWR_EXTSCR_C2CSSF
                   | LL_PWR_EXTSCR_C1CSSF
                  );
@@ -225,7 +246,7 @@ void HAL_PWR_DisableBkUpAccess(void)
       (+) Stop 2 mode: all clocks are stopped except LSI and LSE, main regulator off, low power regulator on, reduced set of waking up IPs compared to Stop 1 mode.
 
       (+) Standby mode with SRAM2a: all clocks are stopped except LSI and LSE, SRAM2a content preserved, main regulator off, low power regulator on.
-          Note: On devices STM32WB15xx, STM32WB10xx, retention is extended to SRAM1, SRAM2a, SRAM2b.
+          Note: On devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx retention is extended to SRAM1, SRAM2a, SRAM2b.
       (+) Standby mode without SRAM2a: all clocks are stopped except LSI and LSE, main and low power regulators off.
 
       (+) Shutdown mode: all clocks are stopped except LSE, main and low power regulators off.
@@ -269,7 +290,7 @@ void HAL_PWR_DisableBkUpAccess(void)
           The Stop 0, Stop 1 or Stop 2 modes are entered thru the following API's:
           (++) HAL_PWREx_EnterSTOP0Mode() for mode 0, HAL_PWREx_EnterSTOP1Mode() for mode 1, HAL_PWREx_EnterSTOP2Mode() for mode 2
                or for porting reasons HAL_PWR_EnterSTOPMode().
-               Note: Low power Stop2 mode is not available on devices STM32WB15xx, STM32WB10xx.
+               Note: Low power Stop2 mode is not available on devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx.
 
       (+) Regulator setting (applicable to HAL_PWR_EnterSTOPMode() only):
           (++) PWR_MAINREGULATOR_ON: Regulator in main mode (STOP0 mode)
@@ -375,7 +396,7 @@ HAL_StatusTypeDef HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD)
 
   /* Clear any previous config. Keep it clear if no event or IT mode is selected */
 
-  /* Note: On STM32WB serie, power PVD event is not available on AIEC lines   */
+  /* Note: On STM32WB series, power PVD event is not available on AIEC lines   */
   /*       (only interruption is available through AIEC line 16).             */
   __HAL_PWR_PVD_EXTI_DISABLE_IT();      /*CPU1*/
   __HAL_PWR_PVD_EXTIC2_DISABLE_IT();    /*CPU2*/
@@ -384,19 +405,19 @@ HAL_StatusTypeDef HAL_PWR_ConfigPVD(PWR_PVDTypeDef *sConfigPVD)
   __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE();
 
   /* Configure interrupt mode */
-  if((sConfigPVD->Mode & PVD_MODE_IT) == PVD_MODE_IT)
+  if ((sConfigPVD->Mode & PVD_MODE_IT) == PVD_MODE_IT)
   {
     /* Set CPU1 as wakeup target */
     __HAL_PWR_PVD_EXTI_ENABLE_IT();
   }
 
   /* Configure the edge */
-  if((sConfigPVD->Mode & PVD_RISING_EDGE) == PVD_RISING_EDGE)
+  if ((sConfigPVD->Mode & PVD_RISING_EDGE) == PVD_RISING_EDGE)
   {
     __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE();
   }
 
-  if((sConfigPVD->Mode & PVD_FALLING_EDGE) == PVD_FALLING_EDGE)
+  if ((sConfigPVD->Mode & PVD_FALLING_EDGE) == PVD_FALLING_EDGE)
   {
     __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE();
   }
@@ -529,7 +550,7 @@ void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
   CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
   /* Select SLEEP mode entry -------------------------------------------------*/
-  if(SLEEPEntry == PWR_SLEEPENTRY_WFI)
+  if (SLEEPEntry == PWR_SLEEPENTRY_WFI)
   {
     /* Request Wait For Interrupt */
     __WFI();
@@ -583,7 +604,7 @@ void HAL_PWR_EnterSTOPMode(uint32_t Regulator, uint8_t STOPEntry)
   /* Check the parameters */
   assert_param(IS_PWR_REGULATOR(Regulator));
 
-  if(Regulator == PWR_LOWPOWERREGULATOR_ON)
+  if (Regulator == PWR_LOWPOWERREGULATOR_ON)
   {
     HAL_PWREx_EnterSTOP1Mode(STOPEntry);
   }
@@ -622,10 +643,10 @@ void HAL_PWR_EnterSTANDBYMode(void)
   /* Set SLEEPDEEP bit of Cortex System Control Register */
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
-/* This option is used to ensure that store operations are completed */
-#if defined ( __CC_ARM)
+  /* This option is used to ensure that store operations are completed */
+#if defined (__CC_ARM)
   __force_stores();
-#endif
+#endif /* __CC_ARM */
 
   /* Request Wait For Interrupt */
   __WFI();
@@ -718,4 +739,4 @@ __weak void HAL_PWR_PVDCallback(void)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pwr_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_pwr_ex.c
@@ -11,13 +11,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -86,7 +85,7 @@
   */
 uint32_t HAL_PWREx_GetVoltageRange(void)
 {
-  return  (PWR->CR1 & PWR_CR1_VOS);
+  return (PWR->CR1 & PWR_CR1_VOS);
 }
 
 /**
@@ -147,7 +146,7 @@ HAL_StatusTypeDef HAL_PWREx_ControlVoltageScaling(uint32_t VoltageScaling)
 
   return HAL_OK;
 }
-#endif
+#endif /* PWR_CR1_VOS */
 
 /****************************************************************************/
 
@@ -200,7 +199,7 @@ void HAL_PWREx_DisableVddUSB(void)
 {
   CLEAR_BIT(PWR->CR2, PWR_CR2_USV);
 }
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 /****************************************************************************/
 
@@ -242,7 +241,7 @@ void HAL_PWREx_DisableBORH_SMPSBypassIT(void)
 {
   CLEAR_BIT(PWR->CR3, PWR_CR3_EBORHSMPSFB);
 }
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /**
   * @brief Enable RF Phase interrupt.
@@ -299,7 +298,7 @@ void HAL_PWREx_Disable802ActivityIT(void)
 {
   CLEAR_BIT(PWR->CR3, PWR_CR3_E802A);
 }
-#endif
+#endif /* PWR_CR3_E802A */
 
 /**
   * @brief Enable CPU2 on-Hold interrupt.
@@ -352,31 +351,31 @@ HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber)
   switch (GPIO)
   {
     case PWR_GPIO_A:
-       SET_BIT(PWR->PUCRA, GPIONumber);
-       CLEAR_BIT(PWR->PDCRA, GPIONumber);
-       break;
+      SET_BIT(PWR->PUCRA, GPIONumber);
+      CLEAR_BIT(PWR->PDCRA, GPIONumber);
+      break;
     case PWR_GPIO_B:
-       SET_BIT(PWR->PUCRB, GPIONumber);
-       CLEAR_BIT(PWR->PDCRB, GPIONumber);
-       break;
+      SET_BIT(PWR->PUCRB, GPIONumber);
+      CLEAR_BIT(PWR->PDCRB, GPIONumber);
+      break;
     case PWR_GPIO_C:
-       SET_BIT(PWR->PUCRC, GPIONumber);
-       CLEAR_BIT(PWR->PDCRC, GPIONumber);
-       break;
+      SET_BIT(PWR->PUCRC, GPIONumber);
+      CLEAR_BIT(PWR->PDCRC, GPIONumber);
+      break;
 #if defined(GPIOD)
     case PWR_GPIO_D:
-       SET_BIT(PWR->PUCRD, GPIONumber);
-       CLEAR_BIT(PWR->PDCRD, GPIONumber);
-       break;
-#endif
+      SET_BIT(PWR->PUCRD, GPIONumber);
+      CLEAR_BIT(PWR->PDCRD, GPIONumber);
+      break;
+#endif /* GPIOD */
     case PWR_GPIO_E:
-       SET_BIT(PWR->PUCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
-       CLEAR_BIT(PWR->PDCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
-       break;
+      SET_BIT(PWR->PUCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
+      CLEAR_BIT(PWR->PDCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
+      break;
     case PWR_GPIO_H:
-       SET_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
-       CLEAR_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
-       break;
+      SET_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+      CLEAR_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+      break;
     default:
       status = HAL_ERROR;
       break;
@@ -410,28 +409,28 @@ HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullUp(uint32_t GPIO, uint32_t GPIONumber
   switch (GPIO)
   {
     case PWR_GPIO_A:
-       CLEAR_BIT(PWR->PUCRA, GPIONumber);
-       break;
+      CLEAR_BIT(PWR->PUCRA, GPIONumber);
+      break;
     case PWR_GPIO_B:
-       CLEAR_BIT(PWR->PUCRB, GPIONumber);
-       break;
+      CLEAR_BIT(PWR->PUCRB, GPIONumber);
+      break;
     case PWR_GPIO_C:
-       CLEAR_BIT(PWR->PUCRC, GPIONumber);
-       break;
+      CLEAR_BIT(PWR->PUCRC, GPIONumber);
+      break;
 #if defined(GPIOD)
     case PWR_GPIO_D:
-       CLEAR_BIT(PWR->PUCRD, GPIONumber);
-       break;
-#endif
+      CLEAR_BIT(PWR->PUCRD, GPIONumber);
+      break;
+#endif /* GPIOD */
     case PWR_GPIO_E:
-       CLEAR_BIT(PWR->PUCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
-       break;
+      CLEAR_BIT(PWR->PUCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
+      break;
     case PWR_GPIO_H:
-       CLEAR_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
-       break;
+      CLEAR_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+      break;
     default:
-       status = HAL_ERROR;
-       break;
+      status = HAL_ERROR;
+      break;
   }
 
   return status;
@@ -470,31 +469,31 @@ HAL_StatusTypeDef HAL_PWREx_EnableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumbe
   switch (GPIO)
   {
     case PWR_GPIO_A:
-       SET_BIT(PWR->PDCRA, GPIONumber);
-       CLEAR_BIT(PWR->PUCRA, GPIONumber);
-       break;
+      SET_BIT(PWR->PDCRA, GPIONumber);
+      CLEAR_BIT(PWR->PUCRA, GPIONumber);
+      break;
     case PWR_GPIO_B:
-       SET_BIT(PWR->PDCRB, GPIONumber);
-       CLEAR_BIT(PWR->PUCRB, GPIONumber);
-       break;
+      SET_BIT(PWR->PDCRB, GPIONumber);
+      CLEAR_BIT(PWR->PUCRB, GPIONumber);
+      break;
     case PWR_GPIO_C:
-       SET_BIT(PWR->PDCRC, GPIONumber);
-       CLEAR_BIT(PWR->PUCRC, GPIONumber);
-       break;
+      SET_BIT(PWR->PDCRC, GPIONumber);
+      CLEAR_BIT(PWR->PUCRC, GPIONumber);
+      break;
 #if defined(GPIOD)
-  case PWR_GPIO_D:
-       SET_BIT(PWR->PDCRD, GPIONumber);
-       CLEAR_BIT(PWR->PUCRD, GPIONumber);
-       break;
-#endif
+    case PWR_GPIO_D:
+      SET_BIT(PWR->PDCRD, GPIONumber);
+      CLEAR_BIT(PWR->PUCRD, GPIONumber);
+      break;
+#endif /* GPIOD */
     case PWR_GPIO_E:
-       SET_BIT(PWR->PDCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
-       CLEAR_BIT(PWR->PUCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
-       break;
+      SET_BIT(PWR->PDCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
+      CLEAR_BIT(PWR->PUCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
+      break;
     case PWR_GPIO_H:
-       SET_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
-       CLEAR_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
-       break;
+      SET_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+      CLEAR_BIT(PWR->PUCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
+      break;
     default:
       status = HAL_ERROR;
       break;
@@ -528,25 +527,25 @@ HAL_StatusTypeDef HAL_PWREx_DisableGPIOPullDown(uint32_t GPIO, uint32_t GPIONumb
   switch (GPIO)
   {
     case PWR_GPIO_A:
-       CLEAR_BIT(PWR->PDCRA, GPIONumber);
-       break;
+      CLEAR_BIT(PWR->PDCRA, GPIONumber);
+      break;
     case PWR_GPIO_B:
-       CLEAR_BIT(PWR->PDCRB, GPIONumber);
-       break;
+      CLEAR_BIT(PWR->PDCRB, GPIONumber);
+      break;
     case PWR_GPIO_C:
-       CLEAR_BIT(PWR->PDCRC, GPIONumber);
-       break;
+      CLEAR_BIT(PWR->PDCRC, GPIONumber);
+      break;
 #if defined(GPIOD)
     case PWR_GPIO_D:
-       CLEAR_BIT(PWR->PDCRD, GPIONumber);
-       break;
-#endif
+      CLEAR_BIT(PWR->PDCRD, GPIONumber);
+      break;
+#endif /* GPIOD */
     case PWR_GPIO_E:
-       CLEAR_BIT(PWR->PDCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
-       break;
+      CLEAR_BIT(PWR->PDCRE, (GPIONumber & PWR_PORTE_AVAILABLE_PINS));
+      break;
     case PWR_GPIO_H:
       CLEAR_BIT(PWR->PDCRH, (GPIONumber & PWR_PORTH_AVAILABLE_PINS));
-       break;
+      break;
     default:
       status = HAL_ERROR;
       break;
@@ -605,7 +604,7 @@ uint32_t HAL_PWREx_GetBORConfig(void)
 {
   return LL_PWR_GetBORConfig();
 }
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /****************************************************************************/
 /**
@@ -644,7 +643,7 @@ void HAL_PWREx_ReleaseCore(uint32_t CPU)
   * @brief Enable SRAM2a content retention in Standby mode.
   * @note  When RRS bit is set, SRAM2a is powered by the low-power regulator in
   *         Standby mode and its content is kept.
-  * @note   On devices STM32WB15xx, STM32WB10xx, retention is extended
+  * @note   On devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx retention is extended
   *         to SRAM1, SRAM2a and SRAM2b.
   * @retval None
   */
@@ -657,7 +656,7 @@ void HAL_PWREx_EnableSRAMRetention(void)
   * @brief Disable SRAM2a content retention in Standby mode.
   * @note  When RRS bit is reset, SRAM2a is powered off in Standby mode
   *        and its content is lost.
-  * @note   On devices STM32WB15xx, STM32WB10xx, retention is extended
+  * @note   On devices STM32WB15xx, STM32WB10xx, STM32WB1Mxx retention is extended
   *         to SRAM1, SRAM2a and SRAM2b.
   * @retval None
   */
@@ -680,7 +679,7 @@ void HAL_PWREx_EnableFlashPowerDown(uint32_t PowerMode)
 {
   assert_param(IS_PWR_FLASH_POWERDOWN(PowerMode));
 
-  if((PowerMode & PWR_FLASHPD_LPRUN) != 0U)
+  if ((PowerMode & PWR_FLASHPD_LPRUN) != 0U)
   {
     /* Unlock bit FPDR */
     WRITE_REG(PWR->CR1, 0x0000C1B0UL);
@@ -726,7 +725,7 @@ void HAL_PWREx_DisablePVM1(void)
 {
   CLEAR_BIT(PWR->CR2, PWR_PVM_1);
 }
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 /**
   * @brief Enable the Power Voltage Monitoring 3: VDDA versus 1.62V.
@@ -775,7 +774,7 @@ HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM)
   switch (sConfigPVM->PVMType)
   {
 #if defined(PWR_CR2_PVME1)
-   case PWR_PVM_1:
+    case PWR_PVM_1:
       /* Clear any previous config. Keep it clear if no event or IT mode is selected */
       __HAL_PWR_PVM1_EXTI_DISABLE_EVENT();
       __HAL_PWR_PVM1_EXTI_DISABLE_IT();
@@ -783,29 +782,29 @@ HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM)
       __HAL_PWR_PVM1_EXTI_DISABLE_RISING_EDGE();
 
       /* Configure interrupt mode */
-      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      if ((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
       {
         __HAL_PWR_PVM1_EXTI_ENABLE_IT();
       }
 
       /* Configure event mode */
-      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      if ((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
       {
         __HAL_PWR_PVM1_EXTI_ENABLE_EVENT();
       }
 
       /* Configure the edge */
-      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      if ((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
       {
         __HAL_PWR_PVM1_EXTI_ENABLE_RISING_EDGE();
       }
 
-      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      if ((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
       {
         __HAL_PWR_PVM1_EXTI_ENABLE_FALLING_EDGE();
       }
       break;
-#endif
+#endif /* PWR_CR2_PVME1 */
 
     case PWR_PVM_3:
       /* Clear any previous config. Keep it clear if no event or IT mode is selected */
@@ -815,24 +814,24 @@ HAL_StatusTypeDef HAL_PWREx_ConfigPVM(PWR_PVMTypeDef *sConfigPVM)
       __HAL_PWR_PVM3_EXTI_DISABLE_RISING_EDGE();
 
       /* Configure interrupt mode */
-      if((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
+      if ((sConfigPVM->Mode & PVM_MODE_IT) == PVM_MODE_IT)
       {
         __HAL_PWR_PVM3_EXTI_ENABLE_IT();
       }
 
       /* Configure event mode */
-      if((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
+      if ((sConfigPVM->Mode & PVM_MODE_EVT) == PVM_MODE_EVT)
       {
         __HAL_PWR_PVM3_EXTI_ENABLE_EVENT();
       }
 
       /* Configure the edge */
-      if((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
+      if ((sConfigPVM->Mode & PVM_RISING_EDGE) == PVM_RISING_EDGE)
       {
         __HAL_PWR_PVM3_EXTI_ENABLE_RISING_EDGE();
       }
 
-      if((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
+      if ((sConfigPVM->Mode & PVM_FALLING_EDGE) == PVM_FALLING_EDGE)
       {
         __HAL_PWR_PVM3_EXTI_ENABLE_FALLING_EDGE();
       }
@@ -868,10 +867,10 @@ HAL_StatusTypeDef HAL_PWREx_ConfigSMPS(PWR_SMPSTypeDef *sConfigSMPS)
   assert_param(IS_PWR_SMPS_OUTPUT_VOLTAGE(sConfigSMPS->OutputVoltage));
 
   __IO const uint32_t OutputVoltageLevel_calibration = (((*SMPS_VOLTAGE_CAL_ADDR) & SMPS_VOLTAGE_CAL) >> SMPS_VOLTAGE_CAL_POS);  /* SMPS output voltage level calibrated in production */
-  int32_t TrimmingSteps;                         /* Trimming steps between theorical output voltage and calibrated output voltage */
+  int32_t TrimmingSteps;                         /* Trimming steps between theoretical output voltage and calibrated output voltage */
   int32_t OutputVoltageLevelTrimmed;             /* SMPS output voltage level after calibration: trimming value added to required level */
 
-  if(OutputVoltageLevel_calibration == 0UL)
+  if (OutputVoltageLevel_calibration == 0UL)
   {
     /* Device with SMPS output voltage not calibrated in production: Apply output voltage value directly */
 
@@ -886,14 +885,14 @@ HAL_StatusTypeDef HAL_PWREx_ConfigSMPS(PWR_SMPSTypeDef *sConfigSMPS)
     OutputVoltageLevelTrimmed = ((int32_t)((uint32_t)(sConfigSMPS->OutputVoltage >> PWR_CR5_SMPSVOS_Pos)) + (int32_t)TrimmingSteps);
 
     /* Clamp value to voltage trimming bitfield range */
-    if(OutputVoltageLevelTrimmed < 0)
+    if (OutputVoltageLevelTrimmed < 0)
     {
       OutputVoltageLevelTrimmed = 0;
       status = HAL_ERROR;
     }
     else
     {
-      if(OutputVoltageLevelTrimmed > (int32_t)PWR_CR5_SMPSVOS)
+      if (OutputVoltageLevelTrimmed > (int32_t)PWR_CR5_SMPSVOS)
       {
         OutputVoltageLevelTrimmed = (int32_t)PWR_CR5_SMPSVOS;
         status = HAL_ERROR;
@@ -901,7 +900,8 @@ HAL_StatusTypeDef HAL_PWREx_ConfigSMPS(PWR_SMPSTypeDef *sConfigSMPS)
     }
 
     /* Update register */
-    MODIFY_REG(PWR->CR5, (PWR_CR5_SMPSSC | PWR_CR5_SMPSVOS), (sConfigSMPS->StartupCurrent | ((uint32_t) OutputVoltageLevelTrimmed)));
+    MODIFY_REG(PWR->CR5, (PWR_CR5_SMPSSC | PWR_CR5_SMPSVOS),
+               (sConfigSMPS->StartupCurrent | ((uint32_t) OutputVoltageLevelTrimmed)));
   }
 
   return status;
@@ -947,7 +947,7 @@ uint32_t HAL_PWREx_SMPS_GetEffectiveMode(void)
 {
   return (uint32_t)(READ_BIT(PWR->SR2, (PWR_SR2_SMPSF | PWR_SR2_SMPSBF)));
 }
-#endif
+#endif /* PWR_CR5_SMPSEN */
 
 /****************************************************************************/
 
@@ -980,7 +980,7 @@ void HAL_PWREx_EnableWakeUpPin(uint32_t WakeUpPinPolarity, uint32_t wakeupTarget
   MODIFY_REG(PWR->CR4, (PWR_C2CR3_EWUP & WakeUpPinPolarity), (WakeUpPinPolarity >> PWR_WUP_POLARITY_SHIFT));
 
   /* Enable wake-up pin */
-  if(PWR_CORE_CPU2 == wakeupTarget)
+  if (PWR_CORE_CPU2 == wakeupTarget)
   {
     SET_BIT(PWR->C2CR3, (PWR_C2CR3_EWUP & WakeUpPinPolarity));
   }
@@ -1021,7 +1021,7 @@ HAL_StatusTypeDef HAL_PWREx_ClearWakeupFlag(uint32_t WakeUpFlag)
 {
   PWR->SCR = (1UL << ((WakeUpFlag) & 31U));
 
-  if((PWR->SR1 & (1UL << ((WakeUpFlag) & 31U))) != 0U)
+  if ((PWR->SR1 & (1UL << ((WakeUpFlag) & 31U))) != 0U)
   {
     return HAL_ERROR;
   }
@@ -1117,7 +1117,7 @@ void HAL_PWREx_EnterSTOP0Mode(uint8_t STOPEntry)
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
   /* Select Stop mode entry --------------------------------------------------*/
-  if(STOPEntry == PWR_STOPENTRY_WFI)
+  if (STOPEntry == PWR_STOPENTRY_WFI)
   {
     /* Request Wait For Interrupt */
     __WFI();
@@ -1169,7 +1169,7 @@ void HAL_PWREx_EnterSTOP1Mode(uint8_t STOPEntry)
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
   /* Select Stop mode entry --------------------------------------------------*/
-  if(STOPEntry == PWR_STOPENTRY_WFI)
+  if (STOPEntry == PWR_STOPENTRY_WFI)
   {
     /* Request Wait For Interrupt */
     __WFI();
@@ -1232,7 +1232,7 @@ void HAL_PWREx_EnterSTOP2Mode(uint8_t STOPEntry)
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
   /* Select Stop mode entry --------------------------------------------------*/
-  if(STOPEntry == PWR_STOPENTRY_WFI)
+  if (STOPEntry == PWR_STOPENTRY_WFI)
   {
     /* Request Wait For Interrupt */
     __WFI();
@@ -1248,7 +1248,7 @@ void HAL_PWREx_EnterSTOP2Mode(uint8_t STOPEntry)
   /* Reset SLEEPDEEP bit of Cortex System Control Register */
   CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 }
-#endif
+#endif /* PWR_SUPPORT_STOP2 */
 
 /**
   * @brief Enter Shutdown mode.
@@ -1269,10 +1269,10 @@ void HAL_PWREx_EnterSHUTDOWNMode(void)
   /* Set SLEEPDEEP bit of Cortex System Control Register */
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 
-/* This option is used to ensure that store operations are completed */
-#if defined ( __CC_ARM)
+  /* This option is used to ensure that store operations are completed */
+#if defined (__CC_ARM)
   __force_stores();
-#endif
+#endif /* __CC_ARM */
 
   /* Request Wait For Interrupt */
   __WFI();
@@ -1293,7 +1293,7 @@ void HAL_PWREx_EnterSHUTDOWNMode(void)
 void HAL_PWREx_PVD_PVM_IRQHandler(void)
 {
   /* Check PWR exti flag */
-  if(__HAL_PWR_PVD_EXTI_GET_FLAG() != 0U)
+  if (__HAL_PWR_PVD_EXTI_GET_FLAG() != 0U)
   {
     /* PWR PVD interrupt user callback */
     HAL_PWR_PVDCallback();
@@ -1304,7 +1304,7 @@ void HAL_PWREx_PVD_PVM_IRQHandler(void)
 
 #if defined(PWR_CR2_PVME1)
   /* Next, successively check PVMx exti flags */
-  if(__HAL_PWR_PVM1_EXTI_GET_FLAG() != 0U)
+  if (__HAL_PWR_PVM1_EXTI_GET_FLAG() != 0U)
   {
     /* PWR PVM1 interrupt user callback */
     HAL_PWREx_PVM1Callback();
@@ -1312,9 +1312,9 @@ void HAL_PWREx_PVD_PVM_IRQHandler(void)
     /* Clear PVM1 exti pending bit */
     __HAL_PWR_PVM1_EXTI_CLEAR_FLAG();
   }
-#endif
+#endif /* PWR_CR2_PVME1 */
 
-  if(__HAL_PWR_PVM3_EXTI_GET_FLAG() != 0U)
+  if (__HAL_PWR_PVM3_EXTI_GET_FLAG() != 0U)
   {
     /* PWR PVM3 interrupt user callback */
     HAL_PWREx_PVM3Callback();
@@ -1335,7 +1335,7 @@ __weak void HAL_PWREx_PVM1Callback(void)
             HAL_PWREx_PVM1Callback() API can be implemented in the user file
    */
 }
-#endif
+#endif /* PWR_CR2_PVME1 */
 
 /**
   * @brief PWR PVM3 interrupt callback
@@ -1366,4 +1366,3 @@ __weak void HAL_PWREx_PVM3Callback(void)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_qspi.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_qspi.c
@@ -14,6 +14,17 @@
   *           + Errors management and abort functionality
   *
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
  ===============================================================================
                         ##### How to use this driver #####
@@ -150,7 +161,7 @@
       and a pointer to the user callback function.
 
       Use function HAL_QSPI_UnRegisterCallback() to reset a callback to the default
-      weak (surcharged) function. It allows to reset following callbacks:
+      weak (overridden) function. It allows to reset following callbacks:
         (+) ErrorCallback : callback when error occurs.
         (+) AbortCpltCallback : callback when abort is completed.
         (+) FifoThresholdCallback : callback when the fifo threshold is reached.
@@ -166,9 +177,9 @@
       This function) takes as parameters the HAL peripheral handle and the Callback ID.
 
       By default, after the HAL_QSPI_Init and if the state is HAL_QSPI_STATE_RESET
-      all callbacks are reset to the corresponding legacy weak (surcharged) functions.
+      all callbacks are reset to the corresponding legacy weak (overridden) functions.
       Exception done for MspInit and MspDeInit callbacks that are respectively
-      reset to the legacy weak (surcharged) functions in the HAL_QSPI_Init
+      reset to the legacy weak (overridden) functions in the HAL_QSPI_Init
       and  HAL_QSPI_DeInit only when these callbacks are null (not registered beforehand).
       If not, MspInit or MspDeInit are not null, the HAL_QSPI_Init and HAL_QSPI_DeInit
       keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
@@ -183,7 +194,7 @@
 
       When The compilation define USE_HAL_QSPI_REGISTER_CALLBACKS is set to 0 or
       not defined, the callback registering feature is not available
-      and weak (surcharged) callbacks are used.
+      and weak (overridden) callbacks are used.
 
     *** Workarounds linked to Silicon Limitation ***
     ====================================================
@@ -192,17 +203,6 @@
          (++) Extra data written in the FIFO at the end of a read transfer
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                       opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -307,9 +307,6 @@ HAL_StatusTypeDef HAL_QSPI_Init(QSPI_HandleTypeDef *hqspi)
   assert_param(IS_QSPI_CS_HIGH_TIME(hqspi->Init.ChipSelectHighTime));
   assert_param(IS_QSPI_CLOCK_MODE(hqspi->Init.ClockMode));
 
-  /* Process locked */
-  __HAL_LOCK(hqspi);
-
   if(hqspi->State == HAL_QSPI_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
@@ -392,9 +389,6 @@ HAL_StatusTypeDef HAL_QSPI_DeInit(QSPI_HandleTypeDef *hqspi)
   {
     return HAL_ERROR;
   }
-
-  /* Process locked */
-  __HAL_LOCK(hqspi);
 
   /* Disable the QSPI Peripheral Clock */
   __HAL_QSPI_DISABLE(hqspi);
@@ -1979,7 +1973,7 @@ __weak void HAL_QSPI_TimeOutCallback(QSPI_HandleTypeDef *hqspi)
 #if (USE_HAL_QSPI_REGISTER_CALLBACKS == 1)
 /**
   * @brief  Register a User QSPI Callback
-  *         To be used instead of the weak (surcharged) predefined callback
+  *         To be used to override the weak predefined callback
   * @param hqspi QSPI handle
   * @param CallbackId ID of the callback to be registered
   *        This parameter can be one of the following values:
@@ -2093,7 +2087,7 @@ HAL_StatusTypeDef HAL_QSPI_RegisterCallback (QSPI_HandleTypeDef *hqspi, HAL_QSPI
 
 /**
   * @brief  Unregister a User QSPI Callback
-  *         QSPI Callback is redirected to the weak (surcharged) predefined callback
+  *         QSPI Callback is redirected to the weak predefined callback
   * @param hqspi QSPI handle
   * @param CallbackId ID of the callback to be unregistered
   *        This parameter can be one of the following values:
@@ -2225,7 +2219,7 @@ HAL_StatusTypeDef HAL_QSPI_UnRegisterCallback (QSPI_HandleTypeDef *hqspi, HAL_QS
   * @param  hqspi QSPI handle
   * @retval HAL state
   */
-HAL_QSPI_StateTypeDef HAL_QSPI_GetState(QSPI_HandleTypeDef *hqspi)
+HAL_QSPI_StateTypeDef HAL_QSPI_GetState(const QSPI_HandleTypeDef *hqspi)
 {
   /* Return QSPI handle state */
   return hqspi->State;
@@ -2236,7 +2230,7 @@ HAL_QSPI_StateTypeDef HAL_QSPI_GetState(QSPI_HandleTypeDef *hqspi)
 * @param  hqspi QSPI handle
 * @retval QSPI Error Code
 */
-uint32_t HAL_QSPI_GetError(QSPI_HandleTypeDef *hqspi)
+uint32_t HAL_QSPI_GetError(const QSPI_HandleTypeDef *hqspi)
 {
   return hqspi->ErrorCode;
 }
@@ -2270,25 +2264,33 @@ HAL_StatusTypeDef HAL_QSPI_Abort(QSPI_HandleTypeDef *hqspi)
       }
     }
 
-    /* Configure QSPI: CR register with Abort request */
-    SET_BIT(hqspi->Instance->CR, QUADSPI_CR_ABORT);
-
-    /* Wait until TC flag is set to go back in idle state */
-    status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, tickstart, hqspi->Timeout);
-
-    if (status == HAL_OK)
+    if (__HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_BUSY) != RESET)
     {
-      __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+      /* Configure QSPI: CR register with Abort request */
+      SET_BIT(hqspi->Instance->CR, QUADSPI_CR_ABORT);
 
-      /* Wait until BUSY flag is reset */
-      status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, tickstart, hqspi->Timeout);
+      /* Wait until TC flag is set to go back in idle state */
+      status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_TC, SET, tickstart, hqspi->Timeout);
+
+      if (status == HAL_OK)
+      {
+        __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+
+        /* Wait until BUSY flag is reset */
+        status = QSPI_WaitFlagStateUntilTimeout(hqspi, QSPI_FLAG_BUSY, RESET, tickstart, hqspi->Timeout);
+      }
+
+      if (status == HAL_OK)
+      {
+        /* Reset functional mode configuration to indirect write mode by default */
+        CLEAR_BIT(hqspi->Instance->CCR, QUADSPI_CCR_FMODE);
+
+        /* Update state */
+        hqspi->State = HAL_QSPI_STATE_READY;
+      }
     }
-
-    if (status == HAL_OK)
+    else
     {
-      /* Reset functional mode configuration to indirect write mode by default */
-      CLEAR_BIT(hqspi->Instance->CCR, QUADSPI_CCR_FMODE);
-
       /* Update state */
       hqspi->State = HAL_QSPI_STATE_READY;
     }
@@ -2340,14 +2342,22 @@ HAL_StatusTypeDef HAL_QSPI_Abort_IT(QSPI_HandleTypeDef *hqspi)
     }
     else
     {
-      /* Clear interrupt */
-      __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
+      if (__HAL_QSPI_GET_FLAG(hqspi, QSPI_FLAG_BUSY) != RESET)
+      {
+        /* Clear interrupt */
+        __HAL_QSPI_CLEAR_FLAG(hqspi, QSPI_FLAG_TC);
 
-      /* Enable the QSPI Transfer Complete Interrupt */
-      __HAL_QSPI_ENABLE_IT(hqspi, QSPI_IT_TC);
+        /* Enable the QSPI Transfer Complete Interrupt */
+        __HAL_QSPI_ENABLE_IT(hqspi, QSPI_IT_TC);
 
-      /* Configure QSPI: CR register with Abort request */
-      SET_BIT(hqspi->Instance->CR, QUADSPI_CR_ABORT);
+        /* Configure QSPI: CR register with Abort request */
+        SET_BIT(hqspi->Instance->CR, QUADSPI_CR_ABORT);
+      }
+      else
+      {
+        /* Change state of QSPI */
+        hqspi->State = HAL_QSPI_STATE_READY;
+      }
     }
   }
   return status;
@@ -2400,7 +2410,7 @@ HAL_StatusTypeDef HAL_QSPI_SetFifoThreshold(QSPI_HandleTypeDef *hqspi, uint32_t 
   * @param  hqspi QSPI handle.
   * @retval Fifo threshold (value between 1 and 16)
   */
-uint32_t HAL_QSPI_GetFifoThreshold(QSPI_HandleTypeDef *hqspi)
+uint32_t HAL_QSPI_GetFifoThreshold(const QSPI_HandleTypeDef *hqspi)
 {
   return ((READ_BIT(hqspi->Instance->CR, QUADSPI_CR_FTHRES) >> QUADSPI_CR_FTHRES_Pos) + 1U);
 }
@@ -2621,6 +2631,9 @@ static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uin
                                          cmd->AlternateBytesSize | cmd->AlternateByteMode |
                                          cmd->AddressMode | cmd->InstructionMode |
                                          cmd->Instruction | FunctionalMode));
+
+        /* Clear AR register */
+        CLEAR_REG(hqspi->Instance->AR);
       }
     }
     else
@@ -2648,6 +2661,9 @@ static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uin
                                          cmd->DataMode | (cmd->DummyCycles << QUADSPI_CCR_DCYC_Pos) |
                                          cmd->AlternateByteMode | cmd->AddressMode |
                                          cmd->InstructionMode | cmd->Instruction | FunctionalMode));
+
+        /* Clear AR register */
+        CLEAR_REG(hqspi->Instance->AR);
       }
     }
   }
@@ -2682,6 +2698,9 @@ static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uin
                                          cmd->DataMode | (cmd->DummyCycles << QUADSPI_CCR_DCYC_Pos) |
                                          cmd->AlternateBytesSize | cmd->AlternateByteMode |
                                          cmd->AddressMode | cmd->InstructionMode | FunctionalMode));
+
+        /* Clear AR register */
+        CLEAR_REG(hqspi->Instance->AR);
       }
     }
     else
@@ -2711,6 +2730,9 @@ static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uin
                                            cmd->DataMode | (cmd->DummyCycles << QUADSPI_CCR_DCYC_Pos) |
                                            cmd->AlternateByteMode | cmd->AddressMode |
                                            cmd->InstructionMode | FunctionalMode));
+
+          /* Clear AR register */
+          CLEAR_REG(hqspi->Instance->AR);
         }
       }
     }
@@ -2734,6 +2756,4 @@ static void QSPI_Config(QSPI_HandleTypeDef *hqspi, QSPI_CommandTypeDef *cmd, uin
   * @}
   */
 
-#endif /* defined(QUADSPI) || defined(QUADSPI1) || defined(QUADSPI2) */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
+#endif /* defined(QUADSPI) */

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rcc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rcc.c
@@ -7,10 +7,19 @@
   *          functionalities of the Reset and Clock Control (RCC) peripheral:
   *           + Initialization and de-initialization functions
   *           + Peripheral Control functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
-
                       ##### RCC specific features #####
   ==============================================================================
     [..]
@@ -37,17 +46,6 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -67,8 +65,8 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /** @defgroup RCC_Private_Constants RCC Private Constants
- * @{
- */
+  * @{
+  */
 #define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
 #define HSI_TIMEOUT_VALUE          (2U)    /* 2 ms (minimum Tick + 1)   */
 #define MSI_TIMEOUT_VALUE          (2U)    /* 2 ms (minimum Tick + 1)   */
@@ -78,13 +76,13 @@
 #define PLL_TIMEOUT_VALUE          (2U)    /* 2 ms (minimum Tick + 1)   */
 #if defined(SAI1)
 #define PLLSAI1_TIMEOUT_VALUE      (2U)    /* 2 ms (minimum Tick + 1)   */
-#endif
+#endif /* SAI1 */
 #define PRESCALER_TIMEOUT_VALUE    (2U)    /* 2 ms (minimum Tick + 1)   */
 #define LATENCY_TIMEOUT_VALUE      (2U)    /* 2 ms (minimum Tick + 1)   */
 #define CLOCKSWITCH_TIMEOUT_VALUE  (5000U) /* 5 s                       */
 
 #define PLLSOURCE_NONE             (0U)
-#define MEGA_HZ                     1000000U /* Division factor to convert Hz in Mhz */
+#define MEGA_HZ                    (1000000U) /* Division factor to convert Hz in Mhz */
 /**
   * @}
   */
@@ -93,20 +91,17 @@
 /** @defgroup RCC_Private_Macros RCC Private Macros
   * @{
   */
-#define __MCO1_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
-#define MCO1_GPIO_PORT        GPIOA
-#define MCO1_PIN              GPIO_PIN_8
 
-#define __MCO2_CLK_ENABLE()   __HAL_RCC_GPIOB_CLK_ENABLE()
-#define MCO2_GPIO_PORT        GPIOB
-#define MCO2_PIN              GPIO_PIN_6
+#define RCC_GET_MCO_GPIO_PIN(__RCC_MCOx__)   ((__RCC_MCOx__) & GPIO_PIN_MASK)
 
-#define __MCO3_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
-#define MCO3_GPIO_PORT        GPIOA
-#define MCO3_PIN              GPIO_PIN_15
+#define RCC_GET_MCO_GPIO_AF(__RCC_MCOx__)    (((__RCC_MCOx__) & RCC_MCO_GPIOAF_MASK) >> RCC_MCO_GPIOAF_POS)
+
+#define RCC_GET_MCO_GPIO_INDEX(__RCC_MCOx__) (((__RCC_MCOx__) & RCC_MCO_GPIOPORT_MASK) >> RCC_MCO_GPIOPORT_POS)
+
+#define RCC_GET_MCO_GPIO_PORT(__RCC_MCOx__)  (IOPORT_BASE + ((0x00000400UL) * RCC_GET_MCO_GPIO_INDEX((__RCC_MCOx__))))
 
 #define RCC_PLL_OSCSOURCE_CONFIG(__HAL_RCC_PLLSOURCE__) \
-            (MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (uint32_t)(__HAL_RCC_PLLSOURCE__)))
+  (MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, (uint32_t)(__HAL_RCC_PLLSOURCE__)))
 
 #define __COUNTOF(_A_)   (sizeof(_A_) / sizeof(*(_A_)))
 /**
@@ -155,7 +150,7 @@ static HAL_StatusTypeDef RCC_SetFlashLatency(uint32_t Flash_ClkSrcFreq, uint32_t
          (+) HSI (high-speed internal): 16 MHz factory-trimmed RC used directly or through
              the PLL as System clock source.
 
-         (+) MSI (Mutiple Speed Internal): Its frequency is software trimmable from 100KHZ to 48MHZ.
+         (+) MSI (Multiple Speed Internal): Its frequency is software trimmable from 100KHZ to 48MHZ.
              It can be used to generate the clock for the USB FS (48 MHz).
              The number of flash wait states is automatically adjusted when MSI range is updated with
              HAL_RCC_OscConfig() and the MSI is used as System clock source.
@@ -197,7 +192,8 @@ static HAL_StatusTypeDef RCC_SetFlashLatency(uint32_t Flash_ClkSrcFreq, uint32_t
              the software
 
          (+) MCO (microcontroller clock output): used to output MSI, LSI1, LSI2, HSI, LSE, HSE (before and
-             after stabilization), SYSCLK, HSI48 or main PLL clock (through a configurable prescaler) on PA8, PB6 & PA15 pins.
+             after stabilization), SYSCLK, HSI48 or main PLL clock (through a configurable prescaler)
+             on PA8, PB6 & PA15 pins.
 
     [..] System, AHB and APB buses clocks configuration
          (+) Several clock sources can be used to drive the System clock (SYSCLK): MSI, HSI,
@@ -315,10 +311,11 @@ HAL_StatusTypeDef HAL_RCC_DeInit(void)
 
   /* Reset HSION, HSIKERON, HSIASFS, HSEON, PLLON, PLLSAI11ON, HSEPRE bits */
 #if defined(SAI1)
-  CLEAR_BIT(RCC->CR, RCC_CR_HSION | RCC_CR_HSIKERON | RCC_CR_HSIASFS | RCC_CR_HSEON | RCC_CR_HSEPRE | RCC_CR_PLLON | RCC_CR_PLLSAI1ON);
+  CLEAR_BIT(RCC->CR, RCC_CR_HSION | RCC_CR_HSIKERON | RCC_CR_HSIASFS | RCC_CR_HSEON | RCC_CR_HSEPRE | RCC_CR_PLLON |
+            RCC_CR_PLLSAI1ON);
 #else
   CLEAR_BIT(RCC->CR, RCC_CR_HSION | RCC_CR_HSIKERON | RCC_CR_HSIASFS | RCC_CR_HSEON | RCC_CR_HSEPRE | RCC_CR_PLLON);
-#endif
+#endif /* SAI1 */
 
   /* Get Start Tick*/
   tickstart = HAL_GetTick();
@@ -348,8 +345,9 @@ HAL_StatusTypeDef HAL_RCC_DeInit(void)
     }
   }
   /* once PLLSAI1 is OFF, reset PLLSAI1CFGR register to default value */
-  WRITE_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLR_0 | RCC_PLLSAI1CFGR_PLLQ_0 | RCC_PLLSAI1CFGR_PLLP_1 | RCC_PLLSAI1CFGR_PLLN_0);
-#endif
+  WRITE_REG(RCC->PLLSAI1CFGR, RCC_PLLSAI1CFGR_PLLR_0 | RCC_PLLSAI1CFGR_PLLQ_0 |
+            RCC_PLLSAI1CFGR_PLLP_1 | RCC_PLLSAI1CFGR_PLLN_0);
+#endif /* SAI1 */
 
   /* Disable all interrupts */
   CLEAR_REG(RCC->CIER);
@@ -410,7 +408,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     if ((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_MSI) ||
         ((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (temp_plloscsrc == RCC_PLLSOURCE_MSI)))
     {
-      if ((LL_RCC_MSI_IsReady() != 0U) && (RCC_OscInitStruct->MSIState == RCC_MSI_OFF))
+      if (RCC_OscInitStruct->MSIState == RCC_MSI_OFF)
       {
         return HAL_ERROR;
       }
@@ -476,6 +474,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
             return HAL_TIMEOUT;
           }
         }
+
         /* Selects the Multiple Speed oscillator (MSI) clock range .*/
         __HAL_RCC_MSI_RANGE_CONFIG(RCC_OscInitStruct->MSIClockRange);
         /* Adjusts the Multiple Speed oscillator (MSI) calibration value.*/
@@ -501,6 +500,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       }
     }
   }
+
   /*------------------------------- HSE Configuration ------------------------*/
   if (((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSE) == RCC_OSCILLATORTYPE_HSE)
   {
@@ -513,7 +513,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     if ((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_HSE) ||
         ((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (temp_plloscsrc == RCC_PLLSOURCE_HSE)))
     {
-      if ((LL_RCC_HSE_IsReady() != 0U) && (RCC_OscInitStruct->HSEState == RCC_HSE_OFF))
+      if (RCC_OscInitStruct->HSEState == RCC_HSE_OFF)
       {
         return HAL_ERROR;
       }
@@ -554,6 +554,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       }
     }
   }
+
   /*----------------------------- HSI Configuration --------------------------*/
   if (((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_HSI) == RCC_OSCILLATORTYPE_HSI)
   {
@@ -568,7 +569,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         ((temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_PLLCLK) && (temp_plloscsrc == RCC_PLLSOURCE_HSI)))
     {
       /* When HSI is used as system clock it will not be disabled */
-      if ((LL_RCC_HSI_IsReady() != 0U) && (RCC_OscInitStruct->HSIState == RCC_HSI_OFF))
+      if (RCC_OscInitStruct->HSIState == RCC_HSI_OFF)
       {
         return HAL_ERROR;
       }
@@ -757,10 +758,10 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       }
     }
   }
+
   /*------------------------------ LSE Configuration -------------------------*/
   if (((RCC_OscInitStruct->OscillatorType) & RCC_OSCILLATORTYPE_LSE) == RCC_OSCILLATORTYPE_LSE)
   {
-
     /* Check the parameters */
     assert_param(IS_RCC_LSE(RCC_OscInitStruct->LSEState));
 
@@ -825,7 +826,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     /* Check the parameters */
     assert_param(IS_RCC_HSI48(RCC_OscInitStruct->HSI48State));
 
-    /* Check the LSI State */
+    /* Check the HSI State */
     if (RCC_OscInitStruct->HSI48State != RCC_HSI48_OFF)
     {
       /* Enable the Internal Low Speed oscillator (HSI48). */
@@ -861,18 +862,18 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
       }
     }
   }
-#endif
+#endif /* RCC_HSI48_SUPPORT */
   /*-------------------------------- PLL Configuration -----------------------*/
   /* Check the parameters */
   assert_param(IS_RCC_PLL(RCC_OscInitStruct->PLL.PLLState));
 
-  if(RCC_OscInitStruct->PLL.PLLState != RCC_PLL_NONE)
+  if (RCC_OscInitStruct->PLL.PLLState != RCC_PLL_NONE)
   {
     const uint32_t temp_sysclksrc = __HAL_RCC_GET_SYSCLK_SOURCE();
     const uint32_t temp_pllconfig = RCC->PLLCFGR;
 
     /* PLL On ? */
-    if(RCC_OscInitStruct->PLL.PLLState == RCC_PLL_ON)
+    if (RCC_OscInitStruct->PLL.PLLState == RCC_PLL_ON)
     {
       /* Check the parameters */
       assert_param(IS_RCC_PLLSOURCE(RCC_OscInitStruct->PLL.PLLSource));
@@ -902,7 +903,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
             return HAL_ERROR;
           }
           else
-#endif
+#endif /* SAI1 */
           {
             /* Disable the main PLL. */
             __HAL_RCC_PLL_DISABLE();
@@ -970,7 +971,7 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
           /* Wait till PLL is ready */
           while (READ_BIT(RCC->CR, RCC_CR_PLLRDY) == 0U)
           {
-            if((HAL_GetTick() - tickstart) > PLL_TIMEOUT_VALUE)
+            if ((HAL_GetTick() - tickstart) > PLL_TIMEOUT_VALUE)
             {
               return HAL_TIMEOUT;
             }
@@ -986,16 +987,6 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
         /* Disable the main PLL. */
         __HAL_RCC_PLL_DISABLE();
 
-
-        /* Disable all PLL outputs to save power */
-        MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLSRC, PLLSOURCE_NONE);
-
-#if defined(SAI1) && defined(USB)
-        __HAL_RCC_PLLCLKOUT_DISABLE(RCC_PLL_SYSCLK | RCC_PLL_USBCLK | RCC_PLL_SAI1CLK);
-#else
-        __HAL_RCC_PLLCLKOUT_DISABLE(RCC_PLL_SYSCLK);
-#endif
-
         /* Get Start Tick*/
         tickstart = HAL_GetTick();
 
@@ -1007,6 +998,13 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
             return HAL_TIMEOUT;
           }
         }
+
+        /* Disable the PLL source and outputs to save power when PLL is off */
+#if defined(SAI1) && defined(USB)
+        CLEAR_BIT(RCC->PLLCFGR, (RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLPEN | RCC_PLLCFGR_PLLQEN | RCC_PLLCFGR_PLLREN));
+#else
+        CLEAR_BIT(RCC->PLLCFGR, (RCC_PLLCFGR_PLLSRC | RCC_PLLCFGR_PLLREN));
+#endif /* SAI1 && USB */
       }
       else
       {
@@ -1270,8 +1268,8 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   */
 
 /** @defgroup RCC_Exported_Functions_Group2 Peripheral Control functions
- *  @brief   RCC clocks control functions
- *
+  *  @brief   RCC clocks control functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral Control functions #####
@@ -1279,7 +1277,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
     [..]
     This subsection provides a set of functions allowing to:
 
-    (+) Ouput clock to MCO pin.
+    (+) Output clock to MCO pin.
     (+) Retrieve current clock frequencies.
     (+) Enable the Clock Security System.
 
@@ -1288,23 +1286,23 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   */
 
 /**
-  * @brief  Select the clock source to output on MCO1 pin(PA8) or MC02 pin (PB6) or MCO3 pin (PA15).
+  * @brief  Select the clock source to output on MCO1 pin(PA8) or MCO2 pin (PB6) or MCO3 pin (PA15).
   * @note   PA8, PB6 or PA15 should be configured in alternate function mode.
   * @param  RCC_MCOx  specifies the output direction for the clock source.
-  *            @arg @ref RCC_MCO1  Clock source to output on MCO1 pin(PA8)
-  *            @arg @ref RCC_MCO2  Clock source to output on MCO2 pin(PB6)
-  *            @arg @ref RCC_MCO3  Clock source to output on MCO3 pin(PA15)
+  *            @arg @ref RCC_MCO1_PA8  Clock source to output on MCO1 pin(PA8)
+  *            @arg @ref RCC_MCO2_PB6  Clock source to output on MCO2 pin(PB6)
+  *            @arg @ref RCC_MCO3_PA15  Clock source to output on MCO3 pin(PA15)
   * @param  RCC_MCOSource  specifies the clock source to output.
   *          This parameter can be one of the following values:
   *            @arg @ref RCC_MCO1SOURCE_NOCLOCK  MCO output disabled, no clock on MCO
-  *            @arg @ref RCC_MCO1SOURCE_SYSCLK  system  clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_MSI  MSI clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_HSI  HSI clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_HSE  HSE clock selected as MCO sourcee
+  *            @arg @ref RCC_MCO1SOURCE_SYSCLK  system clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_MSI    MSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSI    HSI clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_HSE    HSE clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_PLLCLK  main PLL clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_LSI1  LSI1 clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_LSI2  LSI2 clock selected as MCO source
-  *            @arg @ref RCC_MCO1SOURCE_LSE  LSE clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSI1   LSI1 clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSI2   LSI2 clock selected as MCO source
+  *            @arg @ref RCC_MCO1SOURCE_LSE    LSE clock selected as MCO source
   *            @arg @ref RCC_MCO1SOURCE_HSI48  HSI48 clock selected as MCO source for devices with HSI48
   *            @arg @ref RCC_MCO1SOURCE_HSE_BEFORE_STAB  HSE clock before stabilization selected as MCO source
   * @param  RCC_MCODiv  specifies the MCO prescaler.
@@ -1318,63 +1316,65 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   */
 void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
 {
-  GPIO_InitTypeDef GPIO_InitStruct;
+  GPIO_InitTypeDef gpio_initstruct;
+  uint32_t mcoindex;
+  uint32_t mco_gpio_index;
+  GPIO_TypeDef *mco_gpio_port;
 
   /* Check the parameters */
   assert_param(IS_RCC_MCO(RCC_MCOx));
-  assert_param(IS_RCC_MCODIV(RCC_MCODiv));
-  assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
 
   /* Common GPIO init parameters */
-  GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Pull      = GPIO_NOPULL;
+  gpio_initstruct.Mode      = GPIO_MODE_AF_PP;
+  gpio_initstruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
+  gpio_initstruct.Pull      = GPIO_NOPULL;
 
-  /* RCC_MCO1 */
-  if (RCC_MCOx == RCC_MCO1)
+  /* Get MCOx selection */
+  mcoindex = RCC_MCOx & RCC_MCO_INDEX_MASK;
+
+  /* Get MCOx GPIO Port */
+  mco_gpio_port = (GPIO_TypeDef *) RCC_GET_MCO_GPIO_PORT(RCC_MCOx);
+
+  /* MCOx Clock Enable */
+  mco_gpio_index = RCC_GET_MCO_GPIO_INDEX(RCC_MCOx);
+  SET_BIT(RCC->AHB2ENR, (1UL << mco_gpio_index));
+
+  /* Configure the MCOx pin in alternate function mode */
+  gpio_initstruct.Pin = RCC_GET_MCO_GPIO_PIN(RCC_MCOx);
+  gpio_initstruct.Alternate = RCC_GET_MCO_GPIO_AF(RCC_MCOx);
+  HAL_GPIO_Init(mco_gpio_port, &gpio_initstruct);
+
+  if (mcoindex == RCC_MCO1_INDEX)
   {
-    /* MCO1 Clock Enable */
-    __MCO1_CLK_ENABLE();
-    /* Configue the MCO1 pin in alternate function mode */
-    GPIO_InitStruct.Pin       = MCO1_PIN;
-    GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
-    HAL_GPIO_Init(MCO1_GPIO_PORT, &GPIO_InitStruct);
-
+    assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+    assert_param(IS_RCC_MCO1SOURCE(RCC_MCOSource));
+    /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
+    LL_RCC_ConfigMCO(RCC_MCOSource, RCC_MCODiv);
   }
-  else if (RCC_MCOx == RCC_MCO2)
+  else if (mcoindex == RCC_MCO2_INDEX)
   {
-    /* MCO2 Clock Enable */
-    __MCO2_CLK_ENABLE();
-    /* Configue the MCO2 pin in alternate function mode */
-    GPIO_InitStruct.Pin       = MCO2_PIN;
-    GPIO_InitStruct.Alternate = GPIO_AF0_MCO;
-    HAL_GPIO_Init(MCO2_GPIO_PORT, &GPIO_InitStruct);
-
+    assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+    assert_param(IS_RCC_MCO2SOURCE(RCC_MCOSource));
+    /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
+    LL_RCC_ConfigMCO(RCC_MCOSource, RCC_MCODiv);
   }
 #if defined(RCC_MCO3_SUPPORT)
-  else if (RCC_MCOx == RCC_MCO3)
+  else if (mcoindex == RCC_MCO3_INDEX)
   {
-    /* MCO3 Clock Enable */
-    __MCO3_CLK_ENABLE();
-    /* Configue the MCO3 pin in alternate function mode */
-    GPIO_InitStruct.Pin       = MCO3_PIN;
-    GPIO_InitStruct.Alternate = GPIO_AF6_MCO;
-    HAL_GPIO_Init(MCO3_GPIO_PORT, &GPIO_InitStruct);
+    assert_param(IS_RCC_MCODIV(RCC_MCODiv));
+    assert_param(IS_RCC_MCO3SOURCE(RCC_MCOSource));
+    /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
+    LL_RCC_ConfigMCO(RCC_MCOSource, RCC_MCODiv);
   }
-#endif
+#endif /* RCC_MCO3_SUPPORT */
   else
-  {
-    ;
-  }
-
-  /* Mask MCOSEL[] and MCOPRE[] bits then set MCO clock source and prescaler */
-  LL_RCC_ConfigMCO(RCC_MCOSource, RCC_MCODiv);
+  {}
 }
 
 /**
   * @brief  Return the SYSCLK frequency.
   *
-  * @note   The system  computed by this function is not the real
+  * @note   The system computed by this function is not the real
   *         frequency in the chip. It is calculated based on the predefined
   *         constant and the selected clock source:
   * @note     If SYSCLK source is MSI, function returns values based on MSI range
@@ -1405,7 +1405,8 @@ void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_M
 uint32_t HAL_RCC_GetSysClockFreq(void)
 {
   uint32_t pllsource;
-  uint32_t sysclockfreq, pllinputfreq;
+  uint32_t sysclockfreq;
+  uint32_t pllinputfreq;
   const uint32_t temp_sysclksrc = __HAL_RCC_GET_SYSCLK_SOURCE();
 
   if (temp_sysclksrc == RCC_SYSCLKSOURCE_STATUS_MSI)
@@ -1455,7 +1456,8 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
         pllinputfreq = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSI_GetRange());
         break;
     }
-    sysclockfreq = __LL_RCC_CALC_PLLCLK_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(), LL_RCC_PLL_GetN(), LL_RCC_PLL_GetR());
+    sysclockfreq = __LL_RCC_CALC_PLLCLK_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(), LL_RCC_PLL_GetN(),
+                                             LL_RCC_PLL_GetR());
   }
 
   return sysclockfreq;
@@ -1524,6 +1526,10 @@ uint32_t HAL_RCC_GetPCLK2Freq(void)
   */
 void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
 {
+  uint32_t regvalue;
+  uint32_t regICSRvalue;
+  uint32_t regPLLCFGRvalue;
+
   /* Check the parameters */
   assert_param(RCC_OscInitStruct != (void *)NULL);
 
@@ -1533,95 +1539,54 @@ void HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
 
 #if defined(RCC_HSI48_SUPPORT)
   RCC_OscInitStruct->OscillatorType |= RCC_OSCILLATORTYPE_HSI48;
-#endif
+#endif /* RCC_HSI48_SUPPORT */
+
+  /* Get register values */
+  regvalue = RCC->CR; /* Control register */
+  regICSRvalue = RCC->ICSCR; /* Get Internal Clock Sources Calibration register */
+  regPLLCFGRvalue = RCC->PLLCFGR; /* Get PLL Configuration register */
 
   /* Get the HSE configuration -----------------------------------------------*/
-  if ((RCC->CR & RCC_CR_HSEON) == RCC_CR_HSEON)
-  {
-    RCC_OscInitStruct->HSEState = RCC_HSE_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->HSEState = RCC_HSE_OFF;
-  }
+  RCC_OscInitStruct->HSEState = (regvalue & RCC_CR_HSEON);
 
   /* Get the MSI configuration -----------------------------------------------*/
-  if ((RCC->CR & RCC_CR_MSION) == RCC_CR_MSION)
-  {
-    RCC_OscInitStruct->MSIState = RCC_MSI_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->MSIState = RCC_MSI_OFF;
-  }
-  RCC_OscInitStruct->MSICalibrationValue  = LL_RCC_MSI_GetCalibTrimming();
-  RCC_OscInitStruct->MSIClockRange        = LL_RCC_MSI_GetRange();
+  RCC_OscInitStruct->MSIState            = (regvalue & RCC_CR_MSION);
+  RCC_OscInitStruct->MSICalibrationValue = (regICSRvalue & RCC_ICSCR_MSITRIM) >> RCC_ICSCR_MSITRIM_Pos;
+  RCC_OscInitStruct->MSIClockRange       = (regvalue & RCC_CR_MSIRANGE);
 
   /* Get the HSI configuration -----------------------------------------------*/
-  if ((RCC->CR & RCC_CR_HSION) == RCC_CR_HSION)
-  {
-    RCC_OscInitStruct->HSIState = RCC_HSI_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->HSIState = RCC_HSI_OFF;
-  }
-
-  RCC_OscInitStruct->HSICalibrationValue = LL_RCC_HSI_GetCalibTrimming();
-
-  /* Get the LSE configuration -----------------------------------------------*/
-  if ((RCC->BDCR & RCC_BDCR_LSEBYP) == RCC_BDCR_LSEBYP)
-  {
-    RCC_OscInitStruct->LSEState = RCC_LSE_BYPASS;
-  }
-  else if ((RCC->BDCR & RCC_BDCR_LSEON) == RCC_BDCR_LSEON)
-  {
-    RCC_OscInitStruct->LSEState = RCC_LSE_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->LSEState = RCC_LSE_OFF;
-  }
-
-  /* Get the LSI configuration -----------------------------------------------*/
-  const uint32_t temp_lsi1on = (RCC->CSR & RCC_CSR_LSI1ON);
-  const uint32_t temp_lsi2on = (RCC->CSR & RCC_CSR_LSI2ON);
-  if ((temp_lsi1on == RCC_CSR_LSI1ON) || (temp_lsi2on == RCC_CSR_LSI2ON))
-  {
-    RCC_OscInitStruct->LSIState = RCC_LSI_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->LSIState = RCC_LSI_OFF;
-  }
-
-#if defined(RCC_HSI48_SUPPORT)
-  /* Get the HSI48 configuration ---------------------------------------------*/
-  if ((RCC->CRRCR & RCC_CRRCR_HSI48ON) == RCC_CRRCR_HSI48ON)
-  {
-    RCC_OscInitStruct->HSI48State = RCC_HSI48_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->HSI48State = RCC_HSI48_OFF;
-  }
-#endif
+  RCC_OscInitStruct->HSIState            = (regvalue & RCC_CR_HSION);
+  RCC_OscInitStruct->HSICalibrationValue = ((regICSRvalue & RCC_ICSCR_HSITRIM) >> RCC_ICSCR_HSITRIM_Pos);
 
   /* Get the PLL configuration -----------------------------------------------*/
-  if ((RCC->CR & RCC_CR_PLLON) == RCC_CR_PLLON)
-  {
-    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_ON;
-  }
-  else
-  {
-    RCC_OscInitStruct->PLL.PLLState = RCC_PLL_OFF;
-  }
-  RCC_OscInitStruct->PLL.PLLSource = LL_RCC_PLL_GetMainSource();
-  RCC_OscInitStruct->PLL.PLLM      = LL_RCC_PLL_GetDivider();
-  RCC_OscInitStruct->PLL.PLLN      = LL_RCC_PLL_GetN();
-  RCC_OscInitStruct->PLL.PLLP      = LL_RCC_PLL_GetP();
-  RCC_OscInitStruct->PLL.PLLQ      = LL_RCC_PLL_GetQ();
-  RCC_OscInitStruct->PLL.PLLR      = LL_RCC_PLL_GetR();
+  RCC_OscInitStruct->PLL.PLLState  = ((regvalue & RCC_CR_PLLON) >> RCC_CR_PLLON_Pos) + 1U;
+  RCC_OscInitStruct->PLL.PLLSource = (regPLLCFGRvalue & RCC_PLLCFGR_PLLSRC);
+  RCC_OscInitStruct->PLL.PLLM      = (regPLLCFGRvalue & RCC_PLLCFGR_PLLM);
+  RCC_OscInitStruct->PLL.PLLN      = ((regPLLCFGRvalue & RCC_PLLCFGR_PLLN) >> RCC_PLLCFGR_PLLN_Pos);
+  RCC_OscInitStruct->PLL.PLLP      = (regPLLCFGRvalue & RCC_PLLCFGR_PLLP);
+  RCC_OscInitStruct->PLL.PLLQ      = (regPLLCFGRvalue & RCC_PLLCFGR_PLLQ);
+  RCC_OscInitStruct->PLL.PLLR      = (regPLLCFGRvalue & RCC_PLLCFGR_PLLR);
+
+  /* Get Backup Domain register */
+  regvalue = RCC->BDCR;
+
+  /* Get the LSE configuration -----------------------------------------------*/
+  RCC_OscInitStruct->LSEState = (regvalue & RCC_LSE_BYPASS);
+
+  /* Get Control/Status register */
+  regvalue = RCC->CSR;
+
+  /* Get the LSI configuration -----------------------------------------------*/
+  RCC_OscInitStruct->LSIState = ((regvalue & RCC_LSI_ON) > 0U) ? RCC_LSI_ON : 0U;
+
+#if defined(RCC_HSI48_SUPPORT)
+  /* Get Control/Status register */
+  regvalue = RCC->CRRCR;
+
+  /* Get the HSI48 configuration ---------------------------------------------*/
+  RCC_OscInitStruct->HSI48State = (regvalue & RCC_CRRCR_HSI48ON);
+#endif /* RCC_HSI48_SUPPORT */
+
 }
 
 /**
@@ -1639,8 +1604,8 @@ void HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t *pF
   assert_param(pFLatency != (void *)NULL);
 
   /* Set all possible values for the Clock type parameter --------------------*/
-  RCC_ClkInitStruct->ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2 |  \
-                                  RCC_CLOCKTYPE_HCLK2 | RCC_CLOCKTYPE_HCLK4);
+  RCC_ClkInitStruct->ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 |
+                                  RCC_CLOCKTYPE_PCLK2 | RCC_CLOCKTYPE_HCLK2 | RCC_CLOCKTYPE_HCLK4);
 
   /* Get the SYSCLK configuration --------------------------------------------*/
   RCC_ClkInitStruct->SYSCLKSource = LL_RCC_GetSysClkSource();
@@ -1709,6 +1674,26 @@ __weak void HAL_RCC_CSSCallback(void)
 }
 
 /**
+  * @brief  Get and clear reset flags
+  * @param  None
+  * @note   Once reset flags are retrieved, this API is clearing them in order
+  *         to isolate next reset reason.
+  * @retval can be a combination of @ref RCC_Reset_Flag
+  */
+uint32_t HAL_RCC_GetResetSource(void)
+{
+  uint32_t reset;
+
+  /* Get all reset flags */
+  reset = RCC->CSR & RCC_RESET_FLAG_ALL;
+
+  /* Clear Reset flags */
+  RCC->CSR |= RCC_CSR_RMVF;
+
+  return reset;
+}
+
+/**
   * @}
   */
 
@@ -1721,7 +1706,6 @@ __weak void HAL_RCC_CSSCallback(void)
   * @{
   */
 
-
 /**
   * @brief  Update number of Flash wait states in line with MSI range and current
             voltage range.
@@ -1730,7 +1714,8 @@ __weak void HAL_RCC_CSSCallback(void)
   */
 static HAL_StatusTypeDef RCC_SetFlashLatencyFromMSIRange(uint32_t MSI_Range)
 {
-  uint32_t flash_clksrcfreq, msifreq;
+  uint32_t flash_clksrcfreq;
+  uint32_t msifreq;
 
   /* Check the parameters */
   assert_param(IS_RCC_MSI_CLOCK_RANGE(MSI_Range));
@@ -1751,7 +1736,7 @@ static HAL_StatusTypeDef RCC_SetFlashLatencyFromMSIRange(uint32_t MSI_Range)
   return RCC_SetFlashLatency((flash_clksrcfreq / MEGA_HZ), HAL_PWREx_GetVoltageRange());
 #else
   return RCC_SetFlashLatency((flash_clksrcfreq / MEGA_HZ), PWR_REGULATOR_VOLTAGE_SCALE1);
-#endif
+#endif /* PWR_CR1_VOS */
 }
 
 
@@ -1768,7 +1753,7 @@ static HAL_StatusTypeDef RCC_SetFlashLatency(uint32_t Flash_ClkSrcFreq, uint32_t
 #if defined(PWR_CR1_VOS)
   /* Flash Clock source (HCLK4) range in MHz with a VCORE is range2 */
   const uint32_t FLASH_CLK_SRC_RANGE_VOS2[] = {6UL, 12UL, 16UL};
-#endif
+#endif /* PWR_CR1_VOS */
   /* Flash Latency range */
   const uint32_t FLASH_LATENCY_RANGE[] = {FLASH_LATENCY_0, FLASH_LATENCY_1, FLASH_LATENCY_2, FLASH_LATENCY_3};
   uint32_t latency   = FLASH_LATENCY_0;  /* default value 0WS */
@@ -1806,7 +1791,7 @@ static HAL_StatusTypeDef RCC_SetFlashLatency(uint32_t Flash_ClkSrcFreq, uint32_t
       break;
     }
   }
-#endif
+#endif /* PWR_CR1_VOS */
 
   __HAL_FLASH_SET_LATENCY(latency);
 
@@ -1824,6 +1809,7 @@ static HAL_StatusTypeDef RCC_SetFlashLatency(uint32_t Flash_ClkSrcFreq, uint32_t
   }
   return HAL_OK;
 }
+
 /**
   * @}
   */
@@ -1836,5 +1822,3 @@ static HAL_StatusTypeDef RCC_SetFlashLatency(uint32_t Flash_ClkSrcFreq, uint32_t
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rcc_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rcc_ex.c
@@ -8,17 +8,15 @@
   *           + Extended Peripheral Control functions
   *           + Extended Clock management functions
   *           + Extended Clock Recovery System Control functions
-  *
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -40,14 +38,14 @@
 /* Private typedef -----------------------------------------------------------*/
 /* Private defines -----------------------------------------------------------*/
 /** @defgroup RCCEx_Private_Constants RCCEx Private Constants
- * @{
- */
+  * @{
+  */
 #if defined(SAI1)
 #define PLLSAI1_TIMEOUT_VALUE    (2U)    /* 2 ms (minimum Tick + 1) */
-#endif
+#endif /* SAI1 */
 #define PLL_TIMEOUT_VALUE        (2U)    /* 2 ms (minimum Tick + 1) */
 
-#define CLOCKSMPS_TIMEOUT_VALUE  (5000U) /* 5 s    */
+#define CLOCKSMPS_TIMEOUT_VALUE  (5000U) /* 5 s */
 
 #define __LSCO1_CLK_ENABLE()   __HAL_RCC_GPIOA_CLK_ENABLE()
 #define LSCO1_GPIO_PORT        GPIOA
@@ -61,9 +59,9 @@
 #define __LSCO3_CLK_ENABLE()   __HAL_RCC_GPIOC_CLK_ENABLE()
 #define LSCO3_GPIO_PORT        GPIOC
 #define LSCO3_PIN              GPIO_PIN_12
-#endif
+#endif /* RCC_LSCO3_SUPPORT */
 
-#define LSI2_TIMEOUT_VALUE         (3U)    /* to be adjusted with DS    */
+#define LSI2_TIMEOUT_VALUE         (3U)   /* to be adjusted with DS    */
 
 /**
   * @}
@@ -73,13 +71,13 @@
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /** @defgroup RCCEx_Private_Functions RCCEx Private Functions
- * @{
- */
+  * @{
+  */
 #if defined(SAI1)
 static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNP(RCC_PLLSAI1InitTypeDef *PLLSAI1);
 static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNQ(RCC_PLLSAI1InitTypeDef *PLLSAI1);
 static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNR(RCC_PLLSAI1InitTypeDef *PLLSAI1);
-#endif
+#endif /* SAI1 */
 
 static uint32_t          RCC_PLL_GetFreqDomain_P(void);
 static uint32_t          RCC_PLL_GetFreqDomain_Q(void);
@@ -88,7 +86,7 @@ static uint32_t          RCC_PLL_GetFreqDomain_Q(void);
 static uint32_t          RCC_PLLSAI1_GetFreqDomain_R(void);
 static uint32_t          RCC_PLLSAI1_GetFreqDomain_P(void);
 static uint32_t          RCC_PLLSAI1_GetFreqDomain_Q(void);
-#endif
+#endif /* SAI1 */
 
 /**
   * @}
@@ -101,8 +99,8 @@ static uint32_t          RCC_PLLSAI1_GetFreqDomain_Q(void);
   */
 
 /** @defgroup RCCEx_Exported_Functions_Group1 Extended Peripheral Control functions
- *  @brief  Extended Peripheral Control functions
- *
+  *  @brief  Extended Peripheral Control functions
+  *
 @verbatim
  ===============================================================================
                 ##### Extended Peripheral Control functions  #####
@@ -171,13 +169,11 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
         /* SAI1 clock source config set later after clock selection check */
         break;
 
-#if defined(SAI1)
       case RCC_SAI1CLKSOURCE_PLLSAI1: /* PLLSAI1 is used as clock source for SAI1 */
         /* PLLSAI1 parameters N & P configuration and clock output (PLLSAI1ClockOut) */
         ret = RCCEx_PLLSAI1_ConfigNP(&(PeriphClkInit->PLLSAI1));
         /* SAI1 clock source config set later after clock selection check */
         break;
-#endif
 
       case RCC_SAI1CLKSOURCE_PIN:      /* External clock is used as source of SAI1 clock*/
         /* SAI1 clock source config set later after clock selection check */
@@ -203,7 +199,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
       status = ret;
     }
   }
-#endif
+#endif /* SAI1 */
 
   /*-------------------------- RTC clock source configuration ----------------------*/
   if ((PeriphClkInit->PeriphClockSelection & RCC_PERIPHCLK_RTC) == RCC_PERIPHCLK_RTC)
@@ -289,7 +285,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* Configure the LPUAR1 clock source */
     __HAL_RCC_LPUART1_CONFIG(PeriphClkInit->Lpuart1ClockSelection);
   }
-#endif
+#endif /* LPUART1 */
 
   /*-------------------------- LPTIM1 clock source configuration -------------------*/
   if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_LPTIM1) == (RCC_PERIPHCLK_LPTIM1))
@@ -325,7 +321,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* Configure the I2C3 clock source */
     __HAL_RCC_I2C3_CONFIG(PeriphClkInit->I2c3ClockSelection);
   }
-#endif
+#endif /* I2C3 */
 
 #if defined(USB)
   /*-------------------------- USB clock source configuration ----------------------*/
@@ -340,20 +336,20 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
       __HAL_RCC_PLLCLKOUT_ENABLE(RCC_PLL_USBCLK);
     }
 #if defined(SAI1)
-  if (PeriphClkInit->UsbClockSelection == RCC_USBCLKSOURCE_PLLSAI1)
-  {
-    /* PLLSAI1 parameters N & Q configuration and clock output (PLLSAI1ClockOut) */
-    ret = RCCEx_PLLSAI1_ConfigNQ(&(PeriphClkInit->PLLSAI1));
-
-    if (ret != HAL_OK)
+    if (PeriphClkInit->UsbClockSelection == RCC_USBCLKSOURCE_PLLSAI1)
     {
-      /* set overall return value */
-      status = ret;
+      /* PLLSAI1 parameters N & Q configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNQ(&(PeriphClkInit->PLLSAI1));
+
+      if (ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
     }
+#endif /* SAI1 */
   }
-#endif
-  }
-#endif
+#endif /* USB */
 
   /*-------------------------- RNG clock source configuration ----------------------*/
   if (((PeriphClkInit->PeriphClockSelection) & RCC_PERIPHCLK_RNG) == (RCC_PERIPHCLK_RNG))
@@ -387,18 +383,18 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     }
 
 #if defined(SAI1)
-  if (PeriphClkInit->AdcClockSelection == RCC_ADCCLKSOURCE_PLLSAI1)
-  {
-    /* PLLSAI1 parameters N & R configuration and clock output (PLLSAI1ClockOut) */
-    ret = RCCEx_PLLSAI1_ConfigNR(&(PeriphClkInit->PLLSAI1));
-
-    if (ret != HAL_OK)
+    if (PeriphClkInit->AdcClockSelection == RCC_ADCCLKSOURCE_PLLSAI1)
     {
-      /* set overall return value */
-      status = ret;
+      /* PLLSAI1 parameters N & R configuration and clock output (PLLSAI1ClockOut) */
+      ret = RCCEx_PLLSAI1_ConfigNR(&(PeriphClkInit->PLLSAI1));
+
+      if (ret != HAL_OK)
+      {
+        /* set overall return value */
+        status = ret;
+      }
     }
-  }
-#endif
+#endif /* SAI1 */
   }
 
   /*-------------------------- RFWKP clock source configuration ----------------------*/
@@ -426,8 +422,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
     /* Configure the SMPS interface clock source */
     __HAL_RCC_SMPS_CONFIG(PeriphClkInit->SmpsClockSelection);
   }
-#endif
-
+#endif /* RCC_SMPS_SUPPORT */
 
   return status;
 }
@@ -451,23 +446,23 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
                                         RCC_PERIPHCLK_RTC    | RCC_PERIPHCLK_RFWAKEUP;
 #if defined(LPUART1)
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_LPUART1;
-#endif
+#endif /* LPUART1 */
 
 #if defined(I2C3)
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_I2C3;
-#endif
+#endif /* I2C3 */
 
 #if defined(SAI1)
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_SAI1;
-#endif
+#endif /* SAI1 */
 
 #if defined(USB)
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_USB;
-#endif
+#endif /* USB */
 
 #if defined(RCC_SMPS_SUPPORT)
   PeriphClkInit->PeriphClockSelection |= RCC_PERIPHCLK_SMPS;
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 
 #if defined(SAI1)
@@ -476,7 +471,7 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
   PeriphClkInit->PLLSAI1.PLLP = LL_RCC_PLLSAI1_GetP();
   PeriphClkInit->PLLSAI1.PLLR = LL_RCC_PLLSAI1_GetR();
   PeriphClkInit->PLLSAI1.PLLQ = LL_RCC_PLLSAI1_GetQ();
-#endif
+#endif /* SAI1 */
 
   /* Get the USART1 clock source ---------------------------------------------*/
   PeriphClkInit->Usart1ClockSelection   = __HAL_RCC_GET_USART1_SOURCE();
@@ -484,7 +479,7 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 #if defined(LPUART1)
   /* Get the LPUART1 clock source --------------------------------------------*/
   PeriphClkInit->Lpuart1ClockSelection  = __HAL_RCC_GET_LPUART1_SOURCE();
-#endif
+#endif /* LPUART1 */
 
   /* Get the I2C1 clock source -----------------------------------------------*/
   PeriphClkInit->I2c1ClockSelection     = __HAL_RCC_GET_I2C1_SOURCE();
@@ -492,7 +487,7 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 #if defined(I2C3)
   /* Get the I2C3 clock source -----------------------------------------------*/
   PeriphClkInit->I2c3ClockSelection     = __HAL_RCC_GET_I2C3_SOURCE();
-#endif
+#endif /* I2C3 */
 
   /* Get the LPTIM1 clock source ---------------------------------------------*/
   PeriphClkInit->Lptim1ClockSelection   = __HAL_RCC_GET_LPTIM1_SOURCE();
@@ -503,7 +498,7 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 #if defined(SAI1)
   /* Get the SAI1 clock source -----------------------------------------------*/
   PeriphClkInit->Sai1ClockSelection     = __HAL_RCC_GET_SAI1_SOURCE();
-#endif
+#endif /* SAI1 */
 
   /* Get the RTC clock source ------------------------------------------------*/
   PeriphClkInit->RTCClockSelection      = __HAL_RCC_GET_RTC_SOURCE();
@@ -511,7 +506,7 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 #if defined(USB)
   /* Get the USB clock source ------------------------------------------------*/
   PeriphClkInit->UsbClockSelection      = __HAL_RCC_GET_USB_SOURCE();
-#endif
+#endif /* USB */
 
   /* Get the RNG clock source ------------------------------------------------*/
   PeriphClkInit->RngClockSelection      = HAL_RCCEx_GetRngCLKSource();
@@ -528,7 +523,7 @@ void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 
   /* Get the SMPS clock source -----------------------------------------------*/
   PeriphClkInit->SmpsClockSelection     = __HAL_RCC_GET_SMPS_SOURCE();
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 }
 
@@ -558,7 +553,7 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
 
 #if defined(RCC_SMPS_SUPPORT)
   uint32_t smps_prescaler_index = ((LL_RCC_GetSMPSPrescaler()) >> RCC_SMPSCR_SMPSDIV_Pos);
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
   /* Check the parameters */
   assert_param(IS_RCC_PERIPHCLOCK(PeriphClk));
@@ -605,47 +600,45 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
   {
     switch (LL_RCC_GetSAIClockSource(LL_RCC_SAI1_CLKSOURCE))
     {
-    case LL_RCC_SAI1_CLKSOURCE_HSI:        /* HSI clock used as SAI1 clock source */
-      if (LL_RCC_HSI_IsReady() == 1U)
-      {
-        frequency = HSI_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_SAI1_CLKSOURCE_HSI:        /* HSI clock used as SAI1 clock source */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          frequency = HSI_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-#if defined(SAI1)
-    case LL_RCC_SAI1_CLKSOURCE_PLLSAI1:    /* PLLSAI1 clock used as SAI1 clock source */
-      if (LL_RCC_PLLSAI1_IsReady() == 1U)
-      {
-        frequency = RCC_PLLSAI1_GetFreqDomain_P();
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
-#endif
+      case LL_RCC_SAI1_CLKSOURCE_PLLSAI1:    /* PLLSAI1 clock used as SAI1 clock source */
+        if (LL_RCC_PLLSAI1_IsReady() == 1U)
+        {
+          frequency = RCC_PLLSAI1_GetFreqDomain_P();
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    case LL_RCC_SAI1_CLKSOURCE_PLL:        /* PLL clock used as SAI1 clock source */
-      if (LL_RCC_PLL_IsReady() == 1U)
-      {
-        frequency = RCC_PLL_GetFreqDomain_P();
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_SAI1_CLKSOURCE_PLL:        /* PLL clock used as SAI1 clock source */
+        if (LL_RCC_PLL_IsReady() == 1U)
+        {
+          frequency = RCC_PLL_GetFreqDomain_P();
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* External input clock used as SAI1 clock source */
-      frequency = EXTERNAL_SAI1_CLOCK_VALUE;
-      break;
+      default: /* External input clock used as SAI1 clock source */
+        frequency = EXTERNAL_SAI1_CLOCK_VALUE;
+        break;
     }
   }
-#endif
+#endif /* SAI1 */
   else if (PeriphClk == RCC_PERIPHCLK_RNG)
   {
     uint32_t rngClockSource = HAL_RCCEx_GetRngCLKSource();
@@ -696,6 +689,19 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
         /* Nothing to do as frequency already initialized to 0U */
       }
     }
+#if defined(SAI1)
+    else if (rngClockSource == RCC_RNGCLKSOURCE_PLLSAI1)    /* PLLSAI1 clock used as SAI1 clock source */
+    {
+      if (LL_RCC_PLLSAI1_IsReady() == 1U)
+      {
+        frequency = RCC_PLLSAI1_GetFreqDomain_Q();
+      }
+      else
+      {
+        /* Nothing to do as frequency already initialized to 0U */
+      }
+    }
+#endif /* SAI1 */
     else                                                    /* HSI48 clock divided by 3 used as RNG clock source */
     {
 #if defined(RCC_HSI48_SUPPORT)
@@ -709,7 +715,7 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
       }
 #else
       /* Nothing to do as frequency already initialized to 0U */
-#endif
+#endif /* RCC_HSI48_SUPPORT */
     }
   }
 #if defined(USB)
@@ -718,87 +724,88 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
     switch (LL_RCC_GetUSBClockSource(LL_RCC_USB_CLKSOURCE))
     {
 #if defined(SAI1)
-    case LL_RCC_USB_CLKSOURCE_PLLSAI1:       /* PLLSAI1 clock used as USB clock source */
-      if (LL_RCC_PLLSAI1_IsReady() == 1U)
-      {
-        frequency = RCC_PLLSAI1_GetFreqDomain_Q();
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
-#endif
+      case LL_RCC_USB_CLKSOURCE_PLLSAI1:       /* PLLSAI1 clock used as USB clock source */
+        if (LL_RCC_PLLSAI1_IsReady() == 1U)
+        {
+          frequency = RCC_PLLSAI1_GetFreqDomain_Q();
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* SAI1 */
 
-    case LL_RCC_USB_CLKSOURCE_PLL:           /* PLL clock used as USB clock source */
-      if (LL_RCC_PLL_IsReady() == 1U)
-      {
-        frequency = RCC_PLL_GetFreqDomain_Q();
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_USB_CLKSOURCE_PLL:           /* PLL clock used as USB clock source */
+        if (LL_RCC_PLL_IsReady() == 1U)
+        {
+          frequency = RCC_PLL_GetFreqDomain_Q();
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    case LL_RCC_USB_CLKSOURCE_MSI:           /* MSI clock used as USB clock source */
-      if (LL_RCC_MSI_IsReady() == 1U)
-      {
-        frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSI_GetRange());
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_USB_CLKSOURCE_MSI:           /* MSI clock used as USB clock source */
+        if (LL_RCC_MSI_IsReady() == 1U)
+        {
+          frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSI_GetRange());
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* HSI48 clock used as USB clock source */
-      if (LL_RCC_HSI48_IsReady() == 1U)
-      {
-        frequency = HSI48_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      default: /* HSI48 clock used as USB clock source */
+        if (LL_RCC_HSI48_IsReady() == 1U)
+        {
+          frequency = HSI48_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
     }
   }
-#endif
+#endif /* USB */
   else if (PeriphClk == RCC_PERIPHCLK_USART1)
   {
     switch (LL_RCC_GetUSARTClockSource(LL_RCC_USART1_CLKSOURCE))
     {
-    case LL_RCC_USART1_CLKSOURCE_SYSCLK: /* USART1 Clock is System Clock */
-      frequency = HAL_RCC_GetSysClockFreq();
-      break;
+      case LL_RCC_USART1_CLKSOURCE_SYSCLK: /* USART1 Clock is System Clock */
+        frequency = HAL_RCC_GetSysClockFreq();
+        break;
 
-    case LL_RCC_USART1_CLKSOURCE_HSI:    /* USART1 Clock is HSI Osc. */
-      if (LL_RCC_HSI_IsReady() == 1U)
-      {
-        frequency = HSI_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_USART1_CLKSOURCE_HSI:    /* USART1 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          frequency = HSI_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    case LL_RCC_USART1_CLKSOURCE_LSE:    /* USART1 Clock is LSE Osc. */
-      if (LL_RCC_LSE_IsReady() == 1U)
-      {
-        frequency = LSE_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_USART1_CLKSOURCE_LSE:    /* USART1 Clock is LSE Osc. */
+        if (LL_RCC_LSE_IsReady() == 1U)
+        {
+          frequency = LSE_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* USART1 Clock is PCLK2 */
-      frequency = __LL_RCC_CALC_PCLK2_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(), \
-        LL_RCC_GetAHBPrescaler()), LL_RCC_GetAPB2Prescaler());
-      break;
+      default: /* USART1 Clock is PCLK2 */
+        frequency = __LL_RCC_CALC_PCLK2_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(),
+                                                                      LL_RCC_GetAHBPrescaler()),
+                                             LL_RCC_GetAPB2Prescaler());
+        break;
     }
   }
 #if defined(LPUART1)
@@ -806,96 +813,109 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
   {
     switch (LL_RCC_GetLPUARTClockSource(LL_RCC_LPUART1_CLKSOURCE))
     {
-    case LL_RCC_LPUART1_CLKSOURCE_SYSCLK: /* LPUART1 Clock is System Clock */
-      frequency = HAL_RCC_GetSysClockFreq();
-      break;
+      case LL_RCC_LPUART1_CLKSOURCE_SYSCLK: /* LPUART1 Clock is System Clock */
+        frequency = HAL_RCC_GetSysClockFreq();
+        break;
 
-    case LL_RCC_LPUART1_CLKSOURCE_HSI:    /* LPUART1 Clock is HSI Osc. */
-      if (LL_RCC_HSI_IsReady() == 1U)
-      {
-        frequency = HSI_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_LPUART1_CLKSOURCE_HSI:    /* LPUART1 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          frequency = HSI_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    case LL_RCC_LPUART1_CLKSOURCE_LSE:    /* LPUART1 Clock is LSE Osc. */
-      if (LL_RCC_LSE_IsReady() == 1U)
-      {
-        frequency = LSE_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_LPUART1_CLKSOURCE_LSE:    /* LPUART1 Clock is LSE Osc. */
+        if (LL_RCC_LSE_IsReady() == 1U)
+        {
+          frequency = LSE_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* LPUART1 Clock is PCLK1 */
-      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(), \
-        LL_RCC_GetAHBPrescaler()), LL_RCC_GetAPB1Prescaler());
-      break;
+      default: /* LPUART1 Clock is PCLK1 */
+        frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(),
+                                                                      LL_RCC_GetAHBPrescaler()),
+                                             LL_RCC_GetAPB1Prescaler());
+        break;
     }
   }
-#endif
+#endif /* LPUART1 */
   else if (PeriphClk == RCC_PERIPHCLK_ADC)
   {
     switch (LL_RCC_GetADCClockSource(LL_RCC_ADC_CLKSOURCE))
     {
 #if defined(STM32WB55xx) || defined (STM32WB5Mxx) || defined(STM32WB35xx)
-    case LL_RCC_ADC_CLKSOURCE_PLLSAI1:       /* PLLSAI1 clock used as ADC clock source */
-      if (LL_RCC_PLLSAI1_IsReady() == 1U)
-      {
-        frequency = RCC_PLLSAI1_GetFreqDomain_R();
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
-#endif
-    case LL_RCC_ADC_CLKSOURCE_SYSCLK:        /* SYSCLK clock used as ADC clock source */
-      frequency = HAL_RCC_GetSysClockFreq();
-      break;
-    case LL_RCC_ADC_CLKSOURCE_PLL:           /* PLL clock used as ADC clock source */
-      if (LL_RCC_PLL_IsReady() == 1U)
-      {
-        frequency = RCC_PLL_GetFreqDomain_P();
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_ADC_CLKSOURCE_PLLSAI1:       /* PLLSAI1 clock used as ADC clock source */
+        if (LL_RCC_PLLSAI1_IsReady() == 1U)
+        {
+          frequency = RCC_PLLSAI1_GetFreqDomain_R();
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#elif defined(STM32WB15xx) || defined(STM32WB1Mxx)
+      case LL_RCC_ADC_CLKSOURCE_HSI:           /* HSI clock used as ADC clock source */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          frequency = HSI_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
+#endif /* STM32WB55xx || STM32WB5Mxx || STM32WB35xx */
+      case LL_RCC_ADC_CLKSOURCE_SYSCLK:        /* SYSCLK clock used as ADC clock source */
+        frequency = HAL_RCC_GetSysClockFreq();
+        break;
+      case LL_RCC_ADC_CLKSOURCE_PLL:           /* PLL clock used as ADC clock source */
+        if (LL_RCC_PLL_IsReady() == 1U)
+        {
+          frequency = RCC_PLL_GetFreqDomain_P();
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* No clock used as ADC clock source */
-      break;
+      default: /* No clock used as ADC clock source */
+        break;
     }
   }
   else if (PeriphClk == RCC_PERIPHCLK_I2C1)
   {
     switch (LL_RCC_GetI2CClockSource(LL_RCC_I2C1_CLKSOURCE))
     {
-    case LL_RCC_I2C1_CLKSOURCE_SYSCLK: /* I2C1 Clock is System Clock */
-      frequency = HAL_RCC_GetSysClockFreq();
-      break;
+      case LL_RCC_I2C1_CLKSOURCE_SYSCLK: /* I2C1 Clock is System Clock */
+        frequency = HAL_RCC_GetSysClockFreq();
+        break;
 
-    case LL_RCC_I2C1_CLKSOURCE_HSI:    /* I2C1 Clock is HSI Osc. */
-      if (LL_RCC_HSI_IsReady() == 1U)
-      {
-        frequency = HSI_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_I2C1_CLKSOURCE_HSI:    /* I2C1 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          frequency = HSI_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* I2C1 Clock is PCLK1 */
-      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(), \
-        LL_RCC_GetAHBPrescaler()), LL_RCC_GetAPB1Prescaler());
-      break;
+      default: /* I2C1 Clock is PCLK1 */
+        frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(),
+                                                                      LL_RCC_GetAHBPrescaler()),
+                                             LL_RCC_GetAPB1Prescaler());
+        break;
     }
   }
 #if defined(I2C3)
@@ -903,28 +923,29 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
   {
     switch (LL_RCC_GetI2CClockSource(LL_RCC_I2C3_CLKSOURCE))
     {
-    case LL_RCC_I2C3_CLKSOURCE_SYSCLK: /* I2C3 Clock is System Clock */
-      frequency = HAL_RCC_GetSysClockFreq();
-      break;
+      case LL_RCC_I2C3_CLKSOURCE_SYSCLK: /* I2C3 Clock is System Clock */
+        frequency = HAL_RCC_GetSysClockFreq();
+        break;
 
-    case LL_RCC_I2C3_CLKSOURCE_HSI: /* I2C3 Clock is HSI Osc. */
-      if (LL_RCC_HSI_IsReady() == 1U)
-      {
-        frequency = HSI_VALUE;
-      }
-      else
-      {
-        /* Nothing to do as frequency already initialized to 0U */
-      }
-      break;
+      case LL_RCC_I2C3_CLKSOURCE_HSI: /* I2C3 Clock is HSI Osc. */
+        if (LL_RCC_HSI_IsReady() == 1U)
+        {
+          frequency = HSI_VALUE;
+        }
+        else
+        {
+          /* Nothing to do as frequency already initialized to 0U */
+        }
+        break;
 
-    default: /* I2C3 Clock is PCLK1 */
-      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(), \
-        LL_RCC_GetAHBPrescaler()), LL_RCC_GetAPB1Prescaler());
-      break;
+      default: /* I2C3 Clock is PCLK1 */
+        frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(),
+                                                                      LL_RCC_GetAHBPrescaler()),
+                                             LL_RCC_GetAPB1Prescaler());
+        break;
     }
   }
-#endif
+#endif /* I2C3 */
   else if (PeriphClk == RCC_PERIPHCLK_LPTIM1)
   {
     uint32_t lptimClockSource = LL_RCC_GetLPTIMClockSource(LL_RCC_LPTIM1_CLKSOURCE);
@@ -966,7 +987,9 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
     }
     else /* LPTIM1 Clock is PCLK1 */
     {
-      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(), LL_RCC_GetAHBPrescaler()), LL_RCC_GetAPB1Prescaler());
+      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(),
+                                                                    LL_RCC_GetAHBPrescaler()),
+                                           LL_RCC_GetAPB1Prescaler());
     }
   }
   else if (PeriphClk == RCC_PERIPHCLK_LPTIM2)
@@ -1010,7 +1033,9 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
     }
     else /* LPTIM2 Clock is PCLK1 */
     {
-      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(), LL_RCC_GetAHBPrescaler()), LL_RCC_GetAPB1Prescaler());
+      frequency = __LL_RCC_CALC_PCLK1_FREQ(__LL_RCC_CALC_HCLK1_FREQ(HAL_RCC_GetSysClockFreq(),
+                                                                    LL_RCC_GetAHBPrescaler()),
+                                           LL_RCC_GetAPB1Prescaler());
     }
   }
   else if (PeriphClk == RCC_PERIPHCLK_RFWAKEUP)
@@ -1070,20 +1095,20 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
     {
       switch (LL_RCC_MSI_GetRange())
       {
-      case LL_RCC_MSIRANGE_8:
-        frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_8) / SmpsPrescalerTable[smps_prescaler_index][4];
-        break;
-      case LL_RCC_MSIRANGE_9:
-        frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_9) / SmpsPrescalerTable[smps_prescaler_index][3];
-        break;
-      case LL_RCC_MSIRANGE_10:
-        frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_10) / SmpsPrescalerTable[smps_prescaler_index][2];
-        break;
-      case LL_RCC_MSIRANGE_11:
-        frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_11) / SmpsPrescalerTable[smps_prescaler_index][1];
-        break;
-      default:
-        break;
+        case LL_RCC_MSIRANGE_8:
+          frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_8) / SmpsPrescalerTable[smps_prescaler_index][4];
+          break;
+        case LL_RCC_MSIRANGE_9:
+          frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_9) / SmpsPrescalerTable[smps_prescaler_index][3];
+          break;
+        case LL_RCC_MSIRANGE_10:
+          frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_10) / SmpsPrescalerTable[smps_prescaler_index][2];
+          break;
+        case LL_RCC_MSIRANGE_11:
+          frequency = __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGE_11) / SmpsPrescalerTable[smps_prescaler_index][1];
+          break;
+        default:
+          break;
       }
       frequency = frequency >> 1U; /* Systematic Div by 2 */
     }
@@ -1092,7 +1117,8 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
       /* Nothing to do as frequency already initialized to 0U */
     }
   }
-#endif
+#endif /* RCC_SMPS_SUPPORT */
+
   return (frequency);
 }
 
@@ -1100,10 +1126,14 @@ uint32_t HAL_RCCEx_GetPeriphCLKFreq(uint32_t PeriphClk)
   * @brief  Return the RNG clock source
   * @retval The RNG clock source can be one of the following values:
   *            @arg @ref RCC_RNGCLKSOURCE_HSI48 HSI48 clock divided by 3 selected as RNG clock
-  *            @arg @ref RCC_RNGCLKSOURCE_PLL   PLL "Q" clock divided by 3  selected as RNG clock
-  *            @arg @ref RCC_RNGCLKSOURCE_MSI   MSI clock divided by 3 selected as RNG clock
-  *            @arg @ref RCC_RNGCLKSOURCE_LSI   LSI clock selected as RNG clock
-  *            @arg @ref RCC_RNGCLKSOURCE_LSE   LSE clock selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLL      PLL "Q" clock divided by 3  selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_MSI      MSI clock divided by 3 selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_PLLSAI1  PLLSAI1 "Q" clock selected as RNG clock (*)
+  *            @arg @ref RCC_RNGCLKSOURCE_LSI      LSI clock selected as RNG clock
+  *            @arg @ref RCC_RNGCLKSOURCE_LSE      LSE clock selected as RNG clock
+  *
+  *         (*) Value not defined in all devices.
+  *
   */
 uint32_t HAL_RCCEx_GetRngCLKSource(void)
 {
@@ -1125,8 +1155,8 @@ uint32_t HAL_RCCEx_GetRngCLKSource(void)
   */
 
 /** @defgroup RCCEx_Exported_Functions_Group2 Extended Clock management functions
- *  @brief  Extended Clock management functions
- *
+  * @brief  Extended Clock management functions
+  *
 @verbatim
  ===============================================================================
                 ##### Extended clock management functions  #####
@@ -1232,7 +1262,7 @@ HAL_StatusTypeDef HAL_RCCEx_DisablePLLSAI1(void)
 
   return status;
 }
-#endif
+#endif /* SAI1 */
 
 /***********************************************************************************************/
 
@@ -1294,8 +1324,6 @@ void HAL_RCCEx_EnableLSECSS_IT(void)
   /* Enable IT on EXTI Line 18 */
   __HAL_RCC_LSECSS_EXTI_ENABLE_IT();
   __HAL_RCC_LSECSS_EXTI_ENABLE_RISING_EDGE();
-
-
 }
 
 /**
@@ -1359,17 +1387,16 @@ void HAL_RCCEx_LSCOConfig(uint32_t RCC_LSCOx, uint32_t RCC_LSCOSource)
   {
     /* LSCO1 Clock Enable */
     __LSCO1_CLK_ENABLE();
-    /* Configue the LSCO1 pin in alternate function mode */
+    /* Configure the LSCO1 pin in alternate function mode */
     GPIO_InitStruct.Pin       = LSCO1_PIN;
     GPIO_InitStruct.Alternate = GPIO_AF0_LSCO;
     HAL_GPIO_Init(LSCO1_GPIO_PORT, &GPIO_InitStruct);
-
   }
   else if (RCC_LSCOx == RCC_LSCO2)
   {
     /* LSCO2 Clock Enable */
     __LSCO2_CLK_ENABLE();
-    /* Configue the LSCO2 pin in alternate function mode */
+    /* Configure the LSCO2 pin in alternate function mode */
     GPIO_InitStruct.Pin       = LSCO2_PIN;
     GPIO_InitStruct.Alternate = GPIO_AF0_LSCO;
     HAL_GPIO_Init(LSCO2_GPIO_PORT, &GPIO_InitStruct);
@@ -1380,12 +1407,12 @@ void HAL_RCCEx_LSCOConfig(uint32_t RCC_LSCOx, uint32_t RCC_LSCOSource)
   {
     /* LSCO3 Clock Enable */
     __LSCO3_CLK_ENABLE();
-    /* Configue the LSCO3 pin in alternate function mode */
+    /* Configure the LSCO3 pin in alternate function mode */
     GPIO_InitStruct.Pin       = LSCO3_PIN;
     GPIO_InitStruct.Alternate = GPIO_AF6_LSCO;
     HAL_GPIO_Init(LSCO3_GPIO_PORT, &GPIO_InitStruct);
   }
-#endif
+#endif /* RCC_LSCO3_SUPPORT */
   else
   {
     ;
@@ -1411,8 +1438,6 @@ void HAL_RCCEx_LSCOConfig(uint32_t RCC_LSCOx, uint32_t RCC_LSCOSource)
 
 }
 
-
-
 /**
   * @brief  Select the Low Speed clock source to output on LSCO pin (PA2).
   * @param  LSCOSource  specifies the Low Speed clock source to output.
@@ -1423,40 +1448,11 @@ void HAL_RCCEx_LSCOConfig(uint32_t RCC_LSCOx, uint32_t RCC_LSCOSource)
   */
 void HAL_RCCEx_EnableLSCO(uint32_t LSCOSource)
 {
-  GPIO_InitTypeDef GPIO_InitStruct;
-  FlagStatus backupchanged;
-
   /* Check the parameters */
   assert_param(IS_RCC_LSCOSOURCE(LSCOSource));
 
-  /* LSCO Pin Clock Enable */
-  __LSCO1_CLK_ENABLE();
-
-  /* Configure the LSCO pin in analog mode */
-  GPIO_InitStruct.Pin   = LSCO1_PIN;
-  GPIO_InitStruct.Mode  = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Pull  = GPIO_NOPULL;
-  GPIO_InitStruct.Alternate = GPIO_AF0_LSCO;
-  HAL_GPIO_Init(LSCO1_GPIO_PORT, &GPIO_InitStruct);
-
-  /* Update LSCOSEL clock source in Backup Domain control register */
-  if (HAL_IS_BIT_CLR(PWR->CR1, PWR_CR1_DBP))
-  {
-    HAL_PWR_EnableBkUpAccess();
-    backupchanged = SET;
-  }
-  else
-  {
-    backupchanged = RESET;
-  }
-
-  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSCOSEL | RCC_BDCR_LSCOEN, LSCOSource | RCC_BDCR_LSCOEN);
-
-  if (backupchanged == SET)
-  {
-    HAL_PWR_DisableBkUpAccess();
-  }
+  /* Update LSCO selection according to parameter and enable LSCO */
+  MODIFY_REG(RCC->BDCR, RCC_BDCR_LSCOSEL, LSCOSource | RCC_BDCR_LSCOEN);
 }
 
 /**
@@ -1465,27 +1461,7 @@ void HAL_RCCEx_EnableLSCO(uint32_t LSCOSource)
   */
 void HAL_RCCEx_DisableLSCO(void)
 {
-  FlagStatus backupchanged;
-
-  if (HAL_IS_BIT_CLR(PWR->CR1, PWR_CR1_DBP))
-  {
-    /* Enable access to the backup domain */
-    HAL_PWR_EnableBkUpAccess();
-    backupchanged = SET;
-  }
-  else
-  {
-    backupchanged = RESET;
-  }
-
   LL_RCC_LSCO_Disable();
-
-  /* Restore previous configuration */
-  if (backupchanged == SET)
-  {
-    /* Disable access to the backup domain */
-    HAL_PWR_DisableBkUpAccess();
-  }
 }
 
 /**
@@ -1547,21 +1523,20 @@ HAL_StatusTypeDef HAL_RCCEx_TrimOsc(uint32_t OscillatorType)
   return status;
 }
 
-
 /**
   * @}
   */
 
 #if defined(CRS)
 /** @defgroup RCCEx_Exported_Functions_Group3 Extended Clock Recovery System Control functions
- *  @brief  Extended Clock Recovery System Control functions
- *
+  *  @brief  Extended Clock Recovery System Control functions
+  *
 @verbatim
  ===============================================================================
                 ##### Extended Clock Recovery System Control functions  #####
  ===============================================================================
     [..]
-      For devices with Clock Recovery System feature (CRS), RCC Extention HAL driver can be used as follows:
+      For devices with Clock Recovery System feature (CRS), RCC Extended HAL driver can be used as follows:
 
       (#) In System clock config, HSI48 needs to be enabled
 
@@ -1572,7 +1547,7 @@ HAL_StatusTypeDef HAL_RCCEx_TrimOsc(uint32_t OscillatorType)
               (+++) Default values can be set for frequency Error Measurement (reload and error limit)
                         and also HSI48 oscillator smooth trimming.
               (+++) Macro __HAL_RCC_CRS_RELOADVALUE_CALCULATE can be also used to calculate
-                        directly reload value with target and sychronization frequencies values
+                        directly reload value with target and synchronization frequencies values
           (##) Call function HAL_RCCEx_CRSConfig which
               (+++) Resets CRS registers to their default values.
               (+++) Configures CRS registers with synchronization configuration
@@ -1614,8 +1589,8 @@ HAL_StatusTypeDef HAL_RCCEx_TrimOsc(uint32_t OscillatorType)
           This function can be called before calling HAL_RCCEx_CRSConfig (for instance in Systick handler)
 
 @endverbatim
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  Start automatic synchronization for polling mode
@@ -1693,20 +1668,20 @@ void HAL_RCCEx_CRSGetSynchronizationInfo(RCC_CRSSynchroInfoTypeDef *pSynchroInfo
 }
 
 /**
-* @brief  Wait for CRS Synchronization status.
-* @param  Timeout  Duration of the timeout
-* @note   Timeout is based on the maximum time to receive a SYNC event based on synchronization
-*         frequency.
-* @note   If Timeout set to HAL_MAX_DELAY, HAL_TIMEOUT will be never returned.
-* @retval Combination of Synchronization status
-*          This parameter can be a combination of the following values:
-*            @arg @ref RCC_CRS_TIMEOUT
-*            @arg @ref RCC_CRS_SYNCOK
-*            @arg @ref RCC_CRS_SYNCWARN
-*            @arg @ref RCC_CRS_SYNCERR
-*            @arg @ref RCC_CRS_SYNCMISS
-*            @arg @ref RCC_CRS_TRIMOVF
-*/
+  * @brief  Wait for CRS Synchronization status.
+  * @param  Timeout  Duration of the timeout
+  * @note   Timeout is based on the maximum time to receive a SYNC event based on synchronization
+  *         frequency.
+  * @note   If Timeout set to HAL_MAX_DELAY, HAL_TIMEOUT will be never returned.
+  * @retval Combination of Synchronization status
+  *          This parameter can be a combination of the following values:
+  *            @arg @ref RCC_CRS_TIMEOUT
+  *            @arg @ref RCC_CRS_SYNCOK
+  *            @arg @ref RCC_CRS_SYNCWARN
+  *            @arg @ref RCC_CRS_SYNCERR
+  *            @arg @ref RCC_CRS_SYNCMISS
+  *            @arg @ref RCC_CRS_TRIMOVF
+  */
 uint32_t HAL_RCCEx_CRSWaitSynchronization(uint32_t Timeout)
 {
   uint32_t crsstatus = RCC_CRS_NONE;
@@ -1781,8 +1756,7 @@ uint32_t HAL_RCCEx_CRSWaitSynchronization(uint32_t Timeout)
       /* frequency error counter reached a zero value */
       __HAL_RCC_CRS_CLEAR_FLAG(RCC_CRS_FLAG_ESYNC);
     }
-  }
-  while (RCC_CRS_NONE == crsstatus);
+  } while (RCC_CRS_NONE == crsstatus);
 
   return crsstatus;
 }
@@ -1907,15 +1881,15 @@ __weak void HAL_RCCEx_CRS_ErrorCallback(uint32_t Error)
 /**
   * @}
   */
-#endif
+#endif /* CRS */
 
 /**
   * @}
   */
 
 /** @addtogroup RCCEx_Private_Functions
- * @{
- */
+  * @{
+  */
 
 #if defined(SAI1)
 /**
@@ -2122,7 +2096,7 @@ static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNR(RCC_PLLSAI1InitTypeDef *PLLSAI1)
 
   return status;
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Return PLL clock (PLLPCLK) frequency used for SAI domain
@@ -2130,7 +2104,8 @@ static HAL_StatusTypeDef RCCEx_PLLSAI1_ConfigNR(RCC_PLLSAI1InitTypeDef *PLLSAI1)
   */
 static uint32_t RCC_PLL_GetFreqDomain_P(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI Value / PLLM) * PLLN
      SAI Domain clock = PLL_VCO / PLLP
@@ -2166,14 +2141,14 @@ static uint32_t RCC_PLL_GetFreqDomain_P(void)
                                        LL_RCC_PLL_GetN(), LL_RCC_PLL_GetP());
 }
 
-
 /**
   * @brief  Return PLL clock (PLLQCLK) frequency used for 48 MHz domain
   * @retval PLLQCLK clock frequency (in Hz)
   */
 static uint32_t RCC_PLL_GetFreqDomain_Q(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLN
      48M Domain clock = PLL_VCO / PLLQ
@@ -2217,7 +2192,8 @@ static uint32_t RCC_PLL_GetFreqDomain_Q(void)
   */
 static uint32_t RCC_PLLSAI1_GetFreqDomain_R(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLLSAI1_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLSAI1N */
   /* 48M Domain clock  = PLLSAI1_VCO / PLLSAI1R */
@@ -2258,7 +2234,8 @@ static uint32_t RCC_PLLSAI1_GetFreqDomain_R(void)
   */
 static uint32_t RCC_PLLSAI1_GetFreqDomain_P(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLLSAI1_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLSAI1N */
   /* SAI Domain clock  = PLLSAI1_VCO / PLLSAI1P */
@@ -2299,7 +2276,8 @@ static uint32_t RCC_PLLSAI1_GetFreqDomain_P(void)
   */
 static uint32_t RCC_PLLSAI1_GetFreqDomain_Q(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLLSAI1_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLSAI1N */
   /* 48M Domain clock  = PLLSAI1_VCO / PLLSAI1Q */
@@ -2333,19 +2311,18 @@ static uint32_t RCC_PLLSAI1_GetFreqDomain_Q(void)
   return __LL_RCC_CALC_PLLSAI1_48M_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(),
                                         LL_RCC_PLLSAI1_GetN(), LL_RCC_PLLSAI1_GetQ());
 }
-#endif
+#endif /* SAI1 */
+
 /**
   * @}
   */
 
 #endif /* HAL_RCC_MODULE_ENABLED */
-/**
-  * @}
-  */
 
 /**
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-
+/**
+  * @}
+  */

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rng.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rng.c
@@ -9,6 +9,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                      ##### How to use this driver #####
@@ -31,8 +42,8 @@
     allows the user to configure dynamically the driver callbacks.
 
     [..]
-    Use Function @ref HAL_RNG_RegisterCallback() to register a user callback.
-    Function @ref HAL_RNG_RegisterCallback() allows to register following callbacks:
+    Use Function HAL_RNG_RegisterCallback() to register a user callback.
+    Function HAL_RNG_RegisterCallback() allows to register following callbacks:
     (+) ErrorCallback             : RNG Error Callback.
     (+) MspInitCallback           : RNG MspInit.
     (+) MspDeInitCallback         : RNG MspDeInit.
@@ -40,9 +51,9 @@
     and a pointer to the user callback function.
 
     [..]
-    Use function @ref HAL_RNG_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
-    @ref HAL_RNG_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+    Use function HAL_RNG_UnRegisterCallback() to reset a callback to the default
+    weak (overridden) function.
+    HAL_RNG_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the Callback ID.
     This function allows to reset following callbacks:
     (+) ErrorCallback             : RNG Error Callback.
@@ -51,16 +62,16 @@
 
     [..]
     For specific callback ReadyDataCallback, use dedicated register callbacks:
-    respectively @ref HAL_RNG_RegisterReadyDataCallback() , @ref HAL_RNG_UnRegisterReadyDataCallback().
+    respectively HAL_RNG_RegisterReadyDataCallback() , HAL_RNG_UnRegisterReadyDataCallback().
 
     [..]
-    By default, after the @ref HAL_RNG_Init() and when the state is HAL_RNG_STATE_RESET
-    all callbacks are set to the corresponding weak (surcharged) functions:
-    example @ref HAL_RNG_ErrorCallback().
+    By default, after the HAL_RNG_Init() and when the state is HAL_RNG_STATE_RESET
+    all callbacks are set to the corresponding weak (overridden) functions:
+    example HAL_RNG_ErrorCallback().
     Exception done for MspInit and MspDeInit functions that are respectively
-    reset to the legacy weak (surcharged) functions in the @ref HAL_RNG_Init()
-    and @ref HAL_RNG_DeInit() only when these callbacks are null (not registered beforehand).
-    If not, MspInit or MspDeInit are not null, the @ref HAL_RNG_Init() and @ref HAL_RNG_DeInit()
+    reset to the legacy weak (overridden) functions in the HAL_RNG_Init()
+    and HAL_RNG_DeInit() only when these callbacks are null (not registered beforehand).
+    If not, MspInit or MspDeInit are not null, the HAL_RNG_Init() and HAL_RNG_DeInit()
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
 
     [..]
@@ -69,26 +80,15 @@
     in HAL_RNG_STATE_READY or HAL_RNG_STATE_RESET state, thus registered (user)
     MspInit/DeInit callbacks can be used during the Init/DeInit.
     In that case first register the MspInit/MspDeInit user callbacks
-    using @ref HAL_RNG_RegisterCallback() before calling @ref HAL_RNG_DeInit()
-    or @ref HAL_RNG_Init() function.
+    using HAL_RNG_RegisterCallback() before calling HAL_RNG_DeInit()
+    or HAL_RNG_Init() function.
 
     [..]
     When The compilation define USE_HAL_RNG_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registration feature is not available
-    and weak (surcharged) callbacks are used.
+    and weak (overridden) callbacks are used.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -129,8 +129,8 @@
   */
 
 /** @addtogroup RNG_Exported_Functions_Group1
- *  @brief   Initialization and configuration functions
- *
+  *  @brief   Initialization and configuration functions
+  *
 @verbatim
  ===============================================================================
           ##### Initialization and configuration functions #####
@@ -301,7 +301,8 @@ __weak void HAL_RNG_MspDeInit(RNG_HandleTypeDef *hrng)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RNG_RegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_CallbackIDTypeDef CallbackID, pRNG_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_RNG_RegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_CallbackIDTypeDef CallbackID,
+                                           pRNG_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -311,8 +312,6 @@ HAL_StatusTypeDef HAL_RNG_RegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_Call
     hrng->ErrorCode = HAL_RNG_ERROR_INVALID_CALLBACK;
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hrng);
 
   if (HAL_RNG_STATE_READY == hrng->State)
   {
@@ -366,14 +365,12 @@ HAL_StatusTypeDef HAL_RNG_RegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_Call
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hrng);
   return status;
 }
 
 /**
   * @brief  Unregister an RNG Callback
-  *         RNG callabck is redirected to the weak predefined callback
+  *         RNG callback is redirected to the weak predefined callback
   * @param  hrng RNG handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
@@ -386,8 +383,6 @@ HAL_StatusTypeDef HAL_RNG_UnRegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_Ca
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(hrng);
 
   if (HAL_RNG_STATE_READY == hrng->State)
   {
@@ -441,8 +436,6 @@ HAL_StatusTypeDef HAL_RNG_UnRegisterCallback(RNG_HandleTypeDef *hrng, HAL_RNG_Ca
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hrng);
   return status;
 }
 
@@ -520,8 +513,8 @@ HAL_StatusTypeDef HAL_RNG_UnRegisterReadyDataCallback(RNG_HandleTypeDef *hrng)
   */
 
 /** @addtogroup RNG_Exported_Functions_Group2
- *  @brief   Peripheral Control functions
- *
+  *  @brief   Peripheral Control functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral Control functions #####
@@ -575,11 +568,15 @@ HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber(RNG_HandleTypeDef *hrng, uint32_t
     {
       if ((HAL_GetTick() - tickstart) > RNG_TIMEOUT_VALUE)
       {
-        hrng->State = HAL_RNG_STATE_READY;
-        hrng->ErrorCode = HAL_RNG_ERROR_TIMEOUT;
-        /* Process Unlocked */
-        __HAL_UNLOCK(hrng);
-        return HAL_ERROR;
+        /* New check to avoid false timeout detection in case of preemption */
+        if (__HAL_RNG_GET_FLAG(hrng, RNG_FLAG_DRDY) == RESET)
+        {
+          hrng->State = HAL_RNG_STATE_READY;
+          hrng->ErrorCode = HAL_RNG_ERROR_TIMEOUT;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hrng);
+          return HAL_ERROR;
+        }
       }
     }
 
@@ -659,15 +656,16 @@ HAL_StatusTypeDef HAL_RNG_GenerateRandomNumber_IT(RNG_HandleTypeDef *hrng)
 void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
 {
   uint32_t rngclockerror = 0U;
+  uint32_t itflag   = hrng->Instance->SR;
 
   /* RNG clock error interrupt occurred */
-  if (__HAL_RNG_GET_IT(hrng, RNG_IT_CEI) != RESET)
+  if ((itflag & RNG_IT_CEI) == RNG_IT_CEI)
   {
     /* Update the error code */
     hrng->ErrorCode = HAL_RNG_ERROR_CLOCK;
     rngclockerror = 1U;
   }
-  else if (__HAL_RNG_GET_IT(hrng, RNG_IT_SEI) != RESET)
+  else if ((itflag & RNG_IT_SEI) == RNG_IT_SEI)
   {
     /* Update the error code */
     hrng->ErrorCode = HAL_RNG_ERROR_SEED;
@@ -693,10 +691,12 @@ void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
 
     /* Clear the clock error flag */
     __HAL_RNG_CLEAR_IT(hrng, RNG_IT_CEI | RNG_IT_SEI);
+
+    return;
   }
 
   /* Check RNG data ready interrupt occurred */
-  if (__HAL_RNG_GET_IT(hrng, RNG_IT_DRDY) != RESET)
+  if ((itflag & RNG_IT_DRDY) == RNG_IT_DRDY)
   {
     /* Generate random number once, so disable the IT */
     __HAL_RNG_DISABLE_IT(hrng);
@@ -728,7 +728,7 @@ void HAL_RNG_IRQHandler(RNG_HandleTypeDef *hrng)
   *                the configuration information for RNG.
   * @retval random value
   */
-uint32_t HAL_RNG_ReadLastRandomNumber(RNG_HandleTypeDef *hrng)
+uint32_t HAL_RNG_ReadLastRandomNumber(const RNG_HandleTypeDef *hrng)
 {
   return (hrng->RandomNumber);
 }
@@ -775,8 +775,8 @@ __weak void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng)
 
 
 /** @addtogroup RNG_Exported_Functions_Group3
- *  @brief   Peripheral State functions
- *
+  *  @brief   Peripheral State functions
+  *
 @verbatim
  ===============================================================================
                       ##### Peripheral State functions #####
@@ -795,7 +795,7 @@ __weak void HAL_RNG_ErrorCallback(RNG_HandleTypeDef *hrng)
   *                the configuration information for RNG.
   * @retval HAL state
   */
-HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
+HAL_RNG_StateTypeDef HAL_RNG_GetState(const RNG_HandleTypeDef *hrng)
 {
   return hrng->State;
 }
@@ -804,8 +804,8 @@ HAL_RNG_StateTypeDef HAL_RNG_GetState(RNG_HandleTypeDef *hrng)
   * @brief  Return the RNG handle error code.
   * @param  hrng: pointer to a RNG_HandleTypeDef structure.
   * @retval RNG Error Code
-*/
-uint32_t HAL_RNG_GetError(RNG_HandleTypeDef *hrng)
+  */
+uint32_t HAL_RNG_GetError(const RNG_HandleTypeDef *hrng)
 {
   /* Return RNG Error Code */
   return hrng->ErrorCode;
@@ -830,4 +830,3 @@ uint32_t HAL_RNG_GetError(RNG_HandleTypeDef *hrng)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rtc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rtc.c
@@ -5,49 +5,77 @@
   * @brief   RTC HAL module driver.
   *          This file provides firmware functions to manage the following
   *          functionalities of the Real-Time Clock (RTC) peripheral:
-  *           + Initialization
-  *           + Calendar (Time and Date) configuration
-  *           + Alarms (Alarm A and Alarm B) configuration
-  *           + WakeUp Timer configuration
-  *           + TimeStamp configuration
-  *           + Tampers configuration
-  *           + Backup Data Registers configuration
-  *           + RTC Tamper and TimeStamp Pins Selection
-  *           + Interrupts and flags management
+  *           + Initialization and de-initialization functions
+  *           + Calendar (Time and Date) configuration functions
+  *           + Alarms (Alarm A and Alarm B) configuration functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
- ===============================================================================
-                          ##### RTC Operating Condition #####
- ===============================================================================
+  ==============================================================================
+               ##### RTC and Backup Domain Operating Condition #####
+  ==============================================================================
   [..] The real-time clock (RTC) and the RTC backup registers can be powered
        from the VBAT voltage when the main VDD supply is powered off.
-       To retain the content of the RTC backup registers and supply the RTC
-       when VDD is turned off, VBAT pin can be connected to an optional
-       standby voltage supplied by a battery or by another source.
+       To retain the content of the RTC backup registers and supply the RTC when
+       VDD is turned off, VBAT pin can be connected to an optional standby
+       voltage supplied by a battery or by another source.
+
+  [..] To allow the RTC operating even when the main digital supply (VDD) is turned
+       off, the VBAT pin powers the following blocks:
+    (#) The RTC
+    (#) The LSE oscillator
+    (#) PC13 to PC15 I/Os, plus PA0 and PC12 I/Os (when available)
+
+  [..] When the backup domain is supplied by VDD (analog switch connected to VDD),
+       the following pins are available:
+    (#) PC14 and PC15 can be used as either GPIO or LSE pins
+    (#) PC13 can be used as a GPIO or as the RTC_AF1 pin
+    (#) PA0 can be used as a GPIO or as the RTC_AF2 pin
+    (#) PC12 can be used as a GPIO or as the RTC_AF3 pin
+
+  [..] When the backup domain is supplied by VBAT (analog switch connected to VBAT
+       because VDD is not present), the following pins are available:
+    (#) PC14 and PC15 can be used as LSE pins only
+    (#) PC13 can be used as the RTC_AF1 pin
+    (#) PA0 can be used as the RTC_AF2 pin
+    (#) PC12 can be used as the RTC_AF3 pin
 
                    ##### Backup Domain Reset #####
- ===============================================================================
+  ==================================================================
   [..] The backup domain reset sets all RTC registers and the RCC_BDCR register
        to their reset values.
-       A backup domain reset is generated when one of the following events occurs:
-    (+) Software reset, triggered by setting the BDRST bit in the
+  [..] A backup domain reset is generated when one of the following events occurs:
+    (#) Software reset, triggered by setting the BDRST bit in the
         RCC Backup domain control register (RCC_BDCR).
-    (+) VDD or VBAT power on, if both supplies have previously been powered off.
-    (+) Tamper detection event resets all data backup registers.
+    (#) VDD or VBAT power on, if both supplies have previously been powered off.
+    (#) Tamper detection event resets all data backup registers.
 
                    ##### Backup Domain Access #####
- ===================================================================
-  [..] After reset, the backup domain (RTC registers, RTC backup data
-       registers and backup SRAM) is protected against possible unwanted write
-       accesses.
-
+  ==================================================================
+  [..] After reset, the backup domain (RTC registers and RTC backup data registers)
+       is protected against possible unwanted write accesses.
   [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
-    (+) Call the function HAL_RCCEx_PeriphCLKConfig with RCC_PERIPHCLK_RTC for
-        PeriphClockSelection and select RTCClockSelection (LSE, LSI or HSEdiv32)
+    (+) Enable the Power Controller (PWR) APB1 interface clock using the
+        __HAL_RCC_PWR_CLK_ENABLE() macro.
+    (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+    (+) Select the RTC clock source using the __HAL_RCC_RTC_CONFIG() macro.
     (+) Enable RTC Clock using the __HAL_RCC_RTC_ENABLE() macro.
 
-                  ##### How to use RTC Driver #####
- ===================================================================
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
   [..]
     (+) Enable the RTC domain access (see description in the section above).
     (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
@@ -58,14 +86,21 @@
   [..]
     (+) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
         and HAL_RTC_SetDate() functions.
-    (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate() functions.
+    (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate()
+        functions.
+    (+) To manage the RTC summer or winter time change, use the following
+        functions:
+        (++) HAL_RTC_DST_Add1Hour() or HAL_RTC_DST_Sub1Hour to add or subtract
+             1 hour from the calendar time.
+        (++) HAL_RTC_DST_SetStoreOperation() or HAL_RTC_DST_ClearStoreOperation
+             to memorize whether the time change has been performed or not.
 
   *** Alarm configuration ***
   ===========================
   [..]
     (+) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
-            You can also configure the RTC Alarm with interrupt mode using the
-            HAL_RTC_SetAlarm_IT() function.
+        You can also configure the RTC Alarm with interrupt mode using the
+        HAL_RTC_SetAlarm_IT() function.
     (+) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
 
                   ##### RTC and low power modes #####
@@ -73,7 +108,7 @@
   [..] The MCU can be woken up from a low power mode by an RTC alternate
        function.
   [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
-       RTC wakeup, RTC tamper event detection and RTC time stamp event detection.
+       RTC wakeup, RTC tamper event detection and RTC timestamp event detection.
        These RTC alternate functions can wake up the system from the Stop and
        Standby low power modes.
   [..] The system can also wake up from low power modes without depending
@@ -81,85 +116,74 @@
        or the RTC wakeup events.
   [..] The RTC provides a programmable time base for waking up from the
        Stop or Standby mode at regular intervals.
-       Wakeup from STOP and STANDBY modes is possible only when the RTC clock source
-       is LSE or LSI.
+       Wakeup from STOP and STANDBY modes is possible only when the RTC clock
+       source is LSE or LSI.
 
   *** Callback registration ***
   =============================================
-
   [..]
-  The compilation define  USE_RTC_REGISTER_CALLBACKS when set to 1
+  When the compilation define USE_HAL_RTC_REGISTER_CALLBACKS is set to 0 or
+  not defined, the callback registration feature is not available and all
+  callbacks are set to the corresponding weak functions.
+  This is the recommended configuration in order to optimize memory/code
+  consumption footprint/performances.
+  [..]
+  The compilation define  USE_HAL_RTC_REGISTER_CALLBACKS when set to 1
   allows the user to configure dynamically the driver callbacks.
-  Use Function @ref HAL_RTC_RegisterCallback() to register an interrupt callback.
-
+  Use Function HAL_RTC_RegisterCallback() to register an interrupt callback.
   [..]
-  Function @ref HAL_RTC_RegisterCallback() allows to register following callbacks:
+  Function HAL_RTC_RegisterCallback() allows to register following callbacks:
     (+) AlarmAEventCallback          : RTC Alarm A Event callback.
     (+) AlarmBEventCallback          : RTC Alarm B Event callback.
-    (+) TimeStampEventCallback       : RTC TimeStamp Event callback.
+    (+) TimeStampEventCallback       : RTC Timestamp Event callback.
     (+) WakeUpTimerEventCallback     : RTC WakeUpTimer Event callback.
-    (+) Tamper1EventCallback         : RTC Tamper 1 Event callback.
+    (+) Tamper1EventCallback         : RTC Tamper 1 Event callback. (*)
     (+) Tamper2EventCallback         : RTC Tamper 2 Event callback.
-    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback.
+    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback. (*)
     (+) MspInitCallback              : RTC MspInit callback.
     (+) MspDeInitCallback            : RTC MspDeInit callback.
+
+  (*) value not applicable to all devices.
   [..]
   This function takes as parameters the HAL peripheral handle, the Callback ID
   and a pointer to the user callback function.
-
   [..]
-  Use function @ref HAL_RTC_UnRegisterCallback() to reset a callback to the default
+  Use function HAL_RTC_UnRegisterCallback() to reset a callback to the default
   weak function.
-  @ref HAL_RTC_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+  HAL_RTC_UnRegisterCallback() takes as parameters the HAL peripheral handle,
   and the Callback ID.
   This function allows to reset following callbacks:
     (+) AlarmAEventCallback          : RTC Alarm A Event callback.
     (+) AlarmBEventCallback          : RTC Alarm B Event callback.
-    (+) TimeStampEventCallback       : RTC TimeStamp Event callback.
+    (+) TimeStampEventCallback       : RTC Timestamp Event callback.
     (+) WakeUpTimerEventCallback     : RTC WakeUpTimer Event callback.
-    (+) Tamper1EventCallback         : RTC Tamper 1 Event callback.
+    (+) Tamper1EventCallback         : RTC Tamper 1 Event callback. (*)
     (+) Tamper2EventCallback         : RTC Tamper 2 Event callback.
-    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback.
+    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback. (*)
     (+) MspInitCallback              : RTC MspInit callback.
     (+) MspDeInitCallback            : RTC MspDeInit callback.
 
+  (*) value not applicable to all devices.
   [..]
-  By default, after the @ref HAL_RTC_Init() and when the state is HAL_RTC_STATE_RESET,
-  all callbacks are set to the corresponding weak functions :
-  examples @ref AlarmAEventCallback(), @ref WakeUpTimerEventCallback().
-  Exception done for MspInit and MspDeInit callbacks that are reset to the legacy weak function
-  in the @ref HAL_RTC_Init()/@ref HAL_RTC_DeInit() only when these callbacks are null
-  (not registered beforehand).
-  If not, MspInit or MspDeInit are not null, @ref HAL_RTC_Init()/@ref HAL_RTC_DeInit()
-  keep and use the user MspInit/MspDeInit callbacks (registered beforehand)
-
+  By default, after the HAL_RTC_Init() and when the state is HAL_RTC_STATE_RESET,
+  all callbacks are set to the corresponding weak functions:
+  examples AlarmAEventCallback(), TimeStampEventCallback().
+  Exception done for MspInit() and MspDeInit() callbacks that are reset to the
+  legacy weak function in the HAL_RTC_Init()/HAL_RTC_DeInit() only when these
+  callbacks are null (not registered beforehand).
+  If not, MspInit() or MspDeInit() are not null, HAL_RTC_Init()/HAL_RTC_DeInit()
+  keep and use the user MspInit()/MspDeInit() callbacks (registered beforehand).
   [..]
   Callbacks can be registered/unregistered in HAL_RTC_STATE_READY state only.
-  Exception done MspInit/MspDeInit that can be registered/unregistered
-  in HAL_RTC_STATE_READY or HAL_RTC_STATE_RESET state,
-  thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
-  In that case first register the MspInit/MspDeInit user callbacks
-  using @ref HAL_RTC_RegisterCallback() before calling @ref HAL_RTC_DeInit()
-  or @ref HAL_RTC_Init() function.
+  Exception done for MspInit() and MspDeInit() that can be registered/unregistered
+  in HAL_RTC_STATE_READY or HAL_RTC_STATE_RESET state.
+  Thus registered (user) MspInit()/MspDeInit() callbacks can be used during the
+  Init/DeInit.
+  In that case first register the MspInit()/MspDeInit() user callbacks using
+  HAL_RTC_RegisterCallback() before calling HAL_RTC_DeInit() or HAL_RTC_Init()
+  functions.
 
-  [..]
-  When The compilation define USE_HAL_RTC_REGISTER_CALLBACKS is set to 0 or
-  not defined, the callback registration feature is not available and all callbacks
-  are set to the corresponding weak functions.
-
-   @endverbatim
-
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
+  @endverbatim
   ******************************************************************************
   */
 
@@ -170,9 +194,8 @@
   * @{
   */
 
-
-/** @addtogroup RTC
-  * @brief RTC HAL module driver
+/** @defgroup RTC RTC
+  * @brief    RTC HAL module driver
   * @{
   */
 
@@ -185,13 +208,13 @@
 /* Private function prototypes -----------------------------------------------*/
 /* Exported functions --------------------------------------------------------*/
 
-/** @addtogroup RTC_Exported_Functions
+/** @defgroup RTC_Exported_Functions RTC Exported Functions
   * @{
   */
 
-/** @addtogroup RTC_Exported_Functions_Group1
- *  @brief    Initialization and Configuration functions
- *
+/** @defgroup RTC_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
@@ -216,7 +239,7 @@
              the software must first clear the RSF flag. The software must then
              wait until it is set again before reading the calendar, which means
              that the calendar registers have been correctly copied into the
-             RTC_TR and RTC_DR shadow registers.The HAL_RTC_WaitForSynchro() function
+             RTC_TR and RTC_DR shadow registers. The HAL_RTC_WaitForSynchro() function
              implements the above software sequence (RSF clear and RSF check).
 
 @endverbatim
@@ -224,16 +247,19 @@
   */
 
 /**
-  * @brief  Initialize the RTC peripheral
-  * @param hrtc RTC handle
+  * @brief  Initializes the RTC peripheral
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
 {
-  /* Check the RTC peripheral state */
-  if(hrtc == NULL)
+  HAL_StatusTypeDef status;
+
+  /* Check RTC handler validity */
+  if (hrtc == NULL)
   {
-     return HAL_ERROR;
+    return HAL_ERROR;
   }
 
   /* Check the parameters */
@@ -247,7 +273,7 @@ HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
   assert_param(IS_RTC_OUTPUT_TYPE(hrtc->Init.OutPutType));
 
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
-  if(hrtc->State == HAL_RTC_STATE_RESET)
+  if (hrtc->State == HAL_RTC_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
     hrtc->Lock = HAL_UNLOCKED;
@@ -258,26 +284,26 @@ HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
     hrtc->WakeUpTimerEventCallback     =  HAL_RTCEx_WakeUpTimerEventCallback; /* Legacy weak WakeUpTimerEventCallback */
 #if defined(RTC_TAMPER1_SUPPORT)
     hrtc->Tamper1EventCallback         =  HAL_RTCEx_Tamper1EventCallback;     /* Legacy weak Tamper1EventCallback     */
-#endif
+#endif /* RTC_TAMPER1_SUPPORT */
     hrtc->Tamper2EventCallback         =  HAL_RTCEx_Tamper2EventCallback;     /* Legacy weak Tamper2EventCallback     */
 #if defined(RTC_TAMPER3_SUPPORT)
     hrtc->Tamper3EventCallback         =  HAL_RTCEx_Tamper3EventCallback;     /* Legacy weak Tamper3EventCallback     */
-#endif
+#endif /* RTC_TAMPER3_SUPPORT */
 
-    if(hrtc->MspInitCallback == NULL)
+    if (hrtc->MspInitCallback == NULL)
     {
       hrtc->MspInitCallback = HAL_RTC_MspInit;
     }
     /* Init the low level hardware */
     hrtc->MspInitCallback(hrtc);
 
-    if(hrtc->MspDeInitCallback == NULL)
+    if (hrtc->MspDeInitCallback == NULL)
     {
       hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
     }
   }
-#else
-  if(hrtc->State == HAL_RTC_STATE_RESET)
+#else /* USE_HAL_RTC_REGISTER_CALLBACKS */
+  if (hrtc->State == HAL_RTC_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
     hrtc->Lock = HAL_UNLOCKED;
@@ -285,78 +311,73 @@ HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
     /* Initialize RTC MSP */
     HAL_RTC_MspInit(hrtc);
   }
-#endif /* (USE_HAL_RTC_REGISTER_CALLBACKS) */
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
   /* Set RTC state */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
-  /* Set Initialization mode */
-  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  /* Check whether the calendar needs to be initialized */
+  if (__HAL_RTC_IS_CALENDAR_INITIALIZED(hrtc) == 0U)
   {
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+    /* Disable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-    /* Set RTC state */
-    hrtc->State = HAL_RTC_STATE_ERROR;
+    /* Enter Initialization mode */
+    status = RTC_EnterInitMode(hrtc);
 
-    return HAL_ERROR;
-  }
-  else
-  {
-    /* Clear RTC_CR FMT, OSEL and POL Bits */
-    hrtc->Instance->CR &= ((uint32_t)~(RTC_CR_FMT | RTC_CR_OSEL | RTC_CR_POL));
-    /* Set RTC_CR register */
-    hrtc->Instance->CR |= (uint32_t)(hrtc->Init.HourFormat | hrtc->Init.OutPut | hrtc->Init.OutPutPolarity);
-
-    /* Configure the RTC PRER */
-    hrtc->Instance->PRER = (uint32_t)(hrtc->Init.SynchPrediv);
-    hrtc->Instance->PRER |= (uint32_t)(hrtc->Init.AsynchPrediv << 16U);
-
-    /* Exit Initialization mode */
-    hrtc->Instance->ISR &= ((uint32_t)~RTC_ISR_INIT);
-
-    hrtc->Instance->OR &= (uint32_t)~(RTC_OR_ALARMOUTTYPE | RTC_OR_OUT_RMP);
-    hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutType | hrtc->Init.OutPutRemap);
-
-    /* If CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
-    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
+    if (status == HAL_OK)
     {
-      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+      /* Clear RTC_CR FMT, OSEL and POL Bits */
+      hrtc->Instance->CR &= ((uint32_t)~(RTC_CR_FMT | RTC_CR_OSEL | RTC_CR_POL));
+      /* Set RTC_CR register */
+      hrtc->Instance->CR |= (uint32_t)(hrtc->Init.HourFormat | hrtc->Init.OutPut | hrtc->Init.OutPutPolarity);
 
-        hrtc->State = HAL_RTC_STATE_ERROR;
+      /* Configure the RTC PRER */
+      hrtc->Instance->PRER = (uint32_t)(hrtc->Init.SynchPrediv);
+      hrtc->Instance->PRER |= (uint32_t)(hrtc->Init.AsynchPrediv << RTC_PRER_PREDIV_A_Pos);
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hrtc);
+      /* Exit Initialization mode */
+      status = RTC_ExitInitMode(hrtc);
+    }
 
-        return HAL_ERROR;
-      }
+    if (status == HAL_OK)
+    {
+#if defined(RTC_OR_ALARMOUTTYPE)
+      hrtc->Instance->OR &= (uint32_t)~(RTC_OUTPUT_TYPE_PUSHPULL | RTC_OUTPUT_REMAP_POS1);
+      hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutType | hrtc->Init.OutPutRemap);
+#else
+      hrtc->Instance->OR &= (uint32_t)~RTC_OUTPUT_REMAP_POS1;
+      hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutRemap);
+#endif /* RTC_OR_ALARMOUTTYPE */
     }
 
     /* Enable the write protection for RTC registers */
     __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-    /* Set RTC state */
-    hrtc->State = HAL_RTC_STATE_READY;
-
-    return HAL_OK;
   }
+  else
+  {
+    /* The calendar is already initialized */
+    status = HAL_OK;
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  return status;
 }
 
 /**
-  * @brief  DeInitialize the RTC peripheral.
-  * @param hrtc RTC handle
-  * @note   This function doesn't reset the RTC Backup Data registers.
+  * @brief  DeInitializes the RTC peripheral
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This function does not reset the RTC Backup Data registers.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t tickstart;
+  HAL_StatusTypeDef status;
 
   /* Check the parameters */
   assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
@@ -367,121 +388,80 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Set Initialization mode */
-  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
   {
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-    /* Set RTC state */
-    hrtc->State = HAL_RTC_STATE_ERROR;
-
-    return HAL_ERROR;
-  }
-  else
-  {
-    /* Reset TR, DR and CR registers */
-    hrtc->Instance->TR = (uint32_t)0x00000000U;
-    hrtc->Instance->DR = ((uint32_t)(RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0));
-    /* Reset All CR bits except CR[2:0] */
-    hrtc->Instance->CR &= RTC_CR_WUCKSEL;
-
-    tickstart = HAL_GetTick();
-
-    /* Wait till WUTWF flag is set and if Time out is reached exit */
-    while(((hrtc->Instance->ISR) & RTC_ISR_WUTWF) == 0U)
-    {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-        /* Set RTC state */
-        hrtc->State = HAL_RTC_STATE_TIMEOUT;
-
-        return HAL_TIMEOUT;
-      }
-    }
-
-    /* Reset all RTC CR register bits */
-    hrtc->Instance->CR &= (uint32_t)0x00000000U;
+    /* Reset RTC registers */
+    hrtc->Instance->TR = 0x00000000U;
+    hrtc->Instance->DR = (RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0);
+    hrtc->Instance->CR = 0x00000000U;
     hrtc->Instance->WUTR = RTC_WUTR_WUT;
-    hrtc->Instance->PRER = ((uint32_t)(RTC_PRER_PREDIV_A | 0x000000FFU));
-    hrtc->Instance->ALRMAR = (uint32_t)0x00000000U;
-    hrtc->Instance->ALRMBR = (uint32_t)0x00000000U;
-    hrtc->Instance->SHIFTR = (uint32_t)0x00000000U;
-    hrtc->Instance->CALR = (uint32_t)0x00000000U;
-    hrtc->Instance->ALRMASSR = (uint32_t)0x00000000U;
-    hrtc->Instance->ALRMBSSR = (uint32_t)0x00000000U;
+    hrtc->Instance->PRER = (uint32_t)(RTC_PRER_PREDIV_A | 0x000000FFU);
+    hrtc->Instance->ALRMAR   = 0x00000000U;
+    hrtc->Instance->ALRMBR   = 0x00000000U;
+    hrtc->Instance->CALR     = 0x00000000U;
+    hrtc->Instance->SHIFTR   = 0x00000000U;
+    hrtc->Instance->ALRMASSR = 0x00000000U;
+    hrtc->Instance->ALRMBSSR = 0x00000000U;
 
-    /* Reset ISR register and exit initialization mode */
-    hrtc->Instance->ISR = (uint32_t)0x00000000U;
-
-    /* Reset Tamper configuration register */
-    hrtc->Instance->TAMPCR = 0x00000000U;
-
-    /* Reset Option register */
-    hrtc->Instance->OR = 0x00000000U;
-
-    /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
-    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
-    {
-      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-        hrtc->State = HAL_RTC_STATE_ERROR;
-
-        return HAL_ERROR;
-      }
-    }
+    /* Exit Initialization mode */
+    status = RTC_ExitInitMode(hrtc);
   }
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
+  if (status == HAL_OK)
+  {
+    /* Reset Tamper and alternate functions configuration register */
+    hrtc->Instance->TAMPCR = 0x00000000U;
+
+    /* Reset Option register */
+    hrtc->Instance->OR = 0x00000000U;
+
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
-    if(hrtc->MspDeInitCallback == NULL)
+    if (hrtc->MspDeInitCallback == NULL)
     {
       hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
     }
 
     /* DeInit the low level hardware: CLOCK, NVIC.*/
     hrtc->MspDeInitCallback(hrtc);
+#else /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    /* De-Initialize RTC MSP */
+    HAL_RTC_MspDeInit(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
-#else
-  /* De-Initialize RTC MSP */
-  HAL_RTC_MspDeInit(hrtc);
-#endif /* (USE_HAL_RTC_REGISTER_CALLBACKS) */
-
-  hrtc->State = HAL_RTC_STATE_RESET;
+    hrtc->State = HAL_RTC_STATE_RESET;
+  }
 
   /* Release Lock */
   __HAL_UNLOCK(hrtc);
 
-  return HAL_OK;
+  return status;
 }
 
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
 /**
-  * @brief  Register a User RTC Callback
+  * @brief  Registers a User RTC Callback
   *         To be used instead of the weak predefined callback
-  * @param  hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @param  CallbackID ID of the callback to be registered
   *         This parameter can be one of the following values:
   *          @arg @ref HAL_RTC_ALARM_A_EVENT_CB_ID          Alarm A Event Callback ID
   *          @arg @ref HAL_RTC_ALARM_B_EVENT_CB_ID          Alarm B Event Callback ID
-  *          @arg @ref HAL_RTC_TIMESTAMP_EVENT_CB_ID        TimeStamp Event Callback ID
-  *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      WakeUp Timer Event Callback ID
-  *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Callback ID (*)
-  *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Callback ID
-  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Callback ID (*)
-  *          @arg @ref HAL_RTC_MSPINIT_CB_ID                Msp Init callback ID
-  *          @arg @ref HAL_RTC_MSPDEINIT_CB_ID              Msp DeInit callback ID
+  *          @arg @ref HAL_RTC_TIMESTAMP_EVENT_CB_ID        Timestamp Event Callback ID
+  *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      Wakeup Timer Event Callback ID
+  *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Event Callback ID (*)
+  *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Event Callback ID
+  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Event Callback ID (*)
+  *          @arg @ref HAL_RTC_MSPINIT_CB_ID                MSP Init callback ID
+  *          @arg @ref HAL_RTC_MSPDEINIT_CB_ID              MSP DeInit callback ID
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
@@ -489,7 +469,7 @@ HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Call
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  if(pCallback == NULL)
+  if (pCallback == NULL)
   {
     return HAL_ERROR;
   }
@@ -497,72 +477,72 @@ HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Call
   /* Process locked */
   __HAL_LOCK(hrtc);
 
-  if(HAL_RTC_STATE_READY == hrtc->State)
+  if (HAL_RTC_STATE_READY == hrtc->State)
   {
     switch (CallbackID)
     {
-    case HAL_RTC_ALARM_A_EVENT_CB_ID :
-      hrtc->AlarmAEventCallback = pCallback;
-      break;
+      case HAL_RTC_ALARM_A_EVENT_CB_ID :
+        hrtc->AlarmAEventCallback = pCallback;
+        break;
 
-    case HAL_RTC_ALARM_B_EVENT_CB_ID :
-      hrtc->AlarmBEventCallback = pCallback;
-      break;
+      case HAL_RTC_ALARM_B_EVENT_CB_ID :
+        hrtc->AlarmBEventCallback = pCallback;
+        break;
 
-    case HAL_RTC_TIMESTAMP_EVENT_CB_ID :
-      hrtc->TimeStampEventCallback = pCallback;
-      break;
+      case HAL_RTC_TIMESTAMP_EVENT_CB_ID :
+        hrtc->TimeStampEventCallback = pCallback;
+        break;
 
-    case HAL_RTC_WAKEUPTIMER_EVENT_CB_ID :
-      hrtc->WakeUpTimerEventCallback = pCallback;
-      break;
+      case HAL_RTC_WAKEUPTIMER_EVENT_CB_ID :
+        hrtc->WakeUpTimerEventCallback = pCallback;
+        break;
 
 #if defined(RTC_TAMPER1_SUPPORT)
-    case HAL_RTC_TAMPER1_EVENT_CB_ID :
-      hrtc->Tamper1EventCallback = pCallback;
-      break;
-#endif
+      case HAL_RTC_TAMPER1_EVENT_CB_ID :
+        hrtc->Tamper1EventCallback = pCallback;
+        break;
+#endif /* RTC_TAMPER1_SUPPORT */
 
-    case HAL_RTC_TAMPER2_EVENT_CB_ID :
-      hrtc->Tamper2EventCallback = pCallback;
-      break;
+      case HAL_RTC_TAMPER2_EVENT_CB_ID :
+        hrtc->Tamper2EventCallback = pCallback;
+        break;
 
 #if defined(RTC_TAMPER3_SUPPORT)
-    case HAL_RTC_TAMPER3_EVENT_CB_ID :
-      hrtc->Tamper3EventCallback = pCallback;
-      break;
-#endif
+      case HAL_RTC_TAMPER3_EVENT_CB_ID :
+        hrtc->Tamper3EventCallback = pCallback;
+        break;
+#endif /* RTC_TAMPER3_SUPPORT */
 
-   case HAL_RTC_MSPINIT_CB_ID :
-      hrtc->MspInitCallback = pCallback;
-      break;
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = pCallback;
+        break;
 
-   case HAL_RTC_MSPDEINIT_CB_ID :
-      hrtc->MspDeInitCallback = pCallback;
-      break;
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = pCallback;
+        break;
 
-    default :
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(HAL_RTC_STATE_RESET == hrtc->State)
+  else if (HAL_RTC_STATE_RESET == hrtc->State)
   {
     switch (CallbackID)
     {
-    case HAL_RTC_MSPINIT_CB_ID :
-      hrtc->MspInitCallback = pCallback;
-      break;
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = pCallback;
+        break;
 
-   case HAL_RTC_MSPDEINIT_CB_ID :
-      hrtc->MspDeInitCallback = pCallback;
-      break;
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = pCallback;
+        break;
 
-    default :
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
@@ -578,23 +558,23 @@ HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Call
 }
 
 /**
-  * @brief  Unregister an RTC Callback
-  *         RTC callabck is redirected to the weak predefined callback
-  * @param  hrtc RTC handle
+  * @brief  Unregisters an RTC Callback
+  *         RTC callback is redirected to the weak predefined callback
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
   *          @arg @ref HAL_RTC_ALARM_A_EVENT_CB_ID          Alarm A Event Callback ID
   *          @arg @ref HAL_RTC_ALARM_B_EVENT_CB_ID          Alarm B Event Callback ID
-  *          @arg @ref HAL_RTC_TIMESTAMP_EVENT_CB_ID        TimeStamp Event Callback ID
-  *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      WakeUp Timer Event Callback ID
-  *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Callback ID (*)
-  *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Callback ID
-  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Callback ID (*)
-  *          @arg @ref HAL_RTC_MSPINIT_CB_ID                Msp Init callback ID
-  *          @arg @ref HAL_RTC_MSPDEINIT_CB_ID              Msp DeInit callback ID
+  *          @arg @ref HAL_RTC_TIMESTAMP_EVENT_CB_ID        Timestamp Event Callback ID
+  *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      Wakeup Timer Event Callback ID
+  *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Event Callback ID (*)
+  *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Event Callback ID
+  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Event Callback ID (*)
+  *          @arg @ref HAL_RTC_MSPINIT_CB_ID                MSP Init callback ID
+  *          @arg @ref HAL_RTC_MSPDEINIT_CB_ID              MSP DeInit callback ID
   *
-  *         (*)  Value not defined in all devices. \n
-  *
+  *         (*) value not applicable to all devices.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID)
@@ -604,72 +584,72 @@ HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Ca
   /* Process locked */
   __HAL_LOCK(hrtc);
 
-  if(HAL_RTC_STATE_READY == hrtc->State)
+  if (HAL_RTC_STATE_READY == hrtc->State)
   {
     switch (CallbackID)
     {
-    case HAL_RTC_ALARM_A_EVENT_CB_ID :
-      hrtc->AlarmAEventCallback = HAL_RTC_AlarmAEventCallback;         /* Legacy weak AlarmAEventCallback    */
-      break;
+      case HAL_RTC_ALARM_A_EVENT_CB_ID :
+        hrtc->AlarmAEventCallback = HAL_RTC_AlarmAEventCallback;             /* Legacy weak AlarmAEventCallback    */
+        break;
 
-    case HAL_RTC_ALARM_B_EVENT_CB_ID :
-      hrtc->AlarmBEventCallback = HAL_RTCEx_AlarmBEventCallback;          /* Legacy weak AlarmBEventCallback */
-      break;
+      case HAL_RTC_ALARM_B_EVENT_CB_ID :
+        hrtc->AlarmBEventCallback = HAL_RTCEx_AlarmBEventCallback;           /* Legacy weak AlarmBEventCallback */
+        break;
 
-    case HAL_RTC_TIMESTAMP_EVENT_CB_ID :
-      hrtc->TimeStampEventCallback = HAL_RTCEx_TimeStampEventCallback;    /* Legacy weak TimeStampEventCallback    */
-      break;
+      case HAL_RTC_TIMESTAMP_EVENT_CB_ID :
+        hrtc->TimeStampEventCallback = HAL_RTCEx_TimeStampEventCallback;     /* Legacy weak TimeStampEventCallback    */
+        break;
 
-    case HAL_RTC_WAKEUPTIMER_EVENT_CB_ID :
-      hrtc->WakeUpTimerEventCallback = HAL_RTCEx_WakeUpTimerEventCallback; /* Legacy weak WakeUpTimerEventCallback */
-      break;
+      case HAL_RTC_WAKEUPTIMER_EVENT_CB_ID :
+        hrtc->WakeUpTimerEventCallback = HAL_RTCEx_WakeUpTimerEventCallback; /* Legacy weak WakeUpTimerEventCallback */
+        break;
 
 #if defined(RTC_TAMPER1_SUPPORT)
-    case HAL_RTC_TAMPER1_EVENT_CB_ID :
-      hrtc->Tamper1EventCallback = HAL_RTCEx_Tamper1EventCallback;         /* Legacy weak Tamper1EventCallback   */
-      break;
-#endif
+      case HAL_RTC_TAMPER1_EVENT_CB_ID :
+        hrtc->Tamper1EventCallback = HAL_RTCEx_Tamper1EventCallback;         /* Legacy weak Tamper1EventCallback   */
+        break;
+#endif /* RTC_TAMPER1_SUPPORT */
 
-    case HAL_RTC_TAMPER2_EVENT_CB_ID :
-      hrtc->Tamper2EventCallback = HAL_RTCEx_Tamper2EventCallback;         /* Legacy weak Tamper2EventCallback         */
-      break;
+      case HAL_RTC_TAMPER2_EVENT_CB_ID :
+        hrtc->Tamper2EventCallback = HAL_RTCEx_Tamper2EventCallback;         /* Legacy weak Tamper2EventCallback         */
+        break;
 
 #if defined(RTC_TAMPER3_SUPPORT)
-    case HAL_RTC_TAMPER3_EVENT_CB_ID :
-      hrtc->Tamper3EventCallback = HAL_RTCEx_Tamper3EventCallback;         /* Legacy weak Tamper3EventCallback         */
-      break;
-#endif
+      case HAL_RTC_TAMPER3_EVENT_CB_ID :
+        hrtc->Tamper3EventCallback = HAL_RTCEx_Tamper3EventCallback;         /* Legacy weak Tamper3EventCallback         */
+        break;
+#endif /* RTC_TAMPER3_SUPPORT */
 
-    case HAL_RTC_MSPINIT_CB_ID :
-      hrtc->MspInitCallback = HAL_RTC_MspInit;
-      break;
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = HAL_RTC_MspInit;
+        break;
 
-    case HAL_RTC_MSPDEINIT_CB_ID :
-      hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
-      break;
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
+        break;
 
-    default :
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
-  else if(HAL_RTC_STATE_RESET == hrtc->State)
+  else if (HAL_RTC_STATE_RESET == hrtc->State)
   {
     switch (CallbackID)
     {
-    case HAL_RTC_MSPINIT_CB_ID :
-      hrtc->MspInitCallback = HAL_RTC_MspInit;
-      break;
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = HAL_RTC_MspInit;
+        break;
 
-    case HAL_RTC_MSPDEINIT_CB_ID :
-      hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
-      break;
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
+        break;
 
-    default :
-     /* Return error status */
-      status =  HAL_ERROR;
-      break;
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
     }
   }
   else
@@ -686,32 +666,34 @@ HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_Ca
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
 /**
-  * @brief  Initialize the RTC MSP.
-  * @param hrtc RTC handle
+  * @brief  Initializes the RTC MSP.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
-__weak void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
+__weak void HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTC_MspInit could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTC_MspInit could be implemented in the user file
    */
 }
 
 /**
-  * @brief  DeInitialize the RTC MSP.
-  * @param hrtc RTC handle
+  * @brief  DeInitializes the RTC MSP.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
-__weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
+__weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTC_MspDeInit could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTC_MspDeInit could be implemented in the user file
    */
 }
 
@@ -719,9 +701,9 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
   * @}
   */
 
-/** @addtogroup RTC_Exported_Functions_Group2
- *  @brief   RTC Time and Date functions
- *
+/** @defgroup RTC_Exported_Functions_Group2 RTC Time and Date functions
+  * @brief    RTC Time and Date functions
+  *
 @verbatim
  ===============================================================================
                  ##### RTC Time and Date functions #####
@@ -734,10 +716,13 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
   */
 
 /**
-  * @brief  Set RTC current time.
-  * @param hrtc RTC handle
-  * @param sTime Pointer to Time structure
-  * @param Format Specifies the format of the entered parameters.
+  * @brief  Sets RTC current time.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime Pointer to Time structure
+  * @note   DayLightSaving and StoreOperation interfaces are deprecated.
+  *         To manage Daylight Saving Time, please use HAL_RTC_DST_xxx functions.
+  * @param  Format Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *            @arg RTC_FORMAT_BIN: Binary data format
   *            @arg RTC_FORMAT_BCD: BCD data format
@@ -745,9 +730,10 @@ __weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
   */
 HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
+  HAL_StatusTypeDef status;
 
- /* Check the parameters */
+  /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
   assert_param(IS_RTC_DAYLIGHT_SAVING(sTime->DayLightSaving));
   assert_param(IS_RTC_STORE_OPERATION(sTime->StoreOperation));
@@ -757,9 +743,9 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
 
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  if(Format == RTC_FORMAT_BIN)
+  if (Format == RTC_FORMAT_BIN)
   {
-    if((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
     {
       assert_param(IS_RTC_HOUR12(sTime->Hours));
       assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
@@ -772,14 +758,14 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
     assert_param(IS_RTC_MINUTES(sTime->Minutes));
     assert_param(IS_RTC_SECONDS(sTime->Seconds));
 
-    tmpreg = (uint32_t)(((uint32_t)RTC_ByteToBcd2(sTime->Hours) << 16U) | \
-                        ((uint32_t)RTC_ByteToBcd2(sTime->Minutes) << 8U) | \
-                        ((uint32_t)RTC_ByteToBcd2(sTime->Seconds)) | \
-                        (((uint32_t)sTime->TimeFormat) << 16U));
+    tmpreg = (uint32_t)(( (uint32_t)RTC_ByteToBcd2(sTime->Hours)   << RTC_TR_HU_Pos)  | \
+                        ( (uint32_t)RTC_ByteToBcd2(sTime->Minutes) << RTC_TR_MNU_Pos) | \
+                        ( (uint32_t)RTC_ByteToBcd2(sTime->Seconds))                   | \
+                        (((uint32_t)sTime->TimeFormat)             << RTC_TR_PM_Pos));
   }
   else
   {
-    if((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
     {
       assert_param(IS_RTC_HOUR12(RTC_Bcd2ToByte(sTime->Hours)));
       assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
@@ -791,100 +777,79 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
     }
     assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sTime->Minutes)));
     assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sTime->Seconds)));
-    tmpreg = (((uint32_t)(sTime->Hours) << 16U) | \
-              ((uint32_t)(sTime->Minutes) << 8U) | \
-              ((uint32_t)sTime->Seconds) | \
-              ((uint32_t)(sTime->TimeFormat) << 16U));
+    tmpreg = (((uint32_t)(sTime->Hours)      << RTC_TR_HU_Pos)  | \
+              ((uint32_t)(sTime->Minutes)    << RTC_TR_MNU_Pos) | \
+              ((uint32_t) sTime->Seconds)                       | \
+              ((uint32_t)(sTime->TimeFormat) << RTC_TR_PM_Pos));
   }
-  UNUSED(tmpreg);
+
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Set Initialization mode */
-  if(RTC_EnterInitMode(hrtc) != HAL_OK)
-  {
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
 
-    /* Set RTC state */
-    hrtc->State = HAL_RTC_STATE_ERROR;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hrtc);
-
-    return HAL_ERROR;
-  }
-  else
+  if (status == HAL_OK)
   {
     /* Set the RTC_TR register */
     hrtc->Instance->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
 
-    /* Clear the bits to be configured */
-    hrtc->Instance->CR &= ((uint32_t)~RTC_CR_BKP);
+    /* Clear the bits to be configured (Deprecated. Use HAL_RTC_DST_xxx functions instead) */
+    hrtc->Instance->CR &= (uint32_t)~RTC_CR_BKP;
 
-    /* Configure the RTC_CR register */
+    /* Configure the RTC_CR register (Deprecated. Use HAL_RTC_DST_xxx functions instead) */
     hrtc->Instance->CR |= (uint32_t)(sTime->DayLightSaving | sTime->StoreOperation);
 
     /* Exit Initialization mode */
-    hrtc->Instance->ISR &= ((uint32_t)~RTC_ISR_INIT);
-
-    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
-    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
-    {
-      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-        hrtc->State = HAL_RTC_STATE_ERROR;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(hrtc);
-
-        return HAL_ERROR;
-      }
-    }
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-   hrtc->State = HAL_RTC_STATE_READY;
-
-   __HAL_UNLOCK(hrtc);
-
-   return HAL_OK;
+    status = RTC_ExitInitMode(hrtc);
   }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
 }
 
 /**
-  * @brief  Get RTC current time.
-  * @param hrtc RTC handle
-  * @param sTime Pointer to Time structure with Hours, Minutes and Seconds fields returned
-  *                with input format (BIN or BCD), also SubSeconds field returning the
-  *                RTC_SSR register content and SecondFraction field the Synchronous pre-scaler
-  *                factor to be used for second fraction ratio computation.
-  * @param Format Specifies the format of the entered parameters.
+  * @brief  Gets RTC current time.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime Pointer to Time structure
+  * @param  Format Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *            @arg RTC_FORMAT_BIN: Binary data format
   *            @arg RTC_FORMAT_BCD: BCD data format
-  * @note  You can use SubSeconds and SecondFraction (sTime structure fields returned) to convert SubSeconds
-  *        value in second fraction ratio with time unit following generic formula:
-  *        Second fraction ratio * time_unit= [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
-  *        This conversion can be performed only if no shift operation is pending (ie. SHFP=0) when PREDIV_S >= SS
-  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
-  *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
-  *        Reading RTC current time locks the values in calendar shadow registers until Current date is read
-  *        to ensure consistency between the time and date values.
+  * @note  You can use SubSeconds and SecondFraction (sTime structure fields
+  *        returned) to convert SubSeconds value in second fraction ratio with
+  *        time unit following generic formula:
+  *        Second fraction ratio * time_unit =
+  *           [(SecondFraction - SubSeconds) / (SecondFraction + 1)] * time_unit
+  *        This conversion can be performed only if no shift operation is pending
+  *        (ie. SHFP=0) when PREDIV_S >= SS
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the
+  *        values in the higher-order calendar shadow registers to ensure
+  *        consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers
+  *        until current date is read to ensure consistency between the time and
+  *        date values.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
 
-  /* Get subseconds structure field from the corresponding register*/
+  /* Get subseconds value from the corresponding register */
   sTime->SubSeconds = (uint32_t)(hrtc->Instance->SSR);
 
   /* Get SecondFraction structure field from the corresponding register field*/
@@ -894,13 +859,13 @@ HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
   tmpreg = (uint32_t)(hrtc->Instance->TR & RTC_TR_RESERVED_MASK);
 
   /* Fill the structure fields with the read parameters */
-  sTime->Hours = (uint8_t)((tmpreg & (RTC_TR_HT | RTC_TR_HU)) >> 16U);
-  sTime->Minutes = (uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >>8U);
-  sTime->Seconds = (uint8_t)(tmpreg & (RTC_TR_ST | RTC_TR_SU));
-  sTime->TimeFormat = (uint8_t)((tmpreg & (RTC_TR_PM)) >> 16U);
+  sTime->Hours      = (uint8_t)((tmpreg & (RTC_TR_HT  | RTC_TR_HU))  >> RTC_TR_HU_Pos);
+  sTime->Minutes    = (uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >> RTC_TR_MNU_Pos);
+  sTime->Seconds    = (uint8_t)( tmpreg & (RTC_TR_ST  | RTC_TR_SU));
+  sTime->TimeFormat = (uint8_t)((tmpreg & (RTC_TR_PM))               >> RTC_TR_PM_Pos);
 
   /* Check the input parameters format */
-  if(Format == RTC_FORMAT_BIN)
+  if (Format == RTC_FORMAT_BIN)
   {
     /* Convert the time structure parameters to Binary format */
     sTime->Hours = (uint8_t)RTC_Bcd2ToByte(sTime->Hours);
@@ -912,10 +877,11 @@ HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
 }
 
 /**
-  * @brief  Set RTC current date.
-  * @param hrtc RTC handle
-  * @param sDate Pointer to date structure
-  * @param Format specifies the format of the entered parameters.
+  * @brief  Sets RTC current date.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate Pointer to date structure
+  * @param  Format specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *            @arg RTC_FORMAT_BIN: Binary data format
   *            @arg RTC_FORMAT_BCD: BCD data format
@@ -923,33 +889,34 @@ HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
   */
 HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
 {
-  uint32_t datetmpreg;
+  uint32_t datetmpreg = 0U;
+  HAL_StatusTypeDef status;
 
- /* Check the parameters */
+  /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
 
- /* Process Locked */
- __HAL_LOCK(hrtc);
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
 
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  if((Format == RTC_FORMAT_BIN) && ((sDate->Month & 0x10U) == 0x10U))
+  if ((Format == RTC_FORMAT_BIN) && ((sDate->Month & 0x10U) == 0x10U))
   {
     sDate->Month = (uint8_t)((sDate->Month & (uint8_t)~(0x10U)) + (uint8_t)0x0AU);
   }
 
   assert_param(IS_RTC_WEEKDAY(sDate->WeekDay));
 
-  if(Format == RTC_FORMAT_BIN)
+  if (Format == RTC_FORMAT_BIN)
   {
     assert_param(IS_RTC_YEAR(sDate->Year));
     assert_param(IS_RTC_MONTH(sDate->Month));
     assert_param(IS_RTC_DATE(sDate->Date));
 
-   datetmpreg = (((uint32_t)RTC_ByteToBcd2(sDate->Year) << 16U) | \
-                 ((uint32_t)RTC_ByteToBcd2(sDate->Month) << 8U) | \
-                 ((uint32_t)RTC_ByteToBcd2(sDate->Date)) | \
-                 ((uint32_t)sDate->WeekDay << 13U));
+    datetmpreg = (((uint32_t)RTC_ByteToBcd2(sDate->Year)  << RTC_DR_YU_Pos) | \
+                  ((uint32_t)RTC_ByteToBcd2(sDate->Month) << RTC_DR_MU_Pos) | \
+                  ((uint32_t)RTC_ByteToBcd2(sDate->Date))                   | \
+                  ((uint32_t)sDate->WeekDay               << RTC_DR_WDU_Pos));
   }
   else
   {
@@ -957,82 +924,61 @@ HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
     assert_param(IS_RTC_MONTH(RTC_Bcd2ToByte(sDate->Month)));
     assert_param(IS_RTC_DATE(RTC_Bcd2ToByte(sDate->Date)));
 
-    datetmpreg = ((((uint32_t)sDate->Year) << 16U) | \
-                  (((uint32_t)sDate->Month) << 8U) | \
-                  ((uint32_t)sDate->Date) | \
-                  (((uint32_t)sDate->WeekDay) << 13U));
+    datetmpreg = ((((uint32_t)sDate->Year)    << RTC_DR_YU_Pos) | \
+                  (((uint32_t)sDate->Month)   << RTC_DR_MU_Pos) | \
+                  ((uint32_t) sDate->Date)                      | \
+                  (((uint32_t)sDate->WeekDay) << RTC_DR_WDU_Pos));
   }
 
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Set Initialization mode */
-  if(RTC_EnterInitMode(hrtc) != HAL_OK)
-  {
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
 
-    /* Set RTC state*/
-    hrtc->State = HAL_RTC_STATE_ERROR;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hrtc);
-
-    return HAL_ERROR;
-  }
-  else
+  if (status == HAL_OK)
   {
     /* Set the RTC_DR register */
     hrtc->Instance->DR = (uint32_t)(datetmpreg & RTC_DR_RESERVED_MASK);
 
     /* Exit Initialization mode */
-    hrtc->Instance->ISR &= ((uint32_t)~RTC_ISR_INIT);
-
-    /* If  CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
-    if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
-    {
-      if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-        hrtc->State = HAL_RTC_STATE_ERROR;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(hrtc);
-
-        return HAL_ERROR;
-      }
-    }
-
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-    hrtc->State = HAL_RTC_STATE_READY ;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hrtc);
-
-    return HAL_OK;
+    status = RTC_ExitInitMode(hrtc);
   }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
 }
 
 /**
-  * @brief  Get RTC current date.
-  * @param hrtc RTC handle
-  * @param sDate Pointer to Date structure
-  * @param Format Specifies the format of the entered parameters.
+  * @brief  Gets RTC current date.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate Pointer to Date structure
+  * @param  Format Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *            @arg RTC_FORMAT_BIN:  Binary data format
   *            @arg RTC_FORMAT_BCD:  BCD data format
-  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the values
-  *        in the higher-order calendar shadow registers to ensure consistency between the time and date values.
-  *        Reading RTC current time locks the values in calendar shadow registers until Current date is read.
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the
+  *        values in the higher-order calendar shadow registers to ensure
+  *        consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers
+  *        until current date is read to ensure consistency between the time and
+  *        date values.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
 {
-  uint32_t datetmpreg;
+  uint32_t datetmpreg = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
@@ -1041,18 +987,18 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   datetmpreg = (uint32_t)(hrtc->Instance->DR & RTC_DR_RESERVED_MASK);
 
   /* Fill the structure fields with the read parameters */
-  sDate->Year = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> 16U);
-  sDate->Month = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> 8U);
-  sDate->Date = (uint8_t)(datetmpreg & (RTC_DR_DT | RTC_DR_DU));
-  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU)) >> 13U);
+  sDate->Year    = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> RTC_DR_YU_Pos);
+  sDate->Month   = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> RTC_DR_MU_Pos);
+  sDate->Date    = (uint8_t) (datetmpreg & (RTC_DR_DT | RTC_DR_DU));
+  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU))            >> RTC_DR_WDU_Pos);
 
   /* Check the input parameters format */
-  if(Format == RTC_FORMAT_BIN)
+  if (Format == RTC_FORMAT_BIN)
   {
     /* Convert the date structure parameters to Binary format */
-    sDate->Year = (uint8_t)RTC_Bcd2ToByte(sDate->Year);
+    sDate->Year  = (uint8_t)RTC_Bcd2ToByte(sDate->Year);
     sDate->Month = (uint8_t)RTC_Bcd2ToByte(sDate->Month);
-    sDate->Date = (uint8_t)RTC_Bcd2ToByte(sDate->Date);
+    sDate->Date  = (uint8_t)RTC_Bcd2ToByte(sDate->Date);
   }
   return HAL_OK;
 }
@@ -1061,9 +1007,9 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   * @}
   */
 
-/** @addtogroup RTC_Exported_Functions_Group3
- *  @brief   RTC Alarm functions
- *
+/** @defgroup RTC_Exported_Functions_Group3 RTC Alarm functions
+  * @brief    RTC Alarm functions
+  *
 @verbatim
  ===============================================================================
                  ##### RTC Alarm functions #####
@@ -1075,19 +1021,24 @@ HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDat
   * @{
   */
 /**
-  * @brief  Set the specified RTC Alarm.
-  * @param hrtc RTC handle
-  * @param sAlarm Pointer to Alarm structure
-  * @param Format Specifies the format of the entered parameters.
+  * @brief  Sets the specified RTC Alarm.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm Pointer to Alarm structure
+  * @param  Format Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
+  * @note   The Alarm register can only be written when the corresponding Alarm
+  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).
+  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
 {
-  uint32_t tickstart;
-  uint32_t tmpreg, subsecondtmpreg;
+  uint32_t tickstart = 0U;
+  uint32_t tmpreg = 0U;
+  uint32_t subsecondtmpreg = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
@@ -1100,11 +1051,14 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
+  /* Change RTC state to BUSY */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  if(Format == RTC_FORMAT_BIN)
+  /* Check the data format (binary or BCD) and store the Alarm time and date
+     configuration accordingly */
+  if (Format == RTC_FORMAT_BIN)
   {
-    if((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
     {
       assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
       assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
@@ -1117,7 +1071,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
     assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
 
-    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
     {
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
     }
@@ -1126,17 +1080,17 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
     }
 
-    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16U) | \
-              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8U) | \
-              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
-              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16U) | \
-              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24U) | \
-              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours)   << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds))                       | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat)            << RTC_ALRMAR_PM_Pos)  | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay)  << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel)                                     | \
               ((uint32_t)sAlarm->AlarmMask));
   }
   else
   {
-    if((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
     {
       assert_param(IS_RTC_HOUR12(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
       assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
@@ -1150,7 +1104,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
     assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
     assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
 
-    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
     {
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
     }
@@ -1159,35 +1113,40 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
     }
 
-    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16U) | \
-              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8U) | \
-              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
-              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16U) | \
-              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24U) | \
-              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
-              ((uint32_t)sAlarm->AlarmMask));
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours)      << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes)    << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds)                           | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << RTC_ALRMAR_PM_Pos)  | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay)     << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t) sAlarm->AlarmDateWeekDaySel)                         | \
+              ((uint32_t) sAlarm->AlarmMask));
   }
 
-  /* Configure the Alarm A or Alarm B Sub Second registers */
-  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+  /* Store the Alarm subseconds configuration */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | \
+                               (uint32_t)(sAlarm->AlarmSubSecondMask));
 
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Configure the Alarm register */
-  if(sAlarm->Alarm == RTC_ALARM_A)
+  if (sAlarm->Alarm == RTC_ALARM_A)
   {
-    /* Disable the Alarm A interrupt */
+    /* Disable Alarm A */
     __HAL_RTC_ALARMA_DISABLE(hrtc);
 
-    /* In case of interrupt mode is used, the interrupt source must disabled */
+    /* In case interrupt mode is used, the interrupt source must be disabled */
     __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
 
+    /* Clear Alarm A flag */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+    /* Get tick */
     tickstart = HAL_GetTick();
-    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
+
+    /* Wait till RTC ALRAWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
     {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1201,25 +1160,31 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
       }
     }
 
+    /* Configure Alarm A register */
     hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
-    /* Configure the Alarm A Sub Second register */
+    /* Configure Alarm A Subseconds register */
     hrtc->Instance->ALRMASSR = subsecondtmpreg;
-    /* Configure the Alarm state: Enable Alarm */
+    /* Enable Alarm A */
     __HAL_RTC_ALARMA_ENABLE(hrtc);
   }
   else
   {
-    /* Disable the Alarm B interrupt */
+    /* Disable Alarm B */
     __HAL_RTC_ALARMB_DISABLE(hrtc);
 
-    /* In case of interrupt mode is used, the interrupt source must disabled */
+    /* In case interrupt mode is used, the interrupt source must be disabled */
     __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
 
+    /* Clear Alarm B flag */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+    /* Get tick */
     tickstart = HAL_GetTick();
-    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
+
+    /* Wait till RTC ALRBWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
     {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1233,17 +1198,18 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
       }
     }
 
+    /* Configure Alarm B register */
     hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
-    /* Configure the Alarm B Sub Second register */
+    /* Configure Alarm B Subseconds register */
     hrtc->Instance->ALRMBSSR = subsecondtmpreg;
-    /* Configure the Alarm state: Enable Alarm */
+    /* Enable Alarm B */
     __HAL_RTC_ALARMB_ENABLE(hrtc);
   }
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-  /* Change RTC state */
+  /* Change RTC state back to READY */
   hrtc->State = HAL_RTC_STATE_READY;
 
   /* Process Unlocked */
@@ -1253,10 +1219,11 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
 }
 
 /**
-  * @brief  Set the specified RTC Alarm with Interrupt.
-  * @param hrtc RTC handle
-  * @param sAlarm Pointer to Alarm structure
-  * @param Format Specifies the format of the entered parameters.
+  * @brief  Sets the specified RTC Alarm with Interrupt.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm Pointer to Alarm structure
+  * @param  Format Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
@@ -1267,8 +1234,9 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
   */
 HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
 {
-  uint32_t tickstart;
-  uint32_t tmpreg, subsecondtmpreg;
+  __IO uint32_t count  = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+       uint32_t tmpreg = 0U;
+       uint32_t subsecondtmpreg = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
@@ -1281,11 +1249,14 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
+  /* Change RTC state to BUSY */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  if(Format == RTC_FORMAT_BIN)
+  /* Check the data format (binary or BCD) and store the Alarm time and date
+     configuration accordingly */
+  if (Format == RTC_FORMAT_BIN)
   {
-    if((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
     {
       assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
       assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
@@ -1298,7 +1269,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
     assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
 
-    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
     {
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
     }
@@ -1306,17 +1277,18 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     {
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
     }
-    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours) << 16U) | \
-              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << 8U) | \
-              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds)) | \
-              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16U) | \
-              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay) << 24U) | \
-              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
+
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours)   << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds))                       | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat)            << RTC_ALRMAR_PM_Pos)  | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay)  << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel)                                     | \
               ((uint32_t)sAlarm->AlarmMask));
   }
   else
   {
-    if((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
     {
       assert_param(IS_RTC_HOUR12(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
       assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
@@ -1330,7 +1302,7 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
     assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
 
-    if(sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
     {
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
     }
@@ -1338,34 +1310,36 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
     {
       assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
     }
-    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours) << 16U) | \
-              ((uint32_t)(sAlarm->AlarmTime.Minutes) << 8U) | \
-              ((uint32_t) sAlarm->AlarmTime.Seconds) | \
-              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << 16U) | \
-              ((uint32_t)(sAlarm->AlarmDateWeekDay) << 24U) | \
-              ((uint32_t)sAlarm->AlarmDateWeekDaySel) | \
-              ((uint32_t)sAlarm->AlarmMask));
+
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours)      << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes)    << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds)                           | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << RTC_ALRMAR_PM_Pos)  | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay)     << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t) sAlarm->AlarmDateWeekDaySel)                         | \
+              ((uint32_t) sAlarm->AlarmMask));
   }
-  /* Configure the Alarm A or Alarm B Sub Second registers */
-  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Store the Alarm subseconds configuration */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | \
+                               (uint32_t)(sAlarm->AlarmSubSecondMask));
 
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Configure the Alarm register */
-  if(sAlarm->Alarm == RTC_ALARM_A)
+  if (sAlarm->Alarm == RTC_ALARM_A)
   {
-    /* Disable the Alarm A interrupt */
+    /* Disable Alarm A */
     __HAL_RTC_ALARMA_DISABLE(hrtc);
 
-    /* Clear flag alarm A */
+    /* Clear Alarm A flag */
     __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
 
-    tickstart = HAL_GetTick();
-    /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
+    /* Wait till RTC ALRAWF flag is set and if timeout is reached exit */
+    do
     {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      count = count - 1U;
+      if (count == 0U)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1377,29 +1351,33 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
 
         return HAL_TIMEOUT;
       }
-    }
+    } while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U);
 
+  /* Configure Alarm A register */
     hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
-    /* Configure the Alarm A Sub Second register */
+    /* Configure Alarm A Subseconds register */
     hrtc->Instance->ALRMASSR = subsecondtmpreg;
-    /* Configure the Alarm state: Enable Alarm */
+    /* Enable Alarm A */
     __HAL_RTC_ALARMA_ENABLE(hrtc);
-    /* Configure the Alarm interrupt */
-    __HAL_RTC_ALARM_ENABLE_IT(hrtc,RTC_IT_ALRA);
+    /* Enable Alarm A interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRA);
   }
   else
   {
-    /* Disable the Alarm B interrupt */
+    /* Disable Alarm B */
     __HAL_RTC_ALARMB_DISABLE(hrtc);
 
-    /* Clear flag alarm B */
+    /* Clear Alarm B flag */
     __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
 
-    tickstart = HAL_GetTick();
-    /* Wait till RTC ALRBWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
+    /* Reload the counter */
+    count = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+
+    /* Wait till RTC ALRBWF flag is set and if timeout is reached exit */
+    do
     {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      count = count - 1U;
+      if (count == 0U)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1411,25 +1389,26 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
 
         return HAL_TIMEOUT;
       }
-    }
+    } while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U);
 
+    /* Configure Alarm B register */
     hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
-    /* Configure the Alarm B Sub Second register */
+    /* Configure Alarm B Subseconds register */
     hrtc->Instance->ALRMBSSR = subsecondtmpreg;
-    /* Configure the Alarm state: Enable Alarm */
+    /* Enable Alarm B */
     __HAL_RTC_ALARMB_ENABLE(hrtc);
-    /* Configure the Alarm interrupt */
+    /* Enable Alarm B interrupt */
     __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRB);
   }
 
-  /* RTC Alarm Interrupt Configuration: EXTI configuration */
+  /* Enable and configure the EXTI line associated to the RTC Alarm interrupt */
   __HAL_RTC_ALARM_EXTI_ENABLE_IT();
-
   __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
+  /* Change RTC state back to READY */
   hrtc->State = HAL_RTC_STATE_READY;
 
   /* Process Unlocked */
@@ -1439,17 +1418,18 @@ HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef 
 }
 
 /**
-  * @brief  Deactivate the specified RTC Alarm.
-  * @param hrtc RTC handle
-  * @param Alarm Specifies the Alarm.
+  * @brief  Deactivates the specified RTC Alarm.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Alarm Specifies the Alarm.
   *          This parameter can be one of the following values:
-  *            @arg RTC_ALARM_A:  AlarmA
-  *            @arg RTC_ALARM_B:  AlarmB
+  *            @arg RTC_ALARM_A: Alarm A
+  *            @arg RTC_ALARM_B: Alarm B
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_ALARM(Alarm));
@@ -1462,20 +1442,21 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  if(Alarm == RTC_ALARM_A)
+  if (Alarm == RTC_ALARM_A)
   {
-    /* AlarmA */
+    /* Disable Alarm A */
     __HAL_RTC_ALARMA_DISABLE(hrtc);
 
-    /* In case of interrupt mode is used, the interrupt source must disabled */
+    /* In case interrupt mode is used, the interrupt source must be disabled */
     __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
 
+    /* Get tick */
     tickstart = HAL_GetTick();
 
-    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
+    /* Wait till RTC ALRAWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
     {
-      if( (HAL_GetTick()  - tickstart ) > RTC_TIMEOUT_VALUE)
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1491,18 +1472,19 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
   }
   else
   {
-    /* AlarmB */
+    /* Disable Alarm B */
     __HAL_RTC_ALARMB_DISABLE(hrtc);
 
-    /* In case of interrupt mode is used, the interrupt source must disabled */
-    __HAL_RTC_ALARM_DISABLE_IT(hrtc,RTC_IT_ALRB);
+    /* In case interrupt mode is used, the interrupt source must be disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
 
+    /* Get tick */
     tickstart = HAL_GetTick();
 
-    /* Wait till RTC ALRxWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
+    /* Wait till RTC ALRBWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
     {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1516,6 +1498,7 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
       }
     }
   }
+
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
@@ -1528,14 +1511,15 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
 }
 
 /**
-  * @brief  Get the RTC Alarm value and masks.
-  * @param hrtc RTC handle
-  * @param sAlarm Pointer to Date structure
-  * @param Alarm Specifies the Alarm.
+  * @brief  Gets the RTC Alarm value and masks.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm Pointer to Date structure
+  * @param  Alarm Specifies the Alarm.
   *          This parameter can be one of the following values:
-  *             @arg RTC_ALARM_A: AlarmA
-  *             @arg RTC_ALARM_B: AlarmB
-  * @param Format Specifies the format of the entered parameters.
+  *            @arg RTC_ALARM_A: Alarm A
+  *            @arg RTC_ALARM_B: Alarm B
+  * @param  Format Specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
@@ -1543,29 +1527,19 @@ HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alar
   */
 HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format)
 {
-  uint32_t tmpreg, subsecondtmpreg;
+  uint32_t tmpreg = 0U;
+  uint32_t subsecondtmpreg = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
   assert_param(IS_RTC_ALARM(Alarm));
 
-  if(Alarm == RTC_ALARM_A)
+  if (Alarm == RTC_ALARM_A)
   {
-    /* AlarmA */
     sAlarm->Alarm = RTC_ALARM_A;
 
     tmpreg = (uint32_t)(hrtc->Instance->ALRMAR);
-    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMASSR ) & RTC_ALRMASSR_SS);
-
-/* Fill the structure with the read parameters */
-  sAlarm->AlarmTime.Hours = (uint8_t)((tmpreg & (RTC_ALRMAR_HT | RTC_ALRMAR_HU)) >> 16U);
-  sAlarm->AlarmTime.Minutes = (uint8_t)((tmpreg & (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU)) >> 8U);
-  sAlarm->AlarmTime.Seconds = (uint8_t)(tmpreg & (RTC_ALRMAR_ST | RTC_ALRMAR_SU));
-  sAlarm->AlarmTime.TimeFormat = (uint8_t)((tmpreg & RTC_ALRMAR_PM) >> 16U);
-  sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
-  sAlarm->AlarmDateWeekDay = (uint8_t)((tmpreg & (RTC_ALRMAR_DT | RTC_ALRMAR_DU)) >> 24U);
-  sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMAR_WDSEL);
-  sAlarm->AlarmMask = (uint32_t)(tmpreg & RTC_ALARMMASK_ALL);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMASSR) & RTC_ALRMASSR_SS);
   }
   else
   {
@@ -1573,73 +1547,75 @@ HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sA
 
     tmpreg = (uint32_t)(hrtc->Instance->ALRMBR);
     subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMBSSR) & RTC_ALRMBSSR_SS);
+  }
 
   /* Fill the structure with the read parameters */
-  sAlarm->AlarmTime.Hours = (uint8_t)((tmpreg & (RTC_ALRMBR_HT | RTC_ALRMBR_HU)) >> 16U);
-  sAlarm->AlarmTime.Minutes = (uint8_t)((tmpreg & (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU)) >> 8U);
-  sAlarm->AlarmTime.Seconds = (uint8_t)(tmpreg & (RTC_ALRMBR_ST | RTC_ALRMBR_SU));
-  sAlarm->AlarmTime.TimeFormat = (uint8_t)((tmpreg & RTC_ALRMBR_PM) >> 16U);
+  sAlarm->AlarmTime.Hours      = (uint8_t) ((tmpreg & (RTC_ALRMAR_HT  | RTC_ALRMAR_HU))  >> RTC_ALRMAR_HU_Pos);
+  sAlarm->AlarmTime.Minutes    = (uint8_t) ((tmpreg & (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU)) >> RTC_ALRMAR_MNU_Pos);
+  sAlarm->AlarmTime.Seconds    = (uint8_t) ( tmpreg & (RTC_ALRMAR_ST  | RTC_ALRMAR_SU));
+  sAlarm->AlarmTime.TimeFormat = (uint8_t) ((tmpreg & RTC_ALRMAR_PM)                     >> RTC_TR_PM_Pos);
   sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
-  sAlarm->AlarmDateWeekDay = (uint8_t)((tmpreg & (RTC_ALRMBR_DT | RTC_ALRMBR_DU)) >> 24U);
-  sAlarm->AlarmDateWeekDaySel = (uint32_t)(tmpreg & RTC_ALRMBR_WDSEL);
-  sAlarm->AlarmMask = (uint32_t)(tmpreg & RTC_ALARMMASK_ALL);
- }
+  sAlarm->AlarmDateWeekDay     = (uint8_t) ((tmpreg & (RTC_ALRMAR_DT  | RTC_ALRMAR_DU))  >> RTC_ALRMAR_DU_Pos);
+  sAlarm->AlarmDateWeekDaySel  = (uint32_t) (tmpreg & RTC_ALRMAR_WDSEL);
+  sAlarm->AlarmMask            = (uint32_t) (tmpreg & RTC_ALARMMASK_ALL);
 
-  if(Format == RTC_FORMAT_BIN)
+  if (Format == RTC_FORMAT_BIN)
   {
-    sAlarm->AlarmTime.Hours = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+    sAlarm->AlarmTime.Hours   = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
     sAlarm->AlarmTime.Minutes = RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes);
     sAlarm->AlarmTime.Seconds = RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds);
-    sAlarm->AlarmDateWeekDay = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+    sAlarm->AlarmDateWeekDay  = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
   }
 
   return HAL_OK;
 }
 
 /**
-  * @brief  Handle Alarm interrupt request.
-  * @param hrtc RTC handle
+  * @brief  Handles Alarm interrupt request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
-void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef* hrtc)
+void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc)
 {
-  /* Get the AlarmA interrupt source enable status */
-  if(__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRA) != 0U)
+  /* Clear the EXTI flag associated to the RTC Alarm interrupt */
+  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG();
+
+  /* Get the Alarm A interrupt source enable status */
+  if (__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRA) != 0U)
   {
-    /* Get the pending status of the AlarmA Interrupt */
-    if(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) != 0U)
+    /* Get the pending status of the Alarm A Interrupt */
+    if (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) != 0U)
     {
-      /* AlarmA callback */
+      /* Clear the Alarm A interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+      /* Alarm A callback */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
       hrtc->AlarmAEventCallback(hrtc);
 #else
       HAL_RTC_AlarmAEventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
-
-      /* Clear the AlarmA interrupt pending bit */
-      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
     }
   }
 
-  /* Get the AlarmB interrupt source enable status */
-  if(__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRB) != 0U)
+  /* Get the Alarm B interrupt source enable status */
+  if (__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRB) != 0U)
   {
-    /* Get the pending status of the AlarmB Interrupt */
-    if(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) != 0U)
+    /* Get the pending status of the Alarm B Interrupt */
+    if (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) != 0U)
     {
-      /* AlarmB callback */
+      /* Clear the Alarm B interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+      /* Alarm B callback */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
       hrtc->AlarmBEventCallback(hrtc);
 #else
       HAL_RTCEx_AlarmBEventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
-
-      /* Clear the AlarmB interrupt pending bit */
-      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
     }
   }
-  /* Clear the EXTI's line Flag for RTC Alarm */
-  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG();
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1647,7 +1623,8 @@ void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef* hrtc)
 
 /**
   * @brief  Alarm A callback.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
@@ -1655,27 +1632,31 @@ __weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTC_AlarmAEventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTC_AlarmAEventCallback could be implemented in the user file
    */
 }
 
 /**
-  * @brief  Handle AlarmA Polling request.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Alarm A Polling request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
+  uint32_t tickstart = 0U;
 
-  uint32_t tickstart = HAL_GetTick();
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
-  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == 0U)
+  /* Wait till RTC ALRAF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == 0U)
   {
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
@@ -1683,7 +1664,7 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
     }
   }
 
-  /* Clear the Alarm interrupt pending bit */
+  /* Clear the Alarm flag */
   __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
 
   /* Change RTC state */
@@ -1696,9 +1677,9 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
   * @}
   */
 
-/** @addtogroup RTC_Exported_Functions_Group4
- *  @brief   Peripheral Control functions
- *
+/** @defgroup RTC_Exported_Functions_Group4 Peripheral Control functions
+  * @brief    Peripheral Control functions
+  *
 @verbatim
  ===============================================================================
                      ##### Peripheral Control functions #####
@@ -1706,13 +1687,14 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
     [..]
     This subsection provides functions allowing to
       (+) Wait for RTC Time and Date Synchronization
+      (+) Manage RTC Summer or Winter time change
 
 @endverbatim
   * @{
   */
 
 /**
-  * @brief  Wait until the RTC Time and Date registers (RTC_TR and RTC_DR) are
+  * @brief  Waits until the RTC Time and Date registers (RTC_TR and RTC_DR) are
   *         synchronized with RTC APB clock.
   * @note   The RTC Resynchronization mode is write protected, use the
   *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
@@ -1722,22 +1704,24 @@ HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t T
   *         The software must then wait until it is set again before reading
   *         the calendar, which means that the calendar registers have been
   *         correctly copied into the RTC_TR and RTC_DR shadow registers.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
 
-  /* Clear RSF flag */
-  hrtc->Instance->ISR &= (uint32_t)RTC_RSF_MASK;
+  /* Clear RSF flag, keep reserved bits at reset values (setting other flags has no effect) */
+  hrtc->Instance->ISR = ((uint32_t)(RTC_RSF_MASK & RTC_ISR_RESERVED_MASK));
 
+  /* Get tick */
   tickstart = HAL_GetTick();
 
   /* Wait the registers to be synchronised */
-  while((hrtc->Instance->ISR & RTC_ISR_RSF) == 0U)
+  while ((hrtc->Instance->ISR & RTC_ISR_RSF) == 0U)
   {
-    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
     {
       return HAL_TIMEOUT;
     }
@@ -1747,12 +1731,77 @@ HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
 }
 
 /**
+  * @brief  Daylight Saving Time, adds one hour to the calendar in one
+  *         single operation without going through the initialization procedure.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_Add1Hour(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  SET_BIT(hrtc->Instance->CR, RTC_CR_ADD1H);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, subtracts one hour from the calendar in one
+  *         single operation without going through the initialization procedure.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_Sub1Hour(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  SET_BIT(hrtc->Instance->CR, RTC_CR_SUB1H);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, sets the store operation bit.
+  * @note   It can be used by the software in order to memorize the DST status.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_SetStoreOperation(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  SET_BIT(hrtc->Instance->CR, RTC_CR_BKP);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, clears the store operation bit.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_ClearStoreOperation(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  CLEAR_BIT(hrtc->Instance->CR, RTC_CR_BKP);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, reads the store operation bit.
+  * @param  hrtc RTC handle
+  * @retval operation see RTC_StoreOperation_Definitions
+  */
+uint32_t HAL_RTC_DST_ReadStoreOperation(RTC_HandleTypeDef *hrtc)
+{
+  return READ_BIT(hrtc->Instance->CR, RTC_CR_BKP);
+}
+
+/**
   * @}
   */
 
-/** @addtogroup RTC_Exported_Functions_Group5
- *  @brief   Peripheral State functions
- *
+/** @defgroup RTC_Exported_Functions_Group5 Peripheral State functions
+  * @brief    Peripheral State functions
+  *
 @verbatim
  ===============================================================================
                      ##### Peripheral State functions #####
@@ -1765,19 +1814,21 @@ HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef* hrtc)
   * @{
   */
 /**
-  * @brief  Return the RTC handle state.
-  * @param hrtc RTC handle
+  * @brief  Returns the RTC state.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL state
   */
-HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc)
 {
-  /* Return RTC handle state */
   return hrtc->State;
 }
 
 /**
   * @}
   */
+
+
 /**
   * @}
   */
@@ -1785,67 +1836,99 @@ HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef* hrtc)
 /** @addtogroup RTC_Private_Functions
   * @{
   */
+
 /**
-  * @brief  Enter the RTC Initialization mode.
+  * @brief  Enters the RTC Initialization mode.
   * @note   The RTC Initialization mode is write protected, use the
   *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
-HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
 
-  /* Check if the Initialization mode is set */
-  if((hrtc->Instance->ISR & RTC_ISR_INITF) == 0U)
+  /* Check that Initialization mode is not already set */
+  if (READ_BIT(hrtc->Instance->ISR, RTC_ISR_INITF) == 0U)
   {
-    /* Set the Initialization mode */
-    hrtc->Instance->ISR = (uint32_t)RTC_INIT_MASK;
+    /* Set INIT bit to enter Initialization mode */
+    SET_BIT(hrtc->Instance->ISR, RTC_ISR_INIT);
 
+    /* Get tick */
     tickstart = HAL_GetTick();
-    /* Wait till RTC is in INIT state and if Time out is reached exit */
-    while((hrtc->Instance->ISR & RTC_ISR_INITF) == 0U)
+
+    /* Wait till RTC is in INIT state and if timeout is reached exit */
+    while ((READ_BIT(hrtc->Instance->ISR, RTC_ISR_INITF) == 0U) && (status != HAL_ERROR))
     {
-      if((HAL_GetTick()  - tickstart ) > RTC_TIMEOUT_VALUE)
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
-        return HAL_TIMEOUT;
+        /* Set RTC state */
+        hrtc->State = HAL_RTC_STATE_ERROR;
+        status = HAL_ERROR;
       }
     }
   }
 
-  return HAL_OK;
+  return status;
 }
 
-
 /**
-  * @brief  Convert a 2 digit decimal to BCD format.
-  * @param Value Byte to be converted
-  * @retval Converted byte
+  * @brief  Exits the RTC Initialization mode.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
   */
-uint8_t RTC_ByteToBcd2(uint8_t Value)
+HAL_StatusTypeDef RTC_ExitInitMode(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t bcdhigh = 0U;
-  uint8_t Param = Value;
+  HAL_StatusTypeDef status = HAL_OK;
 
-  while(Param >= 10U)
+  /* Clear INIT bit to exit Initialization mode */
+  CLEAR_BIT(hrtc->Instance->ISR, RTC_ISR_INIT);
+
+  /* If CR_BYPSHAD bit = 0, wait for synchro */
+  if (READ_BIT(hrtc->Instance->CR, RTC_CR_BYPSHAD) == 0U)
   {
-    bcdhigh++;
-    Param -= 10U;
+    if (HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+    {
+      /* Set RTC state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+      status = HAL_ERROR;
+    }
   }
 
-  return  ((uint8_t)(bcdhigh << 4U) | Param);
+  return status;
 }
 
 /**
-  * @brief  Convert from 2 digit BCD to Binary.
-  * @param Value BCD value to be converted
+  * @brief  Converts a 2-digit number from decimal to BCD format.
+  * @param  number decimal-formatted number (from 0 to 99) to be converted
+  * @retval Converted byte
+  */
+uint8_t RTC_ByteToBcd2(uint8_t number)
+{
+  uint32_t bcdhigh = 0U;
+
+  while (number >= 10U)
+  {
+    bcdhigh++;
+    number -= 10U;
+  }
+
+  return ((uint8_t)(bcdhigh << 4U) | number);
+}
+
+/**
+  * @brief  Converts a 2-digit number from BCD to decimal format.
+  * @param  number BCD-formatted number (from 00 to 99) to be converted
   * @retval Converted word
   */
-uint8_t RTC_Bcd2ToByte(uint8_t Value)
+uint8_t RTC_Bcd2ToByte(uint8_t number)
 {
-  uint32_t tmp;
-  tmp = (((uint32_t)Value & 0xF0U) >> 4U) * 10U;
-  return (uint8_t)(tmp + ((uint32_t)Value & 0x0FU));
+  uint32_t tens = 0U;
+  tens = (((uint32_t)number & 0xF0U) >> 4U) * 10U;
+  return (uint8_t)(tens + ((uint32_t)number & 0x0FU));
 }
 
 /**
@@ -1860,5 +1943,3 @@ uint8_t RTC_Bcd2ToByte(uint8_t Value)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rtc_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_rtc_ex.c
@@ -4,16 +4,27 @@
   * @author  MCD Application Team
   * @brief   Extended RTC HAL module driver.
   *          This file provides firmware functions to manage the following
-  *          functionalities of the Real Time Clock (RTC) Extended peripheral:
-  *           + RTC Time Stamp functions
+  *          functionalities of the Real-Time Clock (RTC) Extended peripheral:
+  *           + RTC Timestamp functions
   *           + RTC Tamper functions
-  *           + RTC Wake-up functions
+  *           + RTC Wakeup functions
   *           + Extended Control functions
   *           + Extended RTC features functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
-                  ##### How to use this driver #####
+                        ##### How to use this driver #####
   ==============================================================================
   [..]
     (+) Enable the RTC domain access.
@@ -23,59 +34,45 @@
   *** RTC Wakeup configuration ***
   ================================
   [..]
-    (+) To configure the RTC Wakeup Clock source and Counter use the HAL_RTCEx_SetWakeUpTimer()
-        function. You can also configure the RTC Wakeup timer with interrupt mode
-        using the HAL_RTCEx_SetWakeUpTimer_IT() function.
-    (+) To read the RTC WakeUp Counter register, use the HAL_RTCEx_GetWakeUpTimer()
+    (+) To configure the RTC Wakeup Clock source and Counter use the
+        HAL_RTCEx_SetWakeUpTimer() function.
+        You can also configure the RTC Wakeup timer in interrupt mode using the
+        HAL_RTCEx_SetWakeUpTimer_IT() function.
+    (+) To read the RTC Wakeup Counter register, use the HAL_RTCEx_GetWakeUpTimer()
         function.
 
-  *** Outputs configuration ***
-  =============================
-  [..]  The RTC has 2 different outputs:
-    (+) RTC_ALARM: this output is used to manage the RTC Alarm A, Alarm B
-        and WaKeUp signals.
-        To output the selected RTC signal, use the HAL_RTC_Init() function.
-    (+) RTC_CALIB: this output is 512Hz signal or 1Hz.
-        To enable the RTC_CALIB, use the HAL_RTCEx_SetCalibrationOutPut() function.
-    (+) Two pins can be used as RTC_ALARM or RTC_CALIB (PC13, PB2) managed on
-        the RTC_OR register.
-    (+) When the RTC_CALIB or RTC_ALARM output is selected, the RTC_OUT pin is
-        automatically configured in output alternate function.
-
-  *** Smooth digital Calibration configuration ***
-  ================================================
-  [..]
-    (+) Configure the RTC Original Digital Calibration Value and the corresponding
-        calibration cycle period (32s,16s and 8s) using the HAL_RTCEx_SetSmoothCalib()
-        function.
-
-  *** TimeStamp configuration ***
+  *** Timestamp configuration ***
   ===============================
   [..]
-    (+) Enable the RTC TimeStamp using the HAL_RTCEx_SetTimeStamp() function.
-        You can also configure the RTC TimeStamp with interrupt mode using the
+    (+) To configure the RTC Timestamp use the HAL_RTCEx_SetTimeStamp() function.
+        You can also configure the RTC Timestamp with interrupt mode using the
         HAL_RTCEx_SetTimeStamp_IT() function.
-    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTCEx_GetTimeStamp()
-        function.
+    (+) To read the RTC Timestamp Time and Date register, use the
+        HAL_RTCEx_GetTimeStamp() function.
+    (+) The Timestamp alternate function is mapped to RTC_AF1 (PC13).
 
-  *** Internal TimeStamp configuration ***
+  *** Internal Timestamp configuration ***
   ===============================
   [..]
-    (+) Enable the RTC internal TimeStamp using the HAL_RTCEx_SetInternalTimeStamp() function.
-        User has to check internal timestamp occurrence using __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG.
-    (+) To read the RTC TimeStamp Time and Date register, use the HAL_RTCEx_GetTimeStamp()
+    (+) To enable the RTC internal Timestamp use the HAL_RTCEx_SetInternalTimeStamp()
+        function.
+    (+) To read the RTC Timestamp Time and Date register, use the HAL_RTCEx_GetTimeStamp()
         function.
 
   *** Tamper configuration ***
   ============================
   [..]
-    (+) Enable the RTC Tamper and configure the Tamper filter count, trigger Edge
-        or Level according to the Tamper filter (if equal to 0 Edge else Level)
-        value, sampling frequency, NoErase, MaskFlag,  precharge or discharge and
-        Pull-UP using the HAL_RTCEx_SetTamper() function. You can configure RTC Tamper
-        with interrupt mode using HAL_RTCEx_SetTamper_IT() function.
-    (+) The default configuration of the Tamper erases the backup registers. To avoid
-        erase, enable the NoErase field on the RTC_TAMPCR register.
+    (+) To enable the RTC Tamper and configure the Tamper filter count, trigger
+        Edge or Level according to the Tamper filter value (if equal to 0 Edge
+        else Level), sampling frequency, NoErase, MaskFlag, precharge or
+        discharge and Pull-UP use the HAL_RTCEx_SetTamper() function.
+        You can configure RTC Tamper in interrupt mode using HAL_RTCEx_SetTamper_IT()
+        function.
+    (+) The default configuration of the Tamper erases the backup registers.
+        To avoid this, enable the NoErase field on the RTC_TAMPCR register.
+    (+) The TAMPER1 alternate function is mapped to RTC_AF1 (PC13).
+    (+) The TAMPER2 alternate function is mapped to RTC_AF2 (PA0).
+    (+) The TAMPER3 alternate function is mapped to RTC_AF3 (PC12).
 
   *** Backup Data Registers configuration ***
   ===========================================
@@ -85,18 +82,36 @@
     (+) To read the RTC Backup Data registers, use the HAL_RTCEx_BKUPRead()
         function.
 
-   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
+  *** Smooth Digital Calibration configuration ***
+  ================================================
+  [..]
+    (+) RTC frequency can be digitally calibrated with a resolution of about
+        0.954 ppm with a range from -487.1 ppm to +488.5 ppm.
+        The correction of the frequency is performed using a series of small
+        adjustments (adding and/or subtracting individual RTCCLK pulses).
+    (+) The smooth digital calibration is performed during a cycle of about 2^20
+        RTCCLK pulses (or 32 seconds) when the input frequency is 32,768 Hz.
+        This cycle is maintained by a 20-bit counter clocked by RTCCLK.
+    (+) The smooth calibration register (RTC_CALR) specifies the number of RTCCLK
+        clock cycles to be masked during the 32-second cycle.
+    (+) To configure the RTC Smooth Digital Calibration value and the corresponding
+        calibration cycle period (32s,16s and 8s) use the HAL_RTCEx_SetSmoothCalib()
+        function.
+
+  *** Outputs configuration ***
+  =============================
+  [..] The RTC has 2 different outputs:
+    (+) RTC_ALARM: this output is used to manage the RTC alarms (Alarm A and Alarm B)
+        and WaKeUp signals.
+        To output the selected RTC signal, use the HAL_RTC_Init() function.
+    (+) RTC_CALIB: this output is 512Hz signal or 1Hz.
+        To enable the RTC_CALIB, use the HAL_RTCEx_SetCalibrationOutPut() function.
+    (+) Two pins can be used as RTC_ALARM or RTC_CALIB output, selected through
+        bit OUT_RMP of the RTC_OR register:
+    (+) When the RTC_CALIB or RTC_ALARM output is selected, the RTC_OUT pin is
+        automatically configured in output alternate function.
+
+  @endverbatim
   ******************************************************************************
   */
 
@@ -107,8 +122,8 @@
   * @{
   */
 
-/** @addtogroup RTCEx
-  * @brief RTC Extended HAL module driver
+/** @defgroup RTCEx RTCEx
+  * @brief    RTC Extended HAL module driver
   * @{
   */
 
@@ -116,117 +131,91 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-
-/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
-  * @{
-  */
-#if defined(RTC_TAMPER1_SUPPORT) && defined(RTC_TAMPER3_SUPPORT)
-#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
-                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
-                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
-                                       (uint32_t)RTC_TAMPCR_TAMP1IE   | (uint32_t)RTC_TAMPCR_TAMP1NOERASE | (uint32_t)RTC_TAMPCR_TAMP1MF  |\
-                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF  |\
-                                       (uint32_t)RTC_TAMPCR_TAMP3IE   | (uint32_t)RTC_TAMPCR_TAMP3NOERASE | (uint32_t)RTC_TAMPCR_TAMP3MF)
-#elif defined(RTC_TAMPER1_SUPPORT)
-#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
-                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
-                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
-                                       (uint32_t)RTC_TAMPCR_TAMP1IE   | (uint32_t)RTC_TAMPCR_TAMP1NOERASE | (uint32_t)RTC_TAMPCR_TAMP1MF  |\
-                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF)
-#elif defined(RTC_TAMPER3_SUPPORT)
-#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
-                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
-                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
-                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF  |\
-                                       (uint32_t)RTC_TAMPCR_TAMP3IE   | (uint32_t)RTC_TAMPCR_TAMP3NOERASE | (uint32_t)RTC_TAMPCR_TAMP3MF)
-#else
-#define RTC_TAMPCR_MASK               ((uint32_t)RTC_TAMPCR_TAMPTS    |\
-                                       (uint32_t)RTC_TAMPCR_TAMPFREQ  | (uint32_t)RTC_TAMPCR_TAMPFLT      | (uint32_t)RTC_TAMPCR_TAMPPRCH |\
-                                       (uint32_t)RTC_TAMPCR_TAMPPUDIS | (uint32_t)RTC_TAMPCR_TAMPIE                                       |\
-                                       (uint32_t)RTC_TAMPCR_TAMP2IE   | (uint32_t)RTC_TAMPCR_TAMP2NOERASE | (uint32_t)RTC_TAMPCR_TAMP2MF)
-#endif /* RTC_TAMPER1_SUPPORT && RTC_TAMPER3_SUPPORT */
-/**
-  * @}
-  */
-
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
 /* Exported functions --------------------------------------------------------*/
 
-/** @addtogroup RTCEx_Exported_Functions
+/** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
   * @{
   */
 
-
-/** @addtogroup RTCEx_Exported_Functions_Group1
- *  @brief   RTC TimeStamp and Tamper functions
+/** @defgroup RTCEx_Exported_Functions_Group1 RTC Timestamp and Tamper functions
+  * @brief    RTC Timestamp and Tamper functions
   *
 @verbatim
  ===============================================================================
-                 ##### RTC TimeStamp and Tamper functions #####
+                 ##### RTC Timestamp and Tamper functions #####
  ===============================================================================
 
- [..] This section provides functions allowing to configure TimeStamp feature
+ [..] This section provides functions allowing to configure Timestamp feature
 
 @endverbatim
   * @{
   */
 
 /**
-  * @brief  Set TimeStamp.
-  * @note   This API must be called before enabling the TimeStamp feature.
-  * @param hrtc RTC handle
-  * @param TimeStampEdge Specifies the pin edge on which the TimeStamp is
+  * @brief  Sets Timestamp.
+  * @note   This API must be called before enabling the Timestamp feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  RTC_TimeStampEdge Specifies the pin edge on which the Timestamp is
   *         activated.
   *          This parameter can be one of the following values:
-  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the
-  *                                        rising edge of the related pin.
-  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the
-  *                                         falling edge of the related pin.
-  * @param RTC_TimeStampPin specifies the RTC TimeStamp Pin.
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Timestamp event occurs on
+  *                                        the rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Timestamp event occurs on
+  *                                        the falling edge of the related pin.
+  * @param  RTC_TimeStampPin Specifies the RTC Timestamp Pin.
   *          This parameter can be one of the following values:
-  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC TimeStamp Pin.
-  *               The RTC TimeStamp Pin is per default PC13, but for reasons of
-  *               compatibility, this parameter is required.
+  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC Timestamp Pin.
+  * @note Although unused, parameter RTC_TimeStampPin has been kept for portability
+  *       reasons.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
 
   /* Check the parameters */
-  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_TIMESTAMP_EDGE(RTC_TimeStampEdge));
   assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Prevent compilation warning due to unused argument(s) if assert_param check
+     is disabled */
+  UNUSED(RTC_TimeStampPin);
 
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
+  /* Change RTC state to BUSY */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
   /* Get the RTC_CR register and clear the bits to be configured */
   tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
 
-  tmpreg|= TimeStampEdge;
+  /* Configure the Timestamp TSEDGE bit */
+  tmpreg |= RTC_TimeStampEdge;
 
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Clear the Timestamp Flag */
-  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
-
-  /* Clear the Timestamp overrun Flag */
-   __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
-
-  /* Configure the Time Stamp TSEDGE and Enable bits */
+  /* Copy the desired configuration into the CR register */
   hrtc->Instance->CR = (uint32_t)tmpreg;
 
+  /* Clear RTC Timestamp flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  /* Clear RTC Timestamp overrun Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+  /* Enable the Timestamp saving */
   __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-  /* Change RTC state */
+  /* Change RTC state back to READY */
   hrtc->State = HAL_RTC_STATE_READY;
 
   /* Process Unlocked */
@@ -236,66 +225,74 @@ HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t TimeS
 }
 
 /**
-  * @brief  Set TimeStamp with Interrupt.
-  * @param hrtc RTC handle
-  * @note   This API must be called before enabling the TimeStamp feature.
-  * @param TimeStampEdge Specifies the pin edge on which the TimeStamp is
+  * @brief  Sets Timestamp with Interrupt.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This API must be called before enabling the Timestamp feature.
+  * @param  RTC_TimeStampEdge Specifies the pin edge on which the Timestamp is
   *         activated.
   *          This parameter can be one of the following values:
-  *             @arg RTC_TIMESTAMPEDGE_RISING: the Time stamp event occurs on the
-  *                                        rising edge of the related pin.
-  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Time stamp event occurs on the
-  *                                         falling edge of the related pin.
-  * @param RTC_TimeStampPin Specifies the RTC TimeStamp Pin.
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Timestamp event occurs on
+  *                                        the rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Timestamp event occurs on
+  *                                        the falling edge of the related pin.
+  * @param  RTC_TimeStampPin Specifies the RTC Timestamp Pin.
   *          This parameter can be one of the following values:
-  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC TimeStamp Pin.
-  *               The RTC TimeStamp Pin is per default PC13, but for reasons of
-  *               compatibility, this parameter is required.
+  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC Timestamp Pin.
+  * @note Although unused, parameter RTC_TimeStampPin has been kept for portability
+  *       reasons.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t TimeStampEdge, uint32_t RTC_TimeStampPin)
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
 
   /* Check the parameters */
-  assert_param(IS_TIMESTAMP_EDGE(TimeStampEdge));
+  assert_param(IS_TIMESTAMP_EDGE(RTC_TimeStampEdge));
   assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Prevent compilation warning due to unused argument(s) if assert_param check
+     is disabled */
+  UNUSED(RTC_TimeStampPin);
 
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
+  /* Change RTC state to BUSY */
   hrtc->State = HAL_RTC_STATE_BUSY;
 
   /* Get the RTC_CR register and clear the bits to be configured */
   tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
 
-  tmpreg |= TimeStampEdge;
+  /* Configure the Timestamp TSEDGE bit */
+  tmpreg |= RTC_TimeStampEdge;
 
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Clear the Timestamp Flag */
-  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
-
-  /* Clear the Timestamp overrun Flag */
-   __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
-
-  /* Configure the Time Stamp TSEDGE and Enable bits */
+  /* Copy the desired configuration into the CR register */
   hrtc->Instance->CR = (uint32_t)tmpreg;
 
+  /* Clear RTC Timestamp flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  /* Clear RTC Timestamp overrun Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+  /* Enable the Timestamp saving */
   __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
 
-  /* Enable IT timestamp */
-  __HAL_RTC_TIMESTAMP_ENABLE_IT(hrtc,RTC_IT_TS);
+  /* Enable IT Timestamp */
+  __HAL_RTC_TIMESTAMP_ENABLE_IT(hrtc, RTC_IT_TS);
 
-  /* RTC timestamp Interrupt Configuration: EXTI configuration */
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Enable and configure the EXTI line associated to the RTC Timestamp and Tamper interrupts */
   __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
-
   __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();
 
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
+  /* Change RTC state back to READY */
   hrtc->State = HAL_RTC_STATE_READY;
 
   /* Process Unlocked */
@@ -305,13 +302,14 @@ HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t Ti
 }
 
 /**
-  * @brief  Deactivate TimeStamp.
-  * @param hrtc RTC handle
+  * @brief  Deactivates Timestamp.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
 
   /* Process Locked */
   __HAL_LOCK(hrtc);
@@ -321,13 +319,13 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* In case of interrupt mode is used, the interrupt source must disabled */
+  /* In case interrupt mode is used, the interrupt source must disabled */
   __HAL_RTC_TIMESTAMP_DISABLE_IT(hrtc, RTC_IT_TS);
 
   /* Get the RTC_CR register and clear the bits to be configured */
   tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
 
-  /* Configure the Time Stamp TSEDGE and Enable bits */
+  /* Configure the Timestamp TSEDGE and Enable bits */
   hrtc->Instance->CR = (uint32_t)tmpreg;
 
   /* Enable the write protection for RTC registers */
@@ -341,11 +339,10 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
   return HAL_OK;
 }
 
-#if defined(RTC_INTERNALTS_SUPPORT)
 /**
-  * @brief  Set Internal TimeStamp.
-  * @note   This API must be called before enabling the internal TimeStamp feature.
-  * @param hrtc pointer to a RTC_HandleTypeDef structure that contains
+  * @brief  Sets Internal Timestamp.
+  * @note   This API must be called before enabling the internal Timestamp feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
   *                the configuration information for RTC.
   * @retval HAL status
   */
@@ -359,10 +356,10 @@ HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc)
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Clear the TIMESTAMP Flags */
+  /* Clear the internal Timestamp flag */
   __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_ITSF);
 
-  /* Configure the internal Time Stamp Enable bits */
+  /* Configure the internal Timestamp Enable bits */
   __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(hrtc);
 
   /* Enable the write protection for RTC registers */
@@ -378,8 +375,8 @@ HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc)
 }
 
 /**
-  * @brief  Deactivate Internal TimeStamp.
-  * @param hrtc pointer to a RTC_HandleTypeDef structure that contains
+  * @brief  Deactivates internal Timestamp.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
   *                the configuration information for RTC.
   * @retval HAL status
   */
@@ -393,7 +390,7 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc)
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Configure the internal Time Stamp Enable bits */
+  /* Configure the internal Timestamp Enable bits */
   __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(hrtc);
 
   /* Enable the write protection for RTC registers */
@@ -406,77 +403,79 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc)
 
   return HAL_OK;
 }
-#endif
 
 /**
-  * @brief  Get the RTC TimeStamp value.
-  * @param hrtc RTC handle
-  * @param sTimeStamp Pointer to Time structure
-  * @param sTimeStampDate Pointer to Date structure
-  * @param Format specifies the format of the entered parameters.
+  * @brief  Gets the RTC Timestamp value.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTimeStamp Pointer to Time structure
+  * @param  sTimeStampDate Pointer to Date structure
+  * @param  Format specifies the format of the entered parameters.
   *          This parameter can be one of the following values:
   *             @arg RTC_FORMAT_BIN: Binary data format
   *             @arg RTC_FORMAT_BCD: BCD data format
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef* sTimeStamp, RTC_DateTypeDef* sTimeStampDate, uint32_t Format)
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format)
 {
-  uint32_t tmptime, tmpdate;
+  uint32_t tmptime = 0U;
+  uint32_t tmpdate = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_FORMAT(Format));
 
-  /* Get the TimeStamp time and date registers values */
+  /* Get the Timestamp time and date registers values */
   tmptime = (uint32_t)(hrtc->Instance->TSTR & RTC_TR_RESERVED_MASK);
   tmpdate = (uint32_t)(hrtc->Instance->TSDR & RTC_DR_RESERVED_MASK);
 
   /* Fill the Time structure fields with the read parameters */
-  sTimeStamp->Hours = (uint8_t)((tmptime & (RTC_TR_HT | RTC_TR_HU)) >> 16U);
-  sTimeStamp->Minutes = (uint8_t)((tmptime & (RTC_TR_MNT | RTC_TR_MNU)) >> 8U);
-  sTimeStamp->Seconds = (uint8_t)(tmptime & (RTC_TR_ST | RTC_TR_SU));
-  sTimeStamp->TimeFormat = (uint8_t)((tmptime & (RTC_TR_PM)) >> 16U);
+  sTimeStamp->Hours      = (uint8_t)((tmptime & (RTC_TSTR_HT  | RTC_TSTR_HU))  >> RTC_TSTR_HU_Pos);
+  sTimeStamp->Minutes    = (uint8_t)((tmptime & (RTC_TSTR_MNT | RTC_TSTR_MNU)) >> RTC_TSTR_MNU_Pos);
+  sTimeStamp->Seconds    = (uint8_t)((tmptime & (RTC_TSTR_ST  | RTC_TSTR_SU))  >> RTC_TSTR_SU_Pos);
+  sTimeStamp->TimeFormat = (uint8_t)((tmptime & (RTC_TSTR_PM))                 >> RTC_TSTR_PM_Pos);
   sTimeStamp->SubSeconds = (uint32_t) hrtc->Instance->TSSSR;
 
   /* Fill the Date structure fields with the read parameters */
-  sTimeStampDate->Year = 0U;
-  sTimeStampDate->Month = (uint8_t)((tmpdate & (RTC_DR_MT | RTC_DR_MU)) >> 8U);
-  sTimeStampDate->Date = (uint8_t)(tmpdate & (RTC_DR_DT | RTC_DR_DU));
-  sTimeStampDate->WeekDay = (uint8_t)((tmpdate & (RTC_DR_WDU)) >> 13U);
+  sTimeStampDate->Year    = 0U;
+  sTimeStampDate->Month   = (uint8_t)((tmpdate & (RTC_TSDR_MT | RTC_TSDR_MU)) >> RTC_TSDR_MU_Pos);
+  sTimeStampDate->Date    = (uint8_t)((tmpdate & (RTC_TSDR_DT | RTC_TSDR_DU)) >> RTC_TSDR_DU_Pos);
+  sTimeStampDate->WeekDay = (uint8_t)((tmpdate & (RTC_TSDR_WDU))              >> RTC_TSDR_WDU_Pos);
 
   /* Check the input parameters format */
-  if(Format == RTC_FORMAT_BIN)
+  if (Format == RTC_FORMAT_BIN)
   {
-    /* Convert the TimeStamp structure parameters to Binary format */
-    sTimeStamp->Hours = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Hours);
+    /* Convert the Timestamp structure parameters to Binary format */
+    sTimeStamp->Hours   = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Hours);
     sTimeStamp->Minutes = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Minutes);
     sTimeStamp->Seconds = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Seconds);
 
     /* Convert the DateTimeStamp structure parameters to Binary format */
-    sTimeStampDate->Month = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Month);
-    sTimeStampDate->Date = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Date);
+    sTimeStampDate->Month   = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Month);
+    sTimeStampDate->Date    = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Date);
     sTimeStampDate->WeekDay = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->WeekDay);
   }
 
-  /* Clear the TIMESTAMP Flags */
-  #if defined(RTC_INTERNALTS_SUPPORT)
+  /* Clear the internal Timestamp Flag */
   __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_ITSF);
-  #endif
 
+  /* Clear the Timestamp Flag */
   __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
 
   return HAL_OK;
 }
 
 /**
-  * @brief  Set Tamper
-  * @note   By calling this API we disable the tamper interrupt for all tampers.
-  * @param hrtc RTC handle
-  * @param sTamper Pointer to Tamper Structure.
+  * @brief  Sets Tamper.
+  * @note   By calling this API the tamper global interrupt will be disabled and
+  *         the selected tamper's interrupt as well.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper Pointer to Tamper Structure.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_TAMPER(sTamper->Tamper));
@@ -484,6 +483,7 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef
   assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
   assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
   assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_FILTER_CONFIG_CORRECT(sTamper->Filter, sTamper->Trigger));
   assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
   assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
   assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
@@ -494,62 +494,142 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef
 
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Configure the tamper trigger */
-  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  /* Copy control register into temporary variable */
+  tmpreg = hrtc->Instance->TAMPCR;
+
+  /* Enable selected tamper */
+  tmpreg |= (sTamper->Tamper);
+
+  /* Configure the tamper trigger bit (this bit is just on the right of the
+       tamper enable bit, hence the one-time right shift before updating it) */
+  if (sTamper->Trigger == RTC_TAMPERTRIGGER_FALLINGEDGE)
   {
-    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1U);
+    /* Set the tamper trigger bit (case of falling edge or high level) */
+    tmpreg |= (uint32_t)(sTamper->Tamper << 1U);
+  }
+  else
+  {
+    /* Clear the tamper trigger bit (case of rising edge or low level) */
+    tmpreg &= (uint32_t)~(sTamper->Tamper << 1U);
   }
 
-  if(sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  /* Configure the backup registers erasure enabling bits */
+  if (sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
   {
-    sTamper->NoErase = 0U;
 #if defined(RTC_TAMPER1_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
     {
-      sTamper->NoErase |= RTC_TAMPCR_TAMP1NOERASE;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1NOERASE);
     }
 #endif /* RTC_TAMPER1_SUPPORT */
-    if((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
     {
-      sTamper->NoErase |= RTC_TAMPCR_TAMP2NOERASE;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2NOERASE);
     }
 #if defined(RTC_TAMPER3_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
     {
-      sTamper->NoErase |= RTC_TAMPCR_TAMP3NOERASE;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3NOERASE);
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+  else
+  {
+#if defined(RTC_TAMPER1_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1NOERASE);
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2NOERASE);
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3NOERASE);
     }
 #endif /* RTC_TAMPER3_SUPPORT */
   }
 
-  if(sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  /* Configure the tamper flags masking bits */
+  if (sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
   {
-    sTamper->MaskFlag = 0U;
 #if defined(RTC_TAMPER1_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
     {
-      sTamper->MaskFlag |= RTC_TAMPCR_TAMP1MF;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1MF);
     }
 #endif /* RTC_TAMPER1_SUPPORT */
-    if((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
     {
-      sTamper->MaskFlag |= RTC_TAMPCR_TAMP2MF;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2MF);
     }
 #if defined(RTC_TAMPER3_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
     {
-      sTamper->MaskFlag |= RTC_TAMPCR_TAMP3MF;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3MF);
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+  else
+  {
+#if defined(RTC_TAMPER1_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1MF);
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2MF);
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3MF);
     }
 #endif /* RTC_TAMPER3_SUPPORT */
   }
 
-  /* Configure the RTC_TAMPCR register */
-  tmpreg = (uint32_t)((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
-            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency |\
-            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | (uint32_t)sTamper->TimeStampOnTamperDetection);
+  /* Clear remaining fields before setting them */
+  tmpreg &= ~(RTC_TAMPERFILTER_MASK              | \
+              RTC_TAMPERSAMPLINGFREQ_RTCCLK_MASK | \
+              RTC_TAMPERPRECHARGEDURATION_MASK   | \
+              RTC_TAMPER_PULLUP_MASK             | \
+              RTC_TIMESTAMPONTAMPERDETECTION_MASK);
 
-  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | RTC_TAMPCR_MASK);
+  /* Set remaining parameters of desired configuration into temporary variable */
+  tmpreg |= ((uint32_t)sTamper->Filter            | \
+             (uint32_t)sTamper->SamplingFrequency | \
+             (uint32_t)sTamper->PrechargeDuration | \
+             (uint32_t)sTamper->TamperPullUp      | \
+             (uint32_t)sTamper->TimeStampOnTamperDetection);
 
-  hrtc->Instance->TAMPCR |= tmpreg;
+  /* Disable interrupt on selected tamper in case it is enabled */
+#if defined(RTC_TAMPER1_SUPPORT)
+  if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+  {
+    tmpreg &= (uint32_t)~RTC_IT_TAMP1;
+  }
+#endif /* RTC_TAMPER1_SUPPORT */
+  if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+  {
+    tmpreg &= (uint32_t)~RTC_IT_TAMP2;
+  }
+#if defined(RTC_TAMPER3_SUPPORT)
+  if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+  {
+    tmpreg &= (uint32_t)~RTC_IT_TAMP3;
+  }
+#endif /* RTC_TAMPER3_SUPPORT */
+
+  /* Disable tamper global interrupt in case it is enabled */
+  tmpreg &= (uint32_t)~RTC_TAMPCR_TAMPIE;
+
+  /* Copy desired configuration into configuration register */
+  hrtc->Instance->TAMPCR = tmpreg;
 
   hrtc->State = HAL_RTC_STATE_READY;
 
@@ -560,23 +640,26 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef
 }
 
 /**
-  * @brief  Set Tamper with interrupt.
-  * @note   By calling this API we force the tamper interrupt for all tampers.
-  * @param hrtc RTC handle
-  * @param sTamper Pointer to RTC Tamper.
+  * @brief  Sets Tamper with interrupt.
+  * @note   By setting the tamper global interrupt bit, interrupts will be
+  *         enabled for all tampers.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper Pointer to RTC Tamper.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef* sTamper)
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper)
 {
-  uint32_t tmpreg;
+  uint32_t tmpreg = 0U;
 
   /* Check the parameters */
-  assert_param( IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
   assert_param(IS_RTC_TAMPER_INTERRUPT(sTamper->Interrupt));
-  assert_param( IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
   assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
   assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
   assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_FILTER_CONFIG_CORRECT(sTamper->Filter, sTamper->Trigger));
   assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
   assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
   assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
@@ -587,66 +670,127 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperType
 
   hrtc->State = HAL_RTC_STATE_BUSY;
 
-  /* Configure the tamper trigger */
-  if(sTamper->Trigger != RTC_TAMPERTRIGGER_RISINGEDGE)
+  /* Copy control register into temporary variable */
+  tmpreg = hrtc->Instance->TAMPCR;
+
+  /* Enable selected tamper */
+  tmpreg |= (sTamper->Tamper);
+
+  /* Configure the tamper trigger bit (this bit is just on the right of the
+       tamper enable bit, hence the one-time right shift before updating it) */
+  if (sTamper->Trigger == RTC_TAMPERTRIGGER_FALLINGEDGE)
   {
-    sTamper->Trigger = (uint32_t)(sTamper->Tamper << 1U);
+    /* Set the tamper trigger bit (case of falling edge or high level) */
+    tmpreg |= (uint32_t)(sTamper->Tamper << 1U);
+  }
+  else
+  {
+    /* Clear the tamper trigger bit (case of rising edge or low level) */
+    tmpreg &= (uint32_t)~(sTamper->Tamper << 1U);
   }
 
-  if(sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  /* Configure the backup registers erasure enabling bits */
+  if (sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
   {
-    sTamper->NoErase = 0U;
 #if defined(RTC_TAMPER1_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
     {
-      sTamper->NoErase |= RTC_TAMPCR_TAMP1NOERASE;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1NOERASE);
     }
 #endif /* RTC_TAMPER1_SUPPORT */
-    if((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
     {
-      sTamper->NoErase |= RTC_TAMPCR_TAMP2NOERASE;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2NOERASE);
     }
 #if defined(RTC_TAMPER3_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
     {
-      sTamper->NoErase |= RTC_TAMPCR_TAMP3NOERASE;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3NOERASE);
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+  else
+  {
+#if defined(RTC_TAMPER1_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1NOERASE);
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2NOERASE);
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3NOERASE);
     }
 #endif /* RTC_TAMPER3_SUPPORT */
   }
 
-  if(sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  /* Configure the tamper flags masking bits */
+  if (sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
   {
-    sTamper->MaskFlag = 0U;
 #if defined(RTC_TAMPER1_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
     {
-      sTamper->MaskFlag |= RTC_TAMPCR_TAMP1MF;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1MF);
     }
 #endif /* RTC_TAMPER1_SUPPORT */
-    if((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
     {
-      sTamper->MaskFlag |= RTC_TAMPCR_TAMP2MF;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2MF);
     }
 #if defined(RTC_TAMPER3_SUPPORT)
-    if((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
     {
-      sTamper->MaskFlag |= RTC_TAMPCR_TAMP3MF;
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3MF);
+    }
+#endif /* RTC_TAMPER3_SUPPORT */
+  }
+  else
+  {
+#if defined(RTC_TAMPER1_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1MF);
+    }
+#endif /* RTC_TAMPER1_SUPPORT */
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2MF);
+    }
+#if defined(RTC_TAMPER3_SUPPORT)
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3MF);
     }
 #endif /* RTC_TAMPER3_SUPPORT */
   }
 
-  /* Configure the RTC_TAMPCR register */
-  tmpreg = (uint32_t)((uint32_t)sTamper->Tamper | (uint32_t)sTamper->Interrupt | (uint32_t)sTamper->Trigger  | (uint32_t)sTamper->NoErase |\
-            (uint32_t)sTamper->MaskFlag | (uint32_t)sTamper->Filter | (uint32_t)sTamper->SamplingFrequency                                |\
-            (uint32_t)sTamper->PrechargeDuration | (uint32_t)sTamper->TamperPullUp | (uint32_t)sTamper->TimeStampOnTamperDetection);
+  /* Clear remaining fields before setting them */
+  tmpreg &= ~(RTC_TAMPERFILTER_MASK              | \
+              RTC_TAMPERSAMPLINGFREQ_RTCCLK_MASK | \
+              RTC_TAMPERPRECHARGEDURATION_MASK   | \
+              RTC_TAMPER_PULLUP_MASK             | \
+              RTC_TIMESTAMPONTAMPERDETECTION_MASK);
 
-  hrtc->Instance->TAMPCR &= (uint32_t)~((uint32_t)sTamper->Tamper | (uint32_t)(sTamper->Tamper << 1) | RTC_TAMPCR_MASK);
+  /* Set remaining parameters of desired configuration into temporary variable */
+  tmpreg |= ((uint32_t)sTamper->Filter            | \
+             (uint32_t)sTamper->SamplingFrequency | \
+             (uint32_t)sTamper->PrechargeDuration | \
+             (uint32_t)sTamper->TamperPullUp      | \
+             (uint32_t)sTamper->TimeStampOnTamperDetection);
 
-  hrtc->Instance->TAMPCR |= tmpreg;
+  /* Enable interrupt on selected tamper */
+  tmpreg |= (uint32_t)sTamper->Interrupt;
 
-  /* RTC Tamper Interrupt Configuration: EXTI configuration */
+  /* Copy desired configuration into configuration register */
+  hrtc->Instance->TAMPCR = tmpreg;
+
+  /* Enable and configure the EXTI line associated to the RTC Timestamp and Tamper interrupts */
   __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
-
   __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();
 
   hrtc->State = HAL_RTC_STATE_READY;
@@ -658,15 +802,22 @@ HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperType
 }
 
 /**
-  * @brief  Deactivate Tamper.
-  * @param hrtc RTC handle
-  * @param Tamper Selected tamper pin.
-  *          This parameter can be any combination of RTC_TAMPER_1, RTC_TAMPER_2 and RTC_TAMPER_3.
+  * @brief  Deactivates Tamper.
+  * @note   By calling this API the tamper global interrupt will be disabled.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Tamper Selected tamper pin.
+  *          This parameter can be any combination of the following values:
+  *            @arg RTC_TAMPER_1:  Tamper 1 (*)
+  *            @arg RTC_TAMPER_2:  Tamper 2
+  *            @arg RTC_TAMPER_3:  Tamper 3 (*)
+  *
+  *         (*) value not applicable to all devices.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper)
 {
-  assert_param( IS_RTC_TAMPER(Tamper));
+  assert_param(IS_RTC_TAMPER(Tamper));
 
   /* Process Locked */
   __HAL_LOCK(hrtc);
@@ -674,27 +825,26 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t T
   hrtc->State = HAL_RTC_STATE_BUSY;
 
   /* Disable the selected Tamper pin */
-  hrtc->Instance->TAMPCR &= ((uint32_t)~Tamper);
+  hrtc->Instance->TAMPCR &= (uint32_t)~Tamper;
 
 #if defined(RTC_TAMPER1_SUPPORT)
   if ((Tamper & RTC_TAMPER_1) != 0U)
   {
-    /* Disable the Tamper1 interrupt */
-    hrtc->Instance->TAMPCR &= ((uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP1));
+    /* Disable the Tamper 1 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP1);
   }
 #endif /* RTC_TAMPER1_SUPPORT */
   if ((Tamper & RTC_TAMPER_2) != 0U)
   {
-    /* Disable the Tamper2 interrupt */
-    hrtc->Instance->TAMPCR &= ((uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP2));
+    /* Disable the Tamper 2 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP2);
   }
 #if defined(RTC_TAMPER3_SUPPORT)
-    if ((Tamper & RTC_TAMPER_3) != 0U)
+  if ((Tamper & RTC_TAMPER_3) != 0U)
   {
-    /* Disable the Tamper3 interrupt */
-    hrtc->Instance->TAMPCR &= ((uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP3));
+    /* Disable the Tamper 3 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP3);
   }
-
 #endif /* RTC_TAMPER3_SUPPORT */
 
   hrtc->State = HAL_RTC_STATE_READY;
@@ -706,99 +856,101 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t T
 }
 
 /**
-  * @brief  Handle TimeStamp interrupt request.
-  * @param hrtc RTC handle
+  * @brief  Handles Timestamp and Tamper interrupt request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 void HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc)
 {
-  /* Get the TimeStamp interrupt source enable status */
-  if(__HAL_RTC_TIMESTAMP_GET_IT_SOURCE(hrtc, RTC_IT_TS) != 0U)
+  /* Clear the EXTI flag associated to the RTC Timestamp and Tamper interrupts */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG();
+
+  /* Get the Timestamp interrupt source enable status */
+  if (__HAL_RTC_TIMESTAMP_GET_IT_SOURCE(hrtc, RTC_IT_TS) != 0U)
   {
-    /* Get the pending status of the TIMESTAMP Interrupt */
-    if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) != 0U)
+    /* Get the pending status of the Timestamp Interrupt */
+    if (__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) != 0U)
     {
-      /* TIMESTAMP callback */
+      /* Timestamp callback */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
       hrtc->TimeStampEventCallback(hrtc);
 #else
       HAL_RTCEx_TimeStampEventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
 
-      /* Clear the TIMESTAMP interrupt pending bit */
+      /* Clear the Timestamp interrupt pending bit after returning from callback
+         as RTC_TSTR and RTC_TSDR registers are cleared when TSF bit is reset */
       __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
     }
   }
 
 #if defined(RTC_TAMPER1_SUPPORT)
-  /* Get the Tamper1 interrupts source enable status */
-  if(__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP1) != 0U)
+  /* Get the Tamper 1 interrupt source enable status */
+  if (__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP1) != 0U)
   {
-    /* Get the pending status of the Tamper1 Interrupt */
-    if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F) != 0U)
+    /* Get the pending status of the Tamper 1 Interrupt */
+    if (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F) != 0U)
     {
-      /* Tamper1 callback */
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
+
+      /* Tamper callback */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
       hrtc->Tamper1EventCallback(hrtc);
 #else
       HAL_RTCEx_Tamper1EventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
-
-      /* Clear the Tamper1 interrupt pending bit */
-      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
     }
   }
 #endif /* RTC_TAMPER1_SUPPORT */
 
-
-  /* Get the Tamper2 interrupts source enable status */
-  if(__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP2) != 0U)
+  /* Get the Tamper 2 interrupt source enable status */
+  if (__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP2) != 0U)
   {
-    /* Get the pending status of the Tamper2 Interrupt */
-    if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) != 0U)
+    /* Get the pending status of the Tamper 2 Interrupt */
+    if (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) != 0U)
     {
-      /* Tamper2 callback */
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+
+      /* Tamper callback */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
       hrtc->Tamper2EventCallback(hrtc);
 #else
       HAL_RTCEx_Tamper2EventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
-
-      /* Clear the Tamper2 interrupt pending bit */
-      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
     }
   }
 
 #if defined(RTC_TAMPER3_SUPPORT)
-  /* Get the Tamper3 interrupts source enable status */
-  if(__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP3) != 0U)
+  /* Get the Tamper 3 interrupt source enable status */
+  if (__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP3) != 0U)
   {
-    /* Get the pending status of the Tamper3 Interrupt */
-    if(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) != 0U)
+    /* Get the pending status of the Tamper 3 Interrupt */
+    if (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) != 0U)
     {
-      /* Tamper3 callback */
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
+
+      /* Tamper callback */
 #if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
       hrtc->Tamper3EventCallback(hrtc);
 #else
       HAL_RTCEx_Tamper3EventCallback(hrtc);
 #endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
-
-      /* Clear the Tamper3 interrupt pending bit */
-      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
     }
   }
 #endif /* RTC_TAMPER3_SUPPORT */
-
-  /* Clear the EXTI's Flag for RTC TimeStamp and Tamper */
-  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG();
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
 }
 
 /**
-  * @brief  TimeStamp callback.
-  * @param hrtc RTC handle
+  * @brief  Timestamp callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
@@ -806,15 +958,16 @@ __weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTCEx_TimeStampEventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_TimeStampEventCallback could be implemented in the user file
   */
 }
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
   * @brief  Tamper 1 callback.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc)
@@ -822,15 +975,16 @@ __weak void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTCEx_Tamper1EventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_Tamper1EventCallback could be implemented in the user file
    */
 }
 #endif /* RTC_TAMPER1_SUPPORT */
 
 /**
   * @brief  Tamper 2 callback.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
@@ -838,15 +992,16 @@ __weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTCEx_Tamper2EventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_Tamper2EventCallback could be implemented in the user file
    */
 }
 
 #if defined(RTC_TAMPER3_SUPPORT)
 /**
   * @brief  Tamper 3 callback.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc)
@@ -854,42 +1009,46 @@ __weak void HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTCEx_Tamper3EventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_Tamper3EventCallback could be implemented in the user file
    */
 }
 #endif /* RTC_TAMPER3_SUPPORT */
 
 /**
-  * @brief  Handle TimeStamp polling request.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Timestamp polling request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
-  uint32_t tickstart = HAL_GetTick();
+  uint32_t tickstart = 0U;
 
-  while(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) == 0U)
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while (__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) == 0U)
   {
-    if(__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSOVF) != 0U)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      /* Clear the TIMESTAMP OverRun Flag */
-      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
-
-      /* Change TIMESTAMP state */
-      hrtc->State = HAL_RTC_STATE_ERROR;
-
-      return HAL_ERROR;
-    }
-
-    if(Timeout != HAL_MAX_DELAY)
-    {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
       }
+    }
+
+    if (__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSOVF) != 0U)
+    {
+      /* Clear the Timestamp Overrun Flag */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+      /* Change Timestamp state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+
+      return HAL_ERROR;
     }
   }
 
@@ -901,21 +1060,25 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint3
 
 #if defined(RTC_TAMPER1_SUPPORT)
 /**
-  * @brief  Handle Tamper 1 Polling.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Tamper 1 Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
-  uint32_t tickstart = HAL_GetTick();
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Get the status of the Interrupt */
-  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F)== 0U)
+  while (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F) == 0U)
   {
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
@@ -924,7 +1087,7 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_
   }
 
   /* Clear the Tamper Flag */
-  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP1F);
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -934,21 +1097,25 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_
 #endif /* RTC_TAMPER1_SUPPORT */
 
 /**
-  * @brief  Handle Tamper 2 Polling.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Tamper 2 Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
-  uint32_t tickstart = HAL_GetTick();
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
   /* Get the status of the Interrupt */
-  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) == 0U)
+  while (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) == 0U)
   {
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
@@ -957,7 +1124,7 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_
   }
 
   /* Clear the Tamper Flag */
-  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP2F);
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -967,9 +1134,10 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_
 
 #if defined(RTC_TAMPER3_SUPPORT)
 /**
-  * @brief  Handle Tamper 3 Polling.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Tamper 3 Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
@@ -977,11 +1145,11 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_
   uint32_t tickstart = HAL_GetTick();
 
   /* Get the status of the Interrupt */
-  while(__HAL_RTC_TAMPER_GET_FLAG(hrtc,RTC_FLAG_TAMP3F) == 0U)
+  while (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) == 0U)
   {
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
@@ -990,7 +1158,7 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_
   }
 
   /* Clear the Tamper Flag */
-  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc,RTC_FLAG_TAMP3F);
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
@@ -1003,30 +1171,31 @@ HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_
   * @}
   */
 
-/** @addtogroup RTCEx_Exported_Functions_Group2
-  * @brief    RTC Wake-up functions
+/** @defgroup RTCEx_Exported_Functions_Group2 RTC Wakeup functions
+  * @brief    RTC Wakeup functions
   *
 @verbatim
  ===============================================================================
-                        ##### RTC Wake-up functions #####
+                        ##### RTC Wakeup functions #####
  ===============================================================================
 
- [..] This section provides functions allowing to configure Wake-up feature
+ [..] This section provides functions allowing to configure Wakeup feature
 
 @endverbatim
   * @{
   */
 
 /**
-  * @brief  Set wake up timer.
-  * @param hrtc RTC handle
-  * @param WakeUpCounter Wake up counter
-  * @param WakeUpClock Wake up clock
+  * @brief  Sets wakeup timer.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter Wakeup counter
+  * @param  WakeUpClock Wakeup clock
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
@@ -1040,128 +1209,42 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t Wak
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
-  if((hrtc->Instance->CR & RTC_CR_WUTE) != 0U){
-    tickstart = HAL_GetTick();
-
-   /* Wait till RTC WUTWF flag is reset and if Time out is reached exit */
-   while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 1U)
-   {
-    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
-      {
-       /* Enable the write protection for RTC registers */
-       __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-       hrtc->State = HAL_RTC_STATE_TIMEOUT;
-
-       /* Process Unlocked */
-       __HAL_UNLOCK(hrtc);
-
-       return HAL_TIMEOUT;
-      }
-    }
-  }
-
-  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
-
-  tickstart = HAL_GetTick();
-
-  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
-  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
+  /* Check RTC WUTWF flag is reset only when wakeup timer enabled*/
+  if ((hrtc->Instance->CR & RTC_CR_WUTE) != 0U)
   {
-    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
-    {
-      /* Enable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-      hrtc->State = HAL_RTC_STATE_TIMEOUT;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hrtc);
-
-      return HAL_TIMEOUT;
-    }
-  }
-
-  /* Clear the Wakeup Timer clock source bits in CR register */
-  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
-
-  /* Configure the clock source */
-  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
-
-  /* Configure the Wakeup Timer counter */
-  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
-
-   /* Enable the Wakeup Timer */
-  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-  hrtc->State = HAL_RTC_STATE_READY;
-
-  /* Process Unlocked */
-  __HAL_UNLOCK(hrtc);
-
-  return HAL_OK;
-}
-
-/**
-  * @brief  Set wake up timer with interrupt.
-  * @param hrtc RTC handle
-  * @param WakeUpCounter Wake up counter
-  * @param WakeUpClock Wake up clock
-  * @retval HAL status
-  */
-HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
-{
-  uint32_t tickstart;
-
-  /* Check the parameters */
-  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
-  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
-
-  /* Process Locked */
-  __HAL_LOCK(hrtc);
-
-  hrtc->State = HAL_RTC_STATE_BUSY;
-
-  /* Disable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
-  /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
-  if((hrtc->Instance->CR & RTC_CR_WUTE) != 0U){
     tickstart = HAL_GetTick();
 
-   /* Wait till RTC WUTWF flag is reset and if Time out is reached exit */
-   while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 1U)
-   {
-    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    /* Wait till RTC WUTWF flag is reset and if timeout is reached exit */
+    while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) != 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
-       /* Enable the write protection for RTC registers */
-       __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-       hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
-       /* Process Unlocked */
-       __HAL_UNLOCK(hrtc);
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
 
-       return HAL_TIMEOUT;
+        return HAL_TIMEOUT;
       }
     }
   }
-  /* Disable the Wake-Up timer */
+
+  /* Disable the Wakeup timer */
   __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
 
-  /* Clear flag Wake-Up */
+  /* Clear the Wakeup flag */
   __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
 
+  /* Get tick */
   tickstart = HAL_GetTick();
 
-  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
-  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
+  /* Wait till RTC WUTWF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
   {
-    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
     {
       /* Enable the write protection for RTC registers */
       __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1175,22 +1258,14 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
     }
   }
 
-  /* Configure the Wakeup Timer counter */
-  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
-
   /* Clear the Wakeup Timer clock source bits in CR register */
   hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
 
   /* Configure the clock source */
   hrtc->Instance->CR |= (uint32_t)WakeUpClock;
 
-  /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
-  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
-
-  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
-
-  /* Configure the Interrupt in the RTC_CR register */
-  __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc,RTC_IT_WUT);
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
 
   /* Enable the Wakeup Timer */
   __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
@@ -1207,13 +1282,117 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
 }
 
 /**
-  * @brief  Deactivate wake up timer counter.
-  * @param hrtc RTC handle
+  * @brief  Sets wakeup timer with interrupt.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter Wakeup counter
+  * @param  WakeUpClock Wakeup clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  __IO uint32_t count  = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Check RTC WUTWF flag is reset only when wakeup timer enabled */
+  if ((hrtc->Instance->CR & RTC_CR_WUTE) != 0U)
+  {
+    /* Wait till RTC WUTWF flag is reset and if timeout is reached exit */
+    do
+    {
+      count = count - 1U;
+      if (count == 0U)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    } while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) != 0U);
+  }
+
+  /* Disable the Wakeup timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* Clear the Wakeup flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+  /* Reload the counter */
+  count = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+
+  /* Wait till RTC WUTWF flag is set and if timeout is reached exit */
+  do
+  {
+    count = count - 1U;
+    if (count == 0U)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  } while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U);
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+  /* Enable and configure the EXTI line associated to the RTC Wakeup Timer interrupt */
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
+
+  /* Configure the interrupt in the RTC_CR register */
+  __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc, RTC_IT_WUT);
+
+  /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates wakeup timer counter.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
 
   /* Process Locked */
   __HAL_LOCK(hrtc);
@@ -1226,14 +1405,16 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
   /* Disable the Wakeup Timer */
   __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
 
-  /* In case of interrupt mode is used, the interrupt source must disabled */
-  __HAL_RTC_WAKEUPTIMER_DISABLE_IT(hrtc,RTC_IT_WUT);
+  /* In case interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_WAKEUPTIMER_DISABLE_IT(hrtc, RTC_IT_WUT);
 
+  /* Get tick */
   tickstart = HAL_GetTick();
-  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
-  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
+
+  /* Wait till RTC WUTWF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
   {
-    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
     {
       /* Enable the write protection for RTC registers */
       __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1259,8 +1440,9 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
 }
 
 /**
-  * @brief  Get wake up timer counter.
-  * @param hrtc RTC handle
+  * @brief  Gets wakeup timer counter.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval Counter value
   */
 uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc)
@@ -1270,36 +1452,43 @@ uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc)
 }
 
 /**
-  * @brief  Handle Wake Up Timer interrupt request.
-  * @param hrtc RTC handle
+  * @brief  Handles Wakeup Timer interrupt request.
+  * @note   Unlike alarm interrupt line (shared by Alarms A and B) or tamper
+  *         interrupt line (shared by timestamp and tampers) wakeup timer
+  *         interrupt line is exclusive to the wakeup timer.
+  *         There is no need in this case to check on the interrupt enable
+  *         status via __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE().
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 void HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc)
 {
-    /* Get the pending status of the WAKEUPTIMER Interrupt */
-    if(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) != 0U)
-    {
-      /* WAKEUPTIMER callback */
-#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
-      hrtc->WakeUpTimerEventCallback(hrtc);
-#else
-      HAL_RTCEx_WakeUpTimerEventCallback(hrtc);
-#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
-
-      /* Clear the WAKEUPTIMER interrupt pending bit */
-      __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
-    }
-
-  /* Clear the EXTI's line Flag for RTC WakeUpTimer */
+  /* Clear the EXTI flag associated to the RTC Wakeup Timer interrupt */
   __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG();
+
+  /* Get the pending status of the Wakeup timer Interrupt */
+  if (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) != 0U)
+  {
+    /* Clear the Wakeup timer interrupt pending bit */
+    __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+    /* Wakeup timer callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+    hrtc->WakeUpTimerEventCallback(hrtc);
+#else
+    HAL_RTCEx_WakeUpTimerEventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+  }
 
   /* Change RTC state */
   hrtc->State = HAL_RTC_STATE_READY;
 }
 
 /**
-  * @brief  Wake Up Timer callback.
-  * @param hrtc RTC handle
+  * @brief  Wakeup Timer callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
@@ -1307,36 +1496,38 @@ __weak void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTCEx_WakeUpTimerEventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_WakeUpTimerEventCallback could be implemented in the user file
    */
 }
 
-
 /**
-  * @brief  Handle Wake Up Timer Polling.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Wakeup Timer Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
-  uint32_t tickstart = HAL_GetTick();
+  uint32_t tickstart = 0U;
 
-  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) == 0U)
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) == 0U)
   {
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
-
         return HAL_TIMEOUT;
       }
     }
   }
 
-  /* Clear the WAKEUPTIMER Flag */
+  /* Clear the Wakeup timer Flag */
   __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
 
   /* Change RTC state */
@@ -1349,8 +1540,7 @@ HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uin
   * @}
   */
 
-
-/** @addtogroup RTCEx_Exported_Functions_Group3
+/** @defgroup RTCEx_Exported_Functions_Group3 Extended Peripheral Control functions
   * @brief    Extended Peripheral Control functions
   *
 @verbatim
@@ -1361,8 +1551,6 @@ HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uin
     This subsection provides functions allowing to
       (+) Write a data in a specified RTC Backup data register
       (+) Read a data in a specified RTC Backup data register
-      (+) Set the Coarse calibration parameters.
-      (+) Deactivate the Coarse calibration parameters
       (+) Set the Smooth calibration parameters.
       (+) Configure the Synchronization Shift Control Settings.
       (+) Configure the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
@@ -1377,22 +1565,23 @@ HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uin
   */
 
 /**
-  * @brief  Write a data in a specified RTC Backup data register.
-  * @param hrtc RTC handle
-  * @param BackupRegister RTC Backup data Register number.
-  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to
-  *                                 specify the register.
-  * @param Data Data to be written in the specified RTC Backup data register.
+  * @brief  Writes a data in a specified RTC Backup data register.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  BackupRegister RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx (where x can be from 0 to 19)
+  *                                 to specify the register.
+  * @param  Data Data to be written in the specified RTC Backup data register.
   * @retval None
   */
 void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data)
 {
-  uint32_t tmp;
+  uint32_t tmp = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_BKP(BackupRegister));
 
-  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp = (uint32_t) &(hrtc->Instance->BKP0R);
   tmp += (BackupRegister * 4U);
 
   /* Write the specified register */
@@ -1401,20 +1590,21 @@ void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint3
 
 /**
   * @brief  Reads data from the specified RTC Backup data Register.
-  * @param hrtc RTC handle
-  * @param BackupRegister RTC Backup data Register number.
-  *          This parameter can be: RTC_BKP_DRx where x can be from 0 to 19 to
-  *                                 specify the register.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  BackupRegister RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx (where x can be from 0 to 19)
+  *                                 to specify the register.
   * @retval Read value
   */
 uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
 {
-  uint32_t tmp;
+  uint32_t tmp = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_BKP(BackupRegister));
 
-  tmp = (uint32_t)&(hrtc->Instance->BKP0R);
+  tmp = (uint32_t) &(hrtc->Instance->BKP0R);
   tmp += (BackupRegister * 4U);
 
   /* Read the specified register */
@@ -1422,27 +1612,28 @@ uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
 }
 
 /**
-  * @brief  Set the Smooth calibration parameters.
-  * @param hrtc RTC handle
-  * @param SmoothCalibPeriod Select the Smooth Calibration Period.
-  *          This parameter can be can be one of the following values :
+  * @brief  Sets the Smooth calibration parameters.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  SmoothCalibPeriod Select the Smooth Calibration Period.
+  *          This parameter can be can be one of the following values:
   *             @arg RTC_SMOOTHCALIB_PERIOD_32SEC: The smooth calibration period is 32s.
   *             @arg RTC_SMOOTHCALIB_PERIOD_16SEC: The smooth calibration period is 16s.
   *             @arg RTC_SMOOTHCALIB_PERIOD_8SEC: The smooth calibration period is 8s.
-  * @param SmoothCalibPlusPulses Select to Set or reset the CALP bit.
+  * @param  SmoothCalibPlusPulses Select to Set or reset the CALP bit.
   *          This parameter can be one of the following values:
   *             @arg RTC_SMOOTHCALIB_PLUSPULSES_SET: Add one RTCCLK pulse every 2*11 pulses.
   *             @arg RTC_SMOOTHCALIB_PLUSPULSES_RESET: No RTCCLK pulses are added.
-  * @param SmoothCalibMinusPulsesValue Select the value of CALM[8:0] bits.
+  * @param  SmoothCalibMinusPulsesValue Select the value of CALM[8:0] bits.
   *          This parameter can be one any value from 0 to 0x000001FF.
   * @note   To deactivate the smooth calibration, the field SmoothCalibPlusPulses
   *         must be equal to SMOOTHCALIB_PLUSPULSES_RESET and the field
-  *         SmoothCalibMinusPulsesValue mut be equal to 0.
+  *         SmoothCalibMinusPulsesValue must be equal to 0.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue)
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_SMOOTH_CALIB_PERIOD(SmoothCalibPeriod));
@@ -1458,14 +1649,15 @@ HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t Smo
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
   /* check if a calibration is pending*/
-  if((hrtc->Instance->ISR & RTC_ISR_RECALPF) != 0U)
+  if ((hrtc->Instance->ISR & RTC_ISR_RECALPF) != 0U)
   {
+    /* Get tick */
     tickstart = HAL_GetTick();
 
     /* check if a calibration is pending*/
-    while((hrtc->Instance->ISR & RTC_ISR_RECALPF) != 0U)
+    while ((hrtc->Instance->ISR & RTC_ISR_RECALPF) != 0U)
     {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1482,7 +1674,9 @@ HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t Smo
   }
 
   /* Configure the Smooth calibration settings */
-  hrtc->Instance->CALR = (uint32_t)((uint32_t)SmoothCalibPeriod | (uint32_t)SmoothCalibPlusPulses | (uint32_t)SmoothCalibMinusPulsesValue);
+  hrtc->Instance->CALR = (uint32_t)((uint32_t)SmoothCalibPeriod     | \
+                                    (uint32_t)SmoothCalibPlusPulses | \
+                                    (uint32_t)SmoothCalibMinusPulsesValue);
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1497,20 +1691,21 @@ HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef* hrtc, uint32_t Smo
 }
 
 /**
-  * @brief  Configure the Synchronization Shift Control Settings.
+  * @brief  Configures the Synchronization Shift Control Settings.
   * @note   When REFCKON is set, firmware must not write to Shift control register.
-  * @param hrtc RTC handle
-  * @param ShiftAdd1S Select to add or not 1 second to the time calendar.
-  *          This parameter can be one of the following values :
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  ShiftAdd1S Select to add or not 1 second to the time calendar.
+  *          This parameter can be one of the following values:
   *             @arg RTC_SHIFTADD1S_SET: Add one second to the clock calendar.
   *             @arg RTC_SHIFTADD1S_RESET: No effect.
-  * @param ShiftSubFS Select the number of Second Fractions to substitute.
+  * @param  ShiftSubFS Select the number of Second Fractions to substitute.
   *          This parameter can be one any value from 0 to 0x7FFF.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef* hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS)
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS)
 {
-  uint32_t tickstart;
+  uint32_t tickstart = 0U;
 
   /* Check the parameters */
   assert_param(IS_RTC_SHIFT_ADD1S(ShiftAdd1S));
@@ -1524,61 +1719,62 @@ HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef* hrtc, uint32_t Sh
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-    tickstart = HAL_GetTick();
+  /* Get tick */
+  tickstart = HAL_GetTick();
 
-    /* Wait until the shift is completed*/
-    while((hrtc->Instance->ISR & RTC_ISR_SHPF) != 0U)
-    {
-      if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
-      {
-        /* Enable the write protection for RTC registers */
-        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-        hrtc->State = HAL_RTC_STATE_TIMEOUT;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(hrtc);
-
-        return HAL_TIMEOUT;
-      }
-    }
-
-    /* Check if the reference clock detection is disabled */
-    if((hrtc->Instance->CR & RTC_CR_REFCKON) == 0U)
-    {
-      /* Configure the Shift settings */
-      hrtc->Instance->SHIFTR = (uint32_t)(uint32_t)(ShiftSubFS) | (uint32_t)(ShiftAdd1S);
-
-      /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
-      if((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
-      {
-        if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
-        {
-          /* Enable the write protection for RTC registers */
-          __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-          hrtc->State = HAL_RTC_STATE_ERROR;
-
-          /* Process Unlocked */
-          __HAL_UNLOCK(hrtc);
-
-          return HAL_ERROR;
-        }
-      }
-    }
-    else
+  /* Wait until the shift is completed */
+  while ((hrtc->Instance->ISR & RTC_ISR_SHPF) != 0U)
+  {
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
     {
       /* Enable the write protection for RTC registers */
       __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-      /* Change RTC state */
-      hrtc->State = HAL_RTC_STATE_ERROR;
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
 
       /* Process Unlocked */
       __HAL_UNLOCK(hrtc);
 
-      return HAL_ERROR;
+      return HAL_TIMEOUT;
     }
+  }
+
+  /* Check if the reference clock detection is disabled */
+  if ((hrtc->Instance->CR & RTC_CR_REFCKON) == 0U)
+  {
+    /* Configure the Shift settings */
+    hrtc->Instance->SHIFTR = (uint32_t)(uint32_t)(ShiftSubFS) | (uint32_t)(ShiftAdd1S);
+
+    /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if ((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
+    {
+      if (HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+  }
+  else
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Change RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1593,15 +1789,16 @@ HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef* hrtc, uint32_t Sh
 }
 
 /**
-  * @brief  Configure the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
-  * @param hrtc RTC handle
-  * @param  CalibOutput : Select the Calibration output Selection .
+  * @brief  Configures the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  CalibOutput Select the Calibration output Selection.
   *          This parameter can be one of the following values:
   *             @arg RTC_CALIBOUTPUT_512HZ: A signal has a regular waveform at 512Hz.
   *             @arg RTC_CALIBOUTPUT_1HZ: A signal has a regular waveform at 1Hz.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef* hrtc, uint32_t CalibOutput)
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32_t CalibOutput)
 {
   /* Check the parameters */
   assert_param(IS_RTC_CALIB_OUTPUT(CalibOutput));
@@ -1635,11 +1832,12 @@ HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef* hrtc, uint32
 }
 
 /**
-  * @brief  Deactivate the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
-  * @param hrtc RTC handle
+  * @brief  Deactivates the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc)
 {
   /* Process Locked */
   __HAL_LOCK(hrtc);
@@ -1664,12 +1862,15 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef* hrtc)
 }
 
 /**
-  * @brief  Enable the RTC reference clock detection.
-  * @param hrtc RTC handle
+  * @brief  Enables the RTC reference clock detection.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc)
 {
+  HAL_StatusTypeDef status;
+
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
@@ -1678,47 +1879,42 @@ HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef* hrtc)
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Set Initialization mode */
-  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
   {
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-    /* Set RTC state*/
-    hrtc->State = HAL_RTC_STATE_ERROR;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hrtc);
-
-    return HAL_ERROR;
-  }
-  else
-  {
+    /* Enable the reference clock detection */
     __HAL_RTC_CLOCKREF_DETECTION_ENABLE(hrtc);
 
     /* Exit Initialization mode */
-    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
   }
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-   /* Change RTC state */
-  hrtc->State = HAL_RTC_STATE_READY;
-
   /* Process Unlocked */
   __HAL_UNLOCK(hrtc);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
   * @brief  Disable the RTC reference clock detection.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc)
 {
+  HAL_StatusTypeDef status;
+
   /* Process Locked */
   __HAL_LOCK(hrtc);
 
@@ -1727,48 +1923,41 @@ HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef* hrtc)
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
-  /* Set Initialization mode */
-  if(RTC_EnterInitMode(hrtc) != HAL_OK)
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
   {
-    /* Enable the write protection for RTC registers */
-    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
-
-    /* Set RTC state*/
-    hrtc->State = HAL_RTC_STATE_ERROR;
-
-    /* Process Unlocked */
-    __HAL_UNLOCK(hrtc);
-
-    return HAL_ERROR;
-  }
-  else
-  {
+    /* Disable the reference clock detection */
     __HAL_RTC_CLOCKREF_DETECTION_DISABLE(hrtc);
 
     /* Exit Initialization mode */
-    hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
   }
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 
-  /* Change RTC state */
-  hrtc->State = HAL_RTC_STATE_READY;
-
   /* Process Unlocked */
   __HAL_UNLOCK(hrtc);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
-  * @brief  Enable the Bypass Shadow feature.
-  * @param hrtc RTC handle
+  * @brief  Enables the Bypass Shadow feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @note   When the Bypass Shadow is enabled the calendar value are taken
   *         directly from the Calendar counter.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc)
 {
   /* Process Locked */
   __HAL_LOCK(hrtc);
@@ -1779,7 +1968,7 @@ HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef* hrtc)
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
   /* Set the BYPSHAD bit */
-  hrtc->Instance->CR |= (uint8_t)RTC_CR_BYPSHAD;
+  hrtc->Instance->CR |= (uint32_t)RTC_CR_BYPSHAD;
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1794,13 +1983,14 @@ HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef* hrtc)
 }
 
 /**
-  * @brief  Disable the Bypass Shadow feature.
-  * @param hrtc RTC handle
+  * @brief  Disables the Bypass Shadow feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @note   When the Bypass Shadow is enabled the calendar value are taken
   *         directly from the Calendar counter.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc)
 {
   /* Process Locked */
   __HAL_LOCK(hrtc);
@@ -1811,7 +2001,7 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
 
   /* Reset the BYPSHAD bit */
-  hrtc->Instance->CR &= ((uint8_t)~RTC_CR_BYPSHAD);
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_BYPSHAD;
 
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
@@ -1829,7 +2019,7 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
   * @}
   */
 
-/** @addtogroup RTCEx_Exported_Functions_Group4
+/** @defgroup RTCEx_Exported_Functions_Group4 Extended features functions
   * @brief    Extended features functions
   *
 @verbatim
@@ -1837,7 +2027,7 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
                  ##### Extended features functions #####
  ===============================================================================
     [..]  This section provides functions allowing to:
-      (+) RTC Alram B callback
+      (+) RTC Alarm B callback
       (+) RTC Poll for Alarm B request
 
 @endverbatim
@@ -1846,7 +2036,8 @@ HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef* hrtc)
 
 /**
   * @brief  Alarm B callback.
-  * @param hrtc RTC handle
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
   * @retval None
   */
 __weak void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc)
@@ -1854,26 +2045,31 @@ __weak void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc)
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hrtc);
 
-  /* NOTE : This function should not be modified, when the callback is needed,
-            the HAL_RTCEx_AlarmBEventCallback could be implemented in the user file
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_AlarmBEventCallback could be implemented in the user file
    */
 }
 
 /**
-  * @brief  Handle Alarm B Polling request.
-  * @param hrtc RTC handle
-  * @param Timeout Timeout duration
+  * @brief  Handles Alarm B Polling request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
 {
-  uint32_t tickstart = HAL_GetTick();
+  uint32_t tickstart = 0U;
 
-  while(__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) == 0U)
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC ALRBF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) == 0U)
   {
-    if(Timeout != HAL_MAX_DELAY)
+    if (Timeout != HAL_MAX_DELAY)
     {
-      if(((HAL_GetTick() - tickstart ) > Timeout)||(Timeout == 0U))
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hrtc->State = HAL_RTC_STATE_TIMEOUT;
         return HAL_TIMEOUT;
@@ -1881,7 +2077,7 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
     }
   }
 
-  /* Clear the Alarm Flag */
+  /* Clear the Alarm flag */
   __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
 
   /* Change RTC state */
@@ -1903,10 +2099,6 @@ HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t
   * @}
   */
 
-
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_sai.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_sai.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                   ##### How to use this driver #####
@@ -159,7 +170,7 @@
 
     [..]
     Use function HAL_SAI_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
+    weak function.
     HAL_SAI_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the callback ID.
     [..]
@@ -174,10 +185,10 @@
 
     [..]
     By default, after the HAL_SAI_Init and if the state is HAL_SAI_STATE_RESET
-    all callbacks are reset to the corresponding legacy weak (surcharged) functions:
+    all callbacks are reset to the corresponding legacy weak functions:
     examples HAL_SAI_RxCpltCallback(), HAL_SAI_ErrorCallback().
     Exception done for MspInit and MspDeInit callbacks that are respectively
-    reset to the legacy weak (surcharged) functions in the HAL_SAI_Init
+    reset to the legacy weak functions in the HAL_SAI_Init
     and HAL_SAI_DeInit only when these callbacks are null (not registered beforehand).
     If not, MspInit or MspDeInit are not null, the HAL_SAI_Init and HAL_SAI_DeInit
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
@@ -194,20 +205,9 @@
     [..]
     When the compilation define USE_HAL_SAI_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registering feature is not available
-    and weak (surcharged) callbacks are used.
+    and weak callbacks are used.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -246,6 +246,8 @@ typedef enum
   */
 #define SAI_DEFAULT_TIMEOUT      4U
 #define SAI_LONG_TIMEOUT         1000U
+#define SAI_SPDIF_FRAME_LENGTH   64U
+#define SAI_AC97_FRAME_LENGTH    256U
 /**
   * @}
   */
@@ -498,12 +500,12 @@ HAL_StatusTypeDef HAL_SAI_Init(SAI_HandleTypeDef *hsai)
       if (hsai->Init.Protocol == SAI_SPDIF_PROTOCOL)
       {
         /* For SPDIF protocol, frame length is set by hardware to 64 */
-        tmpframelength = 64U;
+        tmpframelength = SAI_SPDIF_FRAME_LENGTH;
       }
       else if (hsai->Init.Protocol == SAI_AC97_PROTOCOL)
       {
         /* For AC97 protocol, frame length is set by hardware to 256 */
-        tmpframelength = 256U;
+        tmpframelength = SAI_AC97_FRAME_LENGTH;
       }
       else
       {
@@ -1341,6 +1343,12 @@ HAL_StatusTypeDef HAL_SAI_DMAStop(SAI_HandleTypeDef *hsai)
   /* Process Locked */
   __HAL_LOCK(hsai);
 
+  /* Disable SAI peripheral */
+  if (SAI_Disable(hsai) != HAL_OK)
+  {
+    status = HAL_ERROR;
+  }
+
   /* Disable the SAI DMA request */
   hsai->Instance->CR1 &= ~SAI_xCR1_DMAEN;
 
@@ -1358,12 +1366,6 @@ HAL_StatusTypeDef HAL_SAI_DMAStop(SAI_HandleTypeDef *hsai)
     /* No need to check the returned value of HAL_DMA_Abort. */
     /* Only HAL_DMA_ERROR_NO_XFER can be returned in case of error and it's not an error for SAI. */
     (void) HAL_DMA_Abort(hsai->hdmarx);
-  }
-
-  /* Disable SAI peripheral */
-  if (SAI_Disable(hsai) != HAL_OK)
-  {
-    status = HAL_ERROR;
   }
 
   /* Flush the fifo */
@@ -1391,6 +1393,12 @@ HAL_StatusTypeDef HAL_SAI_Abort(SAI_HandleTypeDef *hsai)
   /* Process Locked */
   __HAL_LOCK(hsai);
 
+  /* Disable SAI peripheral */
+  if (SAI_Disable(hsai) != HAL_OK)
+  {
+    status = HAL_ERROR;
+  }
+
   /* Check SAI DMA is enabled or not */
   if ((hsai->Instance->CR1 & SAI_xCR1_DMAEN) == SAI_xCR1_DMAEN)
   {
@@ -1417,12 +1425,6 @@ HAL_StatusTypeDef HAL_SAI_Abort(SAI_HandleTypeDef *hsai)
   /* Disabled All interrupt and clear all the flag */
   hsai->Instance->IMR = 0;
   hsai->Instance->CLRFR = 0xFFFFFFFFU;
-
-  /* Disable SAI peripheral */
-  if (SAI_Disable(hsai) != HAL_OK)
-  {
-    status = HAL_ERROR;
-  }
 
   /* Flush the fifo */
   SET_BIT(hsai->Instance->CR2, SAI_xCR2_FFLUSH);
@@ -1489,7 +1491,7 @@ HAL_StatusTypeDef HAL_SAI_Transmit_DMA(SAI_HandleTypeDef *hsai, uint8_t *pData, 
     /* Enable SAI Tx DMA Request */
     hsai->Instance->CR1 |= SAI_xCR1_DMAEN;
 
-    /* Wait untill FIFO is not empty */
+    /* Wait until FIFO is not empty */
     while ((hsai->Instance->SR & SAI_xSR_FLVL) == SAI_FIFOSTATUS_EMPTY)
     {
       /* Check for the Timeout */
@@ -2051,7 +2053,7 @@ __weak void HAL_SAI_ErrorCallback(SAI_HandleTypeDef *hsai)
   *              the configuration information for SAI module.
   * @retval HAL state
   */
-HAL_SAI_StateTypeDef HAL_SAI_GetState(SAI_HandleTypeDef *hsai)
+HAL_SAI_StateTypeDef HAL_SAI_GetState(const SAI_HandleTypeDef *hsai)
 {
   return hsai->State;
 }
@@ -2062,7 +2064,7 @@ HAL_SAI_StateTypeDef HAL_SAI_GetState(SAI_HandleTypeDef *hsai)
   *              the configuration information for the specified SAI Block.
   * @retval SAI Error Code
   */
-uint32_t HAL_SAI_GetError(SAI_HandleTypeDef *hsai)
+uint32_t HAL_SAI_GetError(const SAI_HandleTypeDef *hsai)
 {
   return hsai->ErrorCode;
 }
@@ -2742,5 +2744,3 @@ static void SAI_DMAAbort(DMA_HandleTypeDef *hdma)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_sai_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_sai_ex.c
@@ -10,13 +10,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -76,7 +75,8 @@
   * @param  pdmMicDelay Microphone delays configuration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SAIEx_ConfigPdmMicDelay(SAI_HandleTypeDef *hsai, SAIEx_PdmMicDelayParamTypeDef *pdmMicDelay)
+HAL_StatusTypeDef HAL_SAIEx_ConfigPdmMicDelay(const SAI_HandleTypeDef *hsai,
+                                              const SAIEx_PdmMicDelayParamTypeDef *pdmMicDelay)
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint32_t offset;
@@ -131,5 +131,3 @@ HAL_StatusTypeDef HAL_SAIEx_ConfigPdmMicDelay(SAI_HandleTypeDef *hsai, SAIEx_Pdm
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smartcard.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smartcard.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State and Error functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -35,7 +46,8 @@
              (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
              (+++) Configure the DMA Tx/Rx channel.
              (+++) Associate the initialized DMA handle to the SMARTCARD DMA Tx/Rx handle.
-             (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+             (+++) Configure the priority and enable the NVIC for the transfer complete
+                   interrupt on the DMA Tx/Rx channel.
 
     (#) Program the Baud Rate, Parity, Mode(Receiver/Transmitter), clock enabling/disabling and accordingly,
         the clock parameters (parity, phase, last bit), prescaler value, guard time and NACK on transmission
@@ -123,9 +135,9 @@
     and a pointer to the user callback function.
 
     [..]
-    Use function @ref HAL_SMARTCARD_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
-    @ref HAL_SMARTCARD_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+    Use function HAL_SMARTCARD_UnRegisterCallback() to reset a callback to the default
+    weak function.
+    HAL_SMARTCARD_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the Callback ID.
     This function allows to reset following callbacks:
     (+) TxCpltCallback            : Tx Complete Callback.
@@ -141,10 +153,10 @@
 
     [..]
     By default, after the HAL_SMARTCARD_Init() and when the state is HAL_SMARTCARD_STATE_RESET
-    all callbacks are set to the corresponding weak (surcharged) functions:
+    all callbacks are set to the corresponding weak functions:
     examples HAL_SMARTCARD_TxCpltCallback(), HAL_SMARTCARD_RxCpltCallback().
     Exception done for MspInit and MspDeInit functions that are respectively
-    reset to the legacy weak (surcharged) functions in the HAL_SMARTCARD_Init()
+    reset to the legacy weak functions in the HAL_SMARTCARD_Init()
     and HAL_SMARTCARD_DeInit() only when these callbacks are null (not registered beforehand).
     If not, MspInit or MspDeInit are not null, the HAL_SMARTCARD_Init() and HAL_SMARTCARD_DeInit()
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
@@ -161,21 +173,10 @@
     [..]
     When The compilation define USE_HAL_SMARTCARD_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registration feature is not available
-    and weak (surcharged) callbacks are used.
+    and weak callbacks are used.
 
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -198,23 +199,24 @@
 /** @defgroup SMARTCARD_Private_Constants SMARTCARD Private Constants
   * @{
   */
-#define SMARTCARD_TEACK_REACK_TIMEOUT               1000U      /*!< SMARTCARD TX or RX enable acknowledge time-out value  */
+#define SMARTCARD_TEACK_REACK_TIMEOUT  1000U       /*!< SMARTCARD TX or RX enable acknowledge time-out value */
 
-#define USART_CR1_FIELDS      ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS   | \
-                                          USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8| \
-                                          USART_CR1_FIFOEN ))                                         /*!< USART CR1 fields of parameters set by SMARTCARD_SetConfig API */
+#define USART_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | USART_CR1_TE | \
+                                      USART_CR1_RE | USART_CR1_OVER8| \
+                                      USART_CR1_FIFOEN))  /*!< USART CR1 fields of parameters set by SMARTCARD_SetConfig API */
 
-#define USART_CR2_CLK_FIELDS  ((uint32_t)(USART_CR2_CLKEN | USART_CR2_CPOL | USART_CR2_CPHA | \
-                                          USART_CR2_LBCL))                                            /*!< SMARTCARD clock-related USART CR2 fields of parameters */
+#define USART_CR2_CLK_FIELDS  ((uint32_t)(USART_CR2_CLKEN | USART_CR2_CPOL | \
+                                          USART_CR2_CPHA | USART_CR2_LBCL)) /*!< SMARTCARD clock-related USART CR2 fields of parameters */
 
-#define USART_CR2_FIELDS      ((uint32_t)(USART_CR2_RTOEN | USART_CR2_CLK_FIELDS | USART_CR2_STOP))   /*!< USART CR2 fields of parameters set by SMARTCARD_SetConfig API */
+#define USART_CR2_FIELDS  ((uint32_t)(USART_CR2_RTOEN | USART_CR2_CLK_FIELDS | \
+                                      USART_CR2_STOP)) /*!< USART CR2 fields of parameters set by SMARTCARD_SetConfig API */
 
-#define USART_CR3_FIELDS      ((uint32_t)(USART_CR3_ONEBIT | USART_CR3_NACK | USART_CR3_SCARCNT | \
-                                          USART_CR3_TXFTCFG | USART_CR3_RXFTCFG ))                    /*!< USART CR3 fields of parameters set by SMARTCARD_SetConfig API */
+#define USART_CR3_FIELDS  ((uint32_t)(USART_CR3_ONEBIT | USART_CR3_NACK | USART_CR3_SCARCNT | \
+                                      USART_CR3_TXFTCFG | USART_CR3_RXFTCFG )) /*!< USART CR3 fields of parameters set by SMARTCARD_SetConfig API */
 
-#define USART_BRR_MIN    0x10U        /*!< USART BRR minimum authorized value */
+#define USART_BRR_MIN  0x10U        /*!< USART BRR minimum authorized value */
 
-#define USART_BRR_MAX    0x0000FFFFU  /*!< USART BRR maximum authorized value */
+#define USART_BRR_MAX  0x0000FFFFU  /*!< USART BRR maximum authorized value */
 /**
   * @}
   */
@@ -465,7 +467,10 @@ __weak void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsmartcard)
 #if (USE_HAL_SMARTCARD_REGISTER_CALLBACKS == 1)
 /**
   * @brief  Register a User SMARTCARD Callback
-  *         To be used instead of the weak predefined callback
+  *         To be used to override the weak predefined callback
+  * @note   The HAL_SMARTCARD_RegisterCallback() may be called before HAL_SMARTCARD_Init()
+  *         in HAL_SMARTCARD_STATE_RESET to register callbacks for HAL_SMARTCARD_MSPINIT_CB_ID
+  *         and HAL_SMARTCARD_MSPDEINIT_CB_ID
   * @param  hsmartcard smartcard handle
   * @param  CallbackID ID of the callback to be registered
   *         This parameter can be one of the following values:
@@ -483,7 +488,8 @@ __weak void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsmartcard)
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_SMARTCARD_RegisterCallback(SMARTCARD_HandleTypeDef *hsmartcard,
-                                                 HAL_SMARTCARD_CallbackIDTypeDef CallbackID, pSMARTCARD_CallbackTypeDef pCallback)
+                                                 HAL_SMARTCARD_CallbackIDTypeDef CallbackID,
+                                                 pSMARTCARD_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -494,8 +500,6 @@ HAL_StatusTypeDef HAL_SMARTCARD_RegisterCallback(SMARTCARD_HandleTypeDef *hsmart
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hsmartcard);
 
   if (hsmartcard->gState == HAL_SMARTCARD_STATE_READY)
   {
@@ -581,15 +585,15 @@ HAL_StatusTypeDef HAL_SMARTCARD_RegisterCallback(SMARTCARD_HandleTypeDef *hsmart
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hsmartcard);
-
   return status;
 }
 
 /**
   * @brief  Unregister an SMARTCARD callback
   *         SMARTCARD callback is redirected to the weak predefined callback
+  * @note   The HAL_SMARTCARD_UnRegisterCallback() may be called before HAL_SMARTCARD_Init()
+  *         in HAL_SMARTCARD_STATE_RESET to un-register callbacks for HAL_SMARTCARD_MSPINIT_CB_ID
+  *         and HAL_SMARTCARD_MSPDEINIT_CB_ID
   * @param  hsmartcard smartcard handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
@@ -610,51 +614,50 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(hsmartcard);
-
   if (HAL_SMARTCARD_STATE_READY == hsmartcard->gState)
   {
     switch (CallbackID)
     {
       case HAL_SMARTCARD_TX_COMPLETE_CB_ID :
-        hsmartcard->TxCpltCallback = HAL_SMARTCARD_TxCpltCallback;                       /* Legacy weak TxCpltCallback            */
+        hsmartcard->TxCpltCallback = HAL_SMARTCARD_TxCpltCallback;                 /* Legacy weak TxCpltCallback */
         break;
 
       case HAL_SMARTCARD_RX_COMPLETE_CB_ID :
-        hsmartcard->RxCpltCallback = HAL_SMARTCARD_RxCpltCallback;                       /* Legacy weak RxCpltCallback            */
+        hsmartcard->RxCpltCallback = HAL_SMARTCARD_RxCpltCallback;                 /* Legacy weak RxCpltCallback */
         break;
 
       case HAL_SMARTCARD_ERROR_CB_ID :
-        hsmartcard->ErrorCallback = HAL_SMARTCARD_ErrorCallback;                         /* Legacy weak ErrorCallback             */
+        hsmartcard->ErrorCallback = HAL_SMARTCARD_ErrorCallback;                   /* Legacy weak ErrorCallback  */
         break;
 
       case HAL_SMARTCARD_ABORT_COMPLETE_CB_ID :
-        hsmartcard->AbortCpltCallback = HAL_SMARTCARD_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback         */
+        hsmartcard->AbortCpltCallback = HAL_SMARTCARD_AbortCpltCallback;           /* Legacy weak AbortCpltCallback */
         break;
 
       case HAL_SMARTCARD_ABORT_TRANSMIT_COMPLETE_CB_ID :
-        hsmartcard->AbortTransmitCpltCallback = HAL_SMARTCARD_AbortTransmitCpltCallback; /* Legacy weak AbortTransmitCpltCallback */
+        hsmartcard->AbortTransmitCpltCallback = HAL_SMARTCARD_AbortTransmitCpltCallback; /* Legacy weak
+                                                                                            AbortTransmitCpltCallback*/
         break;
 
       case HAL_SMARTCARD_ABORT_RECEIVE_COMPLETE_CB_ID :
-        hsmartcard->AbortReceiveCpltCallback = HAL_SMARTCARD_AbortReceiveCpltCallback;   /* Legacy weak AbortReceiveCpltCallback  */
+        hsmartcard->AbortReceiveCpltCallback = HAL_SMARTCARD_AbortReceiveCpltCallback;  /* Legacy weak
+                                                                                           AbortReceiveCpltCallback */
         break;
 
       case HAL_SMARTCARD_RX_FIFO_FULL_CB_ID :
-        hsmartcard->RxFifoFullCallback = HAL_SMARTCARDEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback        */
+        hsmartcard->RxFifoFullCallback = HAL_SMARTCARDEx_RxFifoFullCallback;      /* Legacy weak RxFifoFullCallback */
         break;
 
       case HAL_SMARTCARD_TX_FIFO_EMPTY_CB_ID :
-        hsmartcard->TxFifoEmptyCallback = HAL_SMARTCARDEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback       */
+        hsmartcard->TxFifoEmptyCallback = HAL_SMARTCARDEx_TxFifoEmptyCallback;    /* Legacy weak TxFifoEmptyCallback */
         break;
 
       case HAL_SMARTCARD_MSPINIT_CB_ID :
-        hsmartcard->MspInitCallback = HAL_SMARTCARD_MspInit;                             /* Legacy weak MspInitCallback           */
+        hsmartcard->MspInitCallback = HAL_SMARTCARD_MspInit;                       /* Legacy weak MspInitCallback  */
         break;
 
       case HAL_SMARTCARD_MSPDEINIT_CB_ID :
-        hsmartcard->MspDeInitCallback = HAL_SMARTCARD_MspDeInit;                         /* Legacy weak MspDeInitCallback         */
+        hsmartcard->MspDeInitCallback = HAL_SMARTCARD_MspDeInit;                   /* Legacy weak MspDeInitCallback */
         break;
 
       default :
@@ -695,9 +698,6 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
     /* Return error status */
     status =  HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(hsmartcard);
 
   return status;
 }
@@ -757,6 +757,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
         (##) HAL_SMARTCARD_RxCpltCallback()
         (##) HAL_SMARTCARD_ErrorCallback()
 
+  [..]
     (#) Non-Blocking mode transfers could be aborted using Abort API's :
         (##) HAL_SMARTCARD_Abort()
         (##) HAL_SMARTCARD_AbortTransmit()
@@ -765,7 +766,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
         (##) HAL_SMARTCARD_AbortTransmit_IT()
         (##) HAL_SMARTCARD_AbortReceive_IT()
 
-    (#) For Abort services based on interrupts (HAL_SMARTCARD_Abortxxx_IT), a set of Abort Complete Callbacks are provided:
+    (#) For Abort services based on interrupts (HAL_SMARTCARD_Abortxxx_IT),
+        a set of Abort Complete Callbacks are provided:
         (##) HAL_SMARTCARD_AbortCpltCallback()
         (##) HAL_SMARTCARD_AbortTransmitCpltCallback()
         (##) HAL_SMARTCARD_AbortReceiveCpltCallback()
@@ -773,13 +775,17 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
     (#) In Non-Blocking mode transfers, possible errors are split into 2 categories.
         Errors are handled as follows :
        (##) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
-           to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
-           Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
+           to be evaluated by user : this concerns Frame Error,
+           Parity Error or Noise Error in Interrupt mode reception .
+           Received character is then retrieved and stored in Rx buffer,
+           Error code is set to allow user to identify error type,
            and HAL_SMARTCARD_ErrorCallback() user callback is executed. Transfer is kept ongoing on SMARTCARD side.
            If user wants to abort it, Abort services should be called by user.
        (##) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
-           This concerns Frame Error in Interrupt mode tranmission, Overrun Error in Interrupt mode reception and all errors in DMA mode.
-           Error code is set to allow user to identify error type, and HAL_SMARTCARD_ErrorCallback() user callback is executed.
+           This concerns Frame Error in Interrupt mode transmission, Overrun Error in Interrupt
+           mode reception and all errors in DMA mode.
+           Error code is set to allow user to identify error type,
+           and HAL_SMARTCARD_ErrorCallback() user callback is executed.
 
 @endverbatim
   * @{
@@ -798,11 +804,11 @@ HAL_StatusTypeDef HAL_SMARTCARD_UnRegisterCallback(SMARTCARD_HandleTypeDef *hsma
   * @param  Timeout  Timeout duration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size,
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, const uint8_t *pData, uint16_t Size,
                                          uint32_t Timeout)
 {
   uint32_t tickstart;
-  uint8_t  *ptmpdata = pData;
+  const uint8_t  *ptmpdata = pData;
 
   /* Check that a Tx process is not already ongoing */
   if (hsmartcard->gState == HAL_SMARTCARD_STATE_READY)
@@ -827,7 +833,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, ui
        the bidirectional line to detect a NACK signal in case of parity error.
        Therefore, the receiver block must be enabled as well (RE bit must be set). */
     if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
-     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+        && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
     {
       SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
     }
@@ -854,8 +860,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, ui
       hsmartcard->Instance->TDR = (uint8_t)(*ptmpdata & 0xFFU);
       ptmpdata++;
     }
-    if (SMARTCARD_WaitOnFlagUntilTimeout(hsmartcard, SMARTCARD_TRANSMISSION_COMPLETION_FLAG(hsmartcard), RESET, tickstart,
-                                         Timeout) != HAL_OK)
+    if (SMARTCARD_WaitOnFlagUntilTimeout(hsmartcard, SMARTCARD_TRANSMISSION_COMPLETION_FLAG(hsmartcard), RESET,
+                                         tickstart, Timeout) != HAL_OK)
     {
       return HAL_TIMEOUT;
     }
@@ -863,14 +869,14 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsmartcard, ui
     /* Disable the Peripheral first to update mode */
     CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
     if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
-     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+        && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
     {
       /* In case of TX only mode, if NACK is enabled, receiver block has been enabled
          for Transmit phase. Disable this receiver block. */
       CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
     }
     if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX_RX)
-     || (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+        || (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
     {
       /* Perform a TX FIFO Flush at end of Tx phase, as all sent bytes are appearing in Rx Data register */
       __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
@@ -972,7 +978,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsmartcard, uin
   * @param  Size amount of data to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsmartcard, const uint8_t *pData, uint16_t Size)
 {
   /* Check that a Tx process is not already ongoing */
   if (hsmartcard->gState == HAL_SMARTCARD_STATE_READY)
@@ -1000,7 +1006,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_IT(SMARTCARD_HandleTypeDef *hsmartcard,
        the bidirectional line to detect a NACK signal in case of parity error.
        Therefore, the receiver block must be enabled as well (RE bit must be set). */
     if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
-     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+        && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
     {
       SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
     }
@@ -1130,7 +1136,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive_IT(SMARTCARD_HandleTypeDef *hsmartcard, 
   * @param  Size amount of data to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsmartcard, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsmartcard, const uint8_t *pData, uint16_t Size)
 {
   /* Check that a Tx process is not already ongoing */
   if (hsmartcard->gState == HAL_SMARTCARD_STATE_READY)
@@ -1157,7 +1163,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit_DMA(SMARTCARD_HandleTypeDef *hsmartcard
        the bidirectional line to detect a NACK signal in case of parity error.
        Therefore, the receiver block must be enabled as well (RE bit must be set). */
     if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
-     && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+        && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
     {
       SET_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
     }
@@ -1310,7 +1316,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive_DMA(SMARTCARD_HandleTypeDef *hsmartcard,
   */
 HAL_StatusTypeDef HAL_SMARTCARD_Abort(SMARTCARD_HandleTypeDef *hsmartcard)
 {
-  /* Disable RTOIE, EOBIE, TXEIE, TCIE, RXNE, PE, RXFT, TXFT and ERR (Frame error, noise error, overrun error) interrupts */
+  /* Disable RTOIE, EOBIE, TXEIE, TCIE, RXNE, PE, RXFT, TXFT and
+     ERR (Frame error, noise error, overrun error) interrupts */
   CLEAR_BIT(hsmartcard->Instance->CR1,
             (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE | USART_CR1_RTOIE |
              USART_CR1_EOBIE));
@@ -1372,8 +1379,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_Abort(SMARTCARD_HandleTypeDef *hsmartcard)
 
   /* Clear the Error flags in the ICR register */
   __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                             SMARTCARD_CLEAR_EOBF);
+                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF |
+                             SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
   /* Restore hsmartcard->gState and hsmartcard->RxState to Ready */
   hsmartcard->gState  = HAL_SMARTCARD_STATE_READY;
@@ -1464,7 +1471,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_AbortTransmit(SMARTCARD_HandleTypeDef *hsmartcar
 HAL_StatusTypeDef HAL_SMARTCARD_AbortReceive(SMARTCARD_HandleTypeDef *hsmartcard)
 {
   /* Disable RTOIE, EOBIE, RXNE, PE, RXFT, TXFT and  ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(hsmartcard->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_RTOIE | USART_CR1_EOBIE));
+  CLEAR_BIT(hsmartcard->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_RTOIE |
+                                        USART_CR1_EOBIE));
   CLEAR_BIT(hsmartcard->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
   /* Check if a Transmit process is ongoing or not. If not disable ERR IT */
@@ -1504,8 +1512,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_AbortReceive(SMARTCARD_HandleTypeDef *hsmartcard
 
   /* Clear the Error flags in the ICR register */
   __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                             SMARTCARD_CLEAR_EOBF);
+                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF |
+                             SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
   /* Restore hsmartcard->RxState to Ready */
   hsmartcard->RxState = HAL_SMARTCARD_STATE_READY;
@@ -1532,14 +1540,16 @@ HAL_StatusTypeDef HAL_SMARTCARD_Abort_IT(SMARTCARD_HandleTypeDef *hsmartcard)
 {
   uint32_t abortcplt = 1U;
 
-  /* Disable RTOIE, EOBIE, TXEIE, TCIE, RXNE, PE, RXFT, TXFT and  ERR (Frame error, noise error, overrun error) interrupts */
+  /* Disable RTOIE, EOBIE, TXEIE, TCIE, RXNE, PE, RXFT, TXFT and
+     ERR (Frame error, noise error, overrun error) interrupts */
   CLEAR_BIT(hsmartcard->Instance->CR1,
             (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE | USART_CR1_RTOIE |
              USART_CR1_EOBIE));
   CLEAR_BIT(hsmartcard->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE));
 
-  /* If DMA Tx and/or DMA Rx Handles are associated to SMARTCARD Handle, DMA Abort complete callbacks should be initialised
-     before any call to DMA Abort functions */
+  /* If DMA Tx and/or DMA Rx Handles are associated to SMARTCARD Handle,
+     DMA Abort complete callbacks should be initialised before any call
+     to DMA Abort functions */
   /* DMA Tx Handle is valid */
   if (hsmartcard->hdmatx != NULL)
   {
@@ -1633,8 +1643,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_Abort_IT(SMARTCARD_HandleTypeDef *hsmartcard)
 
     /* Clear the Error flags in the ICR register */
     __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                               SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                               SMARTCARD_CLEAR_EOBF);
+                               SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF |
+                               SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
     /* Restore hsmartcard->gState and hsmartcard->RxState to Ready */
     hsmartcard->gState  = HAL_SMARTCARD_STATE_READY;
@@ -1766,7 +1776,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_AbortTransmit_IT(SMARTCARD_HandleTypeDef *hsmart
 HAL_StatusTypeDef HAL_SMARTCARD_AbortReceive_IT(SMARTCARD_HandleTypeDef *hsmartcard)
 {
   /* Disable RTOIE, EOBIE, RXNE, PE, RXFT and  ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(hsmartcard->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_RTOIE | USART_CR1_EOBIE));
+  CLEAR_BIT(hsmartcard->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_RTOIE |
+                                        USART_CR1_EOBIE));
   CLEAR_BIT(hsmartcard->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
   /* Check if a Transmit process is ongoing or not. If not disable ERR IT */
@@ -1805,8 +1816,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_AbortReceive_IT(SMARTCARD_HandleTypeDef *hsmartc
 
       /* Clear the Error flags in the ICR register */
       __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                                 SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                                 SMARTCARD_CLEAR_EOBF);
+                                 SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF |
+                                 SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
       /* Restore hsmartcard->RxState to Ready */
       hsmartcard->RxState = HAL_SMARTCARD_STATE_READY;
@@ -1831,8 +1842,8 @@ HAL_StatusTypeDef HAL_SMARTCARD_AbortReceive_IT(SMARTCARD_HandleTypeDef *hsmartc
 
     /* Clear the Error flags in the ICR register */
     __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                               SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                               SMARTCARD_CLEAR_EOBF);
+                               SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF |
+                               SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
     /* Restore hsmartcard->RxState to Ready */
     hsmartcard->RxState = HAL_SMARTCARD_STATE_READY;
@@ -2260,7 +2271,7 @@ __weak void HAL_SMARTCARD_AbortReceiveCpltCallback(SMARTCARD_HandleTypeDef *hsma
   *                    the configuration information for the specified SMARTCARD module.
   * @retval SMARTCARD handle state
   */
-HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(SMARTCARD_HandleTypeDef *hsmartcard)
+HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(const SMARTCARD_HandleTypeDef *hsmartcard)
 {
   /* Return SMARTCARD handle state */
   uint32_t temp1;
@@ -2277,7 +2288,7 @@ HAL_SMARTCARD_StateTypeDef HAL_SMARTCARD_GetState(SMARTCARD_HandleTypeDef *hsmar
   *                    the configuration information for the specified SMARTCARD module.
   * @retval SMARTCARD handle Error Code
   */
-uint32_t HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsmartcard)
+uint32_t HAL_SMARTCARD_GetError(const SMARTCARD_HandleTypeDef *hsmartcard)
 {
   return hsmartcard->ErrorCode;
 }
@@ -2303,14 +2314,18 @@ uint32_t HAL_SMARTCARD_GetError(SMARTCARD_HandleTypeDef *hsmartcard)
 void SMARTCARD_InitCallbacksToDefault(SMARTCARD_HandleTypeDef *hsmartcard)
 {
   /* Init the SMARTCARD Callback settings */
-  hsmartcard->TxCpltCallback            = HAL_SMARTCARD_TxCpltCallback;            /* Legacy weak TxCpltCallback            */
-  hsmartcard->RxCpltCallback            = HAL_SMARTCARD_RxCpltCallback;            /* Legacy weak RxCpltCallback            */
-  hsmartcard->ErrorCallback             = HAL_SMARTCARD_ErrorCallback;             /* Legacy weak ErrorCallback             */
-  hsmartcard->AbortCpltCallback         = HAL_SMARTCARD_AbortCpltCallback;         /* Legacy weak AbortCpltCallback         */
-  hsmartcard->AbortTransmitCpltCallback = HAL_SMARTCARD_AbortTransmitCpltCallback; /* Legacy weak AbortTransmitCpltCallback */
-  hsmartcard->AbortReceiveCpltCallback  = HAL_SMARTCARD_AbortReceiveCpltCallback;  /* Legacy weak AbortReceiveCpltCallback  */
-  hsmartcard->RxFifoFullCallback        = HAL_SMARTCARDEx_RxFifoFullCallback;      /* Legacy weak RxFifoFullCallback        */
-  hsmartcard->TxFifoEmptyCallback       = HAL_SMARTCARDEx_TxFifoEmptyCallback;     /* Legacy weak TxFifoEmptyCallback       */
+  hsmartcard->TxCpltCallback            = HAL_SMARTCARD_TxCpltCallback;            /* Legacy weak TxCpltCallback    */
+  hsmartcard->RxCpltCallback            = HAL_SMARTCARD_RxCpltCallback;            /* Legacy weak RxCpltCallback    */
+  hsmartcard->ErrorCallback             = HAL_SMARTCARD_ErrorCallback;             /* Legacy weak ErrorCallback     */
+  hsmartcard->AbortCpltCallback         = HAL_SMARTCARD_AbortCpltCallback;         /* Legacy weak AbortCpltCallback */
+  hsmartcard->AbortTransmitCpltCallback = HAL_SMARTCARD_AbortTransmitCpltCallback; /* Legacy weak
+                                                                                      AbortTransmitCpltCallback     */
+  hsmartcard->AbortReceiveCpltCallback  = HAL_SMARTCARD_AbortReceiveCpltCallback;  /* Legacy weak
+                                                                                      AbortReceiveCpltCallback      */
+  hsmartcard->RxFifoFullCallback        = HAL_SMARTCARDEx_RxFifoFullCallback;      /* Legacy weak
+                                                                                      RxFifoFullCallback            */
+  hsmartcard->TxFifoEmptyCallback       = HAL_SMARTCARDEx_TxFifoEmptyCallback;     /* Legacy weak
+                                                                                      TxFifoEmptyCallback           */
 
 }
 #endif /* USE_HAL_SMARTCARD_REGISTER_CALLBACKS */
@@ -2326,7 +2341,7 @@ static HAL_StatusTypeDef SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsmartcard
   uint32_t tmpreg;
   SMARTCARD_ClockSourceTypeDef clocksource;
   HAL_StatusTypeDef ret = HAL_OK;
-  const uint16_t SMARTCARDPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
+  static const uint16_t SMARTCARDPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
   uint32_t pclk;
 
   /* Check the parameters */
@@ -2351,8 +2366,8 @@ static HAL_StatusTypeDef SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsmartcard
    * Configure the Parity and Mode:
    *  set PS bit according to hsmartcard->Init.Parity value
    *  set TE and RE bits according to hsmartcard->Init.Mode value */
-  tmpreg = (uint32_t) hsmartcard->Init.Parity | hsmartcard->Init.Mode;
-  tmpreg |= (uint32_t) hsmartcard->Init.WordLength | hsmartcard->FifoMode;
+  tmpreg = (((uint32_t)hsmartcard->Init.Parity) | ((uint32_t)hsmartcard->Init.Mode) |
+            ((uint32_t)hsmartcard->Init.WordLength));
   MODIFY_REG(hsmartcard->Instance->CR1, USART_CR1_FIELDS, tmpreg);
 
   /*-------------------------- USART CR2 Configuration -----------------------*/
@@ -2391,7 +2406,7 @@ static HAL_StatusTypeDef SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsmartcard
     assert_param(IS_SMARTCARD_TIMEOUT_VALUE(hsmartcard->Init.TimeOutValue));
     tmpreg |= (uint32_t) hsmartcard->Init.TimeOutValue;
   }
-  MODIFY_REG(hsmartcard->Instance->RTOR, (USART_RTOR_RTO | USART_RTOR_BLEN), tmpreg);
+  WRITE_REG(hsmartcard->Instance->RTOR, tmpreg);
 
   /*-------------------------- USART BRR Configuration -----------------------*/
   SMARTCARD_GETCLOCKSOURCE(hsmartcard, clocksource);
@@ -2400,17 +2415,21 @@ static HAL_StatusTypeDef SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsmartcard
   {
     case SMARTCARD_CLOCKSOURCE_PCLK2:
       pclk = HAL_RCC_GetPCLK2Freq();
-      tmpreg = (uint16_t)(((pclk / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) + (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
+      tmpreg = (uint32_t)(((pclk / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) +
+                           (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
       break;
     case SMARTCARD_CLOCKSOURCE_HSI:
-      tmpreg = (uint16_t)(((HSI_VALUE / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) + (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
+      tmpreg = (uint32_t)(((HSI_VALUE / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) +
+                           (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
       break;
     case SMARTCARD_CLOCKSOURCE_SYSCLK:
       pclk = HAL_RCC_GetSysClockFreq();
-      tmpreg = (uint16_t)(((pclk / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) + (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
+      tmpreg = (uint32_t)(((pclk / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) +
+                           (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
       break;
     case SMARTCARD_CLOCKSOURCE_LSE:
-      tmpreg = (uint16_t)(((uint16_t)(LSE_VALUE / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) + (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
+      tmpreg = (uint32_t)(((uint16_t)(LSE_VALUE / SMARTCARDPrescTable[hsmartcard->Init.ClockPrescaler]) +
+                           (hsmartcard->Init.BaudRate / 2U)) / hsmartcard->Init.BaudRate);
       break;
     default:
       ret = HAL_ERROR;
@@ -2420,7 +2439,7 @@ static HAL_StatusTypeDef SMARTCARD_SetConfig(SMARTCARD_HandleTypeDef *hsmartcard
   /* USARTDIV must be greater than or equal to 0d16 */
   if ((tmpreg >= USART_BRR_MIN) && (tmpreg <= USART_BRR_MAX))
   {
-    hsmartcard->Instance->BRR = tmpreg;
+    hsmartcard->Instance->BRR = (uint16_t)tmpreg;
   }
   else
   {
@@ -2551,11 +2570,12 @@ static HAL_StatusTypeDef SMARTCARD_CheckIdleState(SMARTCARD_HandleTypeDef *hsmar
 }
 
 /**
-  * @brief  Handle SMARTCARD Communication Timeout.
+  * @brief  Handle SMARTCARD Communication Timeout. It waits
+  *         until a flag is no longer in the specified status.
   * @param  hsmartcard Pointer to a SMARTCARD_HandleTypeDef structure that contains
   *                   the configuration information for the specified SMARTCARD module.
   * @param  Flag Specifies the SMARTCARD flag to check.
-  * @param  Status The new Flag status (SET or RESET).
+  * @param  Status The actual Flag status (SET or RESET).
   * @param  Tickstart Tick start value
   * @param  Timeout Timeout duration.
   * @retval HAL status
@@ -2571,7 +2591,8 @@ static HAL_StatusTypeDef SMARTCARD_WaitOnFlagUntilTimeout(SMARTCARD_HandleTypeDe
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
+        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error)
+           interrupts for the interrupt process */
         CLEAR_BIT(hsmartcard->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE));
         CLEAR_BIT(hsmartcard->Instance->CR3, USART_CR3_EIE);
 
@@ -2765,8 +2786,8 @@ static void SMARTCARD_DMATxAbortCallback(DMA_HandleTypeDef *hdma)
 
   /* Clear the Error flags in the ICR register */
   __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                             SMARTCARD_CLEAR_EOBF);
+                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF |
+                             SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
   /* Restore hsmartcard->gState and hsmartcard->RxState to Ready */
   hsmartcard->gState  = HAL_SMARTCARD_STATE_READY;
@@ -2814,8 +2835,8 @@ static void SMARTCARD_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
 
   /* Clear the Error flags in the ICR register */
   __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                             SMARTCARD_CLEAR_EOBF);
+                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF |
+                             SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
   /* Restore hsmartcard->gState and hsmartcard->RxState to Ready */
   hsmartcard->gState  = HAL_SMARTCARD_STATE_READY;
@@ -2876,8 +2897,8 @@ static void SMARTCARD_DMARxOnlyAbortCallback(DMA_HandleTypeDef *hdma)
 
   /* Clear the Error flags in the ICR register */
   __HAL_SMARTCARD_CLEAR_FLAG(hsmartcard,
-                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF | SMARTCARD_CLEAR_RTOF |
-                             SMARTCARD_CLEAR_EOBF);
+                             SMARTCARD_CLEAR_OREF | SMARTCARD_CLEAR_NEF | SMARTCARD_CLEAR_PEF | SMARTCARD_CLEAR_FEF |
+                             SMARTCARD_CLEAR_RTOF | SMARTCARD_CLEAR_EOBF);
 
   /* Restore hsmartcard->RxState to Ready */
   hsmartcard->RxState = HAL_SMARTCARD_STATE_READY;
@@ -2983,14 +3004,14 @@ static void SMARTCARD_EndTransmit_IT(SMARTCARD_HandleTypeDef *hsmartcard)
   /* Disable the Peripheral first to update mode */
   CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_UE);
   if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX)
-   && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+      && (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
   {
     /* In case of TX only mode, if NACK is enabled, receiver block has been enabled
        for Transmit phase. Disable this receiver block. */
     CLEAR_BIT(hsmartcard->Instance->CR1, USART_CR1_RE);
   }
   if ((hsmartcard->Init.Mode == SMARTCARD_MODE_TX_RX)
-   || (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
+      || (hsmartcard->Init.NACKEnable == SMARTCARD_NACK_ENABLE))
   {
     /* Perform a TX FIFO Flush at end of Tx phase, as all sent bytes are appearing in Rx Data register */
     __HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
@@ -3154,4 +3175,3 @@ static void SMARTCARD_RxISR_FIFOEN(SMARTCARD_HandleTypeDef *hsmartcard)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smartcard_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smartcard_ex.c
@@ -8,6 +8,17 @@
   *           + Initialization and de-initialization functions
   *           + Peripheral Control functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   =============================================================================
                ##### SMARTCARD peripheral extended features  #####
@@ -26,17 +37,6 @@
             configured prior starting RX/TX transfers.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -458,8 +458,8 @@ static void SMARTCARDEx_SetNbDataToProcess(SMARTCARD_HandleTypeDef *hsmartcard)
   uint8_t rx_fifo_threshold;
   uint8_t tx_fifo_threshold;
   /* 2 0U/1U added for MISRAC2012-Rule-18.1_b and MISRAC2012-Rule-18.1_d */
-  uint8_t numerator[]   = {1U, 1U, 1U, 3U, 7U, 1U, 0U, 0U};
-  uint8_t denominator[] = {8U, 4U, 2U, 4U, 8U, 1U, 1U, 1U};
+  static const uint8_t numerator[]   = {1U, 1U, 1U, 3U, 7U, 1U, 0U, 0U};
+  static const uint8_t denominator[] = {8U, 4U, 2U, 4U, 8U, 1U, 1U, 1U};
 
   if (hsmartcard->FifoMode == SMARTCARD_FIFOMODE_DISABLE)
   {
@@ -472,8 +472,10 @@ static void SMARTCARDEx_SetNbDataToProcess(SMARTCARD_HandleTypeDef *hsmartcard)
     tx_fifo_depth = TX_FIFO_DEPTH;
     rx_fifo_threshold = (uint8_t)(READ_BIT(hsmartcard->Instance->CR3, USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos);
     tx_fifo_threshold = (uint8_t)(READ_BIT(hsmartcard->Instance->CR3, USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos);
-    hsmartcard->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) / (uint16_t)denominator[tx_fifo_threshold];
-    hsmartcard->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) / (uint16_t)denominator[rx_fifo_threshold];
+    hsmartcard->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) / \
+                                    (uint16_t)denominator[tx_fifo_threshold];
+    hsmartcard->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) / \
+                                    (uint16_t)denominator[rx_fifo_threshold];
   }
 }
 
@@ -491,4 +493,3 @@ static void SMARTCARDEx_SetNbDataToProcess(SMARTCARD_HandleTypeDef *hsmartcard)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smbus.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smbus.c
@@ -10,6 +10,17 @@
   *           + IO operation functions
   *           + Peripheral State and Errors functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -20,7 +31,7 @@
     (#) Declare a SMBUS_HandleTypeDef handle structure, for example:
         SMBUS_HandleTypeDef  hsmbus;
 
-    (#)Initialize the SMBUS low level resources by implementing the @ref HAL_SMBUS_MspInit() API:
+    (#)Initialize the SMBUS low level resources by implementing the HAL_SMBUS_MspInit() API:
         (##) Enable the SMBUSx interface clock
         (##) SMBUS pins configuration
             (+++) Enable the clock for the SMBUS GPIOs
@@ -33,69 +44,75 @@
         Dual Addressing mode, Own Address2, Own Address2 Mask, General call, Nostretch mode,
         Peripheral mode and Packet Error Check mode in the hsmbus Init structure.
 
-    (#) Initialize the SMBUS registers by calling the @ref HAL_SMBUS_Init() API:
+    (#) Initialize the SMBUS registers by calling the HAL_SMBUS_Init() API:
         (++) These API's configures also the low level Hardware GPIO, CLOCK, CORTEX...etc)
-             by calling the customized @ref HAL_SMBUS_MspInit(&hsmbus) API.
+             by calling the customized HAL_SMBUS_MspInit(&hsmbus) API.
 
-    (#) To check if target device is ready for communication, use the function @ref HAL_SMBUS_IsDeviceReady()
+    (#) To check if target device is ready for communication, use the function HAL_SMBUS_IsDeviceReady()
 
     (#) For SMBUS IO operations, only one mode of operations is available within this driver
 
     *** Interrupt mode IO operation ***
     ===================================
     [..]
-      (+) Transmit in master/host SMBUS mode an amount of data in non-blocking mode using @ref HAL_SMBUS_Master_Transmit_IT()
-      (++) At transmission end of transfer @ref HAL_SMBUS_MasterTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_MasterTxCpltCallback()
-      (+) Receive in master/host SMBUS mode an amount of data in non-blocking mode using @ref HAL_SMBUS_Master_Receive_IT()
-      (++) At reception end of transfer @ref HAL_SMBUS_MasterRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_MasterRxCpltCallback()
-      (+) Abort a master/host SMBUS process communication with Interrupt using @ref HAL_SMBUS_Master_Abort_IT()
+      (+) Transmit in master/host SMBUS mode an amount of data in non-blocking mode
+          using HAL_SMBUS_Master_Transmit_IT()
+      (++) At transmission end of transfer HAL_SMBUS_MasterTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_MasterTxCpltCallback()
+      (+) Receive in master/host SMBUS mode an amount of data in non-blocking mode
+          using HAL_SMBUS_Master_Receive_IT()
+      (++) At reception end of transfer HAL_SMBUS_MasterRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_MasterRxCpltCallback()
+      (+) Abort a master/host SMBUS process communication with Interrupt using HAL_SMBUS_Master_Abort_IT()
       (++) The associated previous transfer callback is called at the end of abort process
-      (++) mean @ref HAL_SMBUS_MasterTxCpltCallback() in case of previous state was master transmit
-      (++) mean @ref HAL_SMBUS_MasterRxCpltCallback() in case of previous state was master receive
+      (++) mean HAL_SMBUS_MasterTxCpltCallback() in case of previous state was master transmit
+      (++) mean HAL_SMBUS_MasterRxCpltCallback() in case of previous state was master receive
       (+) Enable/disable the Address listen mode in slave/device or host/slave SMBUS mode
-           using @ref HAL_SMBUS_EnableListen_IT() @ref HAL_SMBUS_DisableListen_IT()
-      (++) When address slave/device SMBUS match, @ref HAL_SMBUS_AddrCallback() is executed and user can
-           add his own code to check the Address Match Code and the transmission direction request by master/host (Write/Read).
-      (++) At Listen mode end @ref HAL_SMBUS_ListenCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_ListenCpltCallback()
-      (+) Transmit in slave/device SMBUS mode an amount of data in non-blocking mode using @ref HAL_SMBUS_Slave_Transmit_IT()
-      (++) At transmission end of transfer @ref HAL_SMBUS_SlaveTxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_SlaveTxCpltCallback()
-      (+) Receive in slave/device SMBUS mode an amount of data in non-blocking mode using @ref HAL_SMBUS_Slave_Receive_IT()
-      (++) At reception end of transfer @ref HAL_SMBUS_SlaveRxCpltCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_SlaveRxCpltCallback()
-      (+) Enable/Disable the SMBUS alert mode using @ref HAL_SMBUS_EnableAlert_IT() @ref HAL_SMBUS_DisableAlert_IT()
-      (++) When SMBUS Alert is generated @ref HAL_SMBUS_ErrorCallback() is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_ErrorCallback()
-           to check the Alert Error Code using function @ref HAL_SMBUS_GetError()
-      (+) Get HAL state machine or error values using @ref HAL_SMBUS_GetState() or @ref HAL_SMBUS_GetError()
-      (+) In case of transfer Error, @ref HAL_SMBUS_ErrorCallback() function is executed and user can
-           add his own code by customization of function pointer @ref HAL_SMBUS_ErrorCallback()
-           to check the Error Code using function @ref HAL_SMBUS_GetError()
+           using HAL_SMBUS_EnableListen_IT() HAL_SMBUS_DisableListen_IT()
+      (++) When address slave/device SMBUS match, HAL_SMBUS_AddrCallback() is executed and users can
+           add their own code to check the Address Match Code and the transmission direction
+           request by master/host (Write/Read).
+      (++) At Listen mode end HAL_SMBUS_ListenCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_ListenCpltCallback()
+      (+) Transmit in slave/device SMBUS mode an amount of data in non-blocking mode
+          using HAL_SMBUS_Slave_Transmit_IT()
+      (++) At transmission end of transfer HAL_SMBUS_SlaveTxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_SlaveTxCpltCallback()
+      (+) Receive in slave/device SMBUS mode an amount of data in non-blocking mode
+          using HAL_SMBUS_Slave_Receive_IT()
+      (++) At reception end of transfer HAL_SMBUS_SlaveRxCpltCallback() is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_SlaveRxCpltCallback()
+      (+) Enable/Disable the SMBUS alert mode using
+          HAL_SMBUS_EnableAlert_IT() or HAL_SMBUS_DisableAlert_IT()
+      (++) When SMBUS Alert is generated HAL_SMBUS_ErrorCallback() is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_ErrorCallback()
+           to check the Alert Error Code using function HAL_SMBUS_GetError()
+      (+) Get HAL state machine or error values using HAL_SMBUS_GetState() or HAL_SMBUS_GetError()
+      (+) In case of transfer Error, HAL_SMBUS_ErrorCallback() function is executed and users can
+           add their own code by customization of function pointer HAL_SMBUS_ErrorCallback()
+           to check the Error Code using function HAL_SMBUS_GetError()
 
      *** SMBUS HAL driver macros list ***
      ==================================
      [..]
        Below the list of most used macros in SMBUS HAL driver.
 
-      (+) @ref __HAL_SMBUS_ENABLE:      Enable the SMBUS peripheral
-      (+) @ref __HAL_SMBUS_DISABLE:     Disable the SMBUS peripheral
-      (+) @ref __HAL_SMBUS_GET_FLAG:    Check whether the specified SMBUS flag is set or not
-      (+) @ref __HAL_SMBUS_CLEAR_FLAG:  Clear the specified SMBUS pending flag
-      (+) @ref __HAL_SMBUS_ENABLE_IT:   Enable the specified SMBUS interrupt
-      (+) @ref __HAL_SMBUS_DISABLE_IT:  Disable the specified SMBUS interrupt
+      (+) __HAL_SMBUS_ENABLE:      Enable the SMBUS peripheral
+      (+) __HAL_SMBUS_DISABLE:     Disable the SMBUS peripheral
+      (+) __HAL_SMBUS_GET_FLAG:    Check whether the specified SMBUS flag is set or not
+      (+) __HAL_SMBUS_CLEAR_FLAG:  Clear the specified SMBUS pending flag
+      (+) __HAL_SMBUS_ENABLE_IT:   Enable the specified SMBUS interrupt
+      (+) __HAL_SMBUS_DISABLE_IT:  Disable the specified SMBUS interrupt
 
      *** Callback registration ***
      =============================================
     [..]
      The compilation flag USE_HAL_SMBUS_REGISTER_CALLBACKS when set to 1
      allows the user to configure dynamically the driver callbacks.
-     Use Functions @ref HAL_SMBUS_RegisterCallback() or @ref HAL_SMBUS_RegisterAddrCallback()
+     Use Functions HAL_SMBUS_RegisterCallback() or HAL_SMBUS_RegisterAddrCallback()
      to register an interrupt callback.
     [..]
-     Function @ref HAL_SMBUS_RegisterCallback() allows to register following callbacks:
+     Function HAL_SMBUS_RegisterCallback() allows to register following callbacks:
        (+) MasterTxCpltCallback : callback for Master transmission end of transfer.
        (+) MasterRxCpltCallback : callback for Master reception end of transfer.
        (+) SlaveTxCpltCallback  : callback for Slave transmission end of transfer.
@@ -107,11 +124,11 @@
      This function takes as parameters the HAL peripheral handle, the Callback ID
      and a pointer to the user callback function.
     [..]
-     For specific callback AddrCallback use dedicated register callbacks : @ref HAL_SMBUS_RegisterAddrCallback.
+     For specific callback AddrCallback use dedicated register callbacks : HAL_SMBUS_RegisterAddrCallback.
     [..]
-     Use function @ref HAL_SMBUS_UnRegisterCallback to reset a callback to the default
+     Use function HAL_SMBUS_UnRegisterCallback to reset a callback to the default
      weak function.
-     @ref HAL_SMBUS_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     HAL_SMBUS_UnRegisterCallback takes as parameters the HAL peripheral handle,
      and the Callback ID.
      This function allows to reset following callbacks:
        (+) MasterTxCpltCallback : callback for Master transmission end of transfer.
@@ -123,24 +140,24 @@
        (+) MspInitCallback      : callback for Msp Init.
        (+) MspDeInitCallback    : callback for Msp DeInit.
     [..]
-     For callback AddrCallback use dedicated register callbacks : @ref HAL_SMBUS_UnRegisterAddrCallback.
+     For callback AddrCallback use dedicated register callbacks : HAL_SMBUS_UnRegisterAddrCallback.
     [..]
-     By default, after the @ref HAL_SMBUS_Init() and when the state is @ref HAL_I2C_STATE_RESET
+     By default, after the HAL_SMBUS_Init() and when the state is HAL_I2C_STATE_RESET
      all callbacks are set to the corresponding weak functions:
-     examples @ref HAL_SMBUS_MasterTxCpltCallback(), @ref HAL_SMBUS_MasterRxCpltCallback().
+     examples HAL_SMBUS_MasterTxCpltCallback(), HAL_SMBUS_MasterRxCpltCallback().
      Exception done for MspInit and MspDeInit functions that are
-     reset to the legacy weak functions in the @ref HAL_SMBUS_Init()/ @ref HAL_SMBUS_DeInit() only when
+     reset to the legacy weak functions in the HAL_SMBUS_Init()/ HAL_SMBUS_DeInit() only when
      these callbacks are null (not registered beforehand).
-     If MspInit or MspDeInit are not null, the @ref HAL_SMBUS_Init()/ @ref HAL_SMBUS_DeInit()
+     If MspInit or MspDeInit are not null, the HAL_SMBUS_Init()/ HAL_SMBUS_DeInit()
      keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
     [..]
-     Callbacks can be registered/unregistered in @ref HAL_I2C_STATE_READY state only.
+     Callbacks can be registered/unregistered in HAL_I2C_STATE_READY state only.
      Exception done MspInit/MspDeInit functions that can be registered/unregistered
-     in @ref HAL_I2C_STATE_READY or @ref HAL_I2C_STATE_RESET state,
+     in HAL_I2C_STATE_READY or HAL_I2C_STATE_RESET state,
      thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
      Then, the user first registers the MspInit/MspDeInit user callbacks
-     using @ref HAL_SMBUS_RegisterCallback() before calling @ref HAL_SMBUS_DeInit()
-     or @ref HAL_SMBUS_Init() function.
+     using HAL_SMBUS_RegisterCallback() before calling HAL_SMBUS_DeInit()
+     or HAL_SMBUS_Init() function.
     [..]
      When the compilation flag USE_HAL_SMBUS_REGISTER_CALLBACKS is set to 0 or
      not defined, the callback registration feature is not available and all callbacks
@@ -150,18 +167,6 @@
        (@) You can refer to the SMBUS HAL driver header file for more useful macros
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -203,18 +208,28 @@
 /** @addtogroup SMBUS_Private_Functions SMBUS Private Functions
   * @{
   */
-static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout);
+/* Private functions to handle flags during polling transfer */
+static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag,
+                                                      FlagStatus Status, uint32_t Timeout);
 
-static void SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
-static void SMBUS_Disable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
+/* Private functions for SMBUS transfer IRQ handler */
 static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags);
 static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t StatusFlags);
-
-static void SMBUS_ConvertOtherXferOptions(SMBUS_HandleTypeDef *hsmbus);
-
 static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus);
 
-static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request);
+/* Private functions to centralize the enable/disable of Interrupts */
+static void SMBUS_Enable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
+static void SMBUS_Disable_IRQ(SMBUS_HandleTypeDef *hsmbus, uint32_t InterruptRequest);
+
+/* Private function to flush TXDR register */
+static void SMBUS_Flush_TXDR(SMBUS_HandleTypeDef *hsmbus);
+
+/* Private function to handle start, restart or stop a transfer */
+static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size,
+                                 uint32_t Mode, uint32_t Request);
+
+/* Private function to Convert Specific options */
+static void SMBUS_ConvertOtherXferOptions(SMBUS_HandleTypeDef *hsmbus);
 /**
   * @}
   */
@@ -226,8 +241,8 @@ static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddre
   */
 
 /** @defgroup SMBUS_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
@@ -362,15 +377,20 @@ HAL_StatusTypeDef HAL_SMBUS_Init(SMBUS_HandleTypeDef *hsmbus)
 
   /*---------------------------- SMBUSx OAR2 Configuration -----------------------*/
   /* Configure SMBUSx: Dual mode and Own Address2 */
-  hsmbus->Instance->OAR2 = (hsmbus->Init.DualAddressMode | hsmbus->Init.OwnAddress2 | (hsmbus->Init.OwnAddress2Masks << 8U));
+  hsmbus->Instance->OAR2 = (hsmbus->Init.DualAddressMode | hsmbus->Init.OwnAddress2 | \
+                            (hsmbus->Init.OwnAddress2Masks << 8U));
 
   /*---------------------------- SMBUSx CR1 Configuration ------------------------*/
   /* Configure SMBUSx: Generalcall and NoStretch mode */
-  hsmbus->Instance->CR1 = (hsmbus->Init.GeneralCallMode | hsmbus->Init.NoStretchMode | hsmbus->Init.PacketErrorCheckMode | hsmbus->Init.PeripheralMode | hsmbus->Init.AnalogFilter);
+  hsmbus->Instance->CR1 = (hsmbus->Init.GeneralCallMode | hsmbus->Init.NoStretchMode | \
+                           hsmbus->Init.PacketErrorCheckMode | hsmbus->Init.PeripheralMode | \
+                           hsmbus->Init.AnalogFilter);
 
-  /* Enable Slave Byte Control only in case of Packet Error Check is enabled and SMBUS Peripheral is set in Slave mode */
-  if ((hsmbus->Init.PacketErrorCheckMode == SMBUS_PEC_ENABLE)
-      && ((hsmbus->Init.PeripheralMode == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE) || (hsmbus->Init.PeripheralMode == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP)))
+  /* Enable Slave Byte Control only in case of Packet Error Check is enabled
+     and SMBUS Peripheral is set in Slave mode */
+  if ((hsmbus->Init.PacketErrorCheckMode == SMBUS_PEC_ENABLE) && \
+      ((hsmbus->Init.PeripheralMode == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE) || \
+       (hsmbus->Init.PeripheralMode == SMBUS_PERIPHERAL_MODE_SMBUS_SLAVE_ARP)))
   {
     hsmbus->Instance->CR1 |= I2C_CR1_SBC;
   }
@@ -564,6 +584,9 @@ HAL_StatusTypeDef HAL_SMBUS_ConfigDigitalFilter(SMBUS_HandleTypeDef *hsmbus, uin
 /**
   * @brief  Register a User SMBUS Callback
   *         To be used instead of the weak predefined callback
+  * @note   The HAL_SMBUS_RegisterCallback() may be called before HAL_SMBUS_Init() in
+  *         HAL_SMBUS_STATE_RESET to register callbacks for HAL_SMBUS_MSPINIT_CB_ID and
+  *         HAL_SMBUS_MSPDEINIT_CB_ID.
   * @param  hsmbus Pointer to a SMBUS_HandleTypeDef structure that contains
   *                the configuration information for the specified SMBUS.
   * @param  CallbackID ID of the callback to be registered
@@ -579,7 +602,9 @@ HAL_StatusTypeDef HAL_SMBUS_ConfigDigitalFilter(SMBUS_HandleTypeDef *hsmbus, uin
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SMBUS_CallbackIDTypeDef CallbackID, pSMBUS_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus,
+                                             HAL_SMBUS_CallbackIDTypeDef CallbackID,
+                                             pSMBUS_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -590,9 +615,6 @@ HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SM
 
     return HAL_ERROR;
   }
-
-  /* Process locked */
-  __HAL_LOCK(hsmbus);
 
   if (HAL_SMBUS_STATE_READY == hsmbus->State)
   {
@@ -669,14 +691,15 @@ HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SM
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hsmbus);
   return status;
 }
 
 /**
   * @brief  Unregister an SMBUS Callback
   *         SMBUS callback is redirected to the weak predefined callback
+  * @note   The HAL_SMBUS_UnRegisterCallback() may be called before HAL_SMBUS_Init() in
+  *         HAL_SMBUS_STATE_RESET to un-register callbacks for HAL_SMBUS_MSPINIT_CB_ID and
+  *         HAL_SMBUS_MSPDEINIT_CB_ID
   * @param  hsmbus Pointer to a SMBUS_HandleTypeDef structure that contains
   *                the configuration information for the specified SMBUS.
   * @param  CallbackID ID of the callback to be unregistered
@@ -692,12 +715,10 @@ HAL_StatusTypeDef HAL_SMBUS_RegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SM
   *          @arg @ref HAL_SMBUS_MSPDEINIT_CB_ID MspDeInit callback ID
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_UnRegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_SMBUS_CallbackIDTypeDef CallbackID)
+HAL_StatusTypeDef HAL_SMBUS_UnRegisterCallback(SMBUS_HandleTypeDef *hsmbus,
+                                               HAL_SMBUS_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
-
-  /* Process locked */
-  __HAL_LOCK(hsmbus);
 
   if (HAL_SMBUS_STATE_READY == hsmbus->State)
   {
@@ -774,8 +795,6 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hsmbus);
   return status;
 }
 
@@ -787,7 +806,8 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterCallback(SMBUS_HandleTypeDef *hsmbus, HAL_
   * @param  pCallback pointer to the Address Match Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_RegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus, pSMBUS_AddrCallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_SMBUS_RegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus,
+                                                 pSMBUS_AddrCallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -798,8 +818,6 @@ HAL_StatusTypeDef HAL_SMBUS_RegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus, pS
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(hsmbus);
 
   if (HAL_SMBUS_STATE_READY == hsmbus->State)
   {
@@ -814,8 +832,6 @@ HAL_StatusTypeDef HAL_SMBUS_RegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus, pS
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hsmbus);
   return status;
 }
 
@@ -830,9 +846,6 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(hsmbus);
-
   if (HAL_SMBUS_STATE_READY == hsmbus->State)
   {
     hsmbus->AddrCallback = HAL_SMBUS_AddrCallback; /* Legacy weak AddrCallback  */
@@ -846,8 +859,6 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus)
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(hsmbus);
   return status;
 }
 
@@ -858,8 +869,8 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus)
   */
 
 /** @defgroup SMBUS_Exported_Functions_Group2 Input and Output operation functions
- *  @brief   Data transfers functions
- *
+  *  @brief   Data transfers functions
+  *
 @verbatim
  ===============================================================================
                       ##### IO operation functions #####
@@ -911,9 +922,11 @@ HAL_StatusTypeDef HAL_SMBUS_UnRegisterAddrCallback(SMBUS_HandleTypeDef *hsmbus)
   * @param  XferOptions Options of Transfer, value of @ref SMBUS_XferOptions_definition
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress,
+                                               uint8_t *pData, uint16_t Size, uint32_t XferOptions)
 {
   uint32_t tmp;
+  uint32_t sizetoxfer;
 
   /* Check the parameters */
   assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -946,11 +959,37 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint
       hsmbus->XferSize = Size;
     }
 
+    sizetoxfer = hsmbus->XferSize;
+    if ((sizetoxfer > 0U) && ((XferOptions == SMBUS_FIRST_FRAME) ||
+                              (XferOptions == SMBUS_FIRST_AND_LAST_FRAME_NO_PEC) ||
+                              (XferOptions == SMBUS_FIRST_FRAME_WITH_PEC) ||
+                              (XferOptions == SMBUS_FIRST_AND_LAST_FRAME_WITH_PEC)))
+    {
+      if (hsmbus->pBuffPtr != NULL)
+      {
+        /* Preload TX register */
+        /* Write data to TXDR */
+        hsmbus->Instance->TXDR = *hsmbus->pBuffPtr;
+
+        /* Increment Buffer pointer */
+        hsmbus->pBuffPtr++;
+
+        hsmbus->XferCount--;
+        hsmbus->XferSize--;
+      }
+      else
+      {
+        return HAL_ERROR;
+      }
+    }
+
     /* Send Slave Address */
     /* Set NBYTES to write and reload if size > MAX_NBYTE_SIZE and generate RESTART */
-    if ((hsmbus->XferSize < hsmbus->XferCount) && (hsmbus->XferSize == MAX_NBYTE_SIZE))
+    if ((sizetoxfer < hsmbus->XferCount) && (sizetoxfer == MAX_NBYTE_SIZE))
     {
-      SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE), SMBUS_GENERATE_START_WRITE);
+      SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)sizetoxfer,
+                           SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE),
+                           SMBUS_GENERATE_START_WRITE);
     }
     else
     {
@@ -960,9 +999,11 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint
       /* Store current volatile XferOptions, misra rule */
       tmp = hsmbus->XferOptions;
 
-      if ((hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_TX) && (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(tmp) == 0))
+      if ((hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_TX) && \
+          (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(tmp) == 0))
       {
-        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)sizetoxfer, hsmbus->XferOptions,
+                             SMBUS_NO_STARTSTOP);
       }
       /* Else transfer direction change, so generate Restart with new transfer direction */
       else
@@ -971,15 +1012,24 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint
         SMBUS_ConvertOtherXferOptions(hsmbus);
 
         /* Handle Transfer */
-        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_GENERATE_START_WRITE);
+        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)sizetoxfer,
+                             hsmbus->XferOptions,
+                             SMBUS_GENERATE_START_WRITE);
       }
 
       /* If PEC mode is enable, size to transmit manage by SW part should be Size-1 byte, corresponding to PEC byte */
       /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
       if (SMBUS_GET_PEC_MODE(hsmbus) != 0UL)
       {
-        hsmbus->XferSize--;
-        hsmbus->XferCount--;
+        if (hsmbus->XferSize > 0U)
+        {
+          hsmbus->XferSize--;
+          hsmbus->XferCount--;
+        }
+        else
+        {
+          return HAL_ERROR;
+        }
       }
     }
 
@@ -1010,7 +1060,8 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint
   * @param  XferOptions Options of Transfer, value of @ref SMBUS_XferOptions_definition
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint8_t *pData,
+                                              uint16_t Size, uint32_t XferOptions)
 {
   uint32_t tmp;
 
@@ -1050,7 +1101,9 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint1
     /* Set NBYTES to write and reload if size > MAX_NBYTE_SIZE and generate RESTART */
     if ((hsmbus->XferSize < hsmbus->XferCount) && (hsmbus->XferSize == MAX_NBYTE_SIZE))
     {
-      SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, SMBUS_RELOAD_MODE  | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE), SMBUS_GENERATE_START_READ);
+      SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize,
+                           SMBUS_RELOAD_MODE  | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE),
+                           SMBUS_GENERATE_START_READ);
     }
     else
     {
@@ -1060,9 +1113,11 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint1
       /* Store current volatile XferOptions, Misra rule */
       tmp = hsmbus->XferOptions;
 
-      if ((hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_RX) && (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(tmp) == 0))
+      if ((hsmbus->PreviousState == HAL_SMBUS_STATE_MASTER_BUSY_RX) && \
+          (IS_SMBUS_TRANSFER_OTHER_OPTIONS_REQUEST(tmp) == 0))
       {
-        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions,
+                             SMBUS_NO_STARTSTOP);
       }
       /* Else transfer direction change, so generate Restart with new transfer direction */
       else
@@ -1071,7 +1126,9 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint1
         SMBUS_ConvertOtherXferOptions(hsmbus);
 
         /* Handle Transfer */
-        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_GENERATE_START_READ);
+        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize,
+                             hsmbus->XferOptions,
+                             SMBUS_GENERATE_START_READ);
       }
     }
 
@@ -1165,7 +1222,8 @@ HAL_StatusTypeDef HAL_SMBUS_Master_Abort_IT(SMBUS_HandleTypeDef *hsmbus, uint16_
   * @param  XferOptions Options of Transfer, value of @ref SMBUS_XferOptions_definition
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size,
+                                              uint32_t XferOptions)
 {
   /* Check the parameters */
   assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -1213,12 +1271,15 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8
     /* Set NBYTES to write and reload if size > MAX_NBYTE_SIZE and generate RESTART */
     if ((hsmbus->XferSize < hsmbus->XferCount) && (hsmbus->XferSize == MAX_NBYTE_SIZE))
     {
-      SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE), SMBUS_NO_STARTSTOP);
+      SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize,
+                           SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE),
+                           SMBUS_NO_STARTSTOP);
     }
     else
     {
       /* Set NBYTE to transmit */
-      SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+      SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions,
+                           SMBUS_NO_STARTSTOP);
 
       /* If PEC mode is enable, size to transmit should be Size-1 byte, corresponding to PEC byte */
       /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
@@ -1259,7 +1320,8 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Transmit_IT(SMBUS_HandleTypeDef *hsmbus, uint8
   * @param  XferOptions Options of Transfer, value of @ref SMBUS_XferOptions_definition
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size, uint32_t XferOptions)
+HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_t *pData, uint16_t Size,
+                                             uint32_t XferOptions)
 {
   /* Check the parameters */
   assert_param(IS_SMBUS_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -1303,7 +1365,8 @@ HAL_StatusTypeDef HAL_SMBUS_Slave_Receive_IT(SMBUS_HandleTypeDef *hsmbus, uint8_
     /* This RELOAD bit will be reset for last BYTE to be receive in SMBUS_Slave_ISR */
     if (((SMBUS_GET_PEC_MODE(hsmbus) != 0UL) && (hsmbus->XferSize == 2U)) || (hsmbus->XferSize == 1U))
     {
-      SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+      SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions,
+                           SMBUS_NO_STARTSTOP);
     }
     else
     {
@@ -1417,7 +1480,8 @@ HAL_StatusTypeDef HAL_SMBUS_DisableAlert_IT(SMBUS_HandleTypeDef *hsmbus)
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials, uint32_t Timeout)
+HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t DevAddress, uint32_t Trials,
+                                          uint32_t Timeout)
 {
   uint32_t tickstart;
 
@@ -1526,8 +1590,7 @@ HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t 
 
       /* Increment Trials */
       SMBUS_Trials++;
-    }
-    while (SMBUS_Trials < Trials);
+    } while (SMBUS_Trials < Trials);
 
     hsmbus->State = HAL_SMBUS_STATE_READY;
 
@@ -1549,8 +1612,8 @@ HAL_StatusTypeDef HAL_SMBUS_IsDeviceReady(SMBUS_HandleTypeDef *hsmbus, uint16_t 
   */
 
 /** @defgroup SMBUS_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  Handle SMBUS event interrupt request.
@@ -1566,7 +1629,13 @@ void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus)
   uint32_t tmpcr1value = READ_REG(hsmbus->Instance->CR1);
 
   /* SMBUS in mode Transmitter ---------------------------------------------------*/
-  if ((SMBUS_CHECK_IT_SOURCE(tmpcr1value, (SMBUS_IT_TCI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_TXI)) != RESET) && ((SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TXIS) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TCR) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TC) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)))
+  if ((SMBUS_CHECK_IT_SOURCE(tmpcr1value, (SMBUS_IT_TCI | SMBUS_IT_STOPI |
+                                           SMBUS_IT_NACKI | SMBUS_IT_TXI)) != RESET) &&
+      ((SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TXIS) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TCR) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TC) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)))
   {
     /* Slave mode selected */
     if ((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_TX) == HAL_SMBUS_STATE_SLAVE_BUSY_TX)
@@ -1585,7 +1654,13 @@ void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS in mode Receiver ----------------------------------------------------*/
-  if ((SMBUS_CHECK_IT_SOURCE(tmpcr1value, (SMBUS_IT_TCI | SMBUS_IT_STOPI | SMBUS_IT_NACKI | SMBUS_IT_RXI)) != RESET) && ((SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_RXNE) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TCR) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TC) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)))
+  if ((SMBUS_CHECK_IT_SOURCE(tmpcr1value, (SMBUS_IT_TCI | SMBUS_IT_STOPI |
+                                           SMBUS_IT_NACKI | SMBUS_IT_RXI)) != RESET) &&
+      ((SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_RXNE) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TCR) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_TC) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)))
   {
     /* Slave mode selected */
     if ((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_RX) == HAL_SMBUS_STATE_SLAVE_BUSY_RX)
@@ -1604,7 +1679,12 @@ void HAL_SMBUS_EV_IRQHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS in mode Listener Only --------------------------------------------------*/
-  if (((SMBUS_CHECK_IT_SOURCE(tmpcr1value, SMBUS_IT_ADDRI) != RESET) || (SMBUS_CHECK_IT_SOURCE(tmpcr1value, SMBUS_IT_STOPI) != RESET) || (SMBUS_CHECK_IT_SOURCE(tmpcr1value, SMBUS_IT_NACKI) != RESET)) && ((SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_ADDR) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) || (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)))
+  if (((SMBUS_CHECK_IT_SOURCE(tmpcr1value, SMBUS_IT_ADDRI) != RESET) ||
+       (SMBUS_CHECK_IT_SOURCE(tmpcr1value, SMBUS_IT_STOPI) != RESET) ||
+       (SMBUS_CHECK_IT_SOURCE(tmpcr1value, SMBUS_IT_NACKI) != RESET)) &&
+      ((SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_ADDR) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_STOPF) != RESET) ||
+       (SMBUS_CHECK_FLAG(tmpisrvalue, SMBUS_FLAG_AF) != RESET)))
   {
     if ((hsmbus->State & HAL_SMBUS_STATE_LISTEN) == HAL_SMBUS_STATE_LISTEN)
     {
@@ -1695,7 +1775,8 @@ __weak void HAL_SMBUS_SlaveRxCpltCallback(SMBUS_HandleTypeDef *hsmbus)
   * @param  AddrMatchCode Address Match Code
   * @retval None
   */
-__weak void HAL_SMBUS_AddrCallback(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection, uint16_t AddrMatchCode)
+__weak void HAL_SMBUS_AddrCallback(SMBUS_HandleTypeDef *hsmbus, uint8_t TransferDirection,
+                                   uint16_t AddrMatchCode)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(hsmbus);
@@ -1744,8 +1825,8 @@ __weak void HAL_SMBUS_ErrorCallback(SMBUS_HandleTypeDef *hsmbus)
   */
 
 /** @defgroup SMBUS_Exported_Functions_Group3 Peripheral State and Errors functions
- *  @brief   Peripheral State and Errors functions
- *
+  *  @brief   Peripheral State and Errors functions
+  *
 @verbatim
  ===============================================================================
             ##### Peripheral State and Errors functions #####
@@ -1764,19 +1845,19 @@ __weak void HAL_SMBUS_ErrorCallback(SMBUS_HandleTypeDef *hsmbus)
   *                the configuration information for the specified SMBUS.
   * @retval HAL state
   */
-uint32_t HAL_SMBUS_GetState(SMBUS_HandleTypeDef *hsmbus)
+uint32_t HAL_SMBUS_GetState(const SMBUS_HandleTypeDef *hsmbus)
 {
   /* Return SMBUS handle state */
   return hsmbus->State;
 }
 
 /**
-* @brief  Return the SMBUS error code.
+  * @brief  Return the SMBUS error code.
   * @param  hsmbus Pointer to a SMBUS_HandleTypeDef structure that contains
   *              the configuration information for the specified SMBUS.
-* @retval SMBUS Error Code
-*/
-uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus)
+  * @retval SMBUS Error Code
+  */
+uint32_t HAL_SMBUS_GetError(const SMBUS_HandleTypeDef *hsmbus)
 {
   return hsmbus->ErrorCode;
 }
@@ -1790,7 +1871,7 @@ uint32_t HAL_SMBUS_GetError(SMBUS_HandleTypeDef *hsmbus)
   */
 
 /** @addtogroup SMBUS_Private_Functions SMBUS Private Functions
- *  @brief   Data transfers Private functions
+  *  @brief   Data transfers Private functions
   * @{
   */
 
@@ -1816,6 +1897,9 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t 
     /* Set corresponding Error Code */
     /* No need to generate STOP, it is automatically done */
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ACKF;
+
+    /* Flush TX register */
+    SMBUS_Flush_TXDR(hsmbus);
 
     /* Process Unlocked */
     __HAL_UNLOCK(hsmbus);
@@ -1875,7 +1959,7 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t 
         /* Increment Buffer pointer */
         hsmbus->pBuffPtr++;
 
-        if ((hsmbus->XferSize > 0U))
+        if (hsmbus->XferSize > 0U)
         {
           hsmbus->XferSize--;
           hsmbus->XferCount--;
@@ -1941,13 +2025,16 @@ static HAL_StatusTypeDef SMBUS_Master_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t 
 
       if (hsmbus->XferCount > MAX_NBYTE_SIZE)
       {
-        SMBUS_TransferConfig(hsmbus, DevAddress, MAX_NBYTE_SIZE, (SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE)), SMBUS_NO_STARTSTOP);
+        SMBUS_TransferConfig(hsmbus, DevAddress, MAX_NBYTE_SIZE,
+                             (SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE)),
+                             SMBUS_NO_STARTSTOP);
         hsmbus->XferSize = MAX_NBYTE_SIZE;
       }
       else
       {
         hsmbus->XferSize = hsmbus->XferCount;
-        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+        SMBUS_TransferConfig(hsmbus, DevAddress, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions,
+                             SMBUS_NO_STARTSTOP);
         /* If PEC mode is enable, size to transmit should be Size-1 byte, corresponding to PEC byte */
         /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
         if (SMBUS_GET_PEC_MODE(hsmbus) != 0UL)
@@ -2104,6 +2191,9 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t S
       /* Clear NACK Flag */
       __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_AF);
 
+      /* Flush TX register */
+      SMBUS_Flush_TXDR(hsmbus);
+
       /* Process Unlocked */
       __HAL_UNLOCK(hsmbus);
     }
@@ -2124,6 +2214,9 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t S
 
       /* Set ErrorCode corresponding to a Non-Acknowledge */
       hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ACKF;
+
+      /* Flush TX register */
+      SMBUS_Flush_TXDR(hsmbus);
 
       /* Process Unlocked */
       __HAL_UNLOCK(hsmbus);
@@ -2155,7 +2248,8 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t S
     HAL_SMBUS_AddrCallback(hsmbus, TransferDirection, SlaveAddrCode);
 #endif /* USE_HAL_SMBUS_REGISTER_CALLBACKS */
   }
-  else if ((SMBUS_CHECK_FLAG(StatusFlags, SMBUS_FLAG_RXNE) != RESET) || (SMBUS_CHECK_FLAG(StatusFlags, SMBUS_FLAG_TCR) != RESET))
+  else if ((SMBUS_CHECK_FLAG(StatusFlags, SMBUS_FLAG_RXNE) != RESET) ||
+           (SMBUS_CHECK_FLAG(StatusFlags, SMBUS_FLAG_TCR) != RESET))
   {
     if ((hsmbus->State & HAL_SMBUS_STATE_SLAVE_BUSY_RX) == HAL_SMBUS_STATE_SLAVE_BUSY_RX)
     {
@@ -2198,7 +2292,9 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t S
       else
       {
         /* Set Reload for next Bytes */
-        SMBUS_TransferConfig(hsmbus, 0, 1, SMBUS_RELOAD_MODE  | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE), SMBUS_NO_STARTSTOP);
+        SMBUS_TransferConfig(hsmbus, 0, 1,
+                             SMBUS_RELOAD_MODE  | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE),
+                             SMBUS_NO_STARTSTOP);
 
         /* Ack last Byte Read */
         hsmbus->Instance->CR2 &= ~I2C_CR2_NACK;
@@ -2210,13 +2306,16 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t S
       {
         if (hsmbus->XferCount > MAX_NBYTE_SIZE)
         {
-          SMBUS_TransferConfig(hsmbus, 0, MAX_NBYTE_SIZE, (SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE)), SMBUS_NO_STARTSTOP);
+          SMBUS_TransferConfig(hsmbus, 0, MAX_NBYTE_SIZE,
+                               (SMBUS_RELOAD_MODE | (hsmbus->XferOptions & SMBUS_SENDPEC_MODE)),
+                               SMBUS_NO_STARTSTOP);
           hsmbus->XferSize = MAX_NBYTE_SIZE;
         }
         else
         {
           hsmbus->XferSize = hsmbus->XferCount;
-          SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions, SMBUS_NO_STARTSTOP);
+          SMBUS_TransferConfig(hsmbus, 0, (uint8_t)hsmbus->XferSize, hsmbus->XferOptions,
+                               SMBUS_NO_STARTSTOP);
           /* If PEC mode is enable, size to transmit should be Size-1 byte, corresponding to PEC byte */
           /* PEC byte is automatically sent by HW block, no need to manage it in Transmit process */
           if (SMBUS_GET_PEC_MODE(hsmbus) != 0UL)
@@ -2288,7 +2387,7 @@ static HAL_StatusTypeDef SMBUS_Slave_ISR(SMBUS_HandleTypeDef *hsmbus, uint32_t S
         /* Increment Buffer pointer */
         hsmbus->pBuffPtr++;
 
-        if ((hsmbus->XferSize > 0U))
+        if (hsmbus->XferSize > 0U)
         {
           hsmbus->XferSize--;
           hsmbus->XferCount--;
@@ -2461,7 +2560,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   uint32_t tmperror;
 
   /* SMBUS Bus error interrupt occurred ------------------------------------*/
-  if (((itflags & SMBUS_FLAG_BERR) == SMBUS_FLAG_BERR) && ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
+  if (((itflags & SMBUS_FLAG_BERR) == SMBUS_FLAG_BERR) && \
+      ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
   {
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_BERR;
 
@@ -2470,7 +2570,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS Over-Run/Under-Run interrupt occurred ----------------------------------------*/
-  if (((itflags & SMBUS_FLAG_OVR) == SMBUS_FLAG_OVR) && ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
+  if (((itflags & SMBUS_FLAG_OVR) == SMBUS_FLAG_OVR) && \
+      ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
   {
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_OVR;
 
@@ -2479,7 +2580,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS Arbitration Loss error interrupt occurred ------------------------------------*/
-  if (((itflags & SMBUS_FLAG_ARLO) == SMBUS_FLAG_ARLO) && ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
+  if (((itflags & SMBUS_FLAG_ARLO) == SMBUS_FLAG_ARLO) && \
+      ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
   {
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ARLO;
 
@@ -2488,7 +2590,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS Timeout error interrupt occurred ---------------------------------------------*/
-  if (((itflags & SMBUS_FLAG_TIMEOUT) == SMBUS_FLAG_TIMEOUT) && ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
+  if (((itflags & SMBUS_FLAG_TIMEOUT) == SMBUS_FLAG_TIMEOUT) && \
+      ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
   {
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_BUSTIMEOUT;
 
@@ -2497,7 +2600,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS Alert error interrupt occurred -----------------------------------------------*/
-  if (((itflags & SMBUS_FLAG_ALERT) == SMBUS_FLAG_ALERT) && ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
+  if (((itflags & SMBUS_FLAG_ALERT) == SMBUS_FLAG_ALERT) && \
+      ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
   {
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_ALERT;
 
@@ -2506,7 +2610,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   }
 
   /* SMBUS Packet Error Check error interrupt occurred ----------------------------------*/
-  if (((itflags & SMBUS_FLAG_PECERR) == SMBUS_FLAG_PECERR) && ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
+  if (((itflags & SMBUS_FLAG_PECERR) == SMBUS_FLAG_PECERR) && \
+      ((itsources & SMBUS_IT_ERRI) == SMBUS_IT_ERRI))
   {
     hsmbus->ErrorCode |= HAL_SMBUS_ERROR_PECERR;
 
@@ -2514,7 +2619,13 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
     __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_PECERR);
   }
 
-  /* Store current volatile hsmbus->State, misra rule */
+  if (hsmbus->ErrorCode != HAL_SMBUS_ERROR_NONE)
+  {
+    /* Flush TX register */
+    SMBUS_Flush_TXDR(hsmbus);
+  }
+
+  /* Store current volatile hsmbus->ErrorCode, misra rule */
   tmperror = hsmbus->ErrorCode;
 
   /* Call the Error Callback in case of Error detected */
@@ -2554,7 +2665,8 @@ static void SMBUS_ITErrorHandler(SMBUS_HandleTypeDef *hsmbus)
   * @param  Timeout Timeout duration
   * @retval HAL status
   */
-static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag, FlagStatus Status, uint32_t Timeout)
+static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbus, uint32_t Flag,
+                                                      FlagStatus Status, uint32_t Timeout)
 {
   uint32_t tickstart = HAL_GetTick();
 
@@ -2584,6 +2696,27 @@ static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbu
 }
 
 /**
+  * @brief  SMBUS Tx data register flush process.
+  * @param  hsmbus SMBUS handle.
+  * @retval None
+  */
+static void SMBUS_Flush_TXDR(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* If a pending TXIS flag is set */
+  /* Write a dummy data in TXDR to clear it */
+  if (__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TXIS) != RESET)
+  {
+    hsmbus->Instance->TXDR = 0x00U;
+  }
+
+  /* Flush TX register if not empty */
+  if (__HAL_SMBUS_GET_FLAG(hsmbus, SMBUS_FLAG_TXE) == RESET)
+  {
+    __HAL_SMBUS_CLEAR_FLAG(hsmbus, SMBUS_FLAG_TXE);
+  }
+}
+
+/**
   * @brief  Handle SMBUSx communication when starting transfer or during transfer (TC or TCR flag are set).
   * @param  hsmbus SMBUS handle.
   * @param  DevAddress specifies the slave address to be programmed.
@@ -2603,7 +2736,8 @@ static HAL_StatusTypeDef SMBUS_WaitOnFlagUntilTimeout(SMBUS_HandleTypeDef *hsmbu
   *     @arg @ref SMBUS_GENERATE_START_WRITE Generate Restart for write request.
   * @retval None
   */
-static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size, uint32_t Mode, uint32_t Request)
+static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddress, uint8_t Size,
+                                 uint32_t Mode, uint32_t Request)
 {
   /* Check the parameters */
   assert_param(IS_SMBUS_ALL_INSTANCE(hsmbus->Instance));
@@ -2611,8 +2745,13 @@ static void SMBUS_TransferConfig(SMBUS_HandleTypeDef *hsmbus,  uint16_t DevAddre
   assert_param(IS_SMBUS_TRANSFER_REQUEST(Request));
 
   /* update CR2 register */
-  MODIFY_REG(hsmbus->Instance->CR2, ((I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31UL - I2C_CR2_RD_WRN_Pos))) | I2C_CR2_START | I2C_CR2_STOP  | I2C_CR2_PECBYTE)), \
-             (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | (((uint32_t)Size << I2C_CR2_NBYTES_Pos) & I2C_CR2_NBYTES) | (uint32_t)Mode | (uint32_t)Request));
+  MODIFY_REG(hsmbus->Instance->CR2,
+             ((I2C_CR2_SADD | I2C_CR2_NBYTES | I2C_CR2_RELOAD | I2C_CR2_AUTOEND | \
+               (I2C_CR2_RD_WRN & (uint32_t)(Request >> (31UL - I2C_CR2_RD_WRN_Pos))) | \
+               I2C_CR2_START | I2C_CR2_STOP | I2C_CR2_PECBYTE)), \
+             (uint32_t)(((uint32_t)DevAddress & I2C_CR2_SADD) | \
+                        (((uint32_t)Size << I2C_CR2_NBYTES_Pos) & I2C_CR2_NBYTES) | \
+                        (uint32_t)Mode | (uint32_t)Request));
 }
 
 /**
@@ -2669,5 +2808,3 @@ static void SMBUS_ConvertOtherXferOptions(SMBUS_HandleTypeDef *hsmbus)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smbus_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_smbus_ex.c
@@ -1,0 +1,242 @@
+/**
+  ******************************************************************************
+  * @file    stm32wbxx_hal_smbus_ex.c
+  * @author  MCD Application Team
+  * @brief   SMBUS Extended HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of SMBUS Extended peripheral:
+  *           + Extended features functions
+  *           + WakeUp Mode Functions
+  *           + FastModePlus Functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
+  ==============================================================================
+               ##### SMBUS peripheral Extended features  #####
+  ==============================================================================
+
+  [..] Comparing to other previous devices, the SMBUS interface for STM32WBxx
+       devices contains the following additional features
+
+       (+) Disable or enable wakeup from Stop mode(s)
+       (+) Disable or enable Fast Mode Plus
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    (#) Configure the enable or disable of SMBUS Wake Up Mode using the functions :
+          (++) HAL_SMBUSEx_EnableWakeUp()
+          (++) HAL_SMBUSEx_DisableWakeUp()
+    (#) Configure the enable or disable of fast mode plus driving capability using the functions :
+          (++) HAL_SMBUSEx_EnableFastModePlus()
+          (++) HAL_SMBUSEx_DisableFastModePlus()
+  @endverbatim
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32wbxx_hal.h"
+
+/** @addtogroup STM32WBxx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup SMBUSEx SMBUSEx
+  * @brief SMBUS Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_SMBUS_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup SMBUSEx_Exported_Functions SMBUS Extended Exported Functions
+  * @{
+  */
+
+/** @defgroup SMBUSEx_Exported_Functions_Group2 WakeUp Mode Functions
+  * @brief    WakeUp Mode Functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### WakeUp Mode Functions #####
+ ===============================================================================
+    [..] This section provides functions allowing to:
+      (+) Configure Wake Up Feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enable SMBUS wakeup from Stop mode(s).
+  * @param  hsmbus Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUSx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUSEx_EnableWakeUp(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_WAKEUP_FROMSTOP_INSTANCE(hsmbus->Instance));
+
+  if (hsmbus->State == HAL_SMBUS_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+
+    hsmbus->State = HAL_SMBUS_STATE_BUSY;
+
+    /* Disable the selected SMBUS peripheral */
+    __HAL_SMBUS_DISABLE(hsmbus);
+
+    /* Enable wakeup from stop mode */
+    hsmbus->Instance->CR1 |= I2C_CR1_WUPEN;
+
+    __HAL_SMBUS_ENABLE(hsmbus);
+
+    hsmbus->State = HAL_SMBUS_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief  Disable SMBUS wakeup from Stop mode(s).
+  * @param  hsmbus Pointer to a SMBUS_HandleTypeDef structure that contains
+  *                the configuration information for the specified SMBUSx peripheral.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_SMBUSEx_DisableWakeUp(SMBUS_HandleTypeDef *hsmbus)
+{
+  /* Check the parameters */
+  assert_param(IS_I2C_WAKEUP_FROMSTOP_INSTANCE(hsmbus->Instance));
+
+  if (hsmbus->State == HAL_SMBUS_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(hsmbus);
+
+    hsmbus->State = HAL_SMBUS_STATE_BUSY;
+
+    /* Disable the selected SMBUS peripheral */
+    __HAL_SMBUS_DISABLE(hsmbus);
+
+    /* Disable wakeup from stop mode */
+    hsmbus->Instance->CR1 &= ~(I2C_CR1_WUPEN);
+
+    __HAL_SMBUS_ENABLE(hsmbus);
+
+    hsmbus->State = HAL_SMBUS_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hsmbus);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+/**
+  * @}
+  */
+
+/** @defgroup SMBUSEx_Exported_Functions_Group3 Fast Mode Plus Functions
+  * @brief    Fast Mode Plus Functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### Fast Mode Plus Functions #####
+ ===============================================================================
+    [..] This section provides functions allowing to:
+      (+) Configure Fast Mode Plus
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief Enable the SMBUS fast mode plus driving capability.
+  * @param ConfigFastModePlus Selects the pin.
+  *   This parameter can be one of the @ref SMBUSEx_FastModePlus values
+  * @note  For I2C1, fast mode plus driving capability can be enabled on all selected
+  *        I2C1 pins using SMBUS_FASTMODEPLUS_I2C1 parameter or independently
+  *        on each one of the following pins PB6, PB7, PB8 and PB9.
+  * @note  For remaining I2C1 pins (PA14, PA15...) fast mode plus driving capability
+  *        can be enabled only by using SMBUS_FASTMODEPLUS_I2C1 parameter.
+  * @note  For all I2C3 pins fast mode plus driving capability can be enabled
+  *        only by using SMBUS_FASTMODEPLUS_I2C3 parameter.
+  * @retval None
+  */
+void HAL_SMBUSEx_EnableFastModePlus(uint32_t ConfigFastModePlus)
+{
+  /* Check the parameter */
+  assert_param(IS_SMBUS_FASTMODEPLUS(ConfigFastModePlus));
+
+  /* Enable fast mode plus driving capability for selected pin */
+  SET_BIT(SYSCFG->CFGR1, (uint32_t)ConfigFastModePlus);
+}
+
+/**
+  * @brief Disable the SMBUS fast mode plus driving capability.
+  * @param ConfigFastModePlus Selects the pin.
+  *   This parameter can be one of the @ref SMBUSEx_FastModePlus values
+  * @note  For I2C1, fast mode plus driving capability can be disabled on all selected
+  *        I2C1 pins using SMBUS_FASTMODEPLUS_I2C1 parameter or independently
+  *        on each one of the following pins PB6, PB7, PB8 and PB9.
+  * @note  For remaining I2C1 pins (PA14, PA15...) fast mode plus driving capability
+  *        can be disabled only by using SMBUS_FASTMODEPLUS_I2C1 parameter.
+  * @note  For all I2C3 pins fast mode plus driving capability can be disabled
+  *        only by using SMBUS_FASTMODEPLUS_I2C3 parameter.
+  * @retval None
+  */
+void HAL_SMBUSEx_DisableFastModePlus(uint32_t ConfigFastModePlus)
+{
+  /* Check the parameter */
+  assert_param(IS_SMBUS_FASTMODEPLUS(ConfigFastModePlus));
+
+  /* Disable fast mode plus driving capability for selected pin */
+  CLEAR_BIT(SYSCFG->CFGR1, (uint32_t)ConfigFastModePlus);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_SMBUS_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_spi.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_spi.c
@@ -9,7 +9,17 @@
   *           + IO operation functions
   *           + Peripheral Control functions
   *           + Peripheral State functions
+  ******************************************************************************
+  * @attention
   *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                         ##### How to use this driver #####
@@ -34,7 +44,8 @@
               (+++) Configure the DMA handle parameters
               (+++) Configure the DMA Tx or Rx Stream/Channel
               (+++) Associate the initialized hdma_tx(or _rx)  handle to the hspi DMA Tx or Rx handle
-              (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx or Rx Stream/Channel
+              (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx
+                    or Rx Stream/Channel
 
       (#) Program the Mode, BidirectionalMode , Data size, Baudrate Prescaler, NSS
           management, Clock polarity and phase, FirstBit and CRC configuration in the hspi Init structure.
@@ -180,22 +191,11 @@
        @note The max SPI frequency depend on SPI data size (4bits, 5bits,..., 8bits,...15bits, 16bits),
              SPI mode(2 Lines fullduplex, 2 lines RxOnly, 1 line TX/RX) and Process mode (Polling, IT, DMA).
        @note
-            (#) TX/RX processes are HAL_SPI_TransmitReceive(), HAL_SPI_TransmitReceive_IT() and HAL_SPI_TransmitReceive_DMA()
+            (#) TX/RX processes are HAL_SPI_TransmitReceive(), HAL_SPI_TransmitReceive_IT() and
+                HAL_SPI_TransmitReceive_DMA()
             (#) RX processes are HAL_SPI_Receive(), HAL_SPI_Receive_IT() and HAL_SPI_Receive_DMA()
             (#) TX processes are HAL_SPI_Transmit(), HAL_SPI_Transmit_IT() and HAL_SPI_Transmit_DMA()
 
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -815,22 +815,18 @@ HAL_StatusTypeDef HAL_SPI_UnRegisterCallback(SPI_HandleTypeDef *hspi, HAL_SPI_Ca
   * @brief  Transmit an amount of data in blocking mode.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pData pointer to data buffer
-  * @param  Size amount of data to be sent
-  * @param  Timeout Timeout duration
+  * @param  pData pointer to data buffer (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be sent
+  * @param  Timeout Timeout duration in ms
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
-  HAL_StatusTypeDef errorcode = HAL_OK;
   uint16_t initial_TxXferCount;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
-
-  /* Process Locked */
-  __HAL_LOCK(hspi);
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
@@ -838,20 +834,21 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    goto error;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0U))
   {
-    errorcode = HAL_ERROR;
-    goto error;
+    return HAL_ERROR;
   }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
   hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
-  hspi->pTxBuffPtr  = (uint8_t *)pData;
+  hspi->pTxBuffPtr  = (const uint8_t *)pData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
 
@@ -890,7 +887,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
   {
     if ((hspi->Init.Mode == SPI_MODE_SLAVE) || (initial_TxXferCount == 0x01U))
     {
-      hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+      hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
       hspi->pTxBuffPtr += sizeof(uint16_t);
       hspi->TxXferCount--;
     }
@@ -900,7 +897,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
       /* Wait until TXE flag is set to send data */
       if (__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXE))
       {
-        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+        hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr += sizeof(uint16_t);
         hspi->TxXferCount--;
       }
@@ -909,8 +906,9 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
-          errorcode = HAL_TIMEOUT;
-          goto error;
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
         }
       }
     }
@@ -923,13 +921,13 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
       if (hspi->TxXferCount > 1U)
       {
         /* write on the data register in packing mode */
-        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+        hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr += sizeof(uint16_t);
         hspi->TxXferCount -= 2U;
       }
       else
       {
-        *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
+        *((__IO uint8_t *)&hspi->Instance->DR) = *((const uint8_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr ++;
         hspi->TxXferCount--;
       }
@@ -942,13 +940,13 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
         if (hspi->TxXferCount > 1U)
         {
           /* write on the data register in packing mode */
-          hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+          hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
           hspi->pTxBuffPtr += sizeof(uint16_t);
           hspi->TxXferCount -= 2U;
         }
         else
         {
-          *((__IO uint8_t *)&hspi->Instance->DR) = (*hspi->pTxBuffPtr);
+          *((__IO uint8_t *)&hspi->Instance->DR) = *((const uint8_t *)hspi->pTxBuffPtr);
           hspi->pTxBuffPtr++;
           hspi->TxXferCount--;
         }
@@ -958,8 +956,9 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
-          errorcode = HAL_TIMEOUT;
-          goto error;
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
         }
       }
     }
@@ -984,31 +983,50 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
     __HAL_SPI_CLEAR_OVRFLAG(hspi);
   }
 
-  if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
-  {
-    errorcode = HAL_ERROR;
-  }
-
-error:
   hspi->State = HAL_SPI_STATE_READY;
   /* Process Unlocked */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+
+  if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    return HAL_OK;
+  }
 }
 
 /**
   * @brief  Receive an amount of data in blocking mode.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pData pointer to data buffer
-  * @param  Size amount of data to be received
-  * @param  Timeout Timeout duration
+  * @param  pData pointer to data buffer (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be received
+  * @param  Timeout Timeout duration in ms
   * @retval HAL status
+  * @note   In master mode, if the direction is set to SPI_DIRECTION_2LINES
+  *         the receive buffer is written to data register (DR) to generate
+  *         clock pulses and receive data
   */
 HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
+#if (USE_SPI_CRC != 0U)
+  __IO uint32_t tmpreg = 0U;
+  __IO uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
+#endif /* USE_SPI_CRC */
   uint32_t tickstart;
-  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  if (hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if ((pData == NULL) || (Size == 0U))
+  {
+    return HAL_ERROR;
+  }
 
   if ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
   {
@@ -1017,23 +1035,11 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
     return HAL_SPI_TransmitReceive(hspi, pData, pData, Size, Timeout);
   }
 
-  /* Process Locked */
-  __HAL_LOCK(hspi);
-
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
 
-  if (hspi->State != HAL_SPI_STATE_READY)
-  {
-    errorcode = HAL_BUSY;
-    goto error;
-  }
-
-  if ((pData == NULL) || (Size == 0U))
-  {
-    errorcode = HAL_ERROR;
-    goto error;
-  }
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -1105,8 +1111,9 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
-          errorcode = HAL_TIMEOUT;
-          goto error;
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
         }
       }
     }
@@ -1128,8 +1135,9 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
         /* Timeout management */
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
-          errorcode = HAL_TIMEOUT;
-          goto error;
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
         }
       }
     }
@@ -1146,8 +1154,8 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
     if (SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SET, Timeout, tickstart) != HAL_OK)
     {
       /* the latest data has not been received */
-      errorcode = HAL_TIMEOUT;
-      goto error;
+      __HAL_UNLOCK(hspi);
+      return HAL_TIMEOUT;
     }
 
     /* Receive last data in 16 Bit mode */
@@ -1165,20 +1173,27 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
     if (SPI_WaitFlagStateUntilTimeout(hspi, SPI_FLAG_RXNE, SET, Timeout, tickstart) != HAL_OK)
     {
       SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
-      errorcode = HAL_TIMEOUT;
-      goto error;
+      hspi->State = HAL_SPI_STATE_READY;
+      __HAL_UNLOCK(hspi);
+      return HAL_TIMEOUT;
     }
 
     /* Read CRC to Flush DR and RXNE flag */
     if (hspi->Init.DataSize == SPI_DATASIZE_16BIT)
     {
       /* Read 16bit CRC */
-      READ_REG(hspi->Instance->DR);
+      tmpreg = READ_REG(hspi->Instance->DR);
+      /* To avoid GCC warning */
+      UNUSED(tmpreg);
     }
     else
     {
+      /* Initialize the 8bit temporary pointer */
+      ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
       /* Read 8bit CRC */
-      READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+      tmpreg8 = *ptmpreg8;
+      /* To avoid GCC warning */
+      UNUSED(tmpreg8);
 
       if ((hspi->Init.DataSize == SPI_DATASIZE_8BIT) && (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT))
       {
@@ -1186,11 +1201,14 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
         {
           /* Error on the CRC reception */
           SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
-          errorcode = HAL_TIMEOUT;
-          goto error;
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
         }
         /* Read 8bit CRC again in case of 16bit CRC in 8bit Data mode */
-        READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+        tmpreg8 = *ptmpreg8;
+        /* To avoid GCC warning */
+        UNUSED(tmpreg8);
       }
     }
   }
@@ -1211,29 +1229,31 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   }
 #endif /* USE_SPI_CRC */
 
+  hspi->State = HAL_SPI_STATE_READY;
+  /* Unlock the process */
+  __HAL_UNLOCK(hspi);
   if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
   {
-    errorcode = HAL_ERROR;
+    return HAL_ERROR;
   }
-
-error :
-  hspi->State = HAL_SPI_STATE_READY;
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  else
+  {
+    return HAL_OK;
+  }
 }
 
 /**
   * @brief  Transmit and Receive an amount of data in blocking mode.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pTxData pointer to transmission data buffer
-  * @param  pRxData pointer to reception data buffer
-  * @param  Size amount of data to be sent and received
-  * @param  Timeout Timeout duration
+  * @param  pTxData pointer to transmission data buffer (u8 or u16 data elements)
+  * @param  pRxData pointer to reception data buffer (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be sent and received
+  * @param  Timeout Timeout duration in ms
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size,
-                                          uint32_t Timeout)
+HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
+                                          uint16_t Size, uint32_t Timeout)
 {
   uint16_t             initial_TxXferCount;
   uint16_t             initial_RxXferCount;
@@ -1241,19 +1261,18 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   HAL_SPI_StateTypeDef tmp_state;
   uint32_t             tickstart;
 #if (USE_SPI_CRC != 0U)
+  __IO uint32_t tmpreg = 0U;
   uint32_t             spi_cr1;
   uint32_t             spi_cr2;
+  __IO uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
 #endif /* USE_SPI_CRC */
 
   /* Variable used to alternate Rx and Tx during transfer */
   uint32_t             txallowed = 1U;
-  HAL_StatusTypeDef    errorcode = HAL_OK;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
-
-  /* Process Locked */
-  __HAL_LOCK(hspi);
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
@@ -1269,17 +1288,19 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
 #endif /* USE_SPI_CRC */
 
   if (!((tmp_state == HAL_SPI_STATE_READY) || \
-        ((tmp_mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (tmp_state == HAL_SPI_STATE_BUSY_RX))))
+        ((tmp_mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) &&
+         (tmp_state == HAL_SPI_STATE_BUSY_RX))))
   {
-    errorcode = HAL_BUSY;
-    goto error;
+    return HAL_BUSY;
   }
 
   if ((pTxData == NULL) || (pRxData == NULL) || (Size == 0U))
   {
-    errorcode = HAL_ERROR;
-    goto error;
+    return HAL_ERROR;
   }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
   if (hspi->State != HAL_SPI_STATE_BUSY_RX)
@@ -1292,7 +1313,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   hspi->pRxBuffPtr  = (uint8_t *)pRxData;
   hspi->RxXferCount = Size;
   hspi->RxXferSize  = Size;
-  hspi->pTxBuffPtr  = (uint8_t *)pTxData;
+  hspi->pTxBuffPtr  = (const uint8_t *)pTxData;
   hspi->TxXferCount = Size;
   hspi->TxXferSize  = Size;
 
@@ -1332,16 +1353,30 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
   {
     if ((hspi->Init.Mode == SPI_MODE_SLAVE) || (initial_TxXferCount == 0x01U))
     {
-      hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+      hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
       hspi->pTxBuffPtr += sizeof(uint16_t);
       hspi->TxXferCount--;
+
+#if (USE_SPI_CRC != 0U)
+      /* Enable CRC Transmission */
+      if ((hspi->TxXferCount == 0U) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+      {
+        /* Set NSS Soft to received correctly the CRC on slave mode with NSS pulse activated */
+        if ((READ_BIT(spi_cr1, SPI_CR1_MSTR) == 0U) && (READ_BIT(spi_cr2, SPI_CR2_NSSP) == SPI_CR2_NSSP))
+        {
+          SET_BIT(hspi->Instance->CR1, SPI_CR1_SSM);
+        }
+        SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCNEXT);
+      }
+#endif /* USE_SPI_CRC */
+
     }
     while ((hspi->TxXferCount > 0U) || (hspi->RxXferCount > 0U))
     {
       /* Check TXE flag */
       if ((__HAL_SPI_GET_FLAG(hspi, SPI_FLAG_TXE)) && (hspi->TxXferCount > 0U) && (txallowed == 1U))
       {
-        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+        hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr += sizeof(uint16_t);
         hspi->TxXferCount--;
         /* Next Data is a reception (Rx). Tx not allowed */
@@ -1372,8 +1407,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       }
       if (((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY))
       {
-        errorcode = HAL_TIMEOUT;
-        goto error;
+        hspi->State = HAL_SPI_STATE_READY;
+        __HAL_UNLOCK(hspi);
+        return HAL_TIMEOUT;
       }
     }
   }
@@ -1384,15 +1420,28 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
     {
       if (hspi->TxXferCount > 1U)
       {
-        hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+        hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr += sizeof(uint16_t);
         hspi->TxXferCount -= 2U;
       }
       else
       {
-        *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
+        *(__IO uint8_t *)&hspi->Instance->DR = *((const uint8_t *)hspi->pTxBuffPtr);
         hspi->pTxBuffPtr++;
         hspi->TxXferCount--;
+
+#if (USE_SPI_CRC != 0U)
+        /* Enable CRC Transmission */
+        if ((hspi->TxXferCount == 0U) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+        {
+          /* Set NSS Soft to received correctly the CRC on slave mode with NSS pulse activated */
+          if ((READ_BIT(spi_cr1, SPI_CR1_MSTR) == 0U) && (READ_BIT(spi_cr2, SPI_CR2_NSSP) == SPI_CR2_NSSP))
+          {
+            SET_BIT(hspi->Instance->CR1, SPI_CR1_SSM);
+          }
+          SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCNEXT);
+        }
+#endif /* USE_SPI_CRC */
       }
     }
     while ((hspi->TxXferCount > 0U) || (hspi->RxXferCount > 0U))
@@ -1402,13 +1451,13 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       {
         if (hspi->TxXferCount > 1U)
         {
-          hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+          hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
           hspi->pTxBuffPtr += sizeof(uint16_t);
           hspi->TxXferCount -= 2U;
         }
         else
         {
-          *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
+          *(__IO uint8_t *)&hspi->Instance->DR = *((const uint8_t *)hspi->pTxBuffPtr);
           hspi->pTxBuffPtr++;
           hspi->TxXferCount--;
         }
@@ -1454,8 +1503,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       }
       if ((((HAL_GetTick() - tickstart) >=  Timeout) && ((Timeout != HAL_MAX_DELAY))) || (Timeout == 0U))
       {
-        errorcode = HAL_TIMEOUT;
-        goto error;
+        hspi->State = HAL_SPI_STATE_READY;
+        __HAL_UNLOCK(hspi);
+        return HAL_TIMEOUT;
       }
     }
   }
@@ -1469,19 +1519,26 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
     {
       /* Error on the CRC reception */
       SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
-      errorcode = HAL_TIMEOUT;
-      goto error;
+      hspi->State = HAL_SPI_STATE_READY;
+      __HAL_UNLOCK(hspi);
+      return HAL_TIMEOUT;
     }
     /* Read CRC */
     if (hspi->Init.DataSize == SPI_DATASIZE_16BIT)
     {
       /* Read 16bit CRC */
-      READ_REG(hspi->Instance->DR);
+      tmpreg = READ_REG(hspi->Instance->DR);
+      /* To avoid GCC warning */
+      UNUSED(tmpreg);
     }
     else
     {
+      /* Initialize the 8bit temporary pointer */
+      ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
       /* Read 8bit CRC */
-      READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+      tmpreg8 = *ptmpreg8;
+      /* To avoid GCC warning */
+      UNUSED(tmpreg8);
 
       if (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
       {
@@ -1489,11 +1546,14 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
         {
           /* Error on the CRC reception */
           SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
-          errorcode = HAL_TIMEOUT;
-          goto error;
+          hspi->State = HAL_SPI_STATE_READY;
+          __HAL_UNLOCK(hspi);
+          return HAL_TIMEOUT;
         }
         /* Read 8bit CRC again in case of 16bit CRC in 8bit Data mode */
-        READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+        tmpreg8 = *ptmpreg8;
+        /* To avoid GCC warning */
+        UNUSED(tmpreg8);
       }
     }
   }
@@ -1504,58 +1564,66 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
     /* Clear CRC Flag */
     __HAL_SPI_CLEAR_CRCERRFLAG(hspi);
-
-    errorcode = HAL_ERROR;
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
   }
 #endif /* USE_SPI_CRC */
 
   /* Check the end of the transaction */
   if (SPI_EndRxTxTransaction(hspi, Timeout, tickstart) != HAL_OK)
   {
-    errorcode = HAL_ERROR;
     hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
   }
 
-error :
+
   hspi->State = HAL_SPI_STATE_READY;
+  /* Unlock the process */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+
+  if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    return HAL_ERROR;
+  }
+  else
+  {
+    return HAL_OK;
+  }
 }
 
 /**
   * @brief  Transmit an amount of data in non-blocking mode with Interrupt.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pData pointer to data buffer
-  * @param  Size amount of data to be sent
+  * @param  pData pointer to data buffer (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
 
-  /* Process Locked */
-  __HAL_LOCK(hspi);
 
   if ((pData == NULL) || (Size == 0U))
   {
-    errorcode = HAL_ERROR;
-    goto error;
+    return HAL_ERROR;
   }
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    goto error;
+    return HAL_BUSY;
   }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
   hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
-  hspi->pTxBuffPtr  = (uint8_t *)pData;
+  hspi->pTxBuffPtr  = (const uint8_t *)pData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
 
@@ -1591,10 +1659,6 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   }
 #endif /* USE_SPI_CRC */
 
-  /* Enable TXE and ERR interrupt */
-  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
-
-
   /* Check if the SPI is already enabled */
   if ((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
   {
@@ -1602,22 +1666,34 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     __HAL_SPI_ENABLE(hspi);
   }
 
-error :
+  /* Process Unlocked */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+  /* Enable TXE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
+
+  return HAL_OK;
 }
 
 /**
   * @brief  Receive an amount of data in non-blocking mode with Interrupt.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pData pointer to data buffer
-  * @param  Size amount of data to be sent
+  * @param  pData pointer to data buffer (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be received
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
+
+  if (hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if ((pData == NULL) || (Size == 0U))
+  {
+    return HAL_ERROR;
+  }
 
   if ((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
   {
@@ -1626,20 +1702,9 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
     return HAL_SPI_TransmitReceive_IT(hspi, pData, pData, Size);
   }
 
+
   /* Process Locked */
   __HAL_LOCK(hspi);
-
-  if (hspi->State != HAL_SPI_STATE_READY)
-  {
-    errorcode = HAL_BUSY;
-    goto error;
-  }
-
-  if ((pData == NULL) || (Size == 0U))
-  {
-    errorcode = HAL_ERROR;
-    goto error;
-  }
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -1693,9 +1758,6 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
   }
 #endif /* USE_SPI_CRC */
 
-  /* Enable TXE and ERR interrupt */
-  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
-
   /* Note : The SPI must be enabled after unlocking current process
             to avoid the risk of SPI interrupt handle execution before current
             process unlock */
@@ -1707,49 +1769,50 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
     __HAL_SPI_ENABLE(hspi);
   }
 
-error :
   /* Process Unlocked */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+  /* Enable RXNE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+  return HAL_OK;
 }
 
 /**
   * @brief  Transmit and Receive an amount of data in non-blocking mode with Interrupt.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pTxData pointer to transmission data buffer
-  * @param  pRxData pointer to reception data buffer
-  * @param  Size amount of data to be sent and received
+  * @param  pTxData pointer to transmission data buffer (u8 or u16 data elements)
+  * @param  pRxData pointer to reception data buffer (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be sent and received
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
+                                             uint16_t Size)
 {
   uint32_t             tmp_mode;
   HAL_SPI_StateTypeDef tmp_state;
-  HAL_StatusTypeDef    errorcode = HAL_OK;
 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
-
-  /* Process locked */
-  __HAL_LOCK(hspi);
 
   /* Init temporary variables */
   tmp_state           = hspi->State;
   tmp_mode            = hspi->Init.Mode;
 
   if (!((tmp_state == HAL_SPI_STATE_READY) || \
-        ((tmp_mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (tmp_state == HAL_SPI_STATE_BUSY_RX))))
+        ((tmp_mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) &&
+         (tmp_state == HAL_SPI_STATE_BUSY_RX))))
   {
-    errorcode = HAL_BUSY;
-    goto error;
+    return HAL_BUSY;
   }
 
   if ((pTxData == NULL) || (pRxData == NULL) || (Size == 0U))
   {
-    errorcode = HAL_ERROR;
-    goto error;
+    return HAL_ERROR;
   }
+
+  /* Process locked */
+  __HAL_LOCK(hspi);
 
   /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
   if (hspi->State != HAL_SPI_STATE_BUSY_RX)
@@ -1759,7 +1822,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
 
   /* Set the transaction information */
   hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
-  hspi->pTxBuffPtr  = (uint8_t *)pTxData;
+  hspi->pTxBuffPtr  = (const uint8_t *)pTxData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
   hspi->pRxBuffPtr  = (uint8_t *)pRxData;
@@ -1807,8 +1870,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
     SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
   }
 
-  /* Enable TXE, RXNE and ERR interrupt */
-  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
 
   /* Check if the SPI is already enabled */
   if ((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
@@ -1817,23 +1878,24 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
     __HAL_SPI_ENABLE(hspi);
   }
 
-error :
   /* Process Unlocked */
   __HAL_UNLOCK(hspi);
-  return errorcode;
+  /* Enable TXE, RXNE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+  return HAL_OK;
 }
 
 /**
   * @brief  Transmit an amount of data in non-blocking mode with DMA.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pData pointer to data buffer
-  * @param  Size amount of data to be sent
+  * @param  pData pointer to data buffer  (u8 or u16 data elements)
+  * @param  Size amount of data elements (u8 or u16) to be sent
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, const uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
 
   /* Check tx dma handle */
   assert_param(IS_SPI_DMA_HANDLE(hspi->hdmatx));
@@ -1841,25 +1903,23 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
 
-  /* Process Locked */
-  __HAL_LOCK(hspi);
-
   if (hspi->State != HAL_SPI_STATE_READY)
   {
-    errorcode = HAL_BUSY;
-    goto error;
+    return HAL_BUSY;
   }
 
   if ((pData == NULL) || (Size == 0U))
   {
-    errorcode = HAL_ERROR;
-    goto error;
+    return HAL_ERROR;
   }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
   hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
-  hspi->pTxBuffPtr  = (uint8_t *)pData;
+  hspi->pTxBuffPtr  = (const uint8_t *)pData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
 
@@ -1921,10 +1981,9 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-    errorcode = HAL_ERROR;
-
-    hspi->State = HAL_SPI_STATE_READY;
-    goto error;
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
   }
 
   /* Check if the SPI is already enabled */
@@ -1934,16 +1993,16 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
     __HAL_SPI_ENABLE(hspi);
   }
 
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
   /* Enable the SPI Error Interrupt Bit */
   __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_ERR));
 
   /* Enable Tx DMA Request */
   SET_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
 
-error :
-  /* Process Unlocked */
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  return HAL_OK;
 }
 
 /**
@@ -1951,17 +2010,25 @@ error :
   * @note   In case of MASTER mode and SPI_DIRECTION_2LINES direction, hdmatx shall be defined.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pData pointer to data buffer
+  * @param  pData pointer to data buffer (u8 or u16 data elements)
   * @note   When the CRC feature is enabled the pData Length must be Size + 1.
-  * @param  Size amount of data to be sent
+  * @param  Size amount of data elements (u8 or u16) to be received
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, uint16_t Size)
 {
-  HAL_StatusTypeDef errorcode = HAL_OK;
-
   /* Check rx dma handle */
   assert_param(IS_SPI_DMA_HANDLE(hspi->hdmarx));
+
+  if (hspi->State != HAL_SPI_STATE_READY)
+  {
+    return HAL_BUSY;
+  }
+
+  if ((pData == NULL) || (Size == 0U))
+  {
+    return HAL_ERROR;
+  }
 
   if ((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
   {
@@ -1976,18 +2043,6 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
 
   /* Process Locked */
   __HAL_LOCK(hspi);
-
-  if (hspi->State != HAL_SPI_STATE_READY)
-  {
-    errorcode = HAL_BUSY;
-    goto error;
-  }
-
-  if ((pData == NULL) || (Size == 0U))
-  {
-    errorcode = HAL_ERROR;
-    goto error;
-  }
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -2066,10 +2121,9 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-    errorcode = HAL_ERROR;
-
-    hspi->State = HAL_SPI_STATE_READY;
-    goto error;
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
   }
 
   /* Check if the SPI is already enabled */
@@ -2079,34 +2133,33 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     __HAL_SPI_ENABLE(hspi);
   }
 
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
   /* Enable the SPI Error Interrupt Bit */
   __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_ERR));
 
   /* Enable Rx DMA Request */
   SET_BIT(hspi->Instance->CR2, SPI_CR2_RXDMAEN);
 
-error:
-  /* Process Unlocked */
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  return HAL_OK;
 }
 
 /**
   * @brief  Transmit and Receive an amount of data in non-blocking mode with DMA.
   * @param  hspi pointer to a SPI_HandleTypeDef structure that contains
   *               the configuration information for SPI module.
-  * @param  pTxData pointer to transmission data buffer
-  * @param  pRxData pointer to reception data buffer
+  * @param  pTxData pointer to transmission data buffer (u8 or u16 data elements)
+  * @param  pRxData pointer to reception data buffer (u8 or u16 data elements)
   * @note   When the CRC feature is enabled the pRxData Length must be Size + 1
-  * @param  Size amount of data to be sent
+  * @param  Size amount of data elements (u8 or u16) to be sent and received
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pTxData, uint8_t *pRxData,
+HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, const uint8_t *pTxData, uint8_t *pRxData,
                                               uint16_t Size)
 {
   uint32_t             tmp_mode;
   HAL_SPI_StateTypeDef tmp_state;
-  HAL_StatusTypeDef errorcode = HAL_OK;
 
   /* Check rx & tx dma handles */
   assert_param(IS_SPI_DMA_HANDLE(hspi->hdmarx));
@@ -2115,25 +2168,24 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
 
-  /* Process locked */
-  __HAL_LOCK(hspi);
-
   /* Init temporary variables */
   tmp_state           = hspi->State;
   tmp_mode            = hspi->Init.Mode;
 
   if (!((tmp_state == HAL_SPI_STATE_READY) ||
-        ((tmp_mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) && (tmp_state == HAL_SPI_STATE_BUSY_RX))))
+        ((tmp_mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES) &&
+         (tmp_state == HAL_SPI_STATE_BUSY_RX))))
   {
-    errorcode = HAL_BUSY;
-    goto error;
+    return HAL_BUSY;
   }
 
   if ((pTxData == NULL) || (pRxData == NULL) || (Size == 0U))
   {
-    errorcode = HAL_ERROR;
-    goto error;
+    return HAL_ERROR;
   }
+
+  /* Process locked */
+  __HAL_LOCK(hspi);
 
   /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
   if (hspi->State != HAL_SPI_STATE_BUSY_RX)
@@ -2143,7 +2195,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
 
   /* Set the transaction information */
   hspi->ErrorCode   = HAL_SPI_ERROR_NONE;
-  hspi->pTxBuffPtr  = (uint8_t *)pTxData;
+  hspi->pTxBuffPtr  = (const uint8_t *)pTxData;
   hspi->TxXferSize  = Size;
   hspi->TxXferCount = Size;
   hspi->pRxBuffPtr  = (uint8_t *)pRxData;
@@ -2234,10 +2286,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-    errorcode = HAL_ERROR;
-
-    hspi->State = HAL_SPI_STATE_READY;
-    goto error;
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
   }
 
   /* Enable Rx DMA Request */
@@ -2256,10 +2307,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
   {
     /* Update SPI error code */
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
-    errorcode = HAL_ERROR;
-
-    hspi->State = HAL_SPI_STATE_READY;
-    goto error;
+    /* Process Unlocked */
+    __HAL_UNLOCK(hspi);
+    return HAL_ERROR;
   }
 
   /* Check if the SPI is already enabled */
@@ -2268,16 +2318,17 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     /* Enable SPI peripheral */
     __HAL_SPI_ENABLE(hspi);
   }
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hspi);
+
   /* Enable the SPI Error Interrupt Bit */
   __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_ERR));
 
   /* Enable Tx DMA Request */
   SET_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN);
 
-error :
-  /* Process Unlocked */
-  __HAL_UNLOCK(hspi);
-  return errorcode;
+  return HAL_OK;
 }
 
 /**
@@ -2370,7 +2421,8 @@ HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
       __HAL_SPI_DISABLE(hspi);
 
       /* Empty the FRLVL fifo */
-      if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+      if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                        HAL_GetTick()) != HAL_OK)
       {
         hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
       }
@@ -2403,7 +2455,8 @@ HAL_StatusTypeDef HAL_SPI_Abort(SPI_HandleTypeDef *hspi)
       }
 
       /* Empty the FRLVL fifo */
-      if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+      if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                        HAL_GetTick()) != HAL_OK)
       {
         hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
       }
@@ -2658,9 +2711,11 @@ HAL_StatusTypeDef HAL_SPI_DMAStop(SPI_HandleTypeDef *hspi)
 {
   HAL_StatusTypeDef errorcode = HAL_OK;
   /* The Lock is not implemented on this API to allow the user application
-     to call the HAL SPI API under callbacks HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback():
+     to call the HAL SPI API under callbacks HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or
+     HAL_SPI_TxRxCpltCallback():
      when calling HAL_DMA_Abort() API the DMA TX/RX Transfer complete interrupt is generated
-     and the correspond call back is executed HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or HAL_SPI_TxRxCpltCallback()
+     and the correspond call back is executed HAL_SPI_TxCpltCallback() or HAL_SPI_RxCpltCallback() or
+     HAL_SPI_TxRxCpltCallback()
      */
 
   /* Abort the SPI DMA tx Stream/Channel  */
@@ -2950,7 +3005,7 @@ __weak void HAL_SPI_AbortCpltCallback(SPI_HandleTypeDef *hspi)
   *               the configuration information for SPI module.
   * @retval SPI state
   */
-HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
+HAL_SPI_StateTypeDef HAL_SPI_GetState(const SPI_HandleTypeDef *hspi)
 {
   /* Return SPI handle state */
   return hspi->State;
@@ -2962,7 +3017,7 @@ HAL_SPI_StateTypeDef HAL_SPI_GetState(SPI_HandleTypeDef *hspi)
   *               the configuration information for SPI module.
   * @retval SPI error code in bitmap format
   */
-uint32_t HAL_SPI_GetError(SPI_HandleTypeDef *hspi)
+uint32_t HAL_SPI_GetError(const SPI_HandleTypeDef *hspi)
 {
   /* Return SPI ErrorCode */
   return hspi->ErrorCode;
@@ -2989,7 +3044,7 @@ uint32_t HAL_SPI_GetError(SPI_HandleTypeDef *hspi)
   */
 static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
   uint32_t tickstart;
 
   /* Init tickstart for timeout management*/
@@ -3046,8 +3101,13 @@ static void SPI_DMATransmitCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
   uint32_t tickstart;
+#if (USE_SPI_CRC != 0U)
+  __IO uint32_t tmpreg = 0U;
+  __IO uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
+#endif /* USE_SPI_CRC */
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
@@ -3072,12 +3132,18 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
       if (hspi->Init.DataSize > SPI_DATASIZE_8BIT)
       {
         /* Read 16bit CRC */
-        READ_REG(hspi->Instance->DR);
+        tmpreg = READ_REG(hspi->Instance->DR);
+        /* To avoid GCC warning */
+        UNUSED(tmpreg);
       }
       else
       {
+        /* Initialize the 8bit temporary pointer */
+        ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
         /* Read 8bit CRC */
-        READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+        tmpreg8 = *ptmpreg8;
+        /* To avoid GCC warning */
+        UNUSED(tmpreg8);
 
         if (hspi->Init.CRCLength == SPI_CRC_LENGTH_16BIT)
         {
@@ -3087,7 +3153,9 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
             SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
           }
           /* Read 8bit CRC again in case of 16bit CRC in 8bit Data mode */
-          READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+          tmpreg8 = *ptmpreg8;
+          /* To avoid GCC warning */
+          UNUSED(tmpreg8);
         }
       }
     }
@@ -3150,8 +3218,13 @@ static void SPI_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
   uint32_t tickstart;
+#if (USE_SPI_CRC != 0U)
+  __IO uint32_t tmpreg = 0U;
+  __IO uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
+#endif /* USE_SPI_CRC */
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
@@ -3174,18 +3247,25 @@ static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
           /* Error on the CRC reception */
           SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
         }
-        /* Read CRC to Flush DR and RXNE flag */
-        READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+        /* Initialize the 8bit temporary pointer */
+        ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
+        /* Read 8bit CRC */
+        tmpreg8 = *ptmpreg8;
+        /* To avoid GCC warning */
+        UNUSED(tmpreg8);
       }
       else
       {
-        if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_HALF_FULL, SPI_DEFAULT_TIMEOUT, tickstart) != HAL_OK)
+        if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_HALF_FULL, SPI_DEFAULT_TIMEOUT,
+                                          tickstart) != HAL_OK)
         {
           /* Error on the CRC reception */
           SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_CRC);
         }
         /* Read CRC to Flush DR and RXNE flag */
-        READ_REG(hspi->Instance->DR);
+        tmpreg = READ_REG(hspi->Instance->DR);
+        /* To avoid GCC warning */
+        UNUSED(tmpreg);
       }
     }
 #endif /* USE_SPI_CRC */
@@ -3239,7 +3319,7 @@ static void SPI_DMATransmitReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Call user Tx half complete callback */
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1U)
@@ -3257,7 +3337,7 @@ static void SPI_DMAHalfTransmitCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Call user Rx half complete callback */
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1U)
@@ -3275,7 +3355,7 @@ static void SPI_DMAHalfReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Call user TxRx half complete callback */
 #if (USE_HAL_SPI_REGISTER_CALLBACKS == 1U)
@@ -3293,7 +3373,7 @@ static void SPI_DMAHalfTransmitReceiveCplt(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAError(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Stop the disable DMA transfer on SPI side */
   CLEAR_BIT(hspi->Instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
@@ -3316,7 +3396,7 @@ static void SPI_DMAError(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMAAbortOnError(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
   hspi->RxXferCount = 0U;
   hspi->TxXferCount = 0U;
 
@@ -3338,7 +3418,7 @@ static void SPI_DMAAbortOnError(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMATxAbortCallback(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   hspi->hdmatx->XferAbortCallback = NULL;
 
@@ -3354,7 +3434,8 @@ static void SPI_DMATxAbortCallback(DMA_HandleTypeDef *hdma)
   __HAL_SPI_DISABLE(hspi);
 
   /* Empty the FRLVL fifo */
-  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                    HAL_GetTick()) != HAL_OK)
   {
     hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
   }
@@ -3404,7 +3485,7 @@ static void SPI_DMATxAbortCallback(DMA_HandleTypeDef *hdma)
   */
 static void SPI_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
 {
-  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent); /* Derogation MISRAC2012-Rule-11.5 */
+  SPI_HandleTypeDef *hspi = (SPI_HandleTypeDef *)(((DMA_HandleTypeDef *)hdma)->Parent);
 
   /* Disable SPI Peripheral */
   __HAL_SPI_DISABLE(hspi);
@@ -3421,7 +3502,8 @@ static void SPI_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
   }
 
   /* Empty the FRLVL fifo */
-  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                    HAL_GetTick()) != HAL_OK)
   {
     hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
   }
@@ -3520,8 +3602,15 @@ static void SPI_2linesRxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_2linesRxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
 {
+  __IO uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
+
+  /* Initialize the 8bit temporary pointer */
+  ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
   /* Read 8bit CRC to flush Data Register */
-  READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+  tmpreg8 = *ptmpreg8;
+  /* To avoid GCC warning */
+  UNUSED(tmpreg8);
 
   hspi->CRCSize--;
 
@@ -3550,14 +3639,14 @@ static void SPI_2linesTxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
   /* Transmit data in packing Bit mode */
   if (hspi->TxXferCount >= 2U)
   {
-    hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+    hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
     hspi->pTxBuffPtr += sizeof(uint16_t);
     hspi->TxXferCount -= 2U;
   }
   /* Transmit data in 8 Bit mode */
   else
   {
-    *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
+    *(__IO uint8_t *)&hspi->Instance->DR = *((const uint8_t *)hspi->pTxBuffPtr);
     hspi->pTxBuffPtr++;
     hspi->TxXferCount--;
   }
@@ -3628,8 +3717,12 @@ static void SPI_2linesRxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
 {
+  __IO uint32_t tmpreg = 0U;
+
   /* Read 16bit CRC to flush Data Register */
-  READ_REG(hspi->Instance->DR);
+  tmpreg = READ_REG(hspi->Instance->DR);
+  /* To avoid GCC warning */
+  UNUSED(tmpreg);
 
   /* Disable RXNE interrupt */
   __HAL_SPI_DISABLE_IT(hspi, SPI_IT_RXNE);
@@ -3647,7 +3740,7 @@ static void SPI_2linesRxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
 static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 {
   /* Transmit data in 16 Bit mode */
-  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
   hspi->pTxBuffPtr += sizeof(uint16_t);
   hspi->TxXferCount--;
 
@@ -3684,8 +3777,15 @@ static void SPI_2linesTxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_RxISR_8BITCRC(struct __SPI_HandleTypeDef *hspi)
 {
+  __IO uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
+
+  /* Initialize the 8bit temporary pointer */
+  ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
   /* Read 8bit CRC to flush Data Register */
-  READ_REG(*(__IO uint8_t *)&hspi->Instance->DR);
+  tmpreg8 = *ptmpreg8;
+  /* To avoid GCC warning */
+  UNUSED(tmpreg8);
 
   hspi->CRCSize--;
 
@@ -3738,8 +3838,12 @@ static void SPI_RxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_RxISR_16BITCRC(struct __SPI_HandleTypeDef *hspi)
 {
+  __IO uint32_t tmpreg = 0U;
+
   /* Read 16bit CRC to flush Data Register */
-  READ_REG(hspi->Instance->DR);
+  tmpreg = READ_REG(hspi->Instance->DR);
+  /* To avoid GCC warning */
+  UNUSED(tmpreg);
 
   /* Disable RXNE and ERR interrupt */
   __HAL_SPI_DISABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
@@ -3789,7 +3893,7 @@ static void SPI_RxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
   */
 static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
 {
-  *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
+  *(__IO uint8_t *)&hspi->Instance->DR = *((const uint8_t *)hspi->pTxBuffPtr);
   hspi->pTxBuffPtr++;
   hspi->TxXferCount--;
 
@@ -3815,7 +3919,7 @@ static void SPI_TxISR_8BIT(struct __SPI_HandleTypeDef *hspi)
 static void SPI_TxISR_16BIT(struct __SPI_HandleTypeDef *hspi)
 {
   /* Transmit data in 16 Bit mode */
-  hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
+  hspi->Instance->DR = *((const uint16_t *)hspi->pTxBuffPtr);
   hspi->pTxBuffPtr += sizeof(uint16_t);
   hspi->TxXferCount--;
 
@@ -3890,11 +3994,14 @@ static HAL_StatusTypeDef SPI_WaitFlagStateUntilTimeout(SPI_HandleTypeDef *hspi, 
         return HAL_TIMEOUT;
       }
       /* If Systick is disabled or not incremented, deactivate timeout to go in disable loop procedure */
-      if(count == 0U)
+      if (count == 0U)
       {
         tmp_timeout = 0U;
       }
-      count--;
+      else
+      {
+        count--;
+      }
     }
   }
 
@@ -3917,10 +4024,15 @@ static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, 
   __IO uint32_t count;
   uint32_t tmp_timeout;
   uint32_t tmp_tickstart;
+  __IO const uint8_t  *ptmpreg8;
+  __IO uint8_t  tmpreg8 = 0;
 
   /* Adjust Timeout value  in case of end of transfer */
   tmp_timeout = Timeout - (HAL_GetTick() - Tickstart);
   tmp_tickstart = HAL_GetTick();
+
+  /* Initialize the 8bit temporary pointer */
+  ptmpreg8 = (__IO uint8_t *)&hspi->Instance->DR;
 
   /* Calculate Timeout based on a software loop to avoid blocking issue if Systick is disabled */
   count = tmp_timeout * ((SystemCoreClock * 35U) >> 20U);
@@ -3929,8 +4041,10 @@ static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, 
   {
     if ((Fifo == SPI_SR_FRLVL) && (State == SPI_FRLVL_EMPTY))
     {
-      /* Read 8bit CRC to flush Data Register */
-      READ_REG(*((__IO uint8_t *)&hspi->Instance->DR));
+      /* Flush Data Register by a blank read */
+      tmpreg8 = *ptmpreg8;
+      /* To avoid GCC warning */
+      UNUSED(tmpreg8);
     }
 
     if (Timeout != HAL_MAX_DELAY)
@@ -3965,11 +4079,14 @@ static HAL_StatusTypeDef SPI_WaitFifoStateUntilTimeout(SPI_HandleTypeDef *hspi, 
         return HAL_TIMEOUT;
       }
       /* If Systick is disabled or not incremented, deactivate timeout to go in disable loop procedure */
-      if(count == 0U)
+      if (count == 0U)
       {
         tmp_timeout = 0U;
       }
-      count--;
+      else
+      {
+        count--;
+      }
     }
   }
 
@@ -4265,7 +4382,8 @@ static void SPI_AbortRx_ISR(SPI_HandleTypeDef *hspi)
   }
 
   /* Empty the FRLVL fifo */
-  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                    HAL_GetTick()) != HAL_OK)
   {
     hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
   }
@@ -4308,7 +4426,8 @@ static void SPI_AbortTx_ISR(SPI_HandleTypeDef *hspi)
   __HAL_SPI_DISABLE(hspi);
 
   /* Empty the FRLVL fifo */
-  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+  if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                    HAL_GetTick()) != HAL_OK)
   {
     hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
   }
@@ -4337,7 +4456,8 @@ static void SPI_AbortTx_ISR(SPI_HandleTypeDef *hspi)
     }
 
     /* Empty the FRLVL fifo */
-    if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT, HAL_GetTick()) != HAL_OK)
+    if (SPI_WaitFifoStateUntilTimeout(hspi, SPI_FLAG_FRLVL, SPI_FRLVL_EMPTY, SPI_DEFAULT_TIMEOUT,
+                                      HAL_GetTick()) != HAL_OK)
     {
       hspi->ErrorCode = HAL_SPI_ERROR_ABORT;
     }
@@ -4359,4 +4479,3 @@ static void SPI_AbortTx_ISR(SPI_HandleTypeDef *hspi)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_spi_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_spi_ex.c
@@ -10,13 +10,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -77,7 +76,7 @@
   *               the configuration information for the specified SPI module.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi)
+HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(const SPI_HandleTypeDef *hspi)
 {
   __IO uint32_t tmpreg;
   uint8_t  count = 0U;
@@ -111,5 +110,3 @@ HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_tim.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_tim.c
@@ -29,6 +29,17 @@
   *           + Commutation Event configuration with Interruption and DMA
   *           + TIM OCRef clear configuration
   *           + TIM External Clock configuration
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                       ##### TIMER Generic features #####
@@ -103,14 +114,14 @@
   allows the user to configure dynamically the driver callbacks.
 
   [..]
-  Use Function @ref HAL_TIM_RegisterCallback() to register a callback.
-  @ref HAL_TIM_RegisterCallback() takes as parameters the HAL peripheral handle,
+  Use Function HAL_TIM_RegisterCallback() to register a callback.
+  HAL_TIM_RegisterCallback() takes as parameters the HAL peripheral handle,
   the Callback ID and a pointer to the user callback function.
 
   [..]
-  Use function @ref HAL_TIM_UnRegisterCallback() to reset a callback to the default
+  Use function HAL_TIM_UnRegisterCallback() to reset a callback to the default
   weak function.
-  @ref HAL_TIM_UnRegisterCallback takes as parameters the HAL peripheral handle,
+  HAL_TIM_UnRegisterCallback takes as parameters the HAL peripheral handle,
   and the Callback ID.
 
   [..]
@@ -147,7 +158,7 @@
   [..]
 By default, after the Init and when the state is HAL_TIM_STATE_RESET
 all interrupt callbacks are set to the corresponding weak functions:
-  examples @ref HAL_TIM_TriggerCallback(), @ref HAL_TIM_ErrorCallback().
+  examples HAL_TIM_TriggerCallback(), HAL_TIM_ErrorCallback().
 
   [..]
   Exception done for MspInit and MspDeInit functions that are reset to the legacy weak
@@ -161,7 +172,7 @@ all interrupt callbacks are set to the corresponding weak functions:
     in HAL_TIM_STATE_READY or HAL_TIM_STATE_RESET state,
     thus registered(user) MspInit / DeInit callbacks can be used during the Init / DeInit.
   In that case first register the MspInit/MspDeInit user callbacks
-      using @ref HAL_TIM_RegisterCallback() before calling DeInit or Init function.
+      using HAL_TIM_RegisterCallback() before calling DeInit or Init function.
 
   [..]
       When The compilation define USE_HAL_TIM_REGISTER_CALLBACKS is set to 0 or
@@ -169,17 +180,6 @@ all interrupt callbacks are set to the corresponding weak functions:
       are set to the corresponding weak functions.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -213,11 +213,11 @@ all interrupt callbacks are set to the corresponding weak functions:
 /** @addtogroup TIM_Private_Functions
   * @{
   */
-static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
-static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
-static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
-static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
-static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config);
+static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config);
 static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICFilter);
 static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_ICSelection,
                               uint32_t TIM_ICFilter);
@@ -233,7 +233,7 @@ static void TIM_DMADelayPulseCplt(DMA_HandleTypeDef *hdma);
 static void TIM_DMATriggerCplt(DMA_HandleTypeDef *hdma);
 static void TIM_DMATriggerHalfCplt(DMA_HandleTypeDef *hdma);
 static HAL_StatusTypeDef TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
-                                                  TIM_SlaveConfigTypeDef *sSlaveConfig);
+                                                  const TIM_SlaveConfigTypeDef *sSlaveConfig);
 /**
   * @}
   */
@@ -286,6 +286,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Init(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_INSTANCE(htim->Instance));
   assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
 
   if (htim->State == HAL_TIM_STATE_RESET)
@@ -533,7 +534,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Stop_IT(TIM_HandleTypeDef *htim)
   * @param  Length The length of data to be transferred from memory to peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pData, uint16_t Length)
+HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, const uint32_t *pData, uint16_t Length)
 {
   uint32_t tmpsmcr;
 
@@ -547,7 +548,7 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pDat
   }
   else if (htim->State == HAL_TIM_STATE_READY)
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -569,7 +570,8 @@ HAL_StatusTypeDef HAL_TIM_Base_Start_DMA(TIM_HandleTypeDef *htim, uint32_t *pDat
   htim->hdma[TIM_DMA_ID_UPDATE]->XferErrorCallback = TIM_DMAError ;
 
   /* Enable the DMA channel */
-  if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)pData, (uint32_t)&htim->Instance->ARR, Length) != HAL_OK)
+  if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)pData, (uint32_t)&htim->Instance->ARR,
+                       Length) != HAL_OK)
   {
     /* Return error status */
     return HAL_ERROR;
@@ -668,6 +670,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Init(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_INSTANCE(htim->Instance));
   assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
 
   if (htim->State == HAL_TIM_STATE_RESET)
@@ -889,10 +892,11 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
@@ -934,34 +938,38 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the Output compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Enable the main output */
-    __HAL_TIM_MOE_ENABLE(htim);
-  }
+    /* Enable the Output compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
-  {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Enable the main output */
+      __HAL_TIM_MOE_ENABLE(htim);
+    }
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -977,8 +985,10 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1011,26 +1021,30 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Output compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Disable the Main Output */
-    __HAL_TIM_MOE_DISABLE(htim);
+    /* Disable the Output compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Disable the Main Output */
+      __HAL_TIM_MOE_DISABLE(htim);
+    }
+
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
+
+    /* Set the TIM channel state */
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
   }
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
-
-  /* Set the TIM channel state */
-  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1046,12 +1060,14 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   * @param  Length The length of data to be transferred from memory to TIM peripheral
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                       uint16_t Length)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Set the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
@@ -1060,7 +1076,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   }
   else if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -1086,7 +1102,8 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1107,7 +1124,8 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1128,7 +1146,8 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1148,7 +1167,8 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1159,34 +1179,38 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the Output compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Enable the main output */
-    __HAL_TIM_MOE_ENABLE(htim);
-  }
+    /* Enable the Output compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
-  {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Enable the main output */
+      __HAL_TIM_MOE_ENABLE(htim);
+    }
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1202,8 +1226,10 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   */
 HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1240,26 +1266,30 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Output compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Disable the Main Output */
-    __HAL_TIM_MOE_DISABLE(htim);
+    /* Disable the Output compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Disable the Main Output */
+      __HAL_TIM_MOE_DISABLE(htim);
+    }
+
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
+
+    /* Set the TIM channel state */
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
   }
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
-
-  /* Set the TIM channel state */
-  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1309,6 +1339,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Init(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_INSTANCE(htim->Instance));
   assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
 
   if (htim->State == HAL_TIM_STATE_RESET)
@@ -1530,9 +1561,11 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
@@ -1574,34 +1607,38 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the Capture compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Enable the main output */
-    __HAL_TIM_MOE_ENABLE(htim);
-  }
+    /* Enable the Capture compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
-  {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Enable the main output */
+      __HAL_TIM_MOE_ENABLE(htim);
+    }
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1617,8 +1654,10 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel
   */
 HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1651,26 +1690,30 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Capture compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Disable the Main Output */
-    __HAL_TIM_MOE_DISABLE(htim);
+    /* Disable the Capture compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Disable the Main Output */
+      __HAL_TIM_MOE_DISABLE(htim);
+    }
+
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
+
+    /* Set the TIM channel state */
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
   }
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
-
-  /* Set the TIM channel state */
-  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1686,12 +1729,14 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   * @param  Length The length of data to be transferred from memory to TIM peripheral
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                        uint16_t Length)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Set the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
@@ -1700,7 +1745,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
   }
   else if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -1726,7 +1771,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1747,7 +1793,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1767,7 +1814,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1787,7 +1835,8 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
       htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)pData, (uint32_t)&htim->Instance->CCR4,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1798,34 +1847,38 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the Capture compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Enable the main output */
-    __HAL_TIM_MOE_ENABLE(htim);
-  }
+    /* Enable the Capture compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
-  {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Enable the main output */
+      __HAL_TIM_MOE_ENABLE(htim);
+    }
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1841,8 +1894,10 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
   */
 HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1879,26 +1934,30 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Capture compare channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
-
-  if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+  if (status == HAL_OK)
   {
-    /* Disable the Main Output */
-    __HAL_TIM_MOE_DISABLE(htim);
+    /* Disable the Capture compare channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+
+    if (IS_TIM_BREAK_INSTANCE(htim->Instance) != RESET)
+    {
+      /* Disable the Main Output */
+      __HAL_TIM_MOE_DISABLE(htim);
+    }
+
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
+
+    /* Set the TIM channel state */
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
   }
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
-
-  /* Set the TIM channel state */
-  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1948,6 +2007,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Init(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_INSTANCE(htim->Instance));
   assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
 
   if (htim->State == HAL_TIM_STATE_RESET)
@@ -2081,7 +2141,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
@@ -2129,7 +2189,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Disable the Input Capture channel */
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
@@ -2158,12 +2218,14 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
+
   HAL_TIM_ChannelStateTypeDef channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
   HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
@@ -2207,27 +2269,32 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
-  /* Enable the Input Capture channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  if (status == HAL_OK)
   {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    /* Enable the Input Capture channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -2243,8 +2310,10 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -2277,21 +2346,25 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Input Capture channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
+  if (status == HAL_OK)
+  {
+    /* Disable the Input Capture channel */
+    TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
 
-  /* Set the TIM channel state */
-  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    /* Set the TIM channel state */
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -2309,12 +2382,14 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
+
   HAL_TIM_ChannelStateTypeDef channel_state = TIM_CHANNEL_STATE_GET(htim, Channel);
   HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
   assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
 
   /* Set the TIM channel state */
@@ -2326,7 +2401,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   else if ((channel_state == HAL_TIM_CHANNEL_STATE_READY)
            && (complementary_channel_state == HAL_TIM_CHANNEL_STATE_READY))
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -2341,6 +2416,9 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
     return HAL_ERROR;
   }
 
+  /* Enable the Input Capture channel */
+  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
+
   switch (Channel)
   {
     case TIM_CHANNEL_1:
@@ -2353,7 +2431,8 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -2373,7 +2452,8 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -2393,7 +2473,8 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->CCR3, (uint32_t)pData, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->CCR3, (uint32_t)pData,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -2413,7 +2494,8 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
       htim->hdma[TIM_DMA_ID_CC4]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->CCR4, (uint32_t)pData, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->CCR4, (uint32_t)pData,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -2424,11 +2506,9 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
-
-  /* Enable the Input Capture channel */
-  TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
   if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
@@ -2445,7 +2525,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -2461,8 +2541,10 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   */
 HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
   assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channel */
@@ -2503,18 +2585,22 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
+  if (status == HAL_OK)
+  {
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
 
-  /* Set the TIM channel state */
-  TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    /* Set the TIM channel state */
+    TIM_CHANNEL_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 /**
   * @}
@@ -2571,6 +2657,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Init(TIM_HandleTypeDef *htim, uint32_t OnePul
   assert_param(IS_TIM_COUNTER_MODE(htim->Init.CounterMode));
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
   assert_param(IS_TIM_OPM_MODE(OnePulseMode));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
 
   if (htim->State == HAL_TIM_STATE_RESET)
@@ -2698,11 +2785,12 @@ __weak void HAL_TIM_OnePulse_MspDeInit(TIM_HandleTypeDef *htim)
 
 /**
   * @brief  Starts the TIM One Pulse signal generation.
+  * @note Though OutputChannel parameter is deprecated and ignored by the function
+  *        it has been kept to avoid HAL_TIM API compatibility break.
+  * @note The pulse output channel is determined when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channels to be enabled
-  *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
-  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  OutputChannel See note above
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
@@ -2734,7 +2822,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t Outpu
     (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
     if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
     if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
-    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
+    whatever the combination, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
 
     No need to enable the counter, it's enabled automatically by hardware
     (the counter starts in response to a stimulus and generate a pulse */
@@ -2754,11 +2842,12 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Start(TIM_HandleTypeDef *htim, uint32_t Outpu
 
 /**
   * @brief  Stops the TIM One Pulse signal generation.
+  * @note Though OutputChannel parameter is deprecated and ignored by the function
+  *        it has been kept to avoid HAL_TIM API compatibility break.
+  * @note The pulse output channel is determined when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channels to be disable
-  *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
-  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  OutputChannel See note above
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
@@ -2770,7 +2859,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t Output
   (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
   if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
   if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
-  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+  whatever the combination, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
 
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
@@ -2796,11 +2885,12 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop(TIM_HandleTypeDef *htim, uint32_t Output
 
 /**
   * @brief  Starts the TIM One Pulse signal generation in interrupt mode.
+  * @note Though OutputChannel parameter is deprecated and ignored by the function
+  *        it has been kept to avoid HAL_TIM API compatibility break.
+  * @note The pulse output channel is determined when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channels to be enabled
-  *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
-  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  OutputChannel See note above
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
@@ -2832,7 +2922,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t Ou
     (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
     if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
     if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
-    in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
+    whatever the combination, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be enabled together
 
     No need to enable the counter, it's enabled automatically by hardware
     (the counter starts in response to a stimulus and generate a pulse */
@@ -2858,11 +2948,12 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Start_IT(TIM_HandleTypeDef *htim, uint32_t Ou
 
 /**
   * @brief  Stops the TIM One Pulse signal generation in interrupt mode.
+  * @note Though OutputChannel parameter is deprecated and ignored by the function
+  *        it has been kept to avoid HAL_TIM API compatibility break.
+  * @note The pulse output channel is determined when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channels to be enabled
-  *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
-  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  * @param  OutputChannel See note above
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
@@ -2880,7 +2971,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   (in the OPM Mode the two possible channels that can be used are TIM_CHANNEL_1 and TIM_CHANNEL_2)
   if TIM_CHANNEL_1 is used as output, the TIM_CHANNEL_2 will be used as input and
   if TIM_CHANNEL_1 is used as input, the TIM_CHANNEL_2 will be used as output
-  in all combinations, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
+  whatever the combination, the TIM_CHANNEL_1 and TIM_CHANNEL_2 should be disabled together */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_DISABLE);
 
@@ -2944,7 +3035,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   * @param  sConfig TIM Encoder Interface configuration structure
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef *sConfig)
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim, const TIM_Encoder_InitTypeDef *sConfig)
 {
   uint32_t tmpsmcr;
   uint32_t tmpccmr1;
@@ -2970,6 +3061,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_Ini
   assert_param(IS_TIM_IC_PRESCALER(sConfig->IC2Prescaler));
   assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
   assert_param(IS_TIM_IC_FILTER(sConfig->IC2Filter));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
 
   if (htim->State == HAL_TIM_STATE_RESET)
   {
@@ -3479,7 +3571,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
     else if ((channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
              && (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_READY))
     {
-      if ((pData1 == NULL) && (Length > 0U))
+      if ((pData1 == NULL) || (Length == 0U))
       {
         return HAL_ERROR;
       }
@@ -3504,7 +3596,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
     else if ((channel_2_state == HAL_TIM_CHANNEL_STATE_READY)
              && (complementary_channel_2_state == HAL_TIM_CHANNEL_STATE_READY))
     {
-      if ((pData2 == NULL) && (Length > 0U))
+      if ((pData2 == NULL) || (Length == 0U))
       {
         return HAL_ERROR;
       }
@@ -3533,7 +3625,7 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
              && (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
              && (complementary_channel_2_state == HAL_TIM_CHANNEL_STATE_READY))
     {
-      if ((((pData1 == NULL) || (pData2 == NULL))) && (Length > 0U))
+      if ((((pData1 == NULL) || (pData2 == NULL))) || (Length == 0U))
       {
         return HAL_ERROR;
       }
@@ -3563,7 +3655,8 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -3571,11 +3664,12 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Enable the TIM Input Capture DMA request */
       __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
 
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+
       /* Enable the Peripheral */
       __HAL_TIM_ENABLE(htim);
 
-      /* Enable the Capture compare channel */
-      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
       break;
     }
 
@@ -3588,7 +3682,8 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Set the DMA error callback */
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError;
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -3596,15 +3691,16 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       /* Enable the TIM Input Capture  DMA request */
       __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
 
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
       /* Enable the Peripheral */
       __HAL_TIM_ENABLE(htim);
 
-      /* Enable the Capture compare channel */
-      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
       break;
     }
 
-    case TIM_CHANNEL_ALL:
+    default:
     {
       /* Set the DMA capture callbacks */
       htim->hdma[TIM_DMA_ID_CC1]->XferCpltCallback = TIM_DMACaptureCplt;
@@ -3614,7 +3710,8 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->CCR1, (uint32_t)pData1,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -3628,27 +3725,27 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Ch
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAError ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->CCR2, (uint32_t)pData2,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
       }
-      /* Enable the Peripheral */
-      __HAL_TIM_ENABLE(htim);
-
-      /* Enable the Capture compare channel */
-      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
-      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
 
       /* Enable the TIM Input Capture  DMA request */
       __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC1);
       /* Enable the TIM Input Capture  DMA request */
       __HAL_TIM_ENABLE_DMA(htim, TIM_DMA_CC2);
+
+      /* Enable the Capture compare channel */
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
+      TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_2, TIM_CCx_ENABLE);
+
+      /* Enable the Peripheral */
+      __HAL_TIM_ENABLE(htim);
+
       break;
     }
-
-    default:
-      break;
   }
 
   /* Return function status */
@@ -3744,13 +3841,16 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   */
 void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
 {
+  uint32_t itsource = htim->Instance->DIER;
+  uint32_t itflag   = htim->Instance->SR;
+
   /* Capture compare 1 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC1) != RESET)
+  if ((itflag & (TIM_FLAG_CC1)) == (TIM_FLAG_CC1))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC1) != RESET)
+    if ((itsource & (TIM_IT_CC1)) == (TIM_IT_CC1))
     {
       {
-        __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC1);
+        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC1);
         htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
 
         /* Input capture event */
@@ -3778,11 +3878,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* Capture compare 2 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC2) != RESET)
+  if ((itflag & (TIM_FLAG_CC2)) == (TIM_FLAG_CC2))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC2) != RESET)
+    if ((itsource & (TIM_IT_CC2)) == (TIM_IT_CC2))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC2);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC2);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
       /* Input capture event */
       if ((htim->Instance->CCMR1 & TIM_CCMR1_CC2S) != 0x00U)
@@ -3808,11 +3908,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* Capture compare 3 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC3) != RESET)
+  if ((itflag & (TIM_FLAG_CC3)) == (TIM_FLAG_CC3))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC3) != RESET)
+    if ((itsource & (TIM_IT_CC3)) == (TIM_IT_CC3))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC3);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
       /* Input capture event */
       if ((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00U)
@@ -3838,11 +3938,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* Capture compare 4 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC4) != RESET)
+  if ((itflag & (TIM_FLAG_CC4)) == (TIM_FLAG_CC4))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC4) != RESET)
+    if ((itsource & (TIM_IT_CC4)) == (TIM_IT_CC4))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC4);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
       /* Input capture event */
       if ((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00U)
@@ -3868,11 +3968,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Update event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE) != RESET)
+  if ((itflag & (TIM_FLAG_UPDATE)) == (TIM_FLAG_UPDATE))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_UPDATE) != RESET)
+    if ((itsource & (TIM_IT_UPDATE)) == (TIM_IT_UPDATE))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_UPDATE);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->PeriodElapsedCallback(htim);
 #else
@@ -3881,11 +3981,12 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Break input event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK) != RESET)
+  if (((itflag & (TIM_FLAG_BREAK)) == (TIM_FLAG_BREAK)) || \
+      ((itflag & (TIM_FLAG_SYSTEM_BREAK)) == (TIM_FLAG_SYSTEM_BREAK)))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) != RESET)
+    if ((itsource & (TIM_IT_BREAK)) == (TIM_IT_BREAK))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_BREAK);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_BREAK | TIM_FLAG_SYSTEM_BREAK);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->BreakCallback(htim);
 #else
@@ -3894,9 +3995,9 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Break2 input event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK2) != RESET)
+  if ((itflag & (TIM_FLAG_BREAK2)) == (TIM_FLAG_BREAK2))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) != RESET)
+    if ((itsource & (TIM_IT_BREAK)) == (TIM_IT_BREAK))
     {
       __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_BREAK2);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
@@ -3907,11 +4008,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Trigger detection event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_TRIGGER) != RESET)
+  if ((itflag & (TIM_FLAG_TRIGGER)) == (TIM_FLAG_TRIGGER))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_TRIGGER) != RESET)
+    if ((itsource & (TIM_IT_TRIGGER)) == (TIM_IT_TRIGGER))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_TRIGGER);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_TRIGGER);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->TriggerCallback(htim);
 #else
@@ -3920,11 +4021,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM commutation event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_COM) != RESET)
+  if ((itflag & (TIM_FLAG_COM)) == (TIM_FLAG_COM))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_COM) != RESET)
+    if ((itsource & (TIM_IT_COM)) == (TIM_IT_COM))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_COM);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_COM);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->CommutationCallback(htim);
 #else
@@ -3973,9 +4074,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim,
-                                           TIM_OC_InitTypeDef *sConfig,
+                                           const TIM_OC_InitTypeDef *sConfig,
                                            uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_CHANNELS(Channel));
   assert_param(IS_TIM_OC_MODE(sConfig->OCMode));
@@ -4047,12 +4150,13 @@ HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim,
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
   __HAL_UNLOCK(htim);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -4068,8 +4172,10 @@ HAL_StatusTypeDef HAL_TIM_OC_ConfigChannel(TIM_HandleTypeDef *htim,
   *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitTypeDef *sConfig, uint32_t Channel)
+HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, const TIM_IC_InitTypeDef *sConfig, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
   assert_param(IS_TIM_IC_POLARITY(sConfig->ICPolarity));
@@ -4126,7 +4232,7 @@ HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitT
     /* Set the IC3PSC value */
     htim->Instance->CCMR2 |= sConfig->ICPrescaler;
   }
-  else
+  else if (Channel == TIM_CHANNEL_4)
   {
     /* TI4 Configuration */
     assert_param(IS_TIM_CC4_INSTANCE(htim->Instance));
@@ -4142,10 +4248,14 @@ HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitT
     /* Set the IC4PSC value */
     htim->Instance->CCMR2 |= (sConfig->ICPrescaler << 8U);
   }
+  else
+  {
+    status = HAL_ERROR;
+  }
 
   __HAL_UNLOCK(htim);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -4164,9 +4274,11 @@ HAL_StatusTypeDef HAL_TIM_IC_ConfigChannel(TIM_HandleTypeDef *htim, TIM_IC_InitT
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
-                                            TIM_OC_InitTypeDef *sConfig,
+                                            const TIM_OC_InitTypeDef *sConfig,
                                             uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_CHANNELS(Channel));
   assert_param(IS_TIM_PWM_MODE(sConfig->OCMode));
@@ -4281,12 +4393,13 @@ HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
   __HAL_UNLOCK(htim);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -4311,6 +4424,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_ConfigChannel(TIM_HandleTypeDef *htim,
 HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_OnePulse_InitTypeDef *sConfig,
                                                  uint32_t OutputChannel,  uint32_t InputChannel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   TIM_OC_InitTypeDef temp1;
 
   /* Check the parameters */
@@ -4341,6 +4455,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
         TIM_OC1_SetConfig(htim->Instance, &temp1);
         break;
       }
+
       case TIM_CHANNEL_2:
       {
         assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
@@ -4348,60 +4463,67 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
         TIM_OC2_SetConfig(htim->Instance, &temp1);
         break;
       }
+
       default:
+        status = HAL_ERROR;
         break;
     }
 
-    switch (InputChannel)
+    if (status == HAL_OK)
     {
-      case TIM_CHANNEL_1:
+      switch (InputChannel)
       {
-        assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
+        case TIM_CHANNEL_1:
+        {
+          assert_param(IS_TIM_CC1_INSTANCE(htim->Instance));
 
-        TIM_TI1_SetConfig(htim->Instance, sConfig->ICPolarity,
-                          sConfig->ICSelection, sConfig->ICFilter);
+          TIM_TI1_SetConfig(htim->Instance, sConfig->ICPolarity,
+                            sConfig->ICSelection, sConfig->ICFilter);
 
-        /* Reset the IC1PSC Bits */
-        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
+          /* Reset the IC1PSC Bits */
+          htim->Instance->CCMR1 &= ~TIM_CCMR1_IC1PSC;
 
-        /* Select the Trigger source */
-        htim->Instance->SMCR &= ~TIM_SMCR_TS;
-        htim->Instance->SMCR |= TIM_TS_TI1FP1;
+          /* Select the Trigger source */
+          htim->Instance->SMCR &= ~TIM_SMCR_TS;
+          htim->Instance->SMCR |= TIM_TS_TI1FP1;
 
-        /* Select the Slave Mode */
-        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
-        htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
-        break;
+          /* Select the Slave Mode */
+          htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+          htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+          break;
+        }
+
+        case TIM_CHANNEL_2:
+        {
+          assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+
+          TIM_TI2_SetConfig(htim->Instance, sConfig->ICPolarity,
+                            sConfig->ICSelection, sConfig->ICFilter);
+
+          /* Reset the IC2PSC Bits */
+          htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
+
+          /* Select the Trigger source */
+          htim->Instance->SMCR &= ~TIM_SMCR_TS;
+          htim->Instance->SMCR |= TIM_TS_TI2FP2;
+
+          /* Select the Slave Mode */
+          htim->Instance->SMCR &= ~TIM_SMCR_SMS;
+          htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
+          break;
+        }
+
+        default:
+          status = HAL_ERROR;
+          break;
       }
-      case TIM_CHANNEL_2:
-      {
-        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
-
-        TIM_TI2_SetConfig(htim->Instance, sConfig->ICPolarity,
-                          sConfig->ICSelection, sConfig->ICFilter);
-
-        /* Reset the IC2PSC Bits */
-        htim->Instance->CCMR1 &= ~TIM_CCMR1_IC2PSC;
-
-        /* Select the Trigger source */
-        htim->Instance->SMCR &= ~TIM_SMCR_TS;
-        htim->Instance->SMCR |= TIM_TS_TI2FP2;
-
-        /* Select the Slave Mode */
-        htim->Instance->SMCR &= ~TIM_SMCR_SMS;
-        htim->Instance->SMCR |= TIM_SLAVEMODE_TRIGGER;
-        break;
-      }
-
-      default:
-        break;
     }
 
     htim->State = HAL_TIM_STATE_READY;
 
     __HAL_UNLOCK(htim);
 
-    return HAL_OK;
+    return status;
   }
   else
   {
@@ -4454,10 +4576,16 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                              uint32_t BurstRequestSrc, uint32_t *BurstBuffer, uint32_t  BurstLength)
+                                              uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
+                                              uint32_t  BurstLength)
 {
-  return HAL_TIM_DMABurst_MultiWriteStart(htim, BurstBaseAddress, BurstRequestSrc, BurstBuffer, BurstLength,
-                                          ((BurstLength) >> 8U) + 1U);
+  HAL_StatusTypeDef status;
+
+  status = HAL_TIM_DMABurst_MultiWriteStart(htim, BurstBaseAddress, BurstRequestSrc, BurstBuffer, BurstLength,
+                                            ((BurstLength) >> 8U) + 1U);
+
+
+  return status;
 }
 
 /**
@@ -4506,9 +4634,11 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t 
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                                   uint32_t BurstRequestSrc, uint32_t *BurstBuffer,
+                                                   uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
                                                    uint32_t  BurstLength,  uint32_t  DataLength)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
   assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
@@ -4535,6 +4665,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
   {
     /* nothing to do */
   }
+
   switch (BurstRequestSrc)
   {
     case TIM_DMA_UPDATE:
@@ -4548,7 +4679,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4566,7 +4697,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4584,7 +4715,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4602,7 +4733,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4620,7 +4751,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4638,7 +4769,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4656,7 +4787,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)BurstBuffer,
-                         (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
+                           (uint32_t)&htim->Instance->DMAR, DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4664,16 +4795,20 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Configure the DMA Burst Mode */
-  htim->Instance->DCR = (BurstBaseAddress | BurstLength);
-  /* Enable the TIM DMA Request */
-  __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+  if (status == HAL_OK)
+  {
+    /* Configure the DMA Burst Mode */
+    htim->Instance->DCR = (BurstBaseAddress | BurstLength);
+    /* Enable the TIM DMA Request */
+    __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -4684,6 +4819,8 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
 
@@ -4726,17 +4863,21 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t B
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the TIM Update DMA request */
-  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+  if (status == HAL_OK)
+  {
+    /* Disable the TIM Update DMA request */
+    __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
 
-  /* Change the DMA burst operation state */
-  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+    /* Change the DMA burst operation state */
+    htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -4786,8 +4927,13 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStop(TIM_HandleTypeDef *htim, uint32_t B
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                              uint32_t BurstRequestSrc, uint32_t  *BurstBuffer, uint32_t  BurstLength)
 {
-  return HAL_TIM_DMABurst_MultiReadStart(htim, BurstBaseAddress, BurstRequestSrc, BurstBuffer, BurstLength,
-                                         ((BurstLength) >> 8U) + 1U);
+  HAL_StatusTypeDef status;
+
+  status = HAL_TIM_DMABurst_MultiReadStart(htim, BurstBaseAddress, BurstRequestSrc, BurstBuffer, BurstLength,
+                                           ((BurstLength) >> 8U) + 1U);
+
+
+  return status;
 }
 
 /**
@@ -4839,6 +4985,8 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
                                                   uint32_t BurstRequestSrc, uint32_t  *BurstBuffer,
                                                   uint32_t  BurstLength, uint32_t  DataLength)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
   assert_param(IS_TIM_DMA_BASE(BurstBaseAddress));
@@ -4878,7 +5026,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_UPDATE], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4896,7 +5044,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4914,7 +5062,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4932,7 +5080,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4950,7 +5098,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC4], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4968,7 +5116,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_COMMUTATION], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4986,7 +5134,7 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
 
       /* Enable the DMA channel */
       if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_TRIGGER], (uint32_t)&htim->Instance->DMAR, (uint32_t)BurstBuffer,
-                         DataLength) != HAL_OK)
+                           DataLength) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -4994,17 +5142,21 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Configure the DMA Burst Mode */
-  htim->Instance->DCR = (BurstBaseAddress | BurstLength);
+  if (status == HAL_OK)
+  {
+    /* Configure the DMA Burst Mode */
+    htim->Instance->DCR = (BurstBaseAddress | BurstLength);
 
-  /* Enable the TIM DMA Request */
-  __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+    /* Enable the TIM DMA Request */
+    __HAL_TIM_ENABLE_DMA(htim, BurstRequestSrc);
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -5015,6 +5167,8 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_MultiReadStart(TIM_HandleTypeDef *htim, uint3
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t BurstRequestSrc)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_DMA_SOURCE(BurstRequestSrc));
 
@@ -5057,17 +5211,21 @@ HAL_StatusTypeDef HAL_TIM_DMABurst_ReadStop(TIM_HandleTypeDef *htim, uint32_t Bu
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the TIM Update DMA request */
-  __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
+  if (status == HAL_OK)
+  {
+    /* Disable the TIM Update DMA request */
+    __HAL_TIM_DISABLE_DMA(htim, BurstRequestSrc);
 
-  /* Change the DMA burst operation state */
-  htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+    /* Change the DMA burst operation state */
+    htim->DMABurstState = HAL_DMA_BURST_STATE_READY;
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -5131,9 +5289,11 @@ HAL_StatusTypeDef HAL_TIM_GenerateEvent(TIM_HandleTypeDef *htim, uint32_t EventS
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
-                                           TIM_ClearInputConfigTypeDef *sClearInputConfig,
+                                           const TIM_ClearInputConfigTypeDef *sClearInputConfig,
                                            uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_OCXREF_CLEAR_INSTANCE(htim->Instance));
   assert_param(IS_TIM_CLEARINPUT_SOURCE(sClearInputConfig->ClearInputSource));
@@ -5194,104 +5354,108 @@ HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  switch (Channel)
+  if (status == HAL_OK)
   {
-    case TIM_CHANNEL_1:
+    switch (Channel)
     {
-      if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+      case TIM_CHANNEL_1:
       {
-        /* Enable the OCREF clear feature for Channel 1 */
-        SET_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC1CE);
+        if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+        {
+          /* Enable the OCREF clear feature for Channel 1 */
+          SET_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC1CE);
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 1 */
+          CLEAR_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC1CE);
+        }
+        break;
       }
-      else
+      case TIM_CHANNEL_2:
       {
-        /* Disable the OCREF clear feature for Channel 1 */
-        CLEAR_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC1CE);
+        if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+        {
+          /* Enable the OCREF clear feature for Channel 2 */
+          SET_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC2CE);
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 2 */
+          CLEAR_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC2CE);
+        }
+        break;
       }
-      break;
+      case TIM_CHANNEL_3:
+      {
+        if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+        {
+          /* Enable the OCREF clear feature for Channel 3 */
+          SET_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC3CE);
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 3 */
+          CLEAR_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC3CE);
+        }
+        break;
+      }
+      case TIM_CHANNEL_4:
+      {
+        if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+        {
+          /* Enable the OCREF clear feature for Channel 4 */
+          SET_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC4CE);
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 4 */
+          CLEAR_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC4CE);
+        }
+        break;
+      }
+      case TIM_CHANNEL_5:
+      {
+        if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+        {
+          /* Enable the OCREF clear feature for Channel 5 */
+          SET_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC5CE);
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 5 */
+          CLEAR_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC5CE);
+        }
+        break;
+      }
+      case TIM_CHANNEL_6:
+      {
+        if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
+        {
+          /* Enable the OCREF clear feature for Channel 6 */
+          SET_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC6CE);
+        }
+        else
+        {
+          /* Disable the OCREF clear feature for Channel 6 */
+          CLEAR_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC6CE);
+        }
+        break;
+      }
+      default:
+        break;
     }
-    case TIM_CHANNEL_2:
-    {
-      if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
-      {
-        /* Enable the OCREF clear feature for Channel 2 */
-        SET_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC2CE);
-      }
-      else
-      {
-        /* Disable the OCREF clear feature for Channel 2 */
-        CLEAR_BIT(htim->Instance->CCMR1, TIM_CCMR1_OC2CE);
-      }
-      break;
-    }
-    case TIM_CHANNEL_3:
-    {
-      if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
-      {
-        /* Enable the OCREF clear feature for Channel 3 */
-        SET_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC3CE);
-      }
-      else
-      {
-        /* Disable the OCREF clear feature for Channel 3 */
-        CLEAR_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC3CE);
-      }
-      break;
-    }
-    case TIM_CHANNEL_4:
-    {
-      if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
-      {
-        /* Enable the OCREF clear feature for Channel 4 */
-        SET_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC4CE);
-      }
-      else
-      {
-        /* Disable the OCREF clear feature for Channel 4 */
-        CLEAR_BIT(htim->Instance->CCMR2, TIM_CCMR2_OC4CE);
-      }
-      break;
-    }
-    case TIM_CHANNEL_5:
-    {
-      if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
-      {
-        /* Enable the OCREF clear feature for Channel 5 */
-        SET_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC5CE);
-      }
-      else
-      {
-        /* Disable the OCREF clear feature for Channel 5 */
-        CLEAR_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC5CE);
-      }
-      break;
-    }
-    case TIM_CHANNEL_6:
-    {
-      if (sClearInputConfig->ClearInputState != (uint32_t)DISABLE)
-      {
-        /* Enable the OCREF clear feature for Channel 6 */
-        SET_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC6CE);
-      }
-      else
-      {
-        /* Disable the OCREF clear feature for Channel 6 */
-        CLEAR_BIT(htim->Instance->CCMR3, TIM_CCMR3_OC6CE);
-      }
-      break;
-    }
-    default:
-      break;
   }
 
   htim->State = HAL_TIM_STATE_READY;
 
   __HAL_UNLOCK(htim);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -5301,8 +5465,9 @@ HAL_StatusTypeDef HAL_TIM_ConfigOCrefClear(TIM_HandleTypeDef *htim,
   *         contains the clock source information for the TIM peripheral.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockConfigTypeDef *sClockSourceConfig)
+HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, const TIM_ClockConfigTypeDef *sClockSourceConfig)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Process Locked */
@@ -5423,22 +5588,23 @@ HAL_StatusTypeDef HAL_TIM_ConfigClockSource(TIM_HandleTypeDef *htim, TIM_ClockCo
     case TIM_CLOCKSOURCE_ITR1:
     case TIM_CLOCKSOURCE_ITR2:
     case TIM_CLOCKSOURCE_ITR3:
-      {
-        /* Check whether or not the timer instance supports internal trigger input */
-        assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
+    {
+      /* Check whether or not the timer instance supports internal trigger input */
+      assert_param(IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(htim->Instance));
 
-        TIM_ITRx_SetConfig(htim->Instance, sClockSourceConfig->ClockSource);
-        break;
-      }
+      TIM_ITRx_SetConfig(htim->Instance, sClockSourceConfig->ClockSource);
+      break;
+    }
 
     default:
+      status = HAL_ERROR;
       break;
   }
   htim->State = HAL_TIM_STATE_READY;
 
   __HAL_UNLOCK(htim);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -5485,7 +5651,7 @@ HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_S
   *         (Disable, Reset, Gated, Trigger, External clock mode 1).
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, TIM_SlaveConfigTypeDef *sSlaveConfig)
+HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig)
 {
   /* Check the parameters */
   assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
@@ -5526,7 +5692,7 @@ HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, TIM_SlaveC
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim,
-                                                TIM_SlaveConfigTypeDef *sSlaveConfig)
+                                                const TIM_SlaveConfigTypeDef *sSlaveConfig)
 {
   /* Check the parameters */
   assert_param(IS_TIM_SLAVE_INSTANCE(htim->Instance));
@@ -5568,7 +5734,7 @@ HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim,
   *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
   * @retval Captured value
   */
-uint32_t HAL_TIM_ReadCapturedValue(TIM_HandleTypeDef *htim, uint32_t Channel)
+uint32_t HAL_TIM_ReadCapturedValue(const TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   uint32_t tmpreg = 0U;
 
@@ -5843,8 +6009,6 @@ HAL_StatusTypeDef HAL_TIM_RegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Call
   {
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(htim);
 
   if (htim->State == HAL_TIM_STATE_READY)
   {
@@ -5964,7 +6128,7 @@ HAL_StatusTypeDef HAL_TIM_RegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Call
 
       default :
         /* Return error status */
-        status =  HAL_ERROR;
+        status = HAL_ERROR;
         break;
     }
   }
@@ -6030,18 +6194,15 @@ HAL_StatusTypeDef HAL_TIM_RegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Call
 
       default :
         /* Return error status */
-        status =  HAL_ERROR;
+        status = HAL_ERROR;
         break;
     }
   }
   else
   {
     /* Return error status */
-    status =  HAL_ERROR;
+    status = HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(htim);
 
   return status;
 }
@@ -6086,128 +6247,153 @@ HAL_StatusTypeDef HAL_TIM_UnRegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Ca
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(htim);
-
   if (htim->State == HAL_TIM_STATE_READY)
   {
     switch (CallbackID)
     {
       case HAL_TIM_BASE_MSPINIT_CB_ID :
-        htim->Base_MspInitCallback              = HAL_TIM_Base_MspInit;                      /* Legacy weak Base MspInit Callback */
+        /* Legacy weak Base MspInit Callback */
+        htim->Base_MspInitCallback              = HAL_TIM_Base_MspInit;
         break;
 
       case HAL_TIM_BASE_MSPDEINIT_CB_ID :
-        htim->Base_MspDeInitCallback            = HAL_TIM_Base_MspDeInit;                    /* Legacy weak Base Msp DeInit Callback */
+        /* Legacy weak Base Msp DeInit Callback */
+        htim->Base_MspDeInitCallback            = HAL_TIM_Base_MspDeInit;
         break;
 
       case HAL_TIM_IC_MSPINIT_CB_ID :
-        htim->IC_MspInitCallback                = HAL_TIM_IC_MspInit;                        /* Legacy weak IC Msp Init Callback */
+        /* Legacy weak IC Msp Init Callback */
+        htim->IC_MspInitCallback                = HAL_TIM_IC_MspInit;
         break;
 
       case HAL_TIM_IC_MSPDEINIT_CB_ID :
-        htim->IC_MspDeInitCallback              = HAL_TIM_IC_MspDeInit;                      /* Legacy weak IC Msp DeInit Callback */
+        /* Legacy weak IC Msp DeInit Callback */
+        htim->IC_MspDeInitCallback              = HAL_TIM_IC_MspDeInit;
         break;
 
       case HAL_TIM_OC_MSPINIT_CB_ID :
-        htim->OC_MspInitCallback                = HAL_TIM_OC_MspInit;                        /* Legacy weak OC Msp Init Callback */
+        /* Legacy weak OC Msp Init Callback */
+        htim->OC_MspInitCallback                = HAL_TIM_OC_MspInit;
         break;
 
       case HAL_TIM_OC_MSPDEINIT_CB_ID :
-        htim->OC_MspDeInitCallback              = HAL_TIM_OC_MspDeInit;                      /* Legacy weak OC Msp DeInit Callback */
+        /* Legacy weak OC Msp DeInit Callback */
+        htim->OC_MspDeInitCallback              = HAL_TIM_OC_MspDeInit;
         break;
 
       case HAL_TIM_PWM_MSPINIT_CB_ID :
-        htim->PWM_MspInitCallback               = HAL_TIM_PWM_MspInit;                       /* Legacy weak PWM Msp Init Callback */
+        /* Legacy weak PWM Msp Init Callback */
+        htim->PWM_MspInitCallback               = HAL_TIM_PWM_MspInit;
         break;
 
       case HAL_TIM_PWM_MSPDEINIT_CB_ID :
-        htim->PWM_MspDeInitCallback             = HAL_TIM_PWM_MspDeInit;                     /* Legacy weak PWM Msp DeInit Callback */
+        /* Legacy weak PWM Msp DeInit Callback */
+        htim->PWM_MspDeInitCallback             = HAL_TIM_PWM_MspDeInit;
         break;
 
       case HAL_TIM_ONE_PULSE_MSPINIT_CB_ID :
-        htim->OnePulse_MspInitCallback          = HAL_TIM_OnePulse_MspInit;                  /* Legacy weak One Pulse Msp Init Callback */
+        /* Legacy weak One Pulse Msp Init Callback */
+        htim->OnePulse_MspInitCallback          = HAL_TIM_OnePulse_MspInit;
         break;
 
       case HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID :
-        htim->OnePulse_MspDeInitCallback        = HAL_TIM_OnePulse_MspDeInit;                /* Legacy weak One Pulse Msp DeInit Callback */
+        /* Legacy weak One Pulse Msp DeInit Callback */
+        htim->OnePulse_MspDeInitCallback        = HAL_TIM_OnePulse_MspDeInit;
         break;
 
       case HAL_TIM_ENCODER_MSPINIT_CB_ID :
-        htim->Encoder_MspInitCallback           = HAL_TIM_Encoder_MspInit;                   /* Legacy weak Encoder Msp Init Callback */
+        /* Legacy weak Encoder Msp Init Callback */
+        htim->Encoder_MspInitCallback           = HAL_TIM_Encoder_MspInit;
         break;
 
       case HAL_TIM_ENCODER_MSPDEINIT_CB_ID :
-        htim->Encoder_MspDeInitCallback         = HAL_TIM_Encoder_MspDeInit;                 /* Legacy weak Encoder Msp DeInit Callback */
+        /* Legacy weak Encoder Msp DeInit Callback */
+        htim->Encoder_MspDeInitCallback         = HAL_TIM_Encoder_MspDeInit;
         break;
 
       case HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID :
-        htim->HallSensor_MspInitCallback        = HAL_TIMEx_HallSensor_MspInit;              /* Legacy weak Hall Sensor Msp Init Callback */
+        /* Legacy weak Hall Sensor Msp Init Callback */
+        htim->HallSensor_MspInitCallback        = HAL_TIMEx_HallSensor_MspInit;
         break;
 
       case HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID :
-        htim->HallSensor_MspDeInitCallback      = HAL_TIMEx_HallSensor_MspDeInit;            /* Legacy weak Hall Sensor Msp DeInit Callback */
+        /* Legacy weak Hall Sensor Msp DeInit Callback */
+        htim->HallSensor_MspDeInitCallback      = HAL_TIMEx_HallSensor_MspDeInit;
         break;
 
       case HAL_TIM_PERIOD_ELAPSED_CB_ID :
-        htim->PeriodElapsedCallback             = HAL_TIM_PeriodElapsedCallback;             /* Legacy weak Period Elapsed Callback */
+        /* Legacy weak Period Elapsed Callback */
+        htim->PeriodElapsedCallback             = HAL_TIM_PeriodElapsedCallback;
         break;
 
       case HAL_TIM_PERIOD_ELAPSED_HALF_CB_ID :
-        htim->PeriodElapsedHalfCpltCallback     = HAL_TIM_PeriodElapsedHalfCpltCallback;     /* Legacy weak Period Elapsed half complete Callback */
+        /* Legacy weak Period Elapsed half complete Callback */
+        htim->PeriodElapsedHalfCpltCallback     = HAL_TIM_PeriodElapsedHalfCpltCallback;
         break;
 
       case HAL_TIM_TRIGGER_CB_ID :
-        htim->TriggerCallback                   = HAL_TIM_TriggerCallback;                   /* Legacy weak Trigger Callback */
+        /* Legacy weak Trigger Callback */
+        htim->TriggerCallback                   = HAL_TIM_TriggerCallback;
         break;
 
       case HAL_TIM_TRIGGER_HALF_CB_ID :
-        htim->TriggerHalfCpltCallback           = HAL_TIM_TriggerHalfCpltCallback;           /* Legacy weak Trigger half complete Callback */
+        /* Legacy weak Trigger half complete Callback */
+        htim->TriggerHalfCpltCallback           = HAL_TIM_TriggerHalfCpltCallback;
         break;
 
       case HAL_TIM_IC_CAPTURE_CB_ID :
-        htim->IC_CaptureCallback                = HAL_TIM_IC_CaptureCallback;                /* Legacy weak IC Capture Callback */
+        /* Legacy weak IC Capture Callback */
+        htim->IC_CaptureCallback                = HAL_TIM_IC_CaptureCallback;
         break;
 
       case HAL_TIM_IC_CAPTURE_HALF_CB_ID :
-        htim->IC_CaptureHalfCpltCallback        = HAL_TIM_IC_CaptureHalfCpltCallback;        /* Legacy weak IC Capture half complete Callback */
+        /* Legacy weak IC Capture half complete Callback */
+        htim->IC_CaptureHalfCpltCallback        = HAL_TIM_IC_CaptureHalfCpltCallback;
         break;
 
       case HAL_TIM_OC_DELAY_ELAPSED_CB_ID :
-        htim->OC_DelayElapsedCallback           = HAL_TIM_OC_DelayElapsedCallback;           /* Legacy weak OC Delay Elapsed Callback */
+        /* Legacy weak OC Delay Elapsed Callback */
+        htim->OC_DelayElapsedCallback           = HAL_TIM_OC_DelayElapsedCallback;
         break;
 
       case HAL_TIM_PWM_PULSE_FINISHED_CB_ID :
-        htim->PWM_PulseFinishedCallback         = HAL_TIM_PWM_PulseFinishedCallback;         /* Legacy weak PWM Pulse Finished Callback */
+        /* Legacy weak PWM Pulse Finished Callback */
+        htim->PWM_PulseFinishedCallback         = HAL_TIM_PWM_PulseFinishedCallback;
         break;
 
       case HAL_TIM_PWM_PULSE_FINISHED_HALF_CB_ID :
-        htim->PWM_PulseFinishedHalfCpltCallback = HAL_TIM_PWM_PulseFinishedHalfCpltCallback; /* Legacy weak PWM Pulse Finished half complete Callback */
+        /* Legacy weak PWM Pulse Finished half complete Callback */
+        htim->PWM_PulseFinishedHalfCpltCallback = HAL_TIM_PWM_PulseFinishedHalfCpltCallback;
         break;
 
       case HAL_TIM_ERROR_CB_ID :
-        htim->ErrorCallback                     = HAL_TIM_ErrorCallback;                     /* Legacy weak Error Callback */
+        /* Legacy weak Error Callback */
+        htim->ErrorCallback                     = HAL_TIM_ErrorCallback;
         break;
 
       case HAL_TIM_COMMUTATION_CB_ID :
-        htim->CommutationCallback               = HAL_TIMEx_CommutCallback;                  /* Legacy weak Commutation Callback */
+        /* Legacy weak Commutation Callback */
+        htim->CommutationCallback               = HAL_TIMEx_CommutCallback;
         break;
 
       case HAL_TIM_COMMUTATION_HALF_CB_ID :
-        htim->CommutationHalfCpltCallback       = HAL_TIMEx_CommutHalfCpltCallback;          /* Legacy weak Commutation half complete Callback */
+        /* Legacy weak Commutation half complete Callback */
+        htim->CommutationHalfCpltCallback       = HAL_TIMEx_CommutHalfCpltCallback;
         break;
 
       case HAL_TIM_BREAK_CB_ID :
-        htim->BreakCallback                     = HAL_TIMEx_BreakCallback;                   /* Legacy weak Break Callback */
+        /* Legacy weak Break Callback */
+        htim->BreakCallback                     = HAL_TIMEx_BreakCallback;
         break;
 
       case HAL_TIM_BREAK2_CB_ID :
-        htim->Break2Callback                    = HAL_TIMEx_Break2Callback;                  /* Legacy weak Break2 Callback */
+        /* Legacy weak Break2 Callback */
+        htim->Break2Callback                    = HAL_TIMEx_Break2Callback;
         break;
 
       default :
         /* Return error status */
-        status =  HAL_ERROR;
+        status = HAL_ERROR;
         break;
     }
   }
@@ -6216,75 +6402,86 @@ HAL_StatusTypeDef HAL_TIM_UnRegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Ca
     switch (CallbackID)
     {
       case HAL_TIM_BASE_MSPINIT_CB_ID :
-        htim->Base_MspInitCallback         = HAL_TIM_Base_MspInit;              /* Legacy weak Base MspInit Callback */
+        /* Legacy weak Base MspInit Callback */
+        htim->Base_MspInitCallback         = HAL_TIM_Base_MspInit;
         break;
 
       case HAL_TIM_BASE_MSPDEINIT_CB_ID :
-        htim->Base_MspDeInitCallback       = HAL_TIM_Base_MspDeInit;            /* Legacy weak Base Msp DeInit Callback */
+        /* Legacy weak Base Msp DeInit Callback */
+        htim->Base_MspDeInitCallback       = HAL_TIM_Base_MspDeInit;
         break;
 
       case HAL_TIM_IC_MSPINIT_CB_ID :
-        htim->IC_MspInitCallback           = HAL_TIM_IC_MspInit;                /* Legacy weak IC Msp Init Callback */
+        /* Legacy weak IC Msp Init Callback */
+        htim->IC_MspInitCallback           = HAL_TIM_IC_MspInit;
         break;
 
       case HAL_TIM_IC_MSPDEINIT_CB_ID :
-        htim->IC_MspDeInitCallback         = HAL_TIM_IC_MspDeInit;              /* Legacy weak IC Msp DeInit Callback */
+        /* Legacy weak IC Msp DeInit Callback */
+        htim->IC_MspDeInitCallback         = HAL_TIM_IC_MspDeInit;
         break;
 
       case HAL_TIM_OC_MSPINIT_CB_ID :
-        htim->OC_MspInitCallback           = HAL_TIM_OC_MspInit;                /* Legacy weak OC Msp Init Callback */
+        /* Legacy weak OC Msp Init Callback */
+        htim->OC_MspInitCallback           = HAL_TIM_OC_MspInit;
         break;
 
       case HAL_TIM_OC_MSPDEINIT_CB_ID :
-        htim->OC_MspDeInitCallback         = HAL_TIM_OC_MspDeInit;              /* Legacy weak OC Msp DeInit Callback */
+        /* Legacy weak OC Msp DeInit Callback */
+        htim->OC_MspDeInitCallback         = HAL_TIM_OC_MspDeInit;
         break;
 
       case HAL_TIM_PWM_MSPINIT_CB_ID :
-        htim->PWM_MspInitCallback          = HAL_TIM_PWM_MspInit;               /* Legacy weak PWM Msp Init Callback */
+        /* Legacy weak PWM Msp Init Callback */
+        htim->PWM_MspInitCallback          = HAL_TIM_PWM_MspInit;
         break;
 
       case HAL_TIM_PWM_MSPDEINIT_CB_ID :
-        htim->PWM_MspDeInitCallback        = HAL_TIM_PWM_MspDeInit;             /* Legacy weak PWM Msp DeInit Callback */
+        /* Legacy weak PWM Msp DeInit Callback */
+        htim->PWM_MspDeInitCallback        = HAL_TIM_PWM_MspDeInit;
         break;
 
       case HAL_TIM_ONE_PULSE_MSPINIT_CB_ID :
-        htim->OnePulse_MspInitCallback     = HAL_TIM_OnePulse_MspInit;          /* Legacy weak One Pulse Msp Init Callback */
+        /* Legacy weak One Pulse Msp Init Callback */
+        htim->OnePulse_MspInitCallback     = HAL_TIM_OnePulse_MspInit;
         break;
 
       case HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID :
-        htim->OnePulse_MspDeInitCallback   = HAL_TIM_OnePulse_MspDeInit;        /* Legacy weak One Pulse Msp DeInit Callback */
+        /* Legacy weak One Pulse Msp DeInit Callback */
+        htim->OnePulse_MspDeInitCallback   = HAL_TIM_OnePulse_MspDeInit;
         break;
 
       case HAL_TIM_ENCODER_MSPINIT_CB_ID :
-        htim->Encoder_MspInitCallback      = HAL_TIM_Encoder_MspInit;           /* Legacy weak Encoder Msp Init Callback */
+        /* Legacy weak Encoder Msp Init Callback */
+        htim->Encoder_MspInitCallback      = HAL_TIM_Encoder_MspInit;
         break;
 
       case HAL_TIM_ENCODER_MSPDEINIT_CB_ID :
-        htim->Encoder_MspDeInitCallback    = HAL_TIM_Encoder_MspDeInit;         /* Legacy weak Encoder Msp DeInit Callback */
+        /* Legacy weak Encoder Msp DeInit Callback */
+        htim->Encoder_MspDeInitCallback    = HAL_TIM_Encoder_MspDeInit;
         break;
 
       case HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID :
-        htim->HallSensor_MspInitCallback   = HAL_TIMEx_HallSensor_MspInit;      /* Legacy weak Hall Sensor Msp Init Callback */
+        /* Legacy weak Hall Sensor Msp Init Callback */
+        htim->HallSensor_MspInitCallback   = HAL_TIMEx_HallSensor_MspInit;
         break;
 
       case HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID :
-        htim->HallSensor_MspDeInitCallback = HAL_TIMEx_HallSensor_MspDeInit;    /* Legacy weak Hall Sensor Msp DeInit Callback */
+        /* Legacy weak Hall Sensor Msp DeInit Callback */
+        htim->HallSensor_MspDeInitCallback = HAL_TIMEx_HallSensor_MspDeInit;
         break;
 
       default :
         /* Return error status */
-        status =  HAL_ERROR;
+        status = HAL_ERROR;
         break;
     }
   }
   else
   {
     /* Return error status */
-    status =  HAL_ERROR;
+    status = HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(htim);
 
   return status;
 }
@@ -6314,7 +6511,7 @@ HAL_StatusTypeDef HAL_TIM_UnRegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Ca
   * @param  htim TIM Base handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -6324,7 +6521,7 @@ HAL_TIM_StateTypeDef HAL_TIM_Base_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM Output Compare handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -6334,7 +6531,7 @@ HAL_TIM_StateTypeDef HAL_TIM_OC_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -6344,7 +6541,7 @@ HAL_TIM_StateTypeDef HAL_TIM_PWM_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM IC handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -6354,7 +6551,7 @@ HAL_TIM_StateTypeDef HAL_TIM_IC_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM OPM handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -6364,7 +6561,7 @@ HAL_TIM_StateTypeDef HAL_TIM_OnePulse_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM Encoder Interface handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -6374,7 +6571,7 @@ HAL_TIM_StateTypeDef HAL_TIM_Encoder_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM handle
   * @retval Active channel
   */
-HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(TIM_HandleTypeDef *htim)
+HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(const TIM_HandleTypeDef *htim)
 {
   return htim->Channel;
 }
@@ -6392,7 +6589,7 @@ HAL_TIM_ActiveChannel HAL_TIM_GetActiveChannel(TIM_HandleTypeDef *htim)
   *            @arg TIM_CHANNEL_6: TIM Channel 6
   * @retval TIM Channel state
   */
-HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(TIM_HandleTypeDef *htim,  uint32_t Channel)
+HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(const TIM_HandleTypeDef *htim,  uint32_t Channel)
 {
   HAL_TIM_ChannelStateTypeDef channel_state;
 
@@ -6409,7 +6606,7 @@ HAL_TIM_ChannelStateTypeDef HAL_TIM_GetChannelState(TIM_HandleTypeDef *htim,  ui
   * @param  htim TIM handle
   * @retval DMA burst state
   */
-HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(TIM_HandleTypeDef *htim)
+HAL_TIM_DMABurstStateTypeDef HAL_TIM_DMABurstState(const TIM_HandleTypeDef *htim)
 {
   /* Check the parameters */
   assert_param(IS_TIM_DMABURST_INSTANCE(htim->Instance));
@@ -6752,7 +6949,7 @@ static void TIM_DMATriggerHalfCplt(DMA_HandleTypeDef *hdma)
   * @param  Structure TIM Base configuration structure
   * @retval None
   */
-void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
+void TIM_Base_SetConfig(TIM_TypeDef *TIMx, const TIM_Base_InitTypeDef *Structure)
 {
   uint32_t tmpcr1;
   tmpcr1 = TIMx->CR1;
@@ -6775,8 +6972,6 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
   /* Set the auto-reload preload */
   MODIFY_REG(tmpcr1, TIM_CR1_ARPE, Structure->AutoReloadPreload);
 
-  TIMx->CR1 = tmpcr1;
-
   /* Set the Autoreload value */
   TIMx->ARR = (uint32_t)Structure->Period ;
 
@@ -6789,9 +6984,15 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
     TIMx->RCR = Structure->RepetitionCounter;
   }
 
+  /* Disable Update Event (UEV) with Update Generation (UG)
+     by changing Update Request Source (URS) to avoid Update flag (UIF) */
+  SET_BIT(TIMx->CR1, TIM_CR1_URS);
+
   /* Generate an update event to reload the Prescaler
      and the repetition counter (only for advanced timer) value immediately */
   TIMx->EGR = TIM_EGR_UG;
+
+  TIMx->CR1 = tmpcr1;
 }
 
 /**
@@ -6800,17 +7001,18 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, TIM_Base_InitTypeDef *Structure)
   * @param  OC_Config The output configuration structure
   * @retval None
   */
-static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
 {
   uint32_t tmpccmrx;
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 1: Reset the CC1E Bit */
   TIMx->CCER &= ~TIM_CCER_CC1E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -6833,12 +7035,13 @@ static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
     /* Check parameters */
     assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
 
+    /* Disable the Channel 1N: Reset the CC1NE Bit */
+    TIMx->CCER &= ~TIM_CCER_CC1NE;
+
     /* Reset the Output N Polarity level */
     tmpccer &= ~TIM_CCER_CC1NP;
     /* Set the Output N Polarity */
     tmpccer |= OC_Config->OCNPolarity;
-    /* Reset the Output N State */
-    tmpccer &= ~TIM_CCER_CC1NE;
   }
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
@@ -6875,17 +7078,18 @@ static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
   * @param  OC_Config The output configuration structure
   * @retval None
   */
-void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
 {
   uint32_t tmpccmrx;
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 2: Reset the CC2E Bit */
   TIMx->CCER &= ~TIM_CCER_CC2E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -6908,13 +7112,13 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
   {
     assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
 
+    /* Disable the Channel 2N: Reset the CC2NE Bit */
+    TIMx->CCER &= ~TIM_CCER_CC2NE;
+
     /* Reset the Output N Polarity level */
     tmpccer &= ~TIM_CCER_CC2NP;
     /* Set the Output N Polarity */
     tmpccer |= (OC_Config->OCNPolarity << 4U);
-    /* Reset the Output N State */
-    tmpccer &= ~TIM_CCER_CC2NE;
-
   }
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
@@ -6951,17 +7155,18 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
   * @param  OC_Config The output configuration structure
   * @retval None
   */
-static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
 {
   uint32_t tmpccmrx;
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 3: Reset the CC2E Bit */
   TIMx->CCER &= ~TIM_CCER_CC3E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -6983,12 +7188,13 @@ static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
   {
     assert_param(IS_TIM_OCN_POLARITY(OC_Config->OCNPolarity));
 
+    /* Disable the Channel 3N: Reset the CC3NE Bit */
+    TIMx->CCER &= ~TIM_CCER_CC3NE;
+
     /* Reset the Output N Polarity level */
     tmpccer &= ~TIM_CCER_CC3NP;
     /* Set the Output N Polarity */
     tmpccer |= (OC_Config->OCNPolarity << 8U);
-    /* Reset the Output N State */
-    tmpccer &= ~TIM_CCER_CC3NE;
   }
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
@@ -7025,17 +7231,18 @@ static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
   * @param  OC_Config The output configuration structure
   * @retval None
   */
-static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
+static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
 {
   uint32_t tmpccmrx;
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 4: Reset the CC4E Bit */
   TIMx->CCER &= ~TIM_CCER_CC4E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -7086,17 +7293,18 @@ static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, TIM_OC_InitTypeDef *OC_Config)
   * @retval None
   */
 static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
-                              TIM_OC_InitTypeDef *OC_Config)
+                              const TIM_OC_InitTypeDef *OC_Config)
 {
   uint32_t tmpccmrx;
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the output: Reset the CCxE Bit */
   TIMx->CCER &= ~TIM_CCER_CC5E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
   /* Get the TIMx CCMR1 register value */
@@ -7139,17 +7347,18 @@ static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
   * @retval None
   */
 static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
-                              TIM_OC_InitTypeDef *OC_Config)
+                              const TIM_OC_InitTypeDef *OC_Config)
 {
   uint32_t tmpccmrx;
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the output: Reset the CCxE Bit */
   TIMx->CCER &= ~TIM_CCER_CC6E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
   /* Get the TIMx CCMR1 register value */
@@ -7193,8 +7402,9 @@ static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
   * @retval None
   */
 static HAL_StatusTypeDef TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
-                                                  TIM_SlaveConfigTypeDef *sSlaveConfig)
+                                                  const TIM_SlaveConfigTypeDef *sSlaveConfig)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
   uint32_t tmpccmr1;
   uint32_t tmpccer;
@@ -7291,16 +7501,18 @@ static HAL_StatusTypeDef TIM_SlaveTimer_SetConfig(TIM_HandleTypeDef *htim,
     case TIM_TS_ITR1:
     case TIM_TS_ITR2:
     case TIM_TS_ITR3:
-      {
-        /* Check the parameter */
-        assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
-        break;
-      }
+    {
+      /* Check the parameter */
+      assert_param(IS_TIM_CC2_INSTANCE(htim->Instance));
+      break;
+    }
 
     default:
+      status = HAL_ERROR;
       break;
   }
-  return HAL_OK;
+
+  return status;
 }
 
 /**
@@ -7329,10 +7541,19 @@ void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_
   uint32_t tmpccmr1;
   uint32_t tmpccer;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 1: Reset the CC1E Bit */
   TIMx->CCER &= ~TIM_CCER_CC1E;
+  /* Disable the Channel 1N: Reset the CC1NE Bit */
+  if (IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_1))
+  {
+    TIMx->CCER &= ~TIM_CCER_CC1NE;
+  }
+
+  /* Get the TIMx CCMR1 register value */
   tmpccmr1 = TIMx->CCMR1;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   if (IS_TIM_CC2_INSTANCE(TIMx) != RESET)
@@ -7375,9 +7596,18 @@ static void TIM_TI1_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity,
   uint32_t tmpccmr1;
   uint32_t tmpccer;
 
-  /* Disable the Channel 1: Reset the CC1E Bit */
+  /* Get the TIMx CCER register value */
   tmpccer = TIMx->CCER;
+
+  /* Disable the Channel 1: Reset the CC1E Bit */
   TIMx->CCER &= ~TIM_CCER_CC1E;
+  /* Disable the Channel 1N: Reset the CC1NE Bit */
+  if (IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_1))
+  {
+    TIMx->CCER &= ~TIM_CCER_CC1NE;
+  }
+
+  /* Get the TIMx CCMR1 register value */
   tmpccmr1 = TIMx->CCMR1;
 
   /* Set the filter */
@@ -7419,10 +7649,19 @@ static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
   uint32_t tmpccmr1;
   uint32_t tmpccer;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 2: Reset the CC2E Bit */
   TIMx->CCER &= ~TIM_CCER_CC2E;
+  /* Disable the Channel 2N: Reset the CC2NE Bit */
+  if (IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_2))
+  {
+    TIMx->CCER &= ~TIM_CCER_CC2NE;
+  }
+
+  /* Get the TIMx CCMR1 register value */
   tmpccmr1 = TIMx->CCMR1;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   tmpccmr1 &= ~TIM_CCMR1_CC2S;
@@ -7458,10 +7697,19 @@ static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity,
   uint32_t tmpccmr1;
   uint32_t tmpccer;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 2: Reset the CC2E Bit */
   TIMx->CCER &= ~TIM_CCER_CC2E;
+  /* Disable the Channel 2N: Reset the CC2NE Bit */
+  if (IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_2))
+  {
+    TIMx->CCER &= ~TIM_CCER_CC2NE;
+  }
+
+  /* Get the TIMx CCMR1 register value */
   tmpccmr1 = TIMx->CCMR1;
-  tmpccer = TIMx->CCER;
 
   /* Set the filter */
   tmpccmr1 &= ~TIM_CCMR1_IC2F;
@@ -7502,10 +7750,19 @@ static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
   uint32_t tmpccmr2;
   uint32_t tmpccer;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 3: Reset the CC3E Bit */
   TIMx->CCER &= ~TIM_CCER_CC3E;
+  /* Disable the Channel 3N: Reset the CC3NE Bit */
+  if (IS_TIM_CCXN_INSTANCE(TIMx, TIM_CHANNEL_3))
+  {
+    TIMx->CCER &= ~TIM_CCER_CC3NE;
+  }
+
+  /* Get the TIMx CCMR2 register value */
   tmpccmr2 = TIMx->CCMR2;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   tmpccmr2 &= ~TIM_CCMR2_CC3S;
@@ -7550,10 +7807,14 @@ static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
   uint32_t tmpccmr2;
   uint32_t tmpccer;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 4: Reset the CC4E Bit */
   TIMx->CCER &= ~TIM_CCER_CC4E;
+
+  /* Get the TIMx CCMR2 register value */
   tmpccmr2 = TIMx->CCMR2;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   tmpccmr2 &= ~TIM_CCMR2_CC4S;
@@ -7639,10 +7900,10 @@ void TIM_ETR_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ExtTRGPrescaler,
   * @param  TIMx to select the TIM peripheral
   * @param  Channel specifies the TIM Channel
   *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1
-  *            @arg TIM_CHANNEL_2: TIM Channel 2
-  *            @arg TIM_CHANNEL_3: TIM Channel 3
-  *            @arg TIM_CHANNEL_4: TIM Channel 4
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
+  *            @arg TIM_CHANNEL_4: TIM Channel 4 selected
   *            @arg TIM_CHANNEL_5: TIM Channel 5 selected
   *            @arg TIM_CHANNEL_6: TIM Channel 6 selected
   * @param  ChannelState specifies the TIM Channel CCxE bit new state.
@@ -7676,20 +7937,20 @@ void TIM_CCxChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t ChannelStat
 void TIM_ResetCallback(TIM_HandleTypeDef *htim)
 {
   /* Reset the TIM callback to the legacy weak callbacks */
-  htim->PeriodElapsedCallback             = HAL_TIM_PeriodElapsedCallback;             /* Legacy weak PeriodElapsedCallback             */
-  htim->PeriodElapsedHalfCpltCallback     = HAL_TIM_PeriodElapsedHalfCpltCallback;     /* Legacy weak PeriodElapsedHalfCpltCallback     */
-  htim->TriggerCallback                   = HAL_TIM_TriggerCallback;                   /* Legacy weak TriggerCallback                   */
-  htim->TriggerHalfCpltCallback           = HAL_TIM_TriggerHalfCpltCallback;           /* Legacy weak TriggerHalfCpltCallback           */
-  htim->IC_CaptureCallback                = HAL_TIM_IC_CaptureCallback;                /* Legacy weak IC_CaptureCallback                */
-  htim->IC_CaptureHalfCpltCallback        = HAL_TIM_IC_CaptureHalfCpltCallback;        /* Legacy weak IC_CaptureHalfCpltCallback        */
-  htim->OC_DelayElapsedCallback           = HAL_TIM_OC_DelayElapsedCallback;           /* Legacy weak OC_DelayElapsedCallback           */
-  htim->PWM_PulseFinishedCallback         = HAL_TIM_PWM_PulseFinishedCallback;         /* Legacy weak PWM_PulseFinishedCallback         */
-  htim->PWM_PulseFinishedHalfCpltCallback = HAL_TIM_PWM_PulseFinishedHalfCpltCallback; /* Legacy weak PWM_PulseFinishedHalfCpltCallback */
-  htim->ErrorCallback                     = HAL_TIM_ErrorCallback;                     /* Legacy weak ErrorCallback                     */
-  htim->CommutationCallback               = HAL_TIMEx_CommutCallback;                  /* Legacy weak CommutationCallback               */
-  htim->CommutationHalfCpltCallback       = HAL_TIMEx_CommutHalfCpltCallback;          /* Legacy weak CommutationHalfCpltCallback       */
-  htim->BreakCallback                     = HAL_TIMEx_BreakCallback;                   /* Legacy weak BreakCallback                     */
-  htim->Break2Callback                    = HAL_TIMEx_Break2Callback;                  /* Legacy weak Break2Callback                    */
+  htim->PeriodElapsedCallback             = HAL_TIM_PeriodElapsedCallback;
+  htim->PeriodElapsedHalfCpltCallback     = HAL_TIM_PeriodElapsedHalfCpltCallback;
+  htim->TriggerCallback                   = HAL_TIM_TriggerCallback;
+  htim->TriggerHalfCpltCallback           = HAL_TIM_TriggerHalfCpltCallback;
+  htim->IC_CaptureCallback                = HAL_TIM_IC_CaptureCallback;
+  htim->IC_CaptureHalfCpltCallback        = HAL_TIM_IC_CaptureHalfCpltCallback;
+  htim->OC_DelayElapsedCallback           = HAL_TIM_OC_DelayElapsedCallback;
+  htim->PWM_PulseFinishedCallback         = HAL_TIM_PWM_PulseFinishedCallback;
+  htim->PWM_PulseFinishedHalfCpltCallback = HAL_TIM_PWM_PulseFinishedHalfCpltCallback;
+  htim->ErrorCallback                     = HAL_TIM_ErrorCallback;
+  htim->CommutationCallback               = HAL_TIMEx_CommutCallback;
+  htim->CommutationHalfCpltCallback       = HAL_TIMEx_CommutHalfCpltCallback;
+  htim->BreakCallback                     = HAL_TIMEx_BreakCallback;
+  htim->Break2Callback                    = HAL_TIMEx_Break2Callback;
 }
 #endif /* USE_HAL_TIM_REGISTER_CALLBACKS */
 
@@ -7705,4 +7966,3 @@ void TIM_ResetCallback(TIM_HandleTypeDef *htim)
 /**
   * @}
   */
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_tim_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_tim_ex.c
@@ -12,6 +12,17 @@
   *           + Time Output Compare/PWM Channel Configuration (for channels 5 and 6)
   *           + Time OCRef clear configuration
   *           + Timer remapping capabilities configuration
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                       ##### TIMER Extended features #####
@@ -56,23 +67,15 @@
                the commutation event).
 
      (#) Activate the TIM peripheral using one of the start functions:
-           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(), HAL_TIMEx_OCN_Start_IT()
-           (++) Complementary PWM generation : HAL_TIMEx_PWMN_Start(), HAL_TIMEx_PWMN_Start_DMA(), HAL_TIMEx_PWMN_Start_IT()
+           (++) Complementary Output Compare : HAL_TIMEx_OCN_Start(), HAL_TIMEx_OCN_Start_DMA(),
+                HAL_TIMEx_OCN_Start_IT()
+           (++) Complementary PWM generation : HAL_TIMEx_PWMN_Start(), HAL_TIMEx_PWMN_Start_DMA(),
+                HAL_TIMEx_PWMN_Start_IT()
            (++) Complementary One-pulse mode output : HAL_TIMEx_OnePulseN_Start(), HAL_TIMEx_OnePulseN_Start_IT()
-           (++) Hall Sensor output : HAL_TIMEx_HallSensor_Start(), HAL_TIMEx_HallSensor_Start_DMA(), HAL_TIMEx_HallSensor_Start_IT().
+           (++) Hall Sensor output : HAL_TIMEx_HallSensor_Start(), HAL_TIMEx_HallSensor_Start_DMA(),
+                HAL_TIMEx_HallSensor_Start_IT().
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -112,6 +115,13 @@
   (((__INSTANCE__) == TIM1) ? (TIM1_OR_ETR_ADC1_RMP | TIM1_OR_TI1_RMP) :               \
    ((__INSTANCE__) == TIM2) ? (TIM2_OR_TI4_RMP | TIM2_OR_ETR_RMP | TIM2_OR_ITR1_RMP) : \
    ((__INSTANCE__) == TIM16) ? TIM16_OR_TI1_RMP : TIM17_OR_TI1_RMP)
+#elif defined(STM32WB10xx)
+#define TIM_GET_OR_MASK(__INSTANCE__)                                    \
+  (((__INSTANCE__) == TIM1) ? (TIM1_OR_ETR_ADC1_RMP) : (TIM2_OR_ETR_RMP))
+#elif defined(STM32WB15xx) || defined(STM32WB1Mxx)
+#define TIM_GET_OR_MASK(__INSTANCE__)                                    \
+  (((__INSTANCE__) == TIM1) ? (TIM1_OR_ETR_ADC1_RMP | TIM1_OR_TI1_RMP) : \
+   (TIM2_OR_TI4_RMP | TIM2_OR_ETR_RMP))
 #else
 #define TIM_GET_OR_MASK(__INSTANCE__)                                    \
   (((__INSTANCE__) == TIM1) ? (TIM1_OR_ETR_ADC1_RMP | TIM1_OR_TI1_RMP) : \
@@ -163,7 +173,7 @@ static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Cha
   * @param  sConfig TIM Hall Sensor configuration structure
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSensor_InitTypeDef *sConfig)
+HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, const TIM_HallSensor_InitTypeDef *sConfig)
 {
   TIM_OC_InitTypeDef OC_Config;
 
@@ -179,6 +189,7 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Init(TIM_HandleTypeDef *htim, TIM_HallSen
   assert_param(IS_TIM_CLOCKDIVISION_DIV(htim->Init.ClockDivision));
   assert_param(IS_TIM_AUTORELOAD_PRELOAD(htim->Init.AutoReloadPreload));
   assert_param(IS_TIM_IC_POLARITY(sConfig->IC1Polarity));
+  assert_param(IS_TIM_PERIOD(htim, htim->Init.Period));
   assert_param(IS_TIM_IC_PRESCALER(sConfig->IC1Prescaler));
   assert_param(IS_TIM_IC_FILTER(sConfig->IC1Filter));
 
@@ -366,7 +377,8 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start(TIM_HandleTypeDef *htim)
   TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the Input Capture channel 1
-  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1,
+  TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
@@ -398,7 +410,8 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channels 1, 2 and 3
-    (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1,
+  TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
 
   /* Disable the Peripheral */
@@ -449,7 +462,8 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_IT(TIM_HandleTypeDef *htim)
   __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
 
   /* Enable the Input Capture channel 1
-    (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1,
+  TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
 
   /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
@@ -481,7 +495,8 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_IT(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channel 1
-    (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1,
+  TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
 
   /* Disable the capture compare Interrupts event */
@@ -525,7 +540,7 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32
   else if ((channel_1_state == HAL_TIM_CHANNEL_STATE_READY)
            && (complementary_channel_1_state == HAL_TIM_CHANNEL_STATE_READY))
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -541,7 +556,8 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Start_DMA(TIM_HandleTypeDef *htim, uint32
   }
 
   /* Enable the Input Capture channel 1
-    (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1,
+  TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_ENABLE);
 
   /* Set the DMA Input Capture 1 Callbacks */
@@ -588,7 +604,8 @@ HAL_StatusTypeDef HAL_TIMEx_HallSensor_Stop_DMA(TIM_HandleTypeDef *htim)
   assert_param(IS_TIM_HALL_SENSOR_INTERFACE_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channel 1
-    (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1, TIM_CHANNEL_2 and TIM_CHANNEL_3) */
+  (in the Hall Sensor Interface the three possible channels that can be used are TIM_CHANNEL_1,
+  TIM_CHANNEL_2 and TIM_CHANNEL_3) */
   TIM_CCxChannelCmd(htim->Instance, TIM_CHANNEL_1, TIM_CCx_DISABLE);
 
 
@@ -728,6 +745,7 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
@@ -767,34 +785,38 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
 
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the TIM Break interrupt */
-  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
-
-  /* Enable the Capture compare channel N */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
-
-  /* Enable the Main Output */
-  __HAL_TIM_MOE_ENABLE(htim);
-
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  if (status == HAL_OK)
   {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    /* Enable the TIM Break interrupt */
+    __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+
+    /* Enable the Capture compare channel N */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+    /* Enable the Main Output */
+    __HAL_TIM_MOE_ENABLE(htim);
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -810,7 +832,9 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chann
   */
 HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpccer;
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
@@ -838,30 +862,34 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Capture compare channel N */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
-
-  /* Disable the TIM Break interrupt (only if no more channel is active) */
-  tmpccer = htim->Instance->CCER;
-  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == (uint32_t)RESET)
+  if (status == HAL_OK)
   {
-    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+    /* Disable the Capture compare channel N */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+    /* Disable the TIM Break interrupt (only if no more channel is active) */
+    tmpccer = htim->Instance->CCER;
+    if ((tmpccer & TIM_CCER_CCxNE_MASK) == (uint32_t)RESET)
+    {
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+    }
+
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
+
+    /* Set the TIM complementary channel state */
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
   }
 
-  /* Disable the Main Output */
-  __HAL_TIM_MOE_DISABLE(htim);
-
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
-
-  /* Set the TIM complementary channel state */
-  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -877,8 +905,10 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
   * @param  Length The length of data to be transferred from memory to TIM peripheral
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                          uint16_t Length)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
@@ -891,7 +921,7 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   }
   else if (TIM_CHANNEL_N_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -917,7 +947,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -937,7 +968,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -957,7 +989,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
       htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -968,31 +1001,35 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the Capture compare channel N */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
-
-  /* Enable the Main Output */
-  __HAL_TIM_MOE_ENABLE(htim);
-
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  if (status == HAL_OK)
   {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    /* Enable the Capture compare channel N */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+    /* Enable the Main Output */
+    __HAL_TIM_MOE_ENABLE(htim);
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1008,6 +1045,8 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
   */
 HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
@@ -1038,23 +1077,27 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chann
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the Capture compare channel N */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+  if (status == HAL_OK)
+  {
+    /* Disable the Capture compare channel N */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
 
-  /* Disable the Main Output */
-  __HAL_TIM_MOE_DISABLE(htim);
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
 
-  /* Set the TIM complementary channel state */
-  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    /* Set the TIM complementary channel state */
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1076,17 +1119,6 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chann
     (+) Stop the Complementary PWM and disable interrupts.
     (+) Start the Complementary PWM and enable DMA transfers.
     (+) Stop the Complementary PWM and disable DMA transfers.
-    (+) Start the Complementary Input Capture measurement.
-    (+) Stop the Complementary Input Capture.
-    (+) Start the Complementary Input Capture and enable interrupts.
-    (+) Stop the Complementary Input Capture and disable interrupts.
-    (+) Start the Complementary Input Capture and enable DMA transfers.
-    (+) Stop the Complementary Input Capture and disable DMA transfers.
-    (+) Start the Complementary One Pulse generation.
-    (+) Stop the Complementary One Pulse.
-    (+) Start the Complementary One Pulse and enable interrupts.
-    (+) Stop the Complementary One Pulse and disable interrupts.
-
 @endverbatim
   * @{
   */
@@ -1185,6 +1217,7 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
   */
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
@@ -1223,34 +1256,38 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chan
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the TIM Break interrupt */
-  __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
-
-  /* Enable the complementary PWM output  */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
-
-  /* Enable the Main Output */
-  __HAL_TIM_MOE_ENABLE(htim);
-
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  if (status == HAL_OK)
   {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    /* Enable the TIM Break interrupt */
+    __HAL_TIM_ENABLE_IT(htim, TIM_IT_BREAK);
+
+    /* Enable the complementary PWM output  */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+    /* Enable the Main Output */
+    __HAL_TIM_MOE_ENABLE(htim);
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1266,6 +1303,7 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_IT(TIM_HandleTypeDef *htim, uint32_t Chan
   */
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpccer;
 
   /* Check the parameters */
@@ -1295,30 +1333,34 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chann
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the complementary PWM output  */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
-
-  /* Disable the TIM Break interrupt (only if no more channel is active) */
-  tmpccer = htim->Instance->CCER;
-  if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == (uint32_t)RESET)
+  if (status == HAL_OK)
   {
-    __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+    /* Disable the complementary PWM output  */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+
+    /* Disable the TIM Break interrupt (only if no more channel is active) */
+    tmpccer = htim->Instance->CCER;
+    if ((tmpccer & TIM_CCER_CCxNE_MASK) == (uint32_t)RESET)
+    {
+      __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
+    }
+
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
+
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
+
+    /* Set the TIM complementary channel state */
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
   }
 
-  /* Disable the Main Output */
-  __HAL_TIM_MOE_DISABLE(htim);
-
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
-
-  /* Set the TIM complementary channel state */
-  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
-
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1334,8 +1376,10 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chann
   * @param  Length The length of data to be transferred from memory to TIM peripheral
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, uint32_t *pData, uint16_t Length)
+HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel, const uint32_t *pData,
+                                           uint16_t Length)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpsmcr;
 
   /* Check the parameters */
@@ -1348,7 +1392,7 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   }
   else if (TIM_CHANNEL_N_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_READY)
   {
-    if ((pData == NULL) && (Length > 0U))
+    if ((pData == NULL) || (Length == 0U))
     {
       return HAL_ERROR;
     }
@@ -1374,7 +1418,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
       htim->hdma[TIM_DMA_ID_CC1]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC1], (uint32_t)pData, (uint32_t)&htim->Instance->CCR1,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1394,7 +1439,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
       htim->hdma[TIM_DMA_ID_CC2]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC2], (uint32_t)pData, (uint32_t)&htim->Instance->CCR2,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1414,7 +1460,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
       htim->hdma[TIM_DMA_ID_CC3]->XferErrorCallback = TIM_DMAErrorCCxN ;
 
       /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3, Length) != HAL_OK)
+      if (HAL_DMA_Start_IT(htim->hdma[TIM_DMA_ID_CC3], (uint32_t)pData, (uint32_t)&htim->Instance->CCR3,
+                           Length) != HAL_OK)
       {
         /* Return error status */
         return HAL_ERROR;
@@ -1425,31 +1472,35 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Enable the complementary PWM output  */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
-
-  /* Enable the Main Output */
-  __HAL_TIM_MOE_ENABLE(htim);
-
-  /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
-  if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+  if (status == HAL_OK)
   {
-    tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
-    if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+    /* Enable the complementary PWM output  */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_ENABLE);
+
+    /* Enable the Main Output */
+    __HAL_TIM_MOE_ENABLE(htim);
+
+    /* Enable the Peripheral, except in trigger mode where enable is automatically done with trigger */
+    if (IS_TIM_SLAVE_INSTANCE(htim->Instance))
+    {
+      tmpsmcr = htim->Instance->SMCR & TIM_SMCR_SMS;
+      if (!IS_TIM_SLAVEMODE_TRIGGER_ENABLED(tmpsmcr))
+      {
+        __HAL_TIM_ENABLE(htim);
+      }
+    }
+    else
     {
       __HAL_TIM_ENABLE(htim);
     }
   }
-  else
-  {
-    __HAL_TIM_ENABLE(htim);
-  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1465,6 +1516,8 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   */
 HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
+  HAL_StatusTypeDef status = HAL_OK;
+
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, Channel));
 
@@ -1495,23 +1548,27 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
     }
 
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  /* Disable the complementary PWM output */
-  TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
+  if (status == HAL_OK)
+  {
+    /* Disable the complementary PWM output */
+    TIM_CCxNChannelCmd(htim->Instance, Channel, TIM_CCxN_DISABLE);
 
-  /* Disable the Main Output */
-  __HAL_TIM_MOE_DISABLE(htim);
+    /* Disable the Main Output */
+    __HAL_TIM_MOE_DISABLE(htim);
 
-  /* Disable the Peripheral */
-  __HAL_TIM_DISABLE(htim);
+    /* Disable the Peripheral */
+    __HAL_TIM_DISABLE(htim);
 
-  /* Set the TIM complementary channel state */
-  TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+    /* Set the TIM complementary channel state */
+    TIM_CHANNEL_N_STATE_SET(htim, Channel, HAL_TIM_CHANNEL_STATE_READY);
+  }
 
   /* Return function status */
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -1539,8 +1596,10 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
 /**
   * @brief  Starts the TIM One Pulse signal generation on the complementary
   *         output.
+  * @note OutputChannel must match the pulse output channel chosen when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channel to be enabled
+  * @param  OutputChannel pulse output channel to enable
   *          This parameter can be one of the following values:
   *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
   *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
@@ -1549,22 +1608,28 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chan
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
   uint32_t input_channel = (OutputChannel == TIM_CHANNEL_1) ? TIM_CHANNEL_2 : TIM_CHANNEL_1;
-  HAL_TIM_ChannelStateTypeDef input_channel_state = TIM_CHANNEL_STATE_GET(htim, input_channel);
-  HAL_TIM_ChannelStateTypeDef output_channel_state = TIM_CHANNEL_N_STATE_GET(htim, OutputChannel);
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
 
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
 
   /* Check the TIM channels state */
-  if ((output_channel_state != HAL_TIM_CHANNEL_STATE_READY)
-      || (input_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
   {
     return HAL_ERROR;
   }
 
   /* Set the TIM channels state */
-  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_BUSY);
-  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the complementary One Pulse output channel and the Input Capture channel */
   TIM_CCxNChannelCmd(htim->Instance, OutputChannel, TIM_CCxN_ENABLE);
@@ -1580,8 +1645,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start(TIM_HandleTypeDef *htim, uint32_t Ou
 /**
   * @brief  Stops the TIM One Pulse signal generation on the complementary
   *         output.
+  * @note OutputChannel must match the pulse output channel chosen when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channel to be disabled
+  * @param  OutputChannel pulse output channel to disable
   *          This parameter can be one of the following values:
   *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
   *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
@@ -1605,8 +1672,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t Out
   __HAL_TIM_DISABLE(htim);
 
   /* Set the TIM  channels state */
-  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_READY);
-  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1615,8 +1684,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t Out
 /**
   * @brief  Starts the TIM One Pulse signal generation in interrupt mode on the
   *         complementary channel.
+  * @note OutputChannel must match the pulse output channel chosen when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channel to be enabled
+  * @param  OutputChannel pulse output channel to enable
   *          This parameter can be one of the following values:
   *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
   *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
@@ -1625,22 +1696,28 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop(TIM_HandleTypeDef *htim, uint32_t Out
 HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t OutputChannel)
 {
   uint32_t input_channel = (OutputChannel == TIM_CHANNEL_1) ? TIM_CHANNEL_2 : TIM_CHANNEL_1;
-  HAL_TIM_ChannelStateTypeDef input_channel_state = TIM_CHANNEL_STATE_GET(htim, input_channel);
-  HAL_TIM_ChannelStateTypeDef output_channel_state = TIM_CHANNEL_N_STATE_GET(htim, OutputChannel);
+  HAL_TIM_ChannelStateTypeDef channel_1_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef channel_2_state = TIM_CHANNEL_STATE_GET(htim, TIM_CHANNEL_2);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_1_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_1);
+  HAL_TIM_ChannelStateTypeDef complementary_channel_2_state = TIM_CHANNEL_N_STATE_GET(htim, TIM_CHANNEL_2);
 
   /* Check the parameters */
   assert_param(IS_TIM_CCXN_INSTANCE(htim->Instance, OutputChannel));
 
   /* Check the TIM channels state */
-  if ((output_channel_state != HAL_TIM_CHANNEL_STATE_READY)
-      || (input_channel_state != HAL_TIM_CHANNEL_STATE_READY))
+  if ((channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (channel_2_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_1_state != HAL_TIM_CHANNEL_STATE_READY)
+      || (complementary_channel_2_state != HAL_TIM_CHANNEL_STATE_READY))
   {
     return HAL_ERROR;
   }
 
   /* Set the TIM channels state */
-  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_BUSY);
-  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_BUSY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_BUSY);
 
   /* Enable the TIM Capture/Compare 1 interrupt */
   __HAL_TIM_ENABLE_IT(htim, TIM_IT_CC1);
@@ -1662,8 +1739,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Start_IT(TIM_HandleTypeDef *htim, uint32_t
 /**
   * @brief  Stops the TIM One Pulse signal generation in interrupt mode on the
   *         complementary channel.
+  * @note OutputChannel must match the pulse output channel chosen when calling
+  *       @ref HAL_TIM_OnePulse_ConfigChannel().
   * @param  htim TIM One Pulse handle
-  * @param  OutputChannel TIM Channel to be disabled
+  * @param  OutputChannel pulse output channel to disable
   *          This parameter can be one of the following values:
   *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
   *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
@@ -1693,8 +1772,10 @@ HAL_StatusTypeDef HAL_TIMEx_OnePulseN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t 
   __HAL_TIM_DISABLE(htim);
 
   /* Set the TIM  channels state */
-  TIM_CHANNEL_N_STATE_SET(htim, OutputChannel, HAL_TIM_CHANNEL_STATE_READY);
-  TIM_CHANNEL_STATE_SET(htim, input_channel, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_1, HAL_TIM_CHANNEL_STATE_READY);
+  TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_2, HAL_TIM_CHANNEL_STATE_READY);
 
   /* Return function status */
   return HAL_OK;
@@ -1910,7 +1991,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigCommutEvent_DMA(TIM_HandleTypeDef *htim, uint3
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
-                                                        TIM_MasterConfigTypeDef *sMasterConfig)
+                                                        const TIM_MasterConfigTypeDef *sMasterConfig)
 {
   uint32_t tmpcr2;
   uint32_t tmpsmcr;
@@ -1983,7 +2064,7 @@ HAL_StatusTypeDef HAL_TIMEx_MasterConfigSynchronization(TIM_HandleTypeDef *htim,
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
-                                                TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig)
+                                                const TIM_BreakDeadTimeConfigTypeDef *sBreakDeadTimeConfig)
 {
   /* Keep this variable initialized to 0 as it is used to configure BDTR register */
   uint32_t tmpbdtr = 0U;
@@ -1998,6 +2079,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   assert_param(IS_TIM_BREAK_POLARITY(sBreakDeadTimeConfig->BreakPolarity));
   assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->BreakFilter));
   assert_param(IS_TIM_AUTOMATIC_OUTPUT_STATE(sBreakDeadTimeConfig->AutomaticOutput));
+  assert_param(IS_TIM_BREAK_AFMODE(sBreakDeadTimeConfig->BreakAFMode));
 
   /* Check input state */
   __HAL_LOCK(htim);
@@ -2014,15 +2096,7 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKP, sBreakDeadTimeConfig->BreakPolarity);
   MODIFY_REG(tmpbdtr, TIM_BDTR_AOE, sBreakDeadTimeConfig->AutomaticOutput);
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKF, (sBreakDeadTimeConfig->BreakFilter << TIM_BDTR_BKF_Pos));
-
-  if (IS_TIM_ADVANCED_INSTANCE(htim->Instance))
-  {
-    /* Check the parameters */
-    assert_param(IS_TIM_BREAK_AFMODE(sBreakDeadTimeConfig->BreakAFMode));
-
-    /* Set BREAK AF mode */
-    MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, sBreakDeadTimeConfig->BreakAFMode);
-  }
+  MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, sBreakDeadTimeConfig->BreakAFMode);
 
   if (IS_TIM_BKIN2_INSTANCE(htim->Instance))
   {
@@ -2030,20 +2104,13 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
     assert_param(IS_TIM_BREAK2_STATE(sBreakDeadTimeConfig->Break2State));
     assert_param(IS_TIM_BREAK2_POLARITY(sBreakDeadTimeConfig->Break2Polarity));
     assert_param(IS_TIM_BREAK_FILTER(sBreakDeadTimeConfig->Break2Filter));
+    assert_param(IS_TIM_BREAK2_AFMODE(sBreakDeadTimeConfig->Break2AFMode));
 
     /* Set the BREAK2 input related BDTR bits */
     MODIFY_REG(tmpbdtr, TIM_BDTR_BK2F, (sBreakDeadTimeConfig->Break2Filter << TIM_BDTR_BK2F_Pos));
     MODIFY_REG(tmpbdtr, TIM_BDTR_BK2E, sBreakDeadTimeConfig->Break2State);
     MODIFY_REG(tmpbdtr, TIM_BDTR_BK2P, sBreakDeadTimeConfig->Break2Polarity);
-
-    if (IS_TIM_ADVANCED_INSTANCE(htim->Instance))
-    {
-      /* Check the parameters */
-      assert_param(IS_TIM_BREAK2_AFMODE(sBreakDeadTimeConfig->Break2AFMode));
-
-      /* Set BREAK2 AF mode */
-      MODIFY_REG(tmpbdtr, TIM_BDTR_BK2BID, sBreakDeadTimeConfig->Break2AFMode);
-    }
+    MODIFY_REG(tmpbdtr, TIM_BDTR_BK2BID, sBreakDeadTimeConfig->Break2AFMode);
   }
 
   /* Set TIMx_BDTR */
@@ -2066,9 +2133,9 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
   */
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
                                              uint32_t BreakInput,
-                                             TIMEx_BreakInputConfigTypeDef *sBreakInputConfig)
-
+                                             const TIMEx_BreakInputConfigTypeDef *sBreakInputConfig)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmporx;
   uint32_t bkin_enable_mask;
   uint32_t bkin_polarity_mask;
@@ -2161,12 +2228,13 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
   __HAL_UNLOCK(htim);
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -2316,10 +2384,11 @@ HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t Chan
   */
 HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t BreakInput)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmpbdtr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
   assert_param(IS_TIM_BREAKINPUT(BreakInput));
 
   switch (BreakInput)
@@ -2336,7 +2405,6 @@ HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t B
       }
       break;
     }
-
     case TIM_BREAKINPUT_BRK2:
     {
       /* Check initial conditions */
@@ -2350,10 +2418,11 @@ HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t B
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -2367,12 +2436,13 @@ HAL_StatusTypeDef HAL_TIMEx_DisarmBreakInput(TIM_HandleTypeDef *htim, uint32_t B
   * @note  Break input is automatically armed as soon as MOE bit is set.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(TIM_HandleTypeDef *htim, uint32_t BreakInput)
+HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(const TIM_HandleTypeDef *htim, uint32_t BreakInput)
 {
+  HAL_StatusTypeDef status = HAL_OK;
   uint32_t tickstart;
 
   /* Check the parameters */
-  assert_param(IS_TIM_ADVANCED_INSTANCE(htim->Instance));
+  assert_param(IS_TIM_BREAK_INSTANCE(htim->Instance));
   assert_param(IS_TIM_BREAKINPUT(BreakInput));
 
   switch (BreakInput)
@@ -2385,15 +2455,17 @@ HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(TIM_HandleTypeDef *htim, uint32_t Br
         /* Break input BRK is re-armed automatically by hardware. Poll to check whether fault condition disappeared */
         /* Init tickstart for timeout management */
         tickstart = HAL_GetTick();
-        do
+        while (READ_BIT(htim->Instance->BDTR, TIM_BDTR_BKDSRM) != 0UL)
         {
-          if (READ_BIT(htim->Instance->BDTR, TIM_BDTR_BKDSRM) != TIM_BDTR_BKDSRM)
+          if ((HAL_GetTick() - tickstart) > TIM_BREAKINPUT_REARM_TIMEOUT)
           {
-            return HAL_OK;
+            /* New check to avoid false timeout detection in case of preemption */
+            if (READ_BIT(htim->Instance->BDTR, TIM_BDTR_BKDSRM) != 0UL)
+            {
+              return HAL_TIMEOUT;
+            }
           }
-        } while ((HAL_GetTick() - tickstart) <= TIM_BREAKINPUT_REARM_TIMEOUT);
-
-        return HAL_TIMEOUT;
+        }
       }
       break;
     }
@@ -2406,23 +2478,26 @@ HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(TIM_HandleTypeDef *htim, uint32_t Br
         /* Break input BRK2 is re-armed automatically by hardware. Poll to check whether fault condition disappeared */
         /* Init tickstart for timeout management */
         tickstart = HAL_GetTick();
-        do
+        while (READ_BIT(htim->Instance->BDTR, TIM_BDTR_BK2DSRM) != 0UL)
         {
-          if (READ_BIT(htim->Instance->BDTR, TIM_BDTR_BK2DSRM) != TIM_BDTR_BK2DSRM)
+          if ((HAL_GetTick() - tickstart) > TIM_BREAKINPUT_REARM_TIMEOUT)
           {
-            return HAL_OK;
+            /* New check to avoid false timeout detection in case of preemption */
+            if (READ_BIT(htim->Instance->BDTR, TIM_BDTR_BK2DSRM) != 0UL)
+            {
+              return HAL_TIMEOUT;
+            }
           }
-        } while ((HAL_GetTick() - tickstart) <= TIM_BREAKINPUT_REARM_TIMEOUT);
-
-        return HAL_TIMEOUT;
+        }
       }
       break;
     }
     default:
+      status = HAL_ERROR;
       break;
   }
 
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -2446,7 +2521,7 @@ HAL_StatusTypeDef HAL_TIMEx_ReArmBreakInput(TIM_HandleTypeDef *htim, uint32_t Br
   */
 
 /**
-  * @brief  Hall commutation changed callback in non-blocking mode
+  * @brief  Commutation callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -2460,7 +2535,7 @@ __weak void HAL_TIMEx_CommutCallback(TIM_HandleTypeDef *htim)
    */
 }
 /**
-  * @brief  Hall commutation changed half complete callback in non-blocking mode
+  * @brief  Commutation half complete callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -2475,7 +2550,7 @@ __weak void HAL_TIMEx_CommutHalfCpltCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
-  * @brief  Hall Break detection callback in non-blocking mode
+  * @brief  Break detection callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -2490,7 +2565,7 @@ __weak void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
-  * @brief  Hall Break2 detection callback in non blocking mode
+  * @brief  Break2 detection callback in non blocking mode
   * @param  htim: TIM handle
   * @retval None
   */
@@ -2527,7 +2602,7 @@ __weak void HAL_TIMEx_Break2Callback(TIM_HandleTypeDef *htim)
   * @param  htim TIM Hall Sensor handle
   * @retval HAL state
   */
-HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim)
+HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(const TIM_HandleTypeDef *htim)
 {
   return htim->State;
 }
@@ -2537,12 +2612,12 @@ HAL_TIM_StateTypeDef HAL_TIMEx_HallSensor_GetState(TIM_HandleTypeDef *htim)
   * @param  htim TIM handle
   * @param  ChannelN TIM Complementary channel
   *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1
-  *            @arg TIM_CHANNEL_2: TIM Channel 2
-  *            @arg TIM_CHANNEL_3: TIM Channel 3
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
   * @retval TIM Complementary channel state
   */
-HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(TIM_HandleTypeDef *htim,  uint32_t ChannelN)
+HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(const TIM_HandleTypeDef *htim,  uint32_t ChannelN)
 {
   HAL_TIM_ChannelStateTypeDef channel_state;
 
@@ -2562,7 +2637,7 @@ HAL_TIM_ChannelStateTypeDef HAL_TIMEx_GetChannelNState(TIM_HandleTypeDef *htim, 
   */
 
 /* Private functions ---------------------------------------------------------*/
-/** @defgroup TIMEx_Private_Functions TIMEx Private Functions
+/** @defgroup TIMEx_Private_Functions TIM Extended Private Functions
   * @{
   */
 
@@ -2641,15 +2716,6 @@ static void TIM_DMADelayPulseNCplt(DMA_HandleTypeDef *hdma)
       TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
     }
   }
-  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
-  {
-    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
-    }
-  }
   else
   {
     /* nothing to do */
@@ -2707,9 +2773,9 @@ static void TIM_DMAErrorCCxN(DMA_HandleTypeDef *hdma)
   * @param  TIMx to select the TIM peripheral
   * @param  Channel specifies the TIM Channel
   *          This parameter can be one of the following values:
-  *            @arg TIM_CHANNEL_1: TIM Channel 1
-  *            @arg TIM_CHANNEL_2: TIM Channel 2
-  *            @arg TIM_CHANNEL_3: TIM Channel 3
+  *            @arg TIM_CHANNEL_1: TIM Channel 1 selected
+  *            @arg TIM_CHANNEL_2: TIM Channel 2 selected
+  *            @arg TIM_CHANNEL_3: TIM Channel 3 selected
   * @param  ChannelNState specifies the TIM Channel CCxNE bit new state.
   *          This parameter can be: TIM_CCxN_ENABLE or TIM_CCxN_Disable.
   * @retval None
@@ -2718,13 +2784,13 @@ static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Cha
 {
   uint32_t tmp;
 
-  tmp = TIM_CCER_CC1NE << (Channel & 0x1FU); /* 0x1FU = 31 bits max shift */
+  tmp = TIM_CCER_CC1NE << (Channel & 0xFU); /* 0xFU = 15 bits max shift */
 
   /* Reset the CCxNE Bit */
   TIMx->CCER &=  ~tmp;
 
   /* Set or reset the CCxNE Bit */
-  TIMx->CCER |= (uint32_t)(ChannelNState << (Channel & 0x1FU)); /* 0x1FU = 31 bits max shift */
+  TIMx->CCER |= (uint32_t)(ChannelNState << (Channel & 0xFU)); /* 0xFU = 15 bits max shift */
 }
 /**
   * @}
@@ -2738,5 +2804,3 @@ static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Cha
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_timebase_rtc_alarm_template.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_timebase_rtc_alarm_template.c
@@ -6,11 +6,24 @@
   *
   *          This file override the native HAL time base functions (defined as weak)
   *          to use the RTC ALARM for time base generation:
-  *           + Intializes the RTC peripheral to increment the seconds registers each 1ms
-  *           + The alarm is configured to assert an interrupt when the RTC reaches 1ms
-  *           + HAL_IncTick is called at each Alarm event and the time is reset to 00:00:00
+  *           + Initializes the RTC peripheral to increment the seconds registers each 1s
+  *           + The alarm is configured to assert an interrupt when the RTC
+  *             subsecond register reaches 1ms when uwTickFreq is set to default
+  *             value, else 10 ms or 100 ms, depending of above global variable value.
+  *           + HAL_IncTick is called at each Alarm event
   *           + HSE (default), LSE or LSI can be selected as RTC clock source
- @verbatim
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
   ==============================================================================
                         ##### How to use this driver #####
   ==============================================================================
@@ -30,21 +43,11 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_hal.h"
+
 /** @addtogroup STM32WBxx_HAL_Driver
   * @{
   */
@@ -63,86 +66,139 @@
   + RTC_CLOCK_SOURCE_LSI: can be selected for applications with low constraint on timing
                           precision.
   */
-#define RTC_CLOCK_SOURCE_HSE
+/* #define RTC_CLOCK_SOURCE_HSE */
 /* #define RTC_CLOCK_SOURCE_LSE */
 /* #define RTC_CLOCK_SOURCE_LSI */
 
-#ifdef RTC_CLOCK_SOURCE_HSE
-  #define RTC_ASYNCH_PREDIV       99U
-  #define RTC_SYNCH_PREDIV        9U
-  #define RCC_RTCCLKSOURCE_1MHZ   ((uint32_t)((uint32_t)RCC_BDCR_RTCSEL | (uint32_t)((HSE_VALUE/1000000U) << 16U)))
-#else /* RTC_CLOCK_SOURCE_LSE || RTC_CLOCK_SOURCE_LSI */
-  #define RTC_ASYNCH_PREDIV       0U
-  #define RTC_SYNCH_PREDIV        31U
-#endif /* RTC_CLOCK_SOURCE_HSE */
+/* Minimize Asynchronous prescaler for power consumption :
+  ck_apre = RTCCLK / (ASYNC prediv + 1)
+  ck_spre = ck_apre /(SYNC prediv + 1) = 1 Hz */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+/* LSE Freq = 32.768 kHz RC */
+#define RTC_ASYNCH_PREDIV                   1U
+#define RTC_SYNCH_PREDIV                    0x3FFFu /* (16384 - 1) */
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+/* LSI Freq = 32 kHz RC  */
+#define RTC_ASYNCH_PREDIV                   1U
+#define RTC_SYNCH_PREDIV                    0x3E7Fu /* (16000 - 1) */
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+/* HSE Freq as RTCCLK = 32 MHz / 32 = 1 MHz */
+#define RTC_ASYNCH_PREDIV                   0x27u
+#define RTC_SYNCH_PREDIV                    0x5161
+#endif /* RTC_CLOCK_SOURCE_LSE */
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 extern RTC_HandleTypeDef hRTC_Handle;
-RTC_HandleTypeDef hRTC_Handle;
+RTC_HandleTypeDef        hRTC_Handle;
 
 /* Private function prototypes -----------------------------------------------*/
 void RTC_Alarm_IRQHandler(void);
+
 /* Private functions ---------------------------------------------------------*/
 
 /**
-  * @brief  This function configures the RTC_ALARMA as a time base source.
-  *         The time source is configured  to have 1ms time base with a dedicated
+  * @brief  This function configures the RTC ALARM A as a time base source.
+  *         The time source is configured to have 1ms time base with a dedicated
   *         Tick interrupt priority.
-  * @note   This function is called  automatically at the beginning of program after
+  *         Calendar time base is = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
+  *                               = 1s
+  *         Alarm interrupt timebase is = (RTC_SYNCH_PREDIV / (1000 / uwTickFreq))
+  *                                     = 1 ms when uwTickFreq is set to 1 kHz
+  * @note   This function is called automatically at the beginning of program after
   *         reset by HAL_Init() or at any time when clock is configured, by HAL_RCC_ClockConfig().
-  * @param  TickPriority: Tick interrupt priority.
+  * @param  TickPriority  Tick interrupt priority.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority)
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
-  __IO uint32_t counter = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
 
   RCC_OscInitTypeDef        RCC_OscInitStruct;
   RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct;
+  RTC_TimeTypeDef           time;
+  RTC_DateTypeDef           date;
+  RTC_AlarmTypeDef          alarm;
 
-#ifdef RTC_CLOCK_SOURCE_LSE
-  /* Configue LSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero) */
+  if ((uint32_t)uwTickFreq != 0U)
+  {
+    /* Disable backup domeain protection */
+    HAL_PWR_EnableBkUpAccess();
+
+    /* Enable RTC APB clock gating */
+    __HAL_RCC_RTCAPB_CLK_ENABLE();
+
+    /* Disable the Alarm A */
+    __HAL_RTC_ALARMA_DISABLE(&hRTC_Handle);
+
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
+    __HAL_RTC_ALARM_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_ALRAF);
+
+    /* Get RTC clock configuration */
+    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkInitStruct);
+
+    /*In case of RTC clock already enable, make sure it's the good one */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSE)
+        && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_LSI)
-  /* Configue LSI as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSIState = RCC_LSI_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSI)
+        && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSI1RDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_HSE)
-  /* Configue HSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-  /* Ensure that RTC is clocked by 1MHz */
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_1MHZ;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_HSE_DIV32)
+        && (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != 0x00u))
 #else
 #error Please select the RTC Clock source
 #endif /* RTC_CLOCK_SOURCE_LSE */
-
-  if(HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK)
-  {
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
-    if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) == HAL_OK)
     {
-      /* Enable RTC Clock */
-      __HAL_RCC_RTC_ENABLE();
-      /* The time base should be 1ms
-         Time base = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
-         HSE as RTC clock
-           Time base = ((99 + 1) * (9 + 1)) / 1MHz
-                     = 1ms
-         LSE as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32.768KHz
-                     = ~1ms
-         LSI as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32KHz
-                     = 1ms
-      */
+      /* Do nothing */
+    }
+    else
+    {
+#ifdef RTC_CLOCK_SOURCE_LSE
+      /* Configure LSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+      /* Configure LSI as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSIState = RCC_LSI_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+      /* Configure HSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+      /* Ensure that RTC is clocked by 1MHz */
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV32;
+#endif /* RTC_CLOCK_SOURCE_LSE */
+
+      /* Configure oscillator */
+      status = HAL_RCC_OscConfig(&RCC_OscInitStruct);
+      if(status == HAL_OK)
+      {
+        /* Configure RTC clock source */
+        PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+        status = HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+
+        /* Enable RTC Clock */
+        if(status == HAL_OK)
+        {
+          __HAL_RCC_RTC_ENABLE();
+        }
+      }
+    }
+
+    /* If RTC Clock configuration is ok */
+    if (status == HAL_OK)
+    {
+      /* The time base is defined to have highest synchronous prescaler but keeping
+         a 1Hz RTC frequency. */
       hRTC_Handle.Instance = RTC;
       hRTC_Handle.Init.HourFormat = RTC_HOURFORMAT_24;
       hRTC_Handle.Init.AsynchPrediv = RTC_ASYNCH_PREDIV;
@@ -150,81 +206,105 @@ HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority)
       hRTC_Handle.Init.OutPut = RTC_OUTPUT_DISABLE;
       hRTC_Handle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
       hRTC_Handle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-      if (HAL_RTC_Init(&hRTC_Handle) != HAL_OK)
+      status = HAL_RTC_Init(&hRTC_Handle);
+    }
+
+    /* HAL RTC Init is ok & calendar has never been initialized */
+    if (status == HAL_OK)
+    {
+      time.Hours = 0x00u;
+      time.Minutes = 0x00u;
+      time.Seconds = 0x00u;
+      time.TimeFormat = RTC_HOURFORMAT12_PM;
+      time.SubSeconds = 0x00u;
+      time.SecondFraction = 0x00u;
+      time.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+      time.StoreOperation = RTC_STOREOPERATION_RESET;
+      status = HAL_RTC_SetTime(&hRTC_Handle, &time, RTC_FORMAT_BCD);
+      if ((status == HAL_OK)&& (__HAL_RTC_IS_CALENDAR_INITIALIZED(&hRTC_Handle) == 0u))
       {
-        return HAL_ERROR;
+        date.WeekDay = RTC_WEEKDAY_MONDAY;
+        date.Date = 0x01u;
+        date.Month = RTC_MONTH_JANUARY;
+        date.Year = 0x01u;
+        status = HAL_RTC_SetDate(&hRTC_Handle, &date, RTC_FORMAT_BCD);
+      }
+    }
+
+    /* If RTC calendar is initialized */
+    if (status == HAL_OK)
+    {
+      alarm.AlarmTime.Hours = 0x00u;
+      alarm.AlarmTime.Minutes = 0x00u;
+      alarm.AlarmTime.Seconds = 0x00u;
+      alarm.AlarmTime.TimeFormat = RTC_HOURFORMAT12_PM;
+      alarm.AlarmTime.SubSeconds = ((RTC_SYNCH_PREDIV + 1) / (1000 / (uint32_t)uwTickFreq));
+      alarm.AlarmTime.SecondFraction = 0x00u;
+      alarm.AlarmTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+      alarm.AlarmTime.StoreOperation = RTC_STOREOPERATION_RESET;
+      alarm.AlarmMask = RTC_ALARMMASK_ALL;
+
+      /* Depending on input frequency select Subsecond mask */
+      if (uwTickFreq == HAL_TICK_FREQ_1KHZ)
+      {
+#if defined (RTC_CLOCK_SOURCE_HSE)
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_5;
+#else
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_4;
+#endif
+      }
+      else if (uwTickFreq == HAL_TICK_FREQ_100HZ)
+      {
+#if defined (RTC_CLOCK_SOURCE_HSE)
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_8;
+#else
+        alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_7;
+#endif
+      }
+      else
+      {
+       alarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_SS14_11;
       }
 
-      /* Disable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-
-      /* Disable the Alarm A interrupt */
-      __HAL_RTC_ALARMA_DISABLE(&hRTC_Handle);
-
-      /* Clear flag alarm A */
-      __HAL_RTC_ALARM_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_ALRAF);
-
-      counter = 0U;
-      /* Wait till RTC ALRAWF flag is set and if Time out is reached exit */
-      while(__HAL_RTC_ALARM_GET_FLAG(&hRTC_Handle, RTC_FLAG_ALRAWF) == 0U)
+      alarm.AlarmDateWeekDaySel = RTC_ALARMDATEWEEKDAYSEL_DATE;
+      alarm.AlarmDateWeekDay = RTC_WEEKDAY_MONDAY;
+      alarm.Alarm = RTC_ALARM_A;
+      status = HAL_RTC_SetAlarm_IT(&hRTC_Handle, &alarm, RTC_FORMAT_BCD);
+      if(status == HAL_OK)
       {
-        if(counter++ == (SystemCoreClock /48U)) /* Timeout = ~ 1s */
+        /* Enable the RTC global Interrupt */
+        HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+
+        /* Configure the SysTick IRQ priority */
+        if (TickPriority < (1UL << __NVIC_PRIO_BITS))
         {
-          return HAL_ERROR;
+          HAL_NVIC_SetPriority(RTC_Alarm_IRQn, TickPriority, 0U);
+          uwTickPrio = TickPriority;
+        }
+        else
+        {
+          status = HAL_ERROR;
         }
       }
-
-      hRTC_Handle.Instance->ALRMAR = (uint32_t)0x01U;
-
-      /* Configure the Alarm state: Enable Alarm */
-      __HAL_RTC_ALARMA_ENABLE(&hRTC_Handle);
-      /* Configure the Alarm interrupt */
-      __HAL_RTC_ALARM_ENABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
-
-      /* RTC Alarm Interrupt Configuration: EXTI configuration */
-      __HAL_RTC_ALARM_EXTI_ENABLE_IT();
-      __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();
-
-      /* Check if the Initialization mode is set */
-      if((hRTC_Handle.Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
-      {
-        /* Set the Initialization mode */
-        hRTC_Handle.Instance->ISR = (uint32_t)RTC_INIT_MASK;
-        counter = 0U;
-        while((hRTC_Handle.Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
-        {
-          if(counter++ == (SystemCoreClock /48U)) /* Timeout = ~ 1s */
-          {
-            return HAL_ERROR;
-          }
-        }
-      }
-      hRTC_Handle.Instance->DR = 0U;
-      hRTC_Handle.Instance->TR = 0U;
-
-      hRTC_Handle.Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
-
-      /* Enable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
-
-      HAL_NVIC_SetPriority(RTC_Alarm_IRQn, TickPriority, 0U);
-      HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
-      return HAL_OK;
     }
   }
-  return HAL_ERROR;
+  else
+  {
+    status = HAL_ERROR;
+  }
+  return status;
 }
 
 /**
   * @brief  Suspend Tick increment.
-  * @note   Disable the tick increment by disabling RTC ALARM interrupt.
+  * @note   Disable the tick increment by disabling ALARM A interrupt.
   * @retval None
   */
 void HAL_SuspendTick(void)
 {
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-  /* Disable RTC ALARM update Interrupt */
+  /* Disable ALARM A Interrupt */
   __HAL_RTC_ALARM_DISABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
@@ -232,57 +312,34 @@ void HAL_SuspendTick(void)
 
 /**
   * @brief  Resume Tick increment.
-  * @note   Enable the tick increment by Enabling RTC ALARM interrupt.
+  * @note   Enable the tick increment by Enabling ALARM A interrupt.
   * @retval None
   */
 void HAL_ResumeTick(void)
 {
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-  /* Enable RTC ALARM Update interrupt */
+  /* Enable ALARM A interrupt */
   __HAL_RTC_ALARM_ENABLE_IT(&hRTC_Handle, RTC_IT_ALRA);
   /* Enable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
 }
 
 /**
-  * @brief  ALARM A Event Callback in non blocking mode
-  * @note   This function is called  when RTC_ALARM interrupt took place, inside
-  * RTC_ALARM_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
-  * a global variable "uwTick" used as application time base.
-  * @param  hrtc : RTC handle
+  * @brief  Alarm Timer Event Callback in non blocking mode
+  * @note   This function is called when RTC Alarm takes place, inside
+  *         HAL_RTC_AlarmIRQHandler(). It makes a direct call to HAL_IncTick() to increment
+  *         a global variable "uwTick" used as application time base.
+  * @param  hrtc  RTC handle
   * @retval None
   */
 void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
 {
-  __IO uint32_t counter = 0U;
-
   HAL_IncTick();
-
-  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-
-  /* Set the Initialization mode */
-  hrtc->Instance->ISR = (uint32_t)RTC_INIT_MASK;
-
-  while((hrtc->Instance->ISR & RTC_ISR_INITF) == (uint32_t)RESET)
-  {
-    if(counter++ == (SystemCoreClock /48U)) /* Timeout = ~ 1s */
-    {
-      break;
-    }
-  }
-
-  hrtc->Instance->DR = 0U;
-  hrtc->Instance->TR = 0U;
-
-  hrtc->Instance->ISR &= (uint32_t)~RTC_ISR_INIT;
-
-  /* Enable the write protection for RTC registers */
-  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
 }
 
 /**
-  * @brief  This function handles RTC ALARM interrupt request.
+  * @brief  This function handles Alarm interrupt request.
   * @retval None
   */
 void RTC_Alarm_IRQHandler(void)
@@ -297,5 +354,3 @@ void RTC_Alarm_IRQHandler(void)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_timebase_rtc_wakeup_template.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_timebase_rtc_wakeup_template.c
@@ -6,12 +6,23 @@
   *
   *          This file overrides the native HAL time base functions (defined as weak)
   *          to use the RTC WAKEUP for the time base generation:
-  *           + Intializes the RTC peripheral and configures the wakeup timer to be
-  *             incremented each 1ms
-  *           + The wakeup feature is configured to assert an interrupt each 1ms
+  *           + Initializes the RTC peripheral and configures the wakeup timer to be
+  *             incremented each 1ms when uwTickFreq is set to default value, else
+  *             10 ms or 100 ms, depending of above global variable value.
   *           + HAL_IncTick is called inside the HAL_RTCEx_WakeUpTimerEventCallback
   *           + HSE (default), LSE or LSI can be selected as RTC clock source
- @verbatim
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
   ==============================================================================
                         ##### How to use this driver #####
   ==============================================================================
@@ -31,21 +42,11 @@
 
   @endverbatim
   ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
   */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_hal.h"
+
 /** @addtogroup STM32WBxx_HAL_Driver
   * @{
   */
@@ -64,18 +65,26 @@
   + RTC_CLOCK_SOURCE_LSI: can be selected for applications with low constraint on timing
                           precision.
   */
-#define RTC_CLOCK_SOURCE_HSE
+/* #define RTC_CLOCK_SOURCE_HSE */
 /* #define RTC_CLOCK_SOURCE_LSE */
 /* #define RTC_CLOCK_SOURCE_LSI */
 
-#ifdef RTC_CLOCK_SOURCE_HSE
-  #define RTC_ASYNCH_PREDIV       99U
-  #define RTC_SYNCH_PREDIV        9U
-  #define RCC_RTCCLKSOURCE_1MHZ   ((uint32_t)((uint32_t)RCC_BDCR_RTCSEL | (uint32_t)((HSE_VALUE/1000000U) << 16U)))
-#else /* RTC_CLOCK_SOURCE_LSE || RTC_CLOCK_SOURCE_LSI */
-  #define RTC_ASYNCH_PREDIV       0U
-  #define RTC_SYNCH_PREDIV        31U
-#endif /* RTC_CLOCK_SOURCE_HSE */
+/* Maximize Asynchronous prescaler for low power consumption :
+  ck_apre = RTCCLK / (ASYNC prediv + 1)
+  ck_spre = ck_apre /(SYNC prediv + 1) = 1 Hz */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+/* LSE Freq = 32.768 kHz RC */
+#define RTC_ASYNCH_PREDIV                   0x7Fu
+#define RTC_SYNCH_PREDIV                    0x00FFu
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+/* LSI Freq = 32 kHz RC  */
+#define RTC_ASYNCH_PREDIV                   0x7Fu
+#define RTC_SYNCH_PREDIV                    0x00FEu
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+/* HSE Freq as RTCCLK = 32 MHz / 32 = 1 MHz */
+#define RTC_ASYNCH_PREDIV                   0x7Fu
+#define RTC_SYNCH_PREDIV                    0x1E83u
+#endif /* RTC_CLOCK_SOURCE_LSE */
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
@@ -89,66 +98,102 @@ void RTC_WKUP_IRQHandler(void);
 
 /**
   * @brief  This function configures the RTC_WKUP as a time base source.
-  *         The time source is configured  to have 1ms time base with a dedicated
+  *         The time source is configured to have 1ms time base with a dedicated
   *         Tick interrupt priority.
   *         Wakeup Time base = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
                              = 1ms
   *         Wakeup Time = WakeupTimebase * WakeUpCounter (0 + 1)
                         = 1 ms
-  * @note   This function is called  automatically at the beginning of program after
+  * @note   This function is called automatically at the beginning of program after
   *         reset by HAL_Init() or at any time when clock is configured, by HAL_RCC_ClockConfig().
-  * @param  TickPriority: Tick interrupt priority.
+  * @param  TickPriority  Tick interrupt priority.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority)
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
-  __IO uint32_t counter = 0U;
-
+  HAL_StatusTypeDef status = HAL_OK;
+  uint32_t wucounter;
   RCC_OscInitTypeDef        RCC_OscInitStruct;
   RCC_PeriphCLKInitTypeDef  PeriphClkInitStruct;
 
-#ifdef RTC_CLOCK_SOURCE_LSE
-  /* Configue LSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSEState = RCC_LSE_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero) */
+  if ((uint32_t)uwTickFreq != 0U)
+  {
+    /* Disable backup domeain protection */
+    HAL_PWR_EnableBkUpAccess();
+
+    /* Enable RTC APB clock gating */
+    __HAL_RCC_RTCAPB_CLK_ENABLE();
+
+    /* Disable the Wake-up Timer */
+    __HAL_RTC_WAKEUPTIMER_DISABLE(&hRTC_Handle);
+    /* In case of interrupt mode is used, the interrupt source must disabled */
+    __HAL_RTC_WAKEUPTIMER_DISABLE_IT(&hRTC_Handle, RTC_IT_WUT);
+    __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_WUTF);
+
+    /* Get RTC clock configuration */
+    HAL_RCCEx_GetPeriphCLKConfig(&PeriphClkInitStruct);
+
+    /*In case of RTC clock already enable, make sure it's the good one */
+#if defined (RTC_CLOCK_SOURCE_LSE)
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSE)
+        && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSERDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_LSI)
-  /* Configue LSI as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.LSIState = RCC_LSI_ON;
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_LSI)
+        && (__HAL_RCC_GET_FLAG(RCC_FLAG_LSI1RDY) != 0x00u))
 #elif defined (RTC_CLOCK_SOURCE_HSE)
-  /* Configue HSE as RTC clock soucre */
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
-  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
-  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
-  /* Ensure that RTC is clocked by 1MHz */
-  PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_1MHZ;
+    if ((PeriphClkInitStruct.RTCClockSelection == RCC_RTCCLKSOURCE_HSE_DIV32)
+        && (__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != 0x00u))
 #else
 #error Please select the RTC Clock source
 #endif /* RTC_CLOCK_SOURCE_LSE */
-
-  if(HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK)
-  {
-    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
-    if(HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) == HAL_OK)
     {
-      /* Enable RTC Clock */
-      __HAL_RCC_RTC_ENABLE();
-      /* The time base should be 1ms
-         Time base = ((RTC_ASYNCH_PREDIV + 1) * (RTC_SYNCH_PREDIV + 1)) / RTC_CLOCK
-         HSE as RTC clock
-           Time base = ((99 + 1) * (9 + 1)) / 1Mhz
-                     = 1ms
-         LSE as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32.768Khz
-                     = ~1ms
-         LSI as RTC clock
-           Time base = ((31 + 1) * (0 + 1)) / 32Khz
-                     = 1ms
-      */
+      /* Do nothing */
+    }
+    else
+    {
+#ifdef RTC_CLOCK_SOURCE_LSE
+      /* Configure LSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSEState = RCC_LSE_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+      /* Configure LSI as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.LSIState = RCC_LSI_ON;
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+      /* Configure HSE as RTC clock source */
+      RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+      RCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
+      RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+      /* Ensure that RTC is clocked by 1MHz */
+      PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_HSE_DIV32;
+#endif /* RTC_CLOCK_SOURCE_LSE */
+
+      /* Configure oscillator */
+      status = HAL_RCC_OscConfig(&RCC_OscInitStruct);
+      if(status == HAL_OK)
+      {
+        /* Configure RTC clock source */
+        PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+        status = HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
+
+        /* Enable RTC Clock */
+        if(status == HAL_OK)
+        {
+          __HAL_RCC_RTC_ENABLE();
+        }
+      }
+    }
+
+    /* If RTC Clock configuration is ok */
+    if (status == HAL_OK)
+    {
+      /* No care of RTC init parameter here. Only needed if RTC is being used
+        for other features in same time: calendar, alarm, timestamp, etc... */
       hRTC_Handle.Instance = RTC;
       hRTC_Handle.Init.HourFormat = RTC_HOURFORMAT_24;
       hRTC_Handle.Init.AsynchPrediv = RTC_ASYNCH_PREDIV;
@@ -156,64 +201,48 @@ HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority)
       hRTC_Handle.Init.OutPut = RTC_OUTPUT_DISABLE;
       hRTC_Handle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
       hRTC_Handle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-      if (HAL_RTC_Init(&hRTC_Handle) != HAL_OK)
+      status = HAL_RTC_Init(&hRTC_Handle);
+
+      if(status == HAL_OK)
       {
-        return HAL_ERROR;
-      }
+        /* The time base should be of (uint32_t)uwTickFreq) ms. Tick counter
+          is incremented eachtime wakeup time reaches zero. Wakeup timer is
+          clocked on RTCCLK divided by 2. So downcounting counter has to be
+          set to (RTCCLK / 2) / (1000 / (uint32_t)uwTickFreq)) minus 1 */
+#ifdef RTC_CLOCK_SOURCE_LSE
+        wucounter = LSE_VALUE;
+#elif defined (RTC_CLOCK_SOURCE_LSI)
+        wucounter = LSI_VALUE;
+#elif defined (RTC_CLOCK_SOURCE_HSE)
+        /* HSE input clock to RTC is divided by 32 */
+        wucounter = (HSE_VALUE >> 5);
+#endif
+        wucounter = ((wucounter >> 1) / (1000U / (uint32_t)uwTickFreq)) -1u;
+        status = HAL_RTCEx_SetWakeUpTimer_IT(&hRTC_Handle, wucounter, RTC_WAKEUPCLOCK_RTCCLK_DIV2);
 
-      /* Disable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_DISABLE(&hRTC_Handle);
-
-      /* Disable the Wake-up Timer */
-      __HAL_RTC_WAKEUPTIMER_DISABLE(&hRTC_Handle);
-
-      /* In case of interrupt mode is used, the interrupt source must disabled */
-      __HAL_RTC_WAKEUPTIMER_DISABLE_IT(&hRTC_Handle,RTC_IT_WUT);
-
-      /* Wait till RTC WUTWF flag is set  */
-      while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(&hRTC_Handle, RTC_FLAG_WUTWF) == 0U)
-      {
-        if(counter++ == (SystemCoreClock /48U))
+        if(status == HAL_OK)
         {
-          return HAL_ERROR;
+          /* Enable the RTC global Interrupt */
+          HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
+          /* Configure the SysTick IRQ priority */
+          if (TickPriority < (1UL << __NVIC_PRIO_BITS))
+          {
+            HAL_NVIC_SetPriority(RTC_WKUP_IRQn, TickPriority, 0U);
+            uwTickPrio = TickPriority;
+          }
+          else
+          {
+            status = HAL_ERROR;
+          }
         }
       }
-
-      /* Clear PWR wake up Flag */
-      __HAL_PWR_CLEAR_FLAG(PWR_FLAG_WU);
-
-      /* Clear RTC Wake Up timer Flag */
-      __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(&hRTC_Handle, RTC_FLAG_WUTF);
-
-      /* Configure the Wake-up Timer counter */
-      hRTC_Handle.Instance->WUTR = 0U;
-
-      /* Clear the Wake-up Timer clock source bits in CR register */
-      hRTC_Handle.Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
-
-      /* Configure the clock source */
-      hRTC_Handle.Instance->CR |= (uint32_t)RTC_WAKEUPCLOCK_CK_SPRE_16BITS;
-
-      /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
-      __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
-
-      __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
-
-      /* Configure the Interrupt in the RTC_CR register */
-      __HAL_RTC_WAKEUPTIMER_ENABLE_IT(&hRTC_Handle,RTC_IT_WUT);
-
-      /* Enable the Wake-up Timer */
-      __HAL_RTC_WAKEUPTIMER_ENABLE(&hRTC_Handle);
-
-      /* Enable the write protection for RTC registers */
-      __HAL_RTC_WRITEPROTECTION_ENABLE(&hRTC_Handle);
-
-      HAL_NVIC_SetPriority(RTC_WKUP_IRQn, TickPriority, 0U);
-      HAL_NVIC_EnableIRQ(RTC_WKUP_IRQn);
-      return HAL_OK;
     }
   }
-  return HAL_ERROR;
+  else
+  {
+    status = HAL_ERROR;
+  }
+  return status;
 }
 
 /**
@@ -248,10 +277,10 @@ void HAL_ResumeTick(void)
 
 /**
   * @brief  Wake Up Timer Event Callback in non blocking mode
-  * @note   This function is called  when RTC_WKUP interrupt took place, inside
-  * RTC_WKUP_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
-  * a global variable "uwTick" used as application time base.
-  * @param  hrtc : RTC handle
+  * @note   This function is called when RTC_WKUP interrupt takes place, inside
+  *         RTC_WKUP_IRQHandler(). It makes a direct call to HAL_IncTick() to increment
+  *         a global variable "uwTick" used as application time base.
+  * @param  hrtc  RTC handle
   * @retval None
   */
 void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
@@ -260,7 +289,7 @@ void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
 }
 
 /**
-  * @brief  This function handles  WAKE UP TIMER  interrupt request.
+  * @brief  This function handles WAKE UP TIMER interrupt request.
   * @retval None
   */
 void RTC_WKUP_IRQHandler(void)
@@ -275,5 +304,3 @@ void RTC_WKUP_IRQHandler(void)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_timebase_tim_template.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_timebase_tim_template.c
@@ -6,21 +6,33 @@
   *
   *          This file overrides the native HAL time base functions (defined as weak)
   *          the TIM time base:
-  *           + Intializes the TIM peripheral generate a Period elapsed Event each 1ms
-  *           + HAL_IncTick is called inside HAL_TIM_PeriodElapsedCallback ie each 1ms
+  *           + Initializes the TIM peripheral generate a Period elapsed Event each 1ms
+  *             when uwTickFreq is set to default value, else 10 ms or
+  *             100 ms, depending of above global variable value.
+  *           + HAL_IncTick is called inside HAL_TIM_PeriodElapsedCallback
   *
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+    [..]
+    This file must be copied to the application folder and modified as follows:
+    (#) Rename it to 'stm32wlxx_hal_timebase_tim.c'
+    (#) Add this file and the TIM HAL drivers to your project and uncomment
+       HAL_TIM_MODULE_ENABLED define in stm32wlxx_hal_conf.h
+
+  @endverbatim
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -40,6 +52,7 @@
 /* Private variables ---------------------------------------------------------*/
 extern TIM_HandleTypeDef TimHandle;
 TIM_HandleTypeDef        TimHandle;
+
 /* Private function prototypes -----------------------------------------------*/
 void TIM2_IRQHandler(void);
 /* Private functions ---------------------------------------------------------*/
@@ -48,67 +61,96 @@ void TIM2_IRQHandler(void);
   * @brief  This function configures the TIM2 as a time base source.
   *         The time source is configured to have 1ms time base with a dedicated
   *         Tick interrupt priority.
-  * @note   This function is called  automatically at the beginning of program after
+  * @note   This function is called automatically at the beginning of program after
   *         reset by HAL_Init() or at any time when clock is configured, by HAL_RCC_ClockConfig().
-  * @param  TickPriority: Tick interrupt priority.
+  * @param  TickPriority Tick interrupt priority.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_InitTick (uint32_t TickPriority)
+HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
   RCC_ClkInitTypeDef    clkconfig;
-  uint32_t              uwTimclock, uwAPB1Prescaler;
+  uint32_t              uwTimclock;
+  uint32_t              uwAPB1Prescaler;
   uint32_t              uwPrescalerValue;
   uint32_t              pFLatency;
+HAL_StatusTypeDef     status = HAL_OK;
 
-    /*Configure the TIM2 IRQ priority */
-  HAL_NVIC_SetPriority(TIM2_IRQn, TickPriority ,0U);
-
-  /* Enable the TIM2 global Interrupt */
-  HAL_NVIC_EnableIRQ(TIM2_IRQn);
-
-  /* Enable TIM2 clock */
-  __HAL_RCC_TIM2_CLK_ENABLE();
-
-  /* Get clock configuration */
-  HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
-
-  /* Get APB1 prescaler */
-  uwAPB1Prescaler = clkconfig.APB1CLKDivider;
-
-  /* Compute TIM2 clock */
-  if (uwAPB1Prescaler == RCC_HCLK_DIV1)
+  /* Check uwTickFreq for MisraC 2012 (even if uwTickFreq is a enum type that don't take the value zero)*/
+  if ((uint32_t)uwTickFreq != 0U)
   {
-    uwTimclock = HAL_RCC_GetPCLK1Freq();
+    /* Enable TIM2 clock */
+    __HAL_RCC_TIM2_CLK_ENABLE();
+
+    /* Get clock configuration */
+    HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
+
+    /* Get APB1 prescaler */
+    uwAPB1Prescaler = clkconfig.APB1CLKDivider;
+
+    /* Compute TIM2 clock */
+    if (uwAPB1Prescaler == RCC_HCLK_DIV1)
+    {
+      uwTimclock = HAL_RCC_GetPCLK1Freq();
+    }
+    else
+    {
+      uwTimclock = 2*HAL_RCC_GetPCLK1Freq();
+    }
+
+    /* Compute the prescaler value to have TIM2 counter clock equal to 1MHz */
+    uwPrescalerValue = (uint32_t) ((uwTimclock / 1000000U) - 1U);
+
+    /* Initialize TIM2 */
+    TimHandle.Instance = TIM2;
+
+    /* Initialize TIMx peripheral as follow:
+    + Period = [(TIM2CLK/uwTickFreq) - 1]. to have a (1/uwTickFreq) s time base.
+    + Prescaler = (uwTimclock/1000000 - 1) to have a 1MHz counter clock.
+    + ClockDivision = 0
+    + Counter direction = Up
+    */
+    TimHandle.Init.Period = (1000000U / (1000U / (uint32_t)uwTickFreq)) - 1U;
+    TimHandle.Init.Prescaler = uwPrescalerValue;
+    TimHandle.Init.ClockDivision = 0U;
+    TimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
+    TimHandle.Init.RepetitionCounter = 0U;
+    if (HAL_TIM_Base_Init(&TimHandle) == HAL_OK)
+    {
+      /* Start the TIM time Base generation in interrupt mode */
+      if (HAL_TIM_Base_Start_IT(&TimHandle) == HAL_OK)
+      {
+        /* Enable the TIM2 global Interrupt */
+        HAL_NVIC_EnableIRQ(TIM2_IRQn);
+
+        /* Configure the SysTick IRQ priority */
+        if (TickPriority < (1UL << __NVIC_PRIO_BITS))
+        {
+          /*Configure the TIM2 IRQ priority */
+          HAL_NVIC_SetPriority(TIM2_IRQn, TickPriority ,0U);
+          uwTickPrio = TickPriority;
+        }
+        else
+        {
+          status = HAL_ERROR;
+        }
+      }
+      else
+      {
+        status = HAL_ERROR;
+      }
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
   }
   else
   {
-    uwTimclock = 2U*HAL_RCC_GetPCLK1Freq();
-  }
-
-  /* Compute the prescaler value to have TIM2 counter clock equal to 1MHz */
-  uwPrescalerValue = (uint32_t) ((uwTimclock / 1000000U) - 1U);
-
-  /* Initialize TIM2 */
-  TimHandle.Instance = TIM2;
-
-  /* Initialize TIMx peripheral as follow:
-  + Period = [(TIM2CLK/1000) - 1]. to have a (1/1000) s time base.
-  + Prescaler = (uwTimclock/1000000 - 1) to have a 1MHz counter clock.
-  + ClockDivision = 0
-  + Counter direction = Up
-  */
-  TimHandle.Init.Period = (1000000U / 1000U) - 1U;
-  TimHandle.Init.Prescaler = uwPrescalerValue;
-  TimHandle.Init.ClockDivision = 0U;
-  TimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
-  if(HAL_TIM_Base_Init(&TimHandle) == HAL_OK)
-  {
-    /* Start the TIM time Base generation in interrupt mode */
-    return HAL_TIM_Base_Start_IT(&TimHandle);
+      status = HAL_ERROR;
   }
 
   /* Return function status */
-  return HAL_ERROR;
+  return status;
 }
 
 /**
@@ -162,5 +204,3 @@ void TIM2_IRQHandler(void)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_tsc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_tsc.c
@@ -10,6 +10,17 @@
   *           + Read acquisition result
   *           + Interrupts and flags management
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
 ================================================================================
                        ##### TSC specific features #####
@@ -82,10 +93,10 @@
   [..]
      The compilation flag USE_HAL_TSC_REGISTER_CALLBACKS when set to 1
      allows the user to configure dynamically the driver callbacks.
-     Use Functions @ref HAL_TSC_RegisterCallback() to register an interrupt callback.
+     Use Functions HAL_TSC_RegisterCallback() to register an interrupt callback.
 
   [..]
-     Function @ref HAL_TSC_RegisterCallback() allows to register following callbacks:
+     Function HAL_TSC_RegisterCallback() allows to register following callbacks:
        (+) ConvCpltCallback   : callback for conversion complete process.
        (+) ErrorCallback      : callback for error detection.
        (+) MspInitCallback    : callback for Msp Init.
@@ -95,9 +106,9 @@
      and a pointer to the user callback function.
 
   [..]
-     Use function @ref HAL_TSC_UnRegisterCallback to reset a callback to the default
+     Use function HAL_TSC_UnRegisterCallback to reset a callback to the default
      weak function.
-     @ref HAL_TSC_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     HAL_TSC_UnRegisterCallback takes as parameters the HAL peripheral handle,
      and the Callback ID.
   [..]
      This function allows to reset following callbacks:
@@ -107,23 +118,23 @@
        (+) MspDeInitCallback  : callback for Msp DeInit.
 
   [..]
-     By default, after the @ref HAL_TSC_Init() and when the state is @ref HAL_TSC_STATE_RESET
+     By default, after the HAL_TSC_Init() and when the state is HAL_TSC_STATE_RESET
      all callbacks are set to the corresponding weak functions:
-     examples @ref HAL_TSC_ConvCpltCallback(), @ref HAL_TSC_ErrorCallback().
+     examples HAL_TSC_ConvCpltCallback(), HAL_TSC_ErrorCallback().
      Exception done for MspInit and MspDeInit functions that are
-     reset to the legacy weak functions in the @ref HAL_TSC_Init()/ @ref HAL_TSC_DeInit() only when
+     reset to the legacy weak functions in the HAL_TSC_Init()/ HAL_TSC_DeInit() only when
      these callbacks are null (not registered beforehand).
-     If MspInit or MspDeInit are not null, the @ref HAL_TSC_Init()/ @ref HAL_TSC_DeInit()
+     If MspInit or MspDeInit are not null, the HAL_TSC_Init()/ HAL_TSC_DeInit()
      keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
 
   [..]
-     Callbacks can be registered/unregistered in @ref HAL_TSC_STATE_READY state only.
+     Callbacks can be registered/unregistered in HAL_TSC_STATE_READY state only.
      Exception done MspInit/MspDeInit functions that can be registered/unregistered
-     in @ref HAL_TSC_STATE_READY or @ref HAL_TSC_STATE_RESET state,
+     in HAL_TSC_STATE_READY or HAL_TSC_STATE_RESET state,
      thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
      Then, the user first registers the MspInit/MspDeInit user callbacks
-     using @ref HAL_TSC_RegisterCallback() before calling @ref HAL_TSC_DeInit()
-     or @ref HAL_TSC_Init() function.
+     using HAL_TSC_RegisterCallback() before calling HAL_TSC_DeInit()
+     or HAL_TSC_Init() function.
 
   [..]
      When the compilation flag USE_HAL_TSC_REGISTER_CALLBACKS is set to 0 or
@@ -176,18 +187,7 @@
     |   PD2  (AF)  |                 |
     +--------------------------------+
 
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
-  ******************************************************************************
+
   */
 
 /* Includes ------------------------------------------------------------------*/
@@ -219,8 +219,8 @@ static uint32_t TSC_extract_groups(uint32_t iomask);
   */
 
 /** @defgroup TSC_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions
- *
+  *  @brief    Initialization and Configuration functions
+  *
 @verbatim
  ===============================================================================
               ##### Initialization and de-initialization functions #####
@@ -254,6 +254,7 @@ HAL_StatusTypeDef HAL_TSC_Init(TSC_HandleTypeDef *htsc)
   assert_param(IS_TSC_SSD(htsc->Init.SpreadSpectrumDeviation));
   assert_param(IS_TSC_SS_PRESC(htsc->Init.SpreadSpectrumPrescaler));
   assert_param(IS_TSC_PG_PRESC(htsc->Init.PulseGeneratorPrescaler));
+  assert_param(IS_TSC_PG_PRESC_VS_CTPL(htsc->Init.PulseGeneratorPrescaler, htsc->Init.CTPulseLowLength));
   assert_param(IS_TSC_MCV(htsc->Init.MaxCountValue));
   assert_param(IS_TSC_IODEF(htsc->Init.IODefaultMode));
   assert_param(IS_TSC_SYNC_POL(htsc->Init.SynchroPinPolarity));
@@ -427,7 +428,8 @@ __weak void HAL_TSC_MspDeInit(TSC_HandleTypeDef *htsc)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TSC_RegisterCallback(TSC_HandleTypeDef *htsc, HAL_TSC_CallbackIDTypeDef CallbackID, pTSC_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_TSC_RegisterCallback(TSC_HandleTypeDef *htsc, HAL_TSC_CallbackIDTypeDef CallbackID,
+                                           pTSC_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -597,8 +599,8 @@ HAL_StatusTypeDef HAL_TSC_UnRegisterCallback(TSC_HandleTypeDef *htsc, HAL_TSC_Ca
   */
 
 /** @defgroup TSC_Exported_Functions_Group2 Input and Output operation functions
- *  @brief    Input and Output operation functions
- *
+  *  @brief    Input and Output operation functions
+  *
 @verbatim
  ===============================================================================
              ##### IO Operation functions #####
@@ -816,7 +818,7 @@ HAL_StatusTypeDef HAL_TSC_PollForAcquisition(TSC_HandleTypeDef *htsc)
   * @param  gx_index Index of the group
   * @retval Group status
   */
-TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(TSC_HandleTypeDef *htsc, uint32_t gx_index)
+TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(const TSC_HandleTypeDef *htsc, uint32_t gx_index)
 {
   /* Check the parameters */
   assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
@@ -833,7 +835,7 @@ TSC_GroupStatusTypeDef HAL_TSC_GroupGetStatus(TSC_HandleTypeDef *htsc, uint32_t 
   * @param  gx_index Index of the group
   * @retval Acquisition measure
   */
-uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef *htsc, uint32_t gx_index)
+uint32_t HAL_TSC_GroupGetValue(const TSC_HandleTypeDef *htsc, uint32_t gx_index)
 {
   /* Check the parameters */
   assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
@@ -848,8 +850,8 @@ uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef *htsc, uint32_t gx_index)
   */
 
 /** @defgroup TSC_Exported_Functions_Group3 Peripheral Control functions
- *  @brief    Peripheral Control functions
- *
+  *  @brief    Peripheral Control functions
+  *
 @verbatim
  ===============================================================================
              ##### Peripheral Control functions #####
@@ -868,7 +870,7 @@ uint32_t HAL_TSC_GroupGetValue(TSC_HandleTypeDef *htsc, uint32_t gx_index)
   * @param  config Pointer to the configuration structure.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef *htsc, TSC_IOConfigTypeDef *config)
+HAL_StatusTypeDef HAL_TSC_IOConfig(TSC_HandleTypeDef *htsc, const TSC_IOConfigTypeDef *config)
 {
   /* Check the parameters */
   assert_param(IS_TSC_ALL_INSTANCE(htsc->Instance));
@@ -937,8 +939,8 @@ HAL_StatusTypeDef HAL_TSC_IODischarge(TSC_HandleTypeDef *htsc, FunctionalState c
   */
 
 /** @defgroup TSC_Exported_Functions_Group4 Peripheral State and Errors functions
- *  @brief   Peripheral State and Errors functions
- *
+  *  @brief   Peripheral State and Errors functions
+  *
 @verbatim
  ===============================================================================
             ##### State and Errors functions #####
@@ -990,8 +992,8 @@ HAL_TSC_StateTypeDef HAL_TSC_GetState(TSC_HandleTypeDef *htsc)
   */
 
 /** @defgroup TSC_IRQ_Handler_and_Callbacks IRQ Handler and Callbacks
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  Handle TSC interrupt request.
@@ -1095,7 +1097,7 @@ static uint32_t TSC_extract_groups(uint32_t iomask)
 
   for (idx = 0UL; idx < (uint32_t)TSC_NB_OF_GROUPS; idx++)
   {
-    if ((iomask & (0x0FUL << (idx * 4UL))) != 0UL )
+    if ((iomask & (0x0FUL << (idx * 4UL))) != 0UL)
     {
       groups |= (1UL << idx);
     }
@@ -1119,4 +1121,3 @@ static uint32_t TSC_extract_groups(uint32_t iomask)
   */
 
 #endif /* TSC */
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_uart.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_uart.c
@@ -10,6 +10,17 @@
   *           + Peripheral Control functions
   *
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
  ===============================================================================
                         ##### How to use this driver #####
@@ -39,7 +50,8 @@
             (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
             (+++) Configure the DMA Tx/Rx channel.
             (+++) Associate the initialized DMA handle to the UART DMA Tx/Rx handle.
-            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+            (+++) Configure the priority and enable the NVIC for the transfer complete
+                  interrupt on the DMA Tx/Rx channel.
 
     (#) Program the Baud Rate, Word Length, Stop Bit, Parity, Prescaler value , Hardware
         flow control and Mode (Receiver/Transmitter) in the huart handle Init structure.
@@ -75,8 +87,8 @@
     allows the user to configure dynamically the driver callbacks.
 
     [..]
-    Use Function @ref HAL_UART_RegisterCallback() to register a user callback.
-    Function @ref HAL_UART_RegisterCallback() allows to register following callbacks:
+    Use Function HAL_UART_RegisterCallback() to register a user callback.
+    Function HAL_UART_RegisterCallback() allows to register following callbacks:
     (+) TxHalfCpltCallback        : Tx Half Complete Callback.
     (+) TxCpltCallback            : Tx Complete Callback.
     (+) RxHalfCpltCallback        : Rx Half Complete Callback.
@@ -94,9 +106,9 @@
     and a pointer to the user callback function.
 
     [..]
-    Use function @ref HAL_UART_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
-    @ref HAL_UART_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+    Use function HAL_UART_UnRegisterCallback() to reset a callback to the default
+    weak function.
+    HAL_UART_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the Callback ID.
     This function allows to reset following callbacks:
     (+) TxHalfCpltCallback        : Tx Half Complete Callback.
@@ -114,13 +126,17 @@
     (+) MspDeInitCallback         : UART MspDeInit.
 
     [..]
-    By default, after the @ref HAL_UART_Init() and when the state is HAL_UART_STATE_RESET
-    all callbacks are set to the corresponding weak (surcharged) functions:
-    examples @ref HAL_UART_TxCpltCallback(), @ref HAL_UART_RxHalfCpltCallback().
+    For specific callback RxEventCallback, use dedicated registration/reset functions:
+    respectively HAL_UART_RegisterRxEventCallback() , HAL_UART_UnRegisterRxEventCallback().
+
+    [..]
+    By default, after the HAL_UART_Init() and when the state is HAL_UART_STATE_RESET
+    all callbacks are set to the corresponding weak functions:
+    examples HAL_UART_TxCpltCallback(), HAL_UART_RxHalfCpltCallback().
     Exception done for MspInit and MspDeInit functions that are respectively
-    reset to the legacy weak (surcharged) functions in the @ref HAL_UART_Init()
-    and @ref HAL_UART_DeInit() only when these callbacks are null (not registered beforehand).
-    If not, MspInit or MspDeInit are not null, the @ref HAL_UART_Init() and @ref HAL_UART_DeInit()
+    reset to the legacy weak functions in the HAL_UART_Init()
+    and HAL_UART_DeInit() only when these callbacks are null (not registered beforehand).
+    If not, MspInit or MspDeInit are not null, the HAL_UART_Init() and HAL_UART_DeInit()
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
 
     [..]
@@ -129,27 +145,16 @@
     in HAL_UART_STATE_READY or HAL_UART_STATE_RESET state, thus registered (user)
     MspInit/DeInit callbacks can be used during the Init/DeInit.
     In that case first register the MspInit/MspDeInit user callbacks
-    using @ref HAL_UART_RegisterCallback() before calling @ref HAL_UART_DeInit()
-    or @ref HAL_UART_Init() function.
+    using HAL_UART_RegisterCallback() before calling HAL_UART_DeInit()
+    or HAL_UART_Init() function.
 
     [..]
     When The compilation define USE_HAL_UART_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registration feature is not available
-    and weak (surcharged) callbacks are used.
+    and weak callbacks are used.
 
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -172,12 +177,11 @@
 /** @defgroup UART_Private_Constants UART Private Constants
   * @{
   */
-#define USART_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | \
-                                      USART_CR1_TE | USART_CR1_RE | USART_CR1_OVER8| \
-                                      USART_CR1_FIFOEN ))                      /*!< UART or USART CR1 fields of parameters set by UART_SetConfig API */
+#define USART_CR1_FIELDS  ((uint32_t)(USART_CR1_M | USART_CR1_PCE | USART_CR1_PS | USART_CR1_TE | USART_CR1_RE | \
+                                      USART_CR1_OVER8 | USART_CR1_FIFOEN)) /*!< UART or USART CR1 fields of parameters set by UART_SetConfig API */
 
-#define USART_CR3_FIELDS  ((uint32_t)(USART_CR3_RTSE | USART_CR3_CTSE | USART_CR3_ONEBIT| \
-                                      USART_CR3_TXFTCFG | USART_CR3_RXFTCFG ))  /*!< UART or USART CR3 fields of parameters set by UART_SetConfig API */
+#define USART_CR3_FIELDS  ((uint32_t)(USART_CR3_RTSE | USART_CR3_CTSE | USART_CR3_ONEBIT | USART_CR3_TXFTCFG | \
+                                      USART_CR3_RXFTCFG)) /*!< UART or USART CR3 fields of parameters set by UART_SetConfig API */
 
 #if defined(LPUART1)
 #define LPUART_BRR_MIN  0x00000300U  /* LPUART BRR minimum authorized value */
@@ -186,21 +190,17 @@
 
 #define UART_BRR_MIN    0x10U        /* UART BRR minimum authorized value */
 #define UART_BRR_MAX    0x0000FFFFU  /* UART BRR maximum authorized value */
-
 /**
   * @}
   */
 
 /* Private macros ------------------------------------------------------------*/
-/* Private variables ---------------------------------------------------------*/
-const uint16_t UARTPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
-
 /* Private function prototypes -----------------------------------------------*/
 /** @addtogroup UART_Private_Functions
   * @{
   */
-static void UART_EndTxTransfer(UART_HandleTypeDef *huart);
 static void UART_EndRxTransfer(UART_HandleTypeDef *huart);
+static void UART_EndTxTransfer(UART_HandleTypeDef *huart);
 static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma);
 static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma);
 static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma);
@@ -224,6 +224,16 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart);
   * @}
   */
 
+/* Private variables ---------------------------------------------------------*/
+/** @addtogroup UART_Private_variables
+  * @{
+  */
+const uint16_t UARTPrescTable[12] = {1U, 2U, 4U, 6U, 8U, 10U, 12U, 16U, 32U, 64U, 128U, 256U};
+/**
+  * @}
+  */
+
+/* Exported Constants --------------------------------------------------------*/
 /* Exported functions --------------------------------------------------------*/
 
 /** @defgroup UART_Exported_Functions UART Exported Functions
@@ -344,15 +354,17 @@ HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
 
   __HAL_UART_DISABLE(huart);
 
+  /* Perform advanced settings configuration */
+  /* For some items, configuration requires to be done prior TE and RE bits are set */
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
   /* Set the UART Communication parameters */
   if (UART_SetConfig(huart) == HAL_ERROR)
   {
     return HAL_ERROR;
-  }
-
-  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
-  {
-    UART_AdvFeatureConfig(huart);
   }
 
   /* In asynchronous mode, the following bits must be kept cleared:
@@ -409,15 +421,17 @@ HAL_StatusTypeDef HAL_HalfDuplex_Init(UART_HandleTypeDef *huart)
 
   __HAL_UART_DISABLE(huart);
 
+  /* Perform advanced settings configuration */
+  /* For some items, configuration requires to be done prior TE and RE bits are set */
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
   /* Set the UART Communication parameters */
   if (UART_SetConfig(huart) == HAL_ERROR)
   {
     return HAL_ERROR;
-  }
-
-  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
-  {
-    UART_AdvFeatureConfig(huart);
   }
 
   /* In half-duplex mode, the following bits must be kept cleared:
@@ -495,15 +509,17 @@ HAL_StatusTypeDef HAL_LIN_Init(UART_HandleTypeDef *huart, uint32_t BreakDetectLe
 
   __HAL_UART_DISABLE(huart);
 
+  /* Perform advanced settings configuration */
+  /* For some items, configuration requires to be done prior TE and RE bits are set */
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
   /* Set the UART Communication parameters */
   if (UART_SetConfig(huart) == HAL_ERROR)
   {
     return HAL_ERROR;
-  }
-
-  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
-  {
-    UART_AdvFeatureConfig(huart);
   }
 
   /* In LIN mode, the following bits must be kept cleared:
@@ -579,15 +595,17 @@ HAL_StatusTypeDef HAL_MultiProcessor_Init(UART_HandleTypeDef *huart, uint8_t Add
 
   __HAL_UART_DISABLE(huart);
 
+  /* Perform advanced settings configuration */
+  /* For some items, configuration requires to be done prior TE and RE bits are set */
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
   /* Set the UART Communication parameters */
   if (UART_SetConfig(huart) == HAL_ERROR)
   {
     return HAL_ERROR;
-  }
-
-  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
-  {
-    UART_AdvFeatureConfig(huart);
   }
 
   /* In multiprocessor mode, the following bits must be kept cleared:
@@ -655,6 +673,8 @@ HAL_StatusTypeDef HAL_UART_DeInit(UART_HandleTypeDef *huart)
   huart->ErrorCode = HAL_UART_ERROR_NONE;
   huart->gState = HAL_UART_STATE_RESET;
   huart->RxState = HAL_UART_STATE_RESET;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+  huart->RxEventType = HAL_UART_RXEVENT_TC;
 
   __HAL_UNLOCK(huart);
 
@@ -694,7 +714,10 @@ __weak void HAL_UART_MspDeInit(UART_HandleTypeDef *huart)
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
 /**
   * @brief  Register a User UART Callback
-  *         To be used instead of the weak predefined callback
+  *         To be used to override the weak predefined callback
+  * @note   The HAL_UART_RegisterCallback() may be called before HAL_UART_Init(), HAL_HalfDuplex_Init(),
+  *         HAL_LIN_Init(), HAL_MultiProcessor_Init() or HAL_RS485Ex_Init() in HAL_UART_STATE_RESET to register
+  *         callbacks for HAL_UART_MSPINIT_CB_ID and HAL_UART_MSPDEINIT_CB_ID
   * @param  huart uart handle
   * @param  CallbackID ID of the callback to be registered
   *         This parameter can be one of the following values:
@@ -725,8 +748,6 @@ HAL_StatusTypeDef HAL_UART_RegisterCallback(UART_HandleTypeDef *huart, HAL_UART_
 
     return HAL_ERROR;
   }
-
-  __HAL_LOCK(huart);
 
   if (huart->gState == HAL_UART_STATE_READY)
   {
@@ -817,14 +838,15 @@ HAL_StatusTypeDef HAL_UART_RegisterCallback(UART_HandleTypeDef *huart, HAL_UART_
     status =  HAL_ERROR;
   }
 
-  __HAL_UNLOCK(huart);
-
   return status;
 }
 
 /**
   * @brief  Unregister an UART Callback
   *         UART callaback is redirected to the weak predefined callback
+  * @note   The HAL_UART_UnRegisterCallback() may be called before HAL_UART_Init(), HAL_HalfDuplex_Init(),
+  *         HAL_LIN_Init(), HAL_MultiProcessor_Init() or HAL_RS485Ex_Init() in HAL_UART_STATE_RESET to un-register
+  *         callbacks for HAL_UART_MSPINIT_CB_ID and HAL_UART_MSPDEINIT_CB_ID
   * @param  huart uart handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
@@ -847,62 +869,62 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  __HAL_LOCK(huart);
-
   if (HAL_UART_STATE_READY == huart->gState)
   {
     switch (CallbackID)
     {
       case HAL_UART_TX_HALFCOMPLETE_CB_ID :
-        huart->TxHalfCpltCallback = HAL_UART_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback       */
+        huart->TxHalfCpltCallback = HAL_UART_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback    */
         break;
 
       case HAL_UART_TX_COMPLETE_CB_ID :
-        huart->TxCpltCallback = HAL_UART_TxCpltCallback;                       /* Legacy weak TxCpltCallback            */
+        huart->TxCpltCallback = HAL_UART_TxCpltCallback;                       /* Legacy weak TxCpltCallback         */
         break;
 
       case HAL_UART_RX_HALFCOMPLETE_CB_ID :
-        huart->RxHalfCpltCallback = HAL_UART_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback        */
+        huart->RxHalfCpltCallback = HAL_UART_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback     */
         break;
 
       case HAL_UART_RX_COMPLETE_CB_ID :
-        huart->RxCpltCallback = HAL_UART_RxCpltCallback;                       /* Legacy weak RxCpltCallback            */
+        huart->RxCpltCallback = HAL_UART_RxCpltCallback;                       /* Legacy weak RxCpltCallback         */
         break;
 
       case HAL_UART_ERROR_CB_ID :
-        huart->ErrorCallback = HAL_UART_ErrorCallback;                         /* Legacy weak ErrorCallback             */
+        huart->ErrorCallback = HAL_UART_ErrorCallback;                         /* Legacy weak ErrorCallback          */
         break;
 
       case HAL_UART_ABORT_COMPLETE_CB_ID :
-        huart->AbortCpltCallback = HAL_UART_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback         */
+        huart->AbortCpltCallback = HAL_UART_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback      */
         break;
 
       case HAL_UART_ABORT_TRANSMIT_COMPLETE_CB_ID :
-        huart->AbortTransmitCpltCallback = HAL_UART_AbortTransmitCpltCallback; /* Legacy weak AbortTransmitCpltCallback */
+        huart->AbortTransmitCpltCallback = HAL_UART_AbortTransmitCpltCallback; /* Legacy weak
+                                                                                  AbortTransmitCpltCallback          */
         break;
 
       case HAL_UART_ABORT_RECEIVE_COMPLETE_CB_ID :
-        huart->AbortReceiveCpltCallback = HAL_UART_AbortReceiveCpltCallback;   /* Legacy weak AbortReceiveCpltCallback  */
+        huart->AbortReceiveCpltCallback = HAL_UART_AbortReceiveCpltCallback;   /* Legacy weak
+                                                                                  AbortReceiveCpltCallback           */
         break;
 
       case HAL_UART_WAKEUP_CB_ID :
-        huart->WakeupCallback = HAL_UARTEx_WakeupCallback;                     /* Legacy weak WakeupCallback            */
+        huart->WakeupCallback = HAL_UARTEx_WakeupCallback;                     /* Legacy weak WakeupCallback         */
         break;
 
       case HAL_UART_RX_FIFO_FULL_CB_ID :
-        huart->RxFifoFullCallback = HAL_UARTEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback        */
+        huart->RxFifoFullCallback = HAL_UARTEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback     */
         break;
 
       case HAL_UART_TX_FIFO_EMPTY_CB_ID :
-        huart->TxFifoEmptyCallback = HAL_UARTEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback       */
+        huart->TxFifoEmptyCallback = HAL_UARTEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback    */
         break;
 
       case HAL_UART_MSPINIT_CB_ID :
-        huart->MspInitCallback = HAL_UART_MspInit;                             /* Legacy weak MspInitCallback           */
+        huart->MspInitCallback = HAL_UART_MspInit;                             /* Legacy weak MspInitCallback        */
         break;
 
       case HAL_UART_MSPDEINIT_CB_ID :
-        huart->MspDeInitCallback = HAL_UART_MspDeInit;                         /* Legacy weak MspDeInitCallback         */
+        huart->MspDeInitCallback = HAL_UART_MspDeInit;                         /* Legacy weak MspDeInitCallback      */
         break;
 
       default :
@@ -938,10 +960,65 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
     status =  HAL_ERROR;
   }
 
-  __HAL_UNLOCK(huart);
+  return status;
+}
+
+/**
+  * @brief  Register a User UART Rx Event Callback
+  *         To be used instead of the weak predefined callback
+  * @param  huart     Uart handle
+  * @param  pCallback Pointer to the Rx Event Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_RegisterRxEventCallback(UART_HandleTypeDef *huart, pUART_RxEventCallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    huart->ErrorCode |= HAL_UART_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    huart->RxEventCallback = pCallback;
+  }
+  else
+  {
+    huart->ErrorCode |= HAL_UART_ERROR_INVALID_CALLBACK;
+
+    status =  HAL_ERROR;
+  }
 
   return status;
 }
+
+/**
+  * @brief  UnRegister the UART Rx Event Callback
+  *         UART Rx Event Callback is redirected to the weak HAL_UARTEx_RxEventCallback() predefined callback
+  * @param  huart     Uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UART_UnRegisterRxEventCallback(UART_HandleTypeDef *huart)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    huart->RxEventCallback = HAL_UARTEx_RxEventCallback; /* Legacy weak UART Rx Event Callback  */
+  }
+  else
+  {
+    huart->ErrorCode |= HAL_UART_ERROR_INVALID_CALLBACK;
+
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
 
 /**
@@ -955,68 +1032,79 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
  ===============================================================================
                       ##### IO operation functions #####
  ===============================================================================
+    [..]
     This subsection provides a set of functions allowing to manage the UART asynchronous
     and Half duplex data transfers.
 
-    (#) There are two mode of transfer:
-       (+) Blocking mode: The communication is performed in polling mode.
-           The HAL status of all data processing is returned by the same function
-           after finishing transfer.
-       (+) Non-Blocking mode: The communication is performed using Interrupts
-           or DMA, These API's return the HAL status.
-           The end of the data processing will be indicated through the
-           dedicated UART IRQ when using Interrupt mode or the DMA IRQ when
-           using DMA mode.
-           The HAL_UART_TxCpltCallback(), HAL_UART_RxCpltCallback() user callbacks
-           will be executed respectively at the end of the transmit or Receive process
-           The HAL_UART_ErrorCallback()user callback will be executed when a communication error is detected
+    (#) There are two modes of transfer:
+       (++) Blocking mode: The communication is performed in polling mode.
+            The HAL status of all data processing is returned by the same function
+            after finishing transfer.
+       (++) Non-Blocking mode: The communication is performed using Interrupts
+            or DMA, These API's return the HAL status.
+            The end of the data processing will be indicated through the
+            dedicated UART IRQ when using Interrupt mode or the DMA IRQ when
+            using DMA mode.
+            The HAL_UART_TxCpltCallback(), HAL_UART_RxCpltCallback() user callbacks
+            will be executed respectively at the end of the transmit or Receive process
+            The HAL_UART_ErrorCallback()user callback will be executed when a communication error is detected
 
     (#) Blocking mode API's are :
-        (+) HAL_UART_Transmit()
-        (+) HAL_UART_Receive()
+        (++) HAL_UART_Transmit()
+        (++) HAL_UART_Receive()
 
     (#) Non-Blocking mode API's with Interrupt are :
-        (+) HAL_UART_Transmit_IT()
-        (+) HAL_UART_Receive_IT()
-        (+) HAL_UART_IRQHandler()
+        (++) HAL_UART_Transmit_IT()
+        (++) HAL_UART_Receive_IT()
+        (++) HAL_UART_IRQHandler()
 
     (#) Non-Blocking mode API's with DMA are :
-        (+) HAL_UART_Transmit_DMA()
-        (+) HAL_UART_Receive_DMA()
-        (+) HAL_UART_DMAPause()
-        (+) HAL_UART_DMAResume()
-        (+) HAL_UART_DMAStop()
+        (++) HAL_UART_Transmit_DMA()
+        (++) HAL_UART_Receive_DMA()
+        (++) HAL_UART_DMAPause()
+        (++) HAL_UART_DMAResume()
+        (++) HAL_UART_DMAStop()
 
     (#) A set of Transfer Complete Callbacks are provided in Non_Blocking mode:
-        (+) HAL_UART_TxHalfCpltCallback()
-        (+) HAL_UART_TxCpltCallback()
-        (+) HAL_UART_RxHalfCpltCallback()
-        (+) HAL_UART_RxCpltCallback()
-        (+) HAL_UART_ErrorCallback()
+        (++) HAL_UART_TxHalfCpltCallback()
+        (++) HAL_UART_TxCpltCallback()
+        (++) HAL_UART_RxHalfCpltCallback()
+        (++) HAL_UART_RxCpltCallback()
+        (++) HAL_UART_ErrorCallback()
 
     (#) Non-Blocking mode transfers could be aborted using Abort API's :
-        (+) HAL_UART_Abort()
-        (+) HAL_UART_AbortTransmit()
-        (+) HAL_UART_AbortReceive()
-        (+) HAL_UART_Abort_IT()
-        (+) HAL_UART_AbortTransmit_IT()
-        (+) HAL_UART_AbortReceive_IT()
+        (++) HAL_UART_Abort()
+        (++) HAL_UART_AbortTransmit()
+        (++) HAL_UART_AbortReceive()
+        (++) HAL_UART_Abort_IT()
+        (++) HAL_UART_AbortTransmit_IT()
+        (++) HAL_UART_AbortReceive_IT()
 
     (#) For Abort services based on interrupts (HAL_UART_Abortxxx_IT), a set of Abort Complete Callbacks are provided:
-        (+) HAL_UART_AbortCpltCallback()
-        (+) HAL_UART_AbortTransmitCpltCallback()
-        (+) HAL_UART_AbortReceiveCpltCallback()
+        (++) HAL_UART_AbortCpltCallback()
+        (++) HAL_UART_AbortTransmitCpltCallback()
+        (++) HAL_UART_AbortReceiveCpltCallback()
+
+    (#) A Rx Event Reception Callback (Rx event notification) is available for Non_Blocking modes of enhanced
+        reception services:
+        (++) HAL_UARTEx_RxEventCallback()
+
+    (#) Wakeup from Stop mode Callback:
+        (++) HAL_UARTEx_WakeupCallback()
 
     (#) In Non-Blocking mode transfers, possible errors are split into 2 categories.
         Errors are handled as follows :
-       (+) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
-           to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
-           Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
-           and HAL_UART_ErrorCallback() user callback is executed. Transfer is kept ongoing on UART side.
-           If user wants to abort it, Abort services should be called by user.
-       (+) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
-           This concerns Overrun Error In Interrupt mode reception and all errors in DMA mode.
-           Error code is set to allow user to identify error type, and HAL_UART_ErrorCallback() user callback is executed.
+       (++) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
+            to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error
+            in Interrupt mode reception .
+            Received character is then retrieved and stored in Rx buffer, Error code is set to allow user
+            to identify error type, and HAL_UART_ErrorCallback() user callback is executed.
+            Transfer is kept ongoing on UART side.
+            If user wants to abort it, Abort services should be called by user.
+       (++) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
+            This concerns Overrun Error In Interrupt mode reception and all errors in DMA mode.
+            Error code is set to allow user to identify error type, and HAL_UART_ErrorCallback()
+            user callback is executed.
 
     -@- In the Half duplex communication, it is forbidden to run the transmit
         and receive process in parallel, the UART state HAL_UART_STATE_BUSY_TX_RX can't be useful.
@@ -1034,16 +1122,24 @@ HAL_StatusTypeDef HAL_UART_UnRegisterCallback(UART_HandleTypeDef *huart, HAL_UAR
   *       data to the TXFIFO. Write operations to the TDR register are performed
   *       when TXFNF flag is set. From hardware perspective, TXFNF flag and
   *       TXE are mapped on the same bit-field.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
+  *         (as sent data will be handled using u16 pointer cast). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
+#endif
   * @param huart   UART handle.
   * @param pData   Pointer to data buffer (u8 or u16 data elements).
   * @param Size    Amount of data elements (u8 or u16) to be sent.
   * @param Timeout Timeout duration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, const uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  uint8_t  *pdata8bits;
-  uint16_t *pdata16bits;
+  const uint8_t  *pdata8bits;
+  const uint16_t *pdata16bits;
   uint32_t tickstart;
 
   /* Check that a Tx process is not already ongoing */
@@ -1054,12 +1150,10 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
       return  HAL_ERROR;
     }
 
-    __HAL_LOCK(huart);
-
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->gState = HAL_UART_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     huart->TxXferSize  = Size;
@@ -1069,7 +1163,7 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
     if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
     {
       pdata8bits  = NULL;
-      pdata16bits = (uint16_t *) pData;
+      pdata16bits = (const uint16_t *) pData;
     }
     else
     {
@@ -1077,12 +1171,13 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
       pdata16bits = NULL;
     }
 
-    __HAL_UNLOCK(huart);
-
     while (huart->TxXferCount > 0U)
     {
       if (UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TXE, RESET, tickstart, Timeout) != HAL_OK)
       {
+
+        huart->gState = HAL_UART_STATE_READY;
+
         return HAL_TIMEOUT;
       }
       if (pdata8bits == NULL)
@@ -1100,6 +1195,8 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
 
     if (UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_TC, RESET, tickstart, Timeout) != HAL_OK)
     {
+      huart->gState = HAL_UART_STATE_READY;
+
       return HAL_TIMEOUT;
     }
 
@@ -1123,6 +1220,14 @@ HAL_StatusTypeDef HAL_UART_Transmit(UART_HandleTypeDef *huart, uint8_t *pData, u
   *       is not empty. Read operations from the RDR register are performed when
   *       RXFNE flag is set. From hardware perspective, RXFNE flag and
   *       RXNE are mapped on the same bit-field.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier
+  *         (16 bits) (as received data will be handled using u16 pointer cast). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
+#endif
   * @param huart   UART handle.
   * @param pData   Pointer to data buffer (u8 or u16 data elements).
   * @param Size    Amount of data elements (u8 or u16) to be received.
@@ -1144,12 +1249,11 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
       return  HAL_ERROR;
     }
 
-    __HAL_LOCK(huart);
-
     huart->ErrorCode = HAL_UART_ERROR_NONE;
     huart->RxState = HAL_UART_STATE_BUSY_RX;
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     huart->RxXferSize  = Size;
@@ -1171,13 +1275,13 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
       pdata16bits = NULL;
     }
 
-    __HAL_UNLOCK(huart);
-
     /* as long as data have to be received */
     while (huart->RxXferCount > 0U)
     {
       if (UART_WaitOnFlagUntilTimeout(huart, UART_FLAG_RXNE, RESET, tickstart, Timeout) != HAL_OK)
       {
+        huart->RxState = HAL_UART_STATE_READY;
+
         return HAL_TIMEOUT;
       }
       if (pdata8bits == NULL)
@@ -1209,12 +1313,20 @@ HAL_StatusTypeDef HAL_UART_Receive(UART_HandleTypeDef *huart, uint8_t *pData, ui
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 provided through pData.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
+  *         (as sent data will be handled using u16 pointer cast). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
+#endif
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, const uint8_t *pData, uint16_t Size)
 {
   /* Check that a Tx process is not already ongoing */
   if (huart->gState == HAL_UART_STATE_READY)
@@ -1223,8 +1335,6 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
     {
       return HAL_ERROR;
     }
-
-    __HAL_LOCK(huart);
 
     huart->pTxBuffPtr  = pData;
     huart->TxXferSize  = Size;
@@ -1247,10 +1357,8 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
         huart->TxISR = UART_TxISR_8BIT_FIFOEN;
       }
 
-      __HAL_UNLOCK(huart);
-
       /* Enable the TX FIFO threshold interrupt */
-      SET_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
+      ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
     }
     else
     {
@@ -1264,10 +1372,8 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
         huart->TxISR = UART_TxISR_8BIT;
       }
 
-      __HAL_UNLOCK(huart);
-
       /* Enable the Transmit Data Register Empty interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
     }
 
     return HAL_OK;
@@ -1283,6 +1389,14 @@ HAL_StatusTypeDef HAL_UART_Transmit_IT(UART_HandleTypeDef *huart, uint8_t *pData
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the received data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 available through pData.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier
+  *         (16 bits) (as received data will be handled using u16 pointer cast). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
+#endif
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be received.
@@ -1298,60 +1412,29 @@ HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData,
       return HAL_ERROR;
     }
 
-    __HAL_LOCK(huart);
+    /* Set Reception type to Standard reception */
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
-    huart->pRxBuffPtr  = pData;
-    huart->RxXferSize  = Size;
-    huart->RxXferCount = Size;
-    huart->RxISR       = NULL;
-
-    /* Computation of UART mask to apply to RDR register */
-    UART_MASK_COMPUTATION(huart);
-
-    huart->ErrorCode = HAL_UART_ERROR_NONE;
-    huart->RxState = HAL_UART_STATE_BUSY_RX;
-
-    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
-    SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
-
-    /* Configure Rx interrupt processing*/
-    if ((huart->FifoMode == UART_FIFOMODE_ENABLE) && (Size >= huart->NbRxDataToProcess))
+#if defined(LPUART1)
+    if (!(IS_LPUART_INSTANCE(huart->Instance)))
     {
-      /* Set the Rx ISR function pointer according to the data word length */
-      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+      /* Check that USART RTOEN bit is set */
+      if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
       {
-        huart->RxISR = UART_RxISR_16BIT_FIFOEN;
+        /* Enable the UART Receiver Timeout Interrupt */
+        ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
       }
-      else
-      {
-        huart->RxISR = UART_RxISR_8BIT_FIFOEN;
-      }
-
-      __HAL_UNLOCK(huart);
-
-      /* Enable the UART Parity Error interrupt and RX FIFO Threshold interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-      SET_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
     }
-    else
+#else
+    /* Check that USART RTOEN bit is set */
+    if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
     {
-      /* Set the Rx ISR function pointer according to the data word length */
-      if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
-      {
-        huart->RxISR = UART_RxISR_16BIT;
-      }
-      else
-      {
-        huart->RxISR = UART_RxISR_8BIT;
-      }
-
-      __HAL_UNLOCK(huart);
-
-      /* Enable the UART Parity Error interrupt and Data Register Not Empty interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+      /* Enable the UART Receiver Timeout Interrupt */
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
     }
+#endif /* LPUART1 */
 
-    return HAL_OK;
+    return (UART_Start_Receive_IT(huart, pData, Size));
   }
   else
   {
@@ -1364,12 +1447,20 @@ HAL_StatusTypeDef HAL_UART_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData,
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the sent data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 provided through pData.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer containing data to be sent, should be aligned on a half word frontier (16 bits)
+  *         (as sent data will be handled by DMA from halfword frontier). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
+#endif
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, const uint8_t *pData, uint16_t Size)
 {
   /* Check that a Tx process is not already ongoing */
   if (huart->gState == HAL_UART_STATE_READY)
@@ -1378,8 +1469,6 @@ HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pDat
     {
       return HAL_ERROR;
     }
-
-    __HAL_LOCK(huart);
 
     huart->pTxBuffPtr  = pData;
     huart->TxXferSize  = Size;
@@ -1408,8 +1497,6 @@ HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pDat
         /* Set error code to DMA */
         huart->ErrorCode = HAL_UART_ERROR_DMA;
 
-        __HAL_UNLOCK(huart);
-
         /* Restore huart->gState to ready */
         huart->gState = HAL_UART_STATE_READY;
 
@@ -1419,11 +1506,9 @@ HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pDat
     /* Clear the TC flag in the ICR register */
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
 
-    __HAL_UNLOCK(huart);
-
     /* Enable the DMA transfer for transmit request by setting the DMAT bit
     in the UART CR3 register */
-    SET_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     return HAL_OK;
   }
@@ -1440,6 +1525,14 @@ HAL_StatusTypeDef HAL_UART_Transmit_DMA(UART_HandleTypeDef *huart, uint8_t *pDat
   * @note   When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
   *         the received data is handled as a set of u16. In this case, Size must indicate the number
   *         of u16 available through pData.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         address of user data buffer for storing data to be received, should be aligned on a half word frontier
+  *         (16 bits) (as received data will be handled by DMA from halfword frontier). Depending on compilation chain,
+  *         use of specific alignment compilation directives or pragmas might be required
+  *         to ensure proper alignment for pData.
+#endif
   * @param huart UART handle.
   * @param pData Pointer to data buffer (u8 or u16 data elements).
   * @param Size  Amount of data elements (u8 or u16) to be received.
@@ -1455,55 +1548,29 @@ HAL_StatusTypeDef HAL_UART_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData
       return HAL_ERROR;
     }
 
-    __HAL_LOCK(huart);
+    /* Set Reception type to Standard reception */
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
-    huart->pRxBuffPtr = pData;
-    huart->RxXferSize = Size;
-
-    huart->ErrorCode = HAL_UART_ERROR_NONE;
-    huart->RxState = HAL_UART_STATE_BUSY_RX;
-
-    if (huart->hdmarx != NULL)
+#if defined(LPUART1)
+    if (!(IS_LPUART_INSTANCE(huart->Instance)))
     {
-      /* Set the UART DMA transfer complete callback */
-      huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
-
-      /* Set the UART DMA Half transfer complete callback */
-      huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
-
-      /* Set the DMA error callback */
-      huart->hdmarx->XferErrorCallback = UART_DMAError;
-
-      /* Set the DMA abort callback */
-      huart->hdmarx->XferAbortCallback = NULL;
-
-      /* Enable the DMA channel */
-      if (HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, (uint32_t)huart->pRxBuffPtr, Size) != HAL_OK)
+      /* Check that USART RTOEN bit is set */
+      if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
       {
-        /* Set error code to DMA */
-        huart->ErrorCode = HAL_UART_ERROR_DMA;
-
-        __HAL_UNLOCK(huart);
-
-        /* Restore huart->gState to ready */
-        huart->gState = HAL_UART_STATE_READY;
-
-        return HAL_ERROR;
+        /* Enable the UART Receiver Timeout Interrupt */
+        ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
       }
     }
-    __HAL_UNLOCK(huart);
+#else
+    /* Check that USART RTOEN bit is set */
+    if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+    {
+      /* Enable the UART Receiver Timeout Interrupt */
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+    }
+#endif /* LPUART1 */
 
-    /* Enable the UART Parity Error Interrupt */
-    SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-
-    /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
-    SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
-
-    /* Enable the DMA transfer for the receiver request by setting the DMAR bit
-    in the UART CR3 register */
-    SET_BIT(huart->Instance->CR3, USART_CR3_DMAR);
-
-    return HAL_OK;
+    return (UART_Start_Receive_DMA(huart, pData, Size));
   }
   else
   {
@@ -1521,26 +1588,22 @@ HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart)
   const HAL_UART_StateTypeDef gstate = huart->gState;
   const HAL_UART_StateTypeDef rxstate = huart->RxState;
 
-  __HAL_LOCK(huart);
-
   if ((HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT)) &&
       (gstate == HAL_UART_STATE_BUSY_TX))
   {
     /* Disable the UART DMA Tx request */
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
   }
   if ((HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR)) &&
       (rxstate == HAL_UART_STATE_BUSY_RX))
   {
     /* Disable PE and ERR (Frame error, noise error, overrun error) interrupts */
-    CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
     /* Disable the UART DMA Rx request */
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
   }
-
-  __HAL_UNLOCK(huart);
 
   return HAL_OK;
 }
@@ -1552,27 +1615,26 @@ HAL_StatusTypeDef HAL_UART_DMAPause(UART_HandleTypeDef *huart)
   */
 HAL_StatusTypeDef HAL_UART_DMAResume(UART_HandleTypeDef *huart)
 {
-  __HAL_LOCK(huart);
-
   if (huart->gState == HAL_UART_STATE_BUSY_TX)
   {
     /* Enable the UART DMA Tx request */
-    SET_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_DMAT);
   }
   if (huart->RxState == HAL_UART_STATE_BUSY_RX)
   {
     /* Clear the Overrun flag before resuming the Rx transfer */
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
 
-    /* Reenable PE and ERR (Frame error, noise error, overrun error) interrupts */
-    SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-    SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
+    /* Re-enable PE and ERR (Frame error, noise error, overrun error) interrupts */
+    if (huart->Init.Parity != UART_PARITY_NONE)
+    {
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+    }
+    ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
     /* Enable the UART DMA Rx request */
-    SET_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_DMAR);
   }
-
-  __HAL_UNLOCK(huart);
 
   return HAL_OK;
 }
@@ -1598,7 +1660,7 @@ HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
   if ((HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT)) &&
       (gstate == HAL_UART_STATE_BUSY_TX))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     /* Abort the UART DMA Tx channel */
     if (huart->hdmatx != NULL)
@@ -1622,7 +1684,7 @@ HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
   if ((HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR)) &&
       (rxstate == HAL_UART_STATE_BUSY_RX))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
     /* Abort the UART DMA Rx channel */
     if (huart->hdmarx != NULL)
@@ -1660,13 +1722,21 @@ HAL_StatusTypeDef HAL_UART_DMAStop(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
 {
   /* Disable TXE, TC, RXNE, PE, RXFT, TXFT and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
-  CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE |
+                                          USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE);
 
-  /* Disable the UART DMA Tx request if enabled */
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
+
+  /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    /* Disable the UART DMA Tx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     /* Abort the UART DMA Tx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmatx != NULL)
@@ -1688,10 +1758,11 @@ HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
     }
   }
 
-  /* Disable the UART DMA Rx request if enabled */
+  /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
     /* Abort the UART DMA Rx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmarx != NULL)
@@ -1732,6 +1803,7 @@ HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
   /* Restore huart->gState and huart->RxState to Ready */
   huart->gState  = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   huart->ErrorCode = HAL_UART_ERROR_NONE;
 
@@ -1753,13 +1825,14 @@ HAL_StatusTypeDef HAL_UART_Abort(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_UART_AbortTransmit(UART_HandleTypeDef *huart)
 {
   /* Disable TCIE, TXEIE and TXFTIE interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TCIE | USART_CR1_TXEIE_TXFNFIE));
-  CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TCIE | USART_CR1_TXEIE_TXFNFIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
 
-  /* Disable the UART DMA Tx request if enabled */
+  /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    /* Disable the UART DMA Tx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     /* Abort the UART DMA Tx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmatx != NULL)
@@ -1811,13 +1884,20 @@ HAL_StatusTypeDef HAL_UART_AbortTransmit(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_UART_AbortReceive(UART_HandleTypeDef *huart)
 {
   /* Disable PEIE, EIE, RXNEIE and RXFTIE interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE));
-  CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE | USART_CR3_RXFTIE);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE | USART_CR3_RXFTIE);
 
-  /* Disable the UART DMA Rx request if enabled */
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
+
+  /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
     /* Abort the UART DMA Rx channel : use blocking DMA Abort API (no callback) */
     if (huart->hdmarx != NULL)
@@ -1850,6 +1930,7 @@ HAL_StatusTypeDef HAL_UART_AbortReceive(UART_HandleTypeDef *huart)
 
   /* Restore huart->RxState to Ready */
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   return HAL_OK;
 }
@@ -1873,8 +1954,15 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
   uint32_t abortcplt = 1U;
 
   /* Disable interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_TCIE | USART_CR1_RXNEIE_RXFNEIE | USART_CR1_TXEIE_TXFNFIE));
-  CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_TCIE | USART_CR1_RXNEIE_RXFNEIE |
+                                          USART_CR1_TXEIE_TXFNFIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE));
+
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
 
   /* If DMA Tx and/or DMA Rx Handles are associated to UART Handle, DMA Abort complete callbacks should be initialised
      before any call to DMA Abort functions */
@@ -1907,11 +1995,11 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
     }
   }
 
-  /* Disable the UART DMA Tx request if enabled */
+  /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
     /* Disable DMA Tx at UART level */
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     /* Abort the UART DMA Tx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmatx != NULL)
@@ -1931,10 +2019,11 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
     }
   }
 
-  /* Disable the UART DMA Rx request if enabled */
+  /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
     /* Abort the UART DMA Rx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmarx != NULL)
@@ -1984,6 +2073,7 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
     /* Restore huart->gState and huart->RxState to Ready */
     huart->gState  = HAL_UART_STATE_READY;
     huart->RxState = HAL_UART_STATE_READY;
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
     /* As no DMA to be aborted, call directly user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -2015,13 +2105,14 @@ HAL_StatusTypeDef HAL_UART_Abort_IT(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_UART_AbortTransmit_IT(UART_HandleTypeDef *huart)
 {
   /* Disable interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TCIE | USART_CR1_TXEIE_TXFNFIE));
-  CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TCIE | USART_CR1_TXEIE_TXFNFIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
 
-  /* Disable the UART DMA Tx request if enabled */
+  /* Abort the UART DMA Tx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAT))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    /* Disable the UART DMA Tx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     /* Abort the UART DMA Tx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmatx != NULL)
@@ -2105,13 +2196,20 @@ HAL_StatusTypeDef HAL_UART_AbortTransmit_IT(UART_HandleTypeDef *huart)
 HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
 {
   /* Disable RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE));
-  CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
-  /* Disable the UART DMA Rx request if enabled */
+  /* If Reception till IDLE event was ongoing, disable IDLEIE interrupt */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_IDLEIE));
+  }
+
+  /* Abort the UART DMA Rx channel if enabled */
   if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
   {
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    /* Disable the UART DMA Rx request if enabled */
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
     /* Abort the UART DMA Rx channel : use non blocking DMA Abort API (callback) */
     if (huart->hdmarx != NULL)
@@ -2143,6 +2241,7 @@ HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
 
       /* Restore huart->RxState to Ready */
       huart->RxState = HAL_UART_STATE_READY;
+      huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
       /* As no DMA to be aborted, call directly user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -2167,6 +2266,7 @@ HAL_StatusTypeDef HAL_UART_AbortReceive_IT(UART_HandleTypeDef *huart)
 
     /* Restore huart->RxState to Ready */
     huart->RxState = HAL_UART_STATE_READY;
+    huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
     /* As no DMA to be aborted, call directly user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -2287,10 +2387,11 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
            Disable Rx Interrupts, and disable Rx DMA request, if ongoing */
         UART_EndRxTransfer(huart);
 
-        /* Disable the UART DMA Rx request if enabled */
+        /* Abort the UART DMA Rx channel if enabled */
         if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
         {
-          CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+          /* Disable the UART DMA Rx request if enabled */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
           /* Abort the UART DMA Rx channel */
           if (huart->hdmarx != NULL)
@@ -2348,6 +2449,125 @@ void HAL_UART_IRQHandler(UART_HandleTypeDef *huart)
     return;
 
   } /* End if some error occurs */
+
+  /* Check current reception Mode :
+     If Reception till IDLE event has been selected : */
+  if ((huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      && ((isrflags & USART_ISR_IDLE) != 0U)
+      && ((cr1its & USART_ISR_IDLE) != 0U))
+  {
+    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+
+    /* Check if DMA mode is enabled in UART */
+    if (HAL_IS_BIT_SET(huart->Instance->CR3, USART_CR3_DMAR))
+    {
+      /* DMA mode enabled */
+      /* Check received length : If all expected data are received, do nothing,
+         (DMA cplt callback will be called).
+         Otherwise, if at least one data has already been received, IDLE event is to be notified to user */
+      uint16_t nb_remaining_rx_data = (uint16_t) __HAL_DMA_GET_COUNTER(huart->hdmarx);
+      if ((nb_remaining_rx_data > 0U)
+          && (nb_remaining_rx_data < huart->RxXferSize))
+      {
+        /* Reception is not complete */
+        huart->RxXferCount = nb_remaining_rx_data;
+
+        /* In Normal mode, end DMA xfer and HAL UART Rx process*/
+        if (HAL_IS_BIT_CLR(huart->hdmarx->Instance->CCR, DMA_CCR_CIRC))
+        {
+          /* Disable PE and ERR (Frame error, noise error, overrun error) interrupts */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+          ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+          /* Disable the DMA transfer for the receiver request by resetting the DMAR bit
+             in the UART CR3 register */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+          /* At end of Rx process, restore huart->RxState to Ready */
+          huart->RxState = HAL_UART_STATE_READY;
+          huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+          /* Last bytes received, so no need as the abort is immediate */
+          (void)HAL_DMA_Abort(huart->hdmarx);
+        }
+
+        /* Initialize type of RxEvent that correspond to RxEvent callback execution;
+           In this case, Rx Event type is Idle Event */
+        huart->RxEventType = HAL_UART_RXEVENT_IDLE;
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx Event callback*/
+        huart->RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
+#else
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+      }
+      else
+      {
+        /* If DMA is in Circular mode, Idle event is to be reported to user
+           even if occurring after a Transfer Complete event from DMA */
+        if (nb_remaining_rx_data == huart->RxXferSize)
+        {
+          if (HAL_IS_BIT_SET(huart->hdmarx->Instance->CCR, DMA_CCR_CIRC))
+          {
+            /* Initialize type of RxEvent that correspond to RxEvent callback execution;
+               In this case, Rx Event type is Idle Event */
+            huart->RxEventType = HAL_UART_RXEVENT_IDLE;
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+            /*Call registered Rx Event callback*/
+            huart->RxEventCallback(huart, huart->RxXferSize);
+#else
+            /*Call legacy weak Rx Event callback*/
+            HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+          }
+        }
+      }
+      return;
+    }
+    else
+    {
+      /* DMA mode not enabled */
+      /* Check received length : If all expected data are received, do nothing.
+         Otherwise, if at least one data has already been received, IDLE event is to be notified to user */
+      uint16_t nb_rx_data = huart->RxXferSize - huart->RxXferCount;
+      if ((huart->RxXferCount > 0U)
+          && (nb_rx_data > 0U))
+      {
+        /* Disable the UART Parity Error Interrupt and RXNE interrupts */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
+
+        /* Disable the UART Error Interrupt:(Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+
+        /* Rx process is completed, restore huart->RxState to Ready */
+        huart->RxState = HAL_UART_STATE_READY;
+        huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+        /* Clear RxISR function pointer */
+        huart->RxISR = NULL;
+
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+        /* Initialize type of RxEvent that correspond to RxEvent callback execution;
+           In this case, Rx Event type is Idle Event */
+        huart->RxEventType = HAL_UART_RXEVENT_IDLE;
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx complete callback*/
+        huart->RxEventCallback(huart, nb_rx_data);
+#else
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, nb_rx_data);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+      }
+      return;
+    }
+  }
 
   /* UART wakeup from Stop mode interrupt occurred ---------------------------*/
   if (((isrflags & USART_ISR_WUF) != 0U) && ((cr3its & USART_CR3_WUFIE) != 0U))
@@ -2534,6 +2754,24 @@ __weak void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart)
 }
 
 /**
+  * @brief  Reception Event Callback (Rx event notification called after use of advanced reception service).
+  * @param  huart UART handle
+  * @param  Size  Number of data available in application reception buffer (indicates a position in
+  *               reception buffer until which, data are available)
+  * @retval None
+  */
+__weak void HAL_UARTEx_RxEventCallback(UART_HandleTypeDef *huart, uint16_t Size)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(huart);
+  UNUSED(Size);
+
+  /* NOTE : This function should not be modified, when the callback is needed,
+            the HAL_UARTEx_RxEventCallback can be implemented in the user file.
+   */
+}
+
+/**
   * @}
   */
 
@@ -2572,11 +2810,16 @@ __weak void HAL_UART_AbortReceiveCpltCallback(UART_HandleTypeDef *huart)
   */
 void HAL_UART_ReceiverTimeout_Config(UART_HandleTypeDef *huart, uint32_t TimeoutValue)
 {
+#if defined(LPUART1)
   if (!(IS_LPUART_INSTANCE(huart->Instance)))
   {
     assert_param(IS_UART_RECEIVER_TIMEOUT_VALUE(TimeoutValue));
     MODIFY_REG(huart->Instance->RTOR, USART_RTOR_RTO, TimeoutValue);
   }
+#else
+  assert_param(IS_UART_RECEIVER_TIMEOUT_VALUE(TimeoutValue));
+  MODIFY_REG(huart->Instance->RTOR, USART_RTOR_RTO, TimeoutValue);
+#endif  /* LPUART1 */
 }
 
 /**
@@ -2587,6 +2830,7 @@ void HAL_UART_ReceiverTimeout_Config(UART_HandleTypeDef *huart, uint32_t Timeout
   */
 HAL_StatusTypeDef HAL_UART_EnableReceiverTimeout(UART_HandleTypeDef *huart)
 {
+#if defined(LPUART1)
   if (!(IS_LPUART_INSTANCE(huart->Instance)))
   {
     if (huart->gState == HAL_UART_STATE_READY)
@@ -2615,6 +2859,29 @@ HAL_StatusTypeDef HAL_UART_EnableReceiverTimeout(UART_HandleTypeDef *huart)
   {
     return HAL_ERROR;
   }
+#else
+  if (huart->gState == HAL_UART_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->gState = HAL_UART_STATE_BUSY;
+
+    /* Set the USART RTOEN bit */
+    SET_BIT(huart->Instance->CR2, USART_CR2_RTOEN);
+
+    huart->gState = HAL_UART_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+#endif /* LPUART1 */
 }
 
 /**
@@ -2625,6 +2892,7 @@ HAL_StatusTypeDef HAL_UART_EnableReceiverTimeout(UART_HandleTypeDef *huart)
   */
 HAL_StatusTypeDef HAL_UART_DisableReceiverTimeout(UART_HandleTypeDef *huart)
 {
+#if defined(LPUART1)
   if (!(IS_LPUART_INSTANCE(huart->Instance)))
   {
     if (huart->gState == HAL_UART_STATE_READY)
@@ -2653,6 +2921,29 @@ HAL_StatusTypeDef HAL_UART_DisableReceiverTimeout(UART_HandleTypeDef *huart)
   {
     return HAL_ERROR;
   }
+#else
+  if (huart->gState == HAL_UART_STATE_READY)
+  {
+    /* Process Locked */
+    __HAL_LOCK(huart);
+
+    huart->gState = HAL_UART_STATE_BUSY;
+
+    /* Clear the USART RTOEN bit */
+    CLEAR_BIT(huart->Instance->CR2, USART_CR2_RTOEN);
+
+    huart->gState = HAL_UART_STATE_READY;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(huart);
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+#endif /* LPUART1 */
 }
 
 /**
@@ -2668,7 +2959,7 @@ HAL_StatusTypeDef HAL_MultiProcessor_EnableMuteMode(UART_HandleTypeDef *huart)
   huart->gState = HAL_UART_STATE_BUSY;
 
   /* Enable USART mute mode by setting the MME bit in the CR1 register */
-  SET_BIT(huart->Instance->CR1, USART_CR1_MME);
+  ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_MME);
 
   huart->gState = HAL_UART_STATE_READY;
 
@@ -2688,7 +2979,7 @@ HAL_StatusTypeDef HAL_MultiProcessor_DisableMuteMode(UART_HandleTypeDef *huart)
   huart->gState = HAL_UART_STATE_BUSY;
 
   /* Disable USART mute mode by clearing the MME bit in the CR1 register */
-  CLEAR_BIT(huart->Instance->CR1, USART_CR1_MME);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_MME);
 
   huart->gState = HAL_UART_STATE_READY;
 
@@ -2717,10 +3008,10 @@ HAL_StatusTypeDef HAL_HalfDuplex_EnableTransmitter(UART_HandleTypeDef *huart)
   huart->gState = HAL_UART_STATE_BUSY;
 
   /* Clear TE and RE bits */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
 
   /* Enable the USART's transmit interface by setting the TE bit in the USART CR1 register */
-  SET_BIT(huart->Instance->CR1, USART_CR1_TE);
+  ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TE);
 
   huart->gState = HAL_UART_STATE_READY;
 
@@ -2740,10 +3031,10 @@ HAL_StatusTypeDef HAL_HalfDuplex_EnableReceiver(UART_HandleTypeDef *huart)
   huart->gState = HAL_UART_STATE_BUSY;
 
   /* Clear TE and RE bits */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TE | USART_CR1_RE));
 
   /* Enable the USART's receive interface by setting the RE bit in the USART CR1 register */
-  SET_BIT(huart->Instance->CR1, USART_CR1_RE);
+  ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RE);
 
   huart->gState = HAL_UART_STATE_READY;
 
@@ -2803,7 +3094,7 @@ HAL_StatusTypeDef HAL_LIN_SendBreak(UART_HandleTypeDef *huart)
   *               the configuration information for the specified UART.
   * @retval HAL state
   */
-HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart)
+HAL_UART_StateTypeDef HAL_UART_GetState(const UART_HandleTypeDef *huart)
 {
   uint32_t temp1;
   uint32_t temp2;
@@ -2819,7 +3110,7 @@ HAL_UART_StateTypeDef HAL_UART_GetState(UART_HandleTypeDef *huart)
   *               the configuration information for the specified UART.
   * @retval UART Error Code
   */
-uint32_t HAL_UART_GetError(UART_HandleTypeDef *huart)
+uint32_t HAL_UART_GetError(const UART_HandleTypeDef *huart)
 {
   return huart->ErrorCode;
 }
@@ -2855,6 +3146,7 @@ void UART_InitCallbacksToDefault(UART_HandleTypeDef *huart)
   huart->WakeupCallback            = HAL_UARTEx_WakeupCallback;          /* Legacy weak WakeupCallback            */
   huart->RxFifoFullCallback        = HAL_UARTEx_RxFifoFullCallback;      /* Legacy weak RxFifoFullCallback        */
   huart->TxFifoEmptyCallback       = HAL_UARTEx_TxFifoEmptyCallback;     /* Legacy weak TxFifoEmptyCallback       */
+  huart->RxEventCallback           = HAL_UARTEx_RxEventCallback;         /* Legacy weak RxEventCallback           */
 
 }
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
@@ -2908,7 +3200,6 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
   *  set TE and RE bits according to huart->Init.Mode value
   *  set OVER8 bit according to huart->Init.OverSampling value */
   tmpreg = (uint32_t)huart->Init.WordLength | huart->Init.Parity | huart->Init.Mode | huart->Init.OverSampling ;
-  tmpreg |= (uint32_t)huart->FifoMode;
   MODIFY_REG(huart->Instance->CR1, USART_CR1_FIELDS, tmpreg);
 
   /*-------------------------- USART CR2 Configuration -----------------------*/
@@ -2983,7 +3274,7 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
       {
         /* Check computed UsartDiv value is in allocated range
            (it is forbidden to write values lower than 0x300 in the LPUART_BRR register) */
-        usartdiv = (uint32_t)(UART_DIV_LPUART(pclk, (uint64_t)huart->Init.BaudRate, huart->Init.ClockPrescaler));
+        usartdiv = (uint32_t)(UART_DIV_LPUART(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
         if ((usartdiv >= LPUART_BRR_MIN) && (usartdiv <= LPUART_BRR_MAX))
         {
           huart->Instance->BRR = usartdiv;
@@ -2992,7 +3283,8 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
         {
           ret = HAL_ERROR;
         }
-      } /* if ( (lpuart_ker_ck_pres < (3 * huart->Init.BaudRate) ) || (lpuart_ker_ck_pres > (4096 * huart->Init.BaudRate) )) */
+      } /* if ( (lpuart_ker_ck_pres < (3 * huart->Init.BaudRate) ) ||
+                (lpuart_ker_ck_pres > (4096 * huart->Init.BaudRate) )) */
     } /* if (pclk != 0) */
   }
   /* Check UART Over Sampling to set Baud Rate Register */
@@ -3024,7 +3316,7 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
     /* USARTDIV must be greater than or equal to 0d16 */
     if (pclk != 0U)
     {
-      usartdiv = (uint16_t)(UART_DIV_SAMPLING8(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+      usartdiv = (uint32_t)(UART_DIV_SAMPLING8(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
       if ((usartdiv >= UART_BRR_MIN) && (usartdiv <= UART_BRR_MAX))
       {
         brrtemp = (uint16_t)(usartdiv & 0xFFF0U);
@@ -3062,10 +3354,10 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
     if (pclk != 0U)
     {
       /* USARTDIV must be greater than or equal to 0d16 */
-      usartdiv = (uint16_t)(UART_DIV_SAMPLING16(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
+      usartdiv = (uint32_t)(UART_DIV_SAMPLING16(pclk, huart->Init.BaudRate, huart->Init.ClockPrescaler));
       if ((usartdiv >= UART_BRR_MIN) && (usartdiv <= UART_BRR_MAX))
       {
-        huart->Instance->BRR = usartdiv;
+        huart->Instance->BRR = (uint16_t)usartdiv;
       }
       else
       {
@@ -3095,6 +3387,13 @@ void UART_AdvFeatureConfig(UART_HandleTypeDef *huart)
   /* Check whether the set of advanced features to configure is properly set */
   assert_param(IS_UART_ADVFEATURE_INIT(huart->AdvancedInit.AdvFeatureInit));
 
+  /* if required, configure RX/TX pins swap */
+  if (HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_SWAP_INIT))
+  {
+    assert_param(IS_UART_ADVFEATURE_SWAP(huart->AdvancedInit.Swap));
+    MODIFY_REG(huart->Instance->CR2, USART_CR2_SWAP, huart->AdvancedInit.Swap);
+  }
+
   /* if required, configure TX pin active level inversion */
   if (HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_TXINVERT_INIT))
   {
@@ -3114,13 +3413,6 @@ void UART_AdvFeatureConfig(UART_HandleTypeDef *huart)
   {
     assert_param(IS_UART_ADVFEATURE_DATAINV(huart->AdvancedInit.DataInvert));
     MODIFY_REG(huart->Instance->CR2, USART_CR2_DATAINV, huart->AdvancedInit.DataInvert);
-  }
-
-  /* if required, configure RX/TX pins swap */
-  if (HAL_IS_BIT_SET(huart->AdvancedInit.AdvFeatureInit, UART_ADVFEATURE_SWAP_INIT))
-  {
-    assert_param(IS_UART_ADVFEATURE_SWAP(huart->AdvancedInit.Swap));
-    MODIFY_REG(huart->Instance->CR2, USART_CR2_SWAP, huart->AdvancedInit.Swap);
   }
 
   /* if required, configure RX overrun detection disabling */
@@ -3171,7 +3463,7 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
   /* Initialize the UART ErrorCode */
   huart->ErrorCode = HAL_UART_ERROR_NONE;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Check if the Transmitter is enabled */
@@ -3180,6 +3472,13 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
     /* Wait until TEACK flag is set */
     if (UART_WaitOnFlagUntilTimeout(huart, USART_ISR_TEACK, RESET, tickstart, HAL_UART_TIMEOUT_VALUE) != HAL_OK)
     {
+      /* Disable TXE interrupt for the interrupt process */
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TXEIE_TXFNFIE));
+
+      huart->gState = HAL_UART_STATE_READY;
+
+      __HAL_UNLOCK(huart);
+
       /* Timeout occurred */
       return HAL_TIMEOUT;
     }
@@ -3191,6 +3490,15 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
     /* Wait until REACK flag is set */
     if (UART_WaitOnFlagUntilTimeout(huart, USART_ISR_REACK, RESET, tickstart, HAL_UART_TIMEOUT_VALUE) != HAL_OK)
     {
+      /* Disable RXNE, PE and ERR (Frame error, noise error, overrun error)
+      interrupts for the interrupt process */
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
+      ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+      huart->RxState = HAL_UART_STATE_READY;
+
+      __HAL_UNLOCK(huart);
+
       /* Timeout occurred */
       return HAL_TIMEOUT;
     }
@@ -3199,6 +3507,8 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
   /* Initialize the UART State */
   huart->gState = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+  huart->RxEventType = HAL_UART_RXEVENT_TC;
 
   __HAL_UNLOCK(huart);
 
@@ -3206,10 +3516,11 @@ HAL_StatusTypeDef UART_CheckIdleState(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief  Handle UART Communication Timeout.
+  * @brief  This function handles UART Communication Timeout. It waits
+  *                  until a flag is no longer in the specified status.
   * @param huart     UART handle.
   * @param Flag      Specifies the UART flag to check
-  * @param Status    Flag status (SET or RESET)
+  * @param Status    The actual Flag status (SET or RESET)
   * @param Tickstart Tick start value
   * @param Timeout   Timeout duration
   * @retval HAL status
@@ -3225,31 +3536,39 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
-        CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE));
-        CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
-
-        huart->gState = HAL_UART_STATE_READY;
-        huart->RxState = HAL_UART_STATE_READY;
-
-        __HAL_UNLOCK(huart);
 
         return HAL_TIMEOUT;
       }
 
-      if (READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U)
+      if ((READ_BIT(huart->Instance->CR1, USART_CR1_RE) != 0U) && (Flag != UART_FLAG_TXE) && (Flag != UART_FLAG_TC))
       {
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) == SET)
+        {
+          /* Clear Overrun Error flag*/
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+
+          /* Blocking error : transfer is aborted
+          Set the UART state ready to be able to start again the process,
+          Disable Rx Interrupts if ongoing */
+          UART_EndRxTransfer(huart);
+
+          huart->ErrorCode = HAL_UART_ERROR_ORE;
+
+          /* Process Unlocked */
+          __HAL_UNLOCK(huart);
+
+          return HAL_ERROR;
+        }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RTOF) == SET)
         {
           /* Clear Receiver Timeout flag*/
           __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_RTOF);
 
-          /* Disable TXE, RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts for the interrupt process */
-          CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE));
-          CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+          /* Blocking error : transfer is aborted
+          Set the UART state ready to be able to start again the process,
+          Disable Rx Interrupts if ongoing */
+          UART_EndRxTransfer(huart);
 
-          huart->gState = HAL_UART_STATE_READY;
-          huart->RxState = HAL_UART_STATE_READY;
           huart->ErrorCode = HAL_UART_ERROR_RTO;
 
           /* Process Unlocked */
@@ -3263,6 +3582,140 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
   return HAL_OK;
 }
 
+/**
+  * @brief  Start Receive operation in interrupt mode.
+  * @note   This function could be called by all HAL UART API providing reception in Interrupt mode.
+  * @note   When calling this function, parameters validity is considered as already checked,
+  *         i.e. Rx State, buffer address, ...
+  *         UART Handle is assumed as Locked.
+  * @param  huart UART handle.
+  * @param  pData Pointer to data buffer (u8 or u16 data elements).
+  * @param  Size  Amount of data elements (u8 or u16) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_Start_Receive_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  huart->pRxBuffPtr  = pData;
+  huart->RxXferSize  = Size;
+  huart->RxXferCount = Size;
+  huart->RxISR       = NULL;
+
+  /* Computation of UART mask to apply to RDR register */
+  UART_MASK_COMPUTATION(huart);
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->RxState = HAL_UART_STATE_BUSY_RX;
+
+  /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+  ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+  /* Configure Rx interrupt processing */
+  if ((huart->FifoMode == UART_FIFOMODE_ENABLE) && (Size >= huart->NbRxDataToProcess))
+  {
+    /* Set the Rx ISR function pointer according to the data word length */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      huart->RxISR = UART_RxISR_16BIT_FIFOEN;
+    }
+    else
+    {
+      huart->RxISR = UART_RxISR_8BIT_FIFOEN;
+    }
+
+    /* Enable the UART Parity Error interrupt and RX FIFO Threshold interrupt */
+    if (huart->Init.Parity != UART_PARITY_NONE)
+    {
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+    }
+    ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
+  }
+  else
+  {
+    /* Set the Rx ISR function pointer according to the data word length */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      huart->RxISR = UART_RxISR_16BIT;
+    }
+    else
+    {
+      huart->RxISR = UART_RxISR_8BIT;
+    }
+
+    /* Enable the UART Parity Error interrupt and Data Register Not Empty interrupt */
+    if (huart->Init.Parity != UART_PARITY_NONE)
+    {
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+    }
+    else
+    {
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Start Receive operation in DMA mode.
+  * @note   This function could be called by all HAL UART API providing reception in DMA mode.
+  * @note   When calling this function, parameters validity is considered as already checked,
+  *         i.e. Rx State, buffer address, ...
+  *         UART Handle is assumed as Locked.
+  * @param  huart UART handle.
+  * @param  pData Pointer to data buffer (u8 or u16 data elements).
+  * @param  Size  Amount of data elements (u8 or u16) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef UART_Start_Receive_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  huart->pRxBuffPtr = pData;
+  huart->RxXferSize = Size;
+
+  huart->ErrorCode = HAL_UART_ERROR_NONE;
+  huart->RxState = HAL_UART_STATE_BUSY_RX;
+
+  if (huart->hdmarx != NULL)
+  {
+    /* Set the UART DMA transfer complete callback */
+    huart->hdmarx->XferCpltCallback = UART_DMAReceiveCplt;
+
+    /* Set the UART DMA Half transfer complete callback */
+    huart->hdmarx->XferHalfCpltCallback = UART_DMARxHalfCplt;
+
+    /* Set the DMA error callback */
+    huart->hdmarx->XferErrorCallback = UART_DMAError;
+
+    /* Set the DMA abort callback */
+    huart->hdmarx->XferAbortCallback = NULL;
+
+    /* Enable the DMA channel */
+    if (HAL_DMA_Start_IT(huart->hdmarx, (uint32_t)&huart->Instance->RDR, (uint32_t)huart->pRxBuffPtr, Size) != HAL_OK)
+    {
+      /* Set error code to DMA */
+      huart->ErrorCode = HAL_UART_ERROR_DMA;
+
+      /* Restore huart->RxState to ready */
+      huart->RxState = HAL_UART_STATE_READY;
+
+      return HAL_ERROR;
+    }
+  }
+
+  /* Enable the UART Parity Error Interrupt */
+  if (huart->Init.Parity != UART_PARITY_NONE)
+  {
+    ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+  }
+
+  /* Enable the UART Error Interrupt: (Frame error, noise error, overrun error) */
+  ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_EIE);
+
+  /* Enable the DMA transfer for the receiver request by setting the DMAR bit
+  in the UART CR3 register */
+  ATOMIC_SET_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+
+  return HAL_OK;
+}
+
 
 /**
   * @brief  End ongoing Tx transfer on UART peripheral (following error detection or Transmit completion).
@@ -3272,8 +3725,8 @@ HAL_StatusTypeDef UART_WaitOnFlagUntilTimeout(UART_HandleTypeDef *huart, uint32_
 static void UART_EndTxTransfer(UART_HandleTypeDef *huart)
 {
   /* Disable TXEIE, TCIE, TXFT interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
-  CLEAR_BIT(huart->Instance->CR3, (USART_CR3_TXFTIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_TXFTIE));
 
   /* At end of Tx process, restore huart->gState to Ready */
   huart->gState = HAL_UART_STATE_READY;
@@ -3288,11 +3741,18 @@ static void UART_EndTxTransfer(UART_HandleTypeDef *huart)
 static void UART_EndRxTransfer(UART_HandleTypeDef *huart)
 {
   /* Disable RXNE, PE and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
-  CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
+  ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+
+  /* In case of reception waiting for IDLE event, disable also the IDLE IE interrupt source */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+  }
 
   /* At end of Rx process, restore huart->RxState to Ready */
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Reset RxIsr function pointer */
   huart->RxISR = NULL;
@@ -3315,10 +3775,10 @@ static void UART_DMATransmitCplt(DMA_HandleTypeDef *hdma)
 
     /* Disable the DMA transfer for transmit request by resetting the DMAT bit
        in the UART CR3 register */
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAT);
 
     /* Enable the UART Transmit Complete Interrupt */
-    SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
+    ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
   }
   /* DMA Circular mode */
   else
@@ -3366,24 +3826,62 @@ static void UART_DMAReceiveCplt(DMA_HandleTypeDef *hdma)
     huart->RxXferCount = 0U;
 
     /* Disable PE and ERR (Frame error, noise error, overrun error) interrupts */
-    CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
     /* Disable the DMA transfer for the receiver request by resetting the DMAR bit
        in the UART CR3 register */
-    CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
+    ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_DMAR);
 
     /* At end of Rx process, restore huart->RxState to Ready */
     huart->RxState = HAL_UART_STATE_READY;
+
+    /* If Reception till IDLE event has been selected, Disable IDLE Interrupt */
+    if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+    {
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+    }
   }
 
+  /* Initialize type of RxEvent that correspond to RxEvent callback execution;
+     In this case, Rx Event type is Transfer Complete */
+  huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+  /* Check current reception Mode :
+     If Reception till IDLE event has been selected : use Rx Event callback */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    huart->RxXferCount = 0;
+
+    /* Check current nb of data still to be received on DMA side.
+       DMA Normal mode, remaining nb of data will be 0
+       DMA Circular mode, remaining nb of data is reset to RxXferSize */
+    uint16_t nb_remaining_rx_data = (uint16_t) __HAL_DMA_GET_COUNTER(hdma);
+    if (nb_remaining_rx_data < huart->RxXferSize)
+    {
+      /* Update nb of remaining data */
+      huart->RxXferCount = nb_remaining_rx_data;
+    }
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-  /*Call registered Rx complete callback*/
-  huart->RxCpltCallback(huart);
+    /*Call registered Rx Event callback*/
+    huart->RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
 #else
-  /*Call legacy weak Rx complete callback*/
-  HAL_UART_RxCpltCallback(huart);
+    /*Call legacy weak Rx Event callback*/
+    HAL_UARTEx_RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
+  else
+  {
+    /* In other cases : use Rx Complete callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+    /*Call registered Rx complete callback*/
+    huart->RxCpltCallback(huart);
+#else
+    /*Call legacy weak Rx complete callback*/
+    HAL_UART_RxCpltCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
 }
 
 /**
@@ -3395,13 +3893,43 @@ static void UART_DMARxHalfCplt(DMA_HandleTypeDef *hdma)
 {
   UART_HandleTypeDef *huart = (UART_HandleTypeDef *)(hdma->Parent);
 
+  /* Initialize type of RxEvent that correspond to RxEvent callback execution;
+     In this case, Rx Event type is Half Transfer */
+  huart->RxEventType = HAL_UART_RXEVENT_HT;
+
+  /* Check current reception Mode :
+     If Reception till IDLE event has been selected : use Rx Event callback */
+  if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+  {
+    huart->RxXferCount = huart->RxXferSize / 2U;
+
+    /* Check current nb of data still to be received on DMA side. */
+    uint16_t nb_remaining_rx_data = (uint16_t) __HAL_DMA_GET_COUNTER(hdma);
+    if (nb_remaining_rx_data <= huart->RxXferSize)
+    {
+      /* Update nb of remaining data */
+      huart->RxXferCount = nb_remaining_rx_data;
+    }
+
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-  /*Call registered Rx Half complete callback*/
-  huart->RxHalfCpltCallback(huart);
+    /*Call registered Rx Event callback*/
+    huart->RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
 #else
-  /*Call legacy weak Rx Half complete callback*/
-  HAL_UART_RxHalfCpltCallback(huart);
+    /*Call legacy weak Rx Event callback*/
+    HAL_UARTEx_RxEventCallback(huart, (huart->RxXferSize - huart->RxXferCount));
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
+  else
+  {
+    /* In other cases : use Rx Half Complete callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+    /*Call registered Rx Half complete callback*/
+    huart->RxHalfCpltCallback(huart);
+#else
+    /*Call legacy weak Rx Half complete callback*/
+    HAL_UART_RxHalfCpltCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+  }
 }
 
 /**
@@ -3453,7 +3981,6 @@ static void UART_DMAAbortOnError(DMA_HandleTypeDef *hdma)
 {
   UART_HandleTypeDef *huart = (UART_HandleTypeDef *)(hdma->Parent);
   huart->RxXferCount = 0U;
-  huart->TxXferCount = 0U;
 
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
   /*Call registered error callback*/
@@ -3506,6 +4033,7 @@ static void UART_DMATxAbortCallback(DMA_HandleTypeDef *hdma)
   /* Restore huart->gState and huart->RxState to Ready */
   huart->gState  = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Call user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -3557,6 +4085,7 @@ static void UART_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
   /* Restore huart->gState and huart->RxState to Ready */
   huart->gState  = HAL_UART_STATE_READY;
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Call user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -3624,6 +4153,7 @@ static void UART_DMARxOnlyAbortCallback(DMA_HandleTypeDef *hdma)
 
   /* Restore huart->RxState to Ready */
   huart->RxState = HAL_UART_STATE_READY;
+  huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
 
   /* Call user Abort complete callback */
 #if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
@@ -3636,7 +4166,7 @@ static void UART_DMARxOnlyAbortCallback(DMA_HandleTypeDef *hdma)
 }
 
 /**
-  * @brief TX interrrupt handler for 7 or 8 bits data word length .
+  * @brief TX interrupt handler for 7 or 8 bits data word length .
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3650,10 +4180,10 @@ static void UART_TxISR_8BIT(UART_HandleTypeDef *huart)
     if (huart->TxXferCount == 0U)
     {
       /* Disable the UART Transmit Data Register Empty Interrupt */
-      CLEAR_BIT(huart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
 
       /* Enable the UART Transmit Complete Interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
     }
     else
     {
@@ -3665,7 +4195,7 @@ static void UART_TxISR_8BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief TX interrrupt handler for 9 bits data word length.
+  * @brief TX interrupt handler for 9 bits data word length.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3673,7 +4203,7 @@ static void UART_TxISR_8BIT(UART_HandleTypeDef *huart)
   */
 static void UART_TxISR_16BIT(UART_HandleTypeDef *huart)
 {
-  uint16_t *tmp;
+  const uint16_t *tmp;
 
   /* Check that a Tx process is ongoing */
   if (huart->gState == HAL_UART_STATE_BUSY_TX)
@@ -3681,14 +4211,14 @@ static void UART_TxISR_16BIT(UART_HandleTypeDef *huart)
     if (huart->TxXferCount == 0U)
     {
       /* Disable the UART Transmit Data Register Empty Interrupt */
-      CLEAR_BIT(huart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
 
       /* Enable the UART Transmit Complete Interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
     }
     else
     {
-      tmp = (uint16_t *) huart->pTxBuffPtr;
+      tmp = (const uint16_t *) huart->pTxBuffPtr;
       huart->Instance->TDR = (((uint32_t)(*tmp)) & 0x01FFUL);
       huart->pTxBuffPtr += 2U;
       huart->TxXferCount--;
@@ -3697,7 +4227,7 @@ static void UART_TxISR_16BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief TX interrrupt handler for 7 or 8 bits data word length and FIFO mode is enabled.
+  * @brief TX interrupt handler for 7 or 8 bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3715,10 +4245,10 @@ static void UART_TxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
       if (huart->TxXferCount == 0U)
       {
         /* Disable the TX FIFO threshold interrupt */
-        CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
+        ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
 
         /* Enable the UART Transmit Complete Interrupt */
-        SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
+        ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
 
         break; /* force exit loop */
       }
@@ -3737,7 +4267,7 @@ static void UART_TxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief TX interrrupt handler for 9 bits data word length and FIFO mode is enabled.
+  * @brief TX interrupt handler for 9 bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Transmit_IT().
   * @param huart UART handle.
@@ -3745,7 +4275,7 @@ static void UART_TxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
   */
 static void UART_TxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
 {
-  uint16_t *tmp;
+  const uint16_t *tmp;
   uint16_t  nb_tx_data;
 
   /* Check that a Tx process is ongoing */
@@ -3756,16 +4286,16 @@ static void UART_TxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
       if (huart->TxXferCount == 0U)
       {
         /* Disable the TX FIFO threshold interrupt */
-        CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
+        ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_TXFTIE);
 
         /* Enable the UART Transmit Complete Interrupt */
-        SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
+        ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_TCIE);
 
         break; /* force exit loop */
       }
       else if (READ_BIT(huart->Instance->ISR, USART_ISR_TXE_TXFNF) != 0U)
       {
-        tmp = (uint16_t *) huart->pTxBuffPtr;
+        tmp = (const uint16_t *) huart->pTxBuffPtr;
         huart->Instance->TDR = (((uint32_t)(*tmp)) & 0x01FFUL);
         huart->pTxBuffPtr += 2U;
         huart->TxXferCount--;
@@ -3787,7 +4317,7 @@ static void UART_TxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
 static void UART_EndTransmit_IT(UART_HandleTypeDef *huart)
 {
   /* Disable the UART Transmit Complete Interrupt */
-  CLEAR_BIT(huart->Instance->CR1, USART_CR1_TCIE);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_TCIE);
 
   /* Tx process is ended, restore huart->gState to Ready */
   huart->gState = HAL_UART_STATE_READY;
@@ -3805,7 +4335,7 @@ static void UART_EndTransmit_IT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 7 or 8 bits data word length .
+  * @brief RX interrupt handler for 7 or 8 bits data word length .
   * @param huart UART handle.
   * @retval None
   */
@@ -3825,10 +4355,10 @@ static void UART_RxISR_8BIT(UART_HandleTypeDef *huart)
     if (huart->RxXferCount == 0U)
     {
       /* Disable the UART Parity Error Interrupt and RXNE interrupts */
-      CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
 
       /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
-      CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+      ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
       /* Rx process is completed, restore huart->RxState to Ready */
       huart->RxState = HAL_UART_STATE_READY;
@@ -3836,13 +4366,63 @@ static void UART_RxISR_8BIT(UART_HandleTypeDef *huart)
       /* Clear RxISR function pointer */
       huart->RxISR = NULL;
 
-#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-      /*Call registered Rx complete callback*/
-      huart->RxCpltCallback(huart);
+      /* Initialize type of RxEvent to Transfer Complete */
+      huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+#if defined(LPUART1)
+      if (!(IS_LPUART_INSTANCE(huart->Instance)))
+      {
+        /* Check that USART RTOEN bit is set */
+        if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+        {
+          /* Enable the UART Receiver Timeout Interrupt */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+        }
+      }
 #else
-      /*Call legacy weak Rx complete callback*/
-      HAL_UART_RxCpltCallback(huart);
+      /* Check that USART RTOEN bit is set */
+      if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+      {
+        /* Enable the UART Receiver Timeout Interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+      }
+#endif /* LPUART1 */
+
+      /* Check current reception Mode :
+         If Reception till IDLE event has been selected : */
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        /* Set reception type to Standard */
+        huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+        /* Disable IDLE interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) == SET)
+        {
+          /* Clear IDLE Flag */
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+        }
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx Event callback*/
+        huart->RxEventCallback(huart, huart->RxXferSize);
+#else
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+      }
+      else
+      {
+        /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx complete callback*/
+        huart->RxCpltCallback(huart);
+#else
+        /*Call legacy weak Rx complete callback*/
+        HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+      }
     }
   }
   else
@@ -3853,7 +4433,7 @@ static void UART_RxISR_8BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 9 bits data word length .
+  * @brief RX interrupt handler for 9 bits data word length .
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Receive_IT()
   * @param huart UART handle.
@@ -3877,10 +4457,10 @@ static void UART_RxISR_16BIT(UART_HandleTypeDef *huart)
     if (huart->RxXferCount == 0U)
     {
       /* Disable the UART Parity Error Interrupt and RXNE interrupt*/
-      CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
+      ATOMIC_CLEAR_BIT(huart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE));
 
       /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) */
-      CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
+      ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_EIE);
 
       /* Rx process is completed, restore huart->RxState to Ready */
       huart->RxState = HAL_UART_STATE_READY;
@@ -3888,13 +4468,63 @@ static void UART_RxISR_16BIT(UART_HandleTypeDef *huart)
       /* Clear RxISR function pointer */
       huart->RxISR = NULL;
 
-#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-      /*Call registered Rx complete callback*/
-      huart->RxCpltCallback(huart);
+      /* Initialize type of RxEvent to Transfer Complete */
+      huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+#if defined(LPUART1)
+      if (!(IS_LPUART_INSTANCE(huart->Instance)))
+      {
+        /* Check that USART RTOEN bit is set */
+        if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+        {
+          /* Enable the UART Receiver Timeout Interrupt */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+        }
+      }
 #else
-      /*Call legacy weak Rx complete callback*/
-      HAL_UART_RxCpltCallback(huart);
+      /* Check that USART RTOEN bit is set */
+      if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+      {
+        /* Enable the UART Receiver Timeout Interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+      }
+#endif /* LPUART1 */
+
+      /* Check current reception Mode :
+         If Reception till IDLE event has been selected : */
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        /* Set reception type to Standard */
+        huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+        /* Disable IDLE interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) == SET)
+        {
+          /* Clear IDLE Flag */
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+        }
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx Event callback*/
+        huart->RxEventCallback(huart, huart->RxXferSize);
+#else
+        /*Call legacy weak Rx Event callback*/
+        HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+      }
+      else
+      {
+        /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+        /*Call registered Rx complete callback*/
+        huart->RxCpltCallback(huart);
+#else
+        /*Call legacy weak Rx complete callback*/
+        HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+      }
     }
   }
   else
@@ -3905,7 +4535,7 @@ static void UART_RxISR_16BIT(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 7 or 8  bits data word length and FIFO mode is enabled.
+  * @brief RX interrupt handler for 7 or 8  bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Receive_IT()
   * @param huart UART handle.
@@ -3915,26 +4545,75 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
 {
   uint16_t  uhMask = huart->Mask;
   uint16_t  uhdata;
-  uint16_t   nb_rx_data;
+  uint16_t  nb_rx_data;
   uint16_t  rxdatacount;
+  uint32_t  isrflags = READ_REG(huart->Instance->ISR);
+  uint32_t  cr1its   = READ_REG(huart->Instance->CR1);
+  uint32_t  cr3its   = READ_REG(huart->Instance->CR3);
 
   /* Check that a Rx process is ongoing */
   if (huart->RxState == HAL_UART_STATE_BUSY_RX)
   {
-    for (nb_rx_data = huart->NbRxDataToProcess ; nb_rx_data > 0U ; nb_rx_data--)
+    nb_rx_data = huart->NbRxDataToProcess;
+    while ((nb_rx_data > 0U) && ((isrflags & USART_ISR_RXNE_RXFNE) != 0U))
     {
       uhdata = (uint16_t) READ_REG(huart->Instance->RDR);
       *huart->pRxBuffPtr = (uint8_t)(uhdata & (uint8_t)uhMask);
       huart->pRxBuffPtr++;
       huart->RxXferCount--;
+      isrflags = READ_REG(huart->Instance->ISR);
+
+      /* If some non blocking errors occurred */
+      if ((isrflags & (USART_ISR_PE | USART_ISR_FE | USART_ISR_NE)) != 0U)
+      {
+        /* UART parity error interrupt occurred -------------------------------------*/
+        if (((isrflags & USART_ISR_PE) != 0U) && ((cr1its & USART_CR1_PEIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_PE;
+        }
+
+        /* UART frame error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_FE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_FE;
+        }
+
+        /* UART noise error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_NE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_NE;
+        }
+
+        /* Call UART Error Call back function if need be ----------------------------*/
+        if (huart->ErrorCode != HAL_UART_ERROR_NONE)
+        {
+          /* Non Blocking error : transfer could go on.
+          Error is notified to user through user error callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered error callback*/
+          huart->ErrorCallback(huart);
+#else
+          /*Call legacy weak error callback*/
+          HAL_UART_ErrorCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+          huart->ErrorCode = HAL_UART_ERROR_NONE;
+        }
+      }
 
       if (huart->RxXferCount == 0U)
       {
         /* Disable the UART Parity Error Interrupt and RXFT interrupt*/
-        CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
 
-        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
-        CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error)
+           and RX FIFO Threshold interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
         /* Rx process is completed, restore huart->RxState to Ready */
         huart->RxState = HAL_UART_STATE_READY;
@@ -3942,13 +4621,64 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
         /* Clear RxISR function pointer */
         huart->RxISR = NULL;
 
-#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-        /*Call registered Rx complete callback*/
-        huart->RxCpltCallback(huart);
+        /* Initialize type of RxEvent to Transfer Complete */
+        huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+#if defined(LPUART1)
+        if (!(IS_LPUART_INSTANCE(huart->Instance)))
+        {
+          /* Check that USART RTOEN bit is set */
+          if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+          {
+            /* Enable the UART Receiver Timeout Interrupt */
+            ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+          }
+        }
 #else
-        /*Call legacy weak Rx complete callback*/
-        HAL_UART_RxCpltCallback(huart);
+        /* Check that USART RTOEN bit is set */
+        if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+        {
+          /* Enable the UART Receiver Timeout Interrupt */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+        }
+#endif /* LPUART1 */
+
+        /* Check current reception Mode :
+           If Reception till IDLE event has been selected : */
+        if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+        {
+          /* Set reception type to Standard */
+          huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+          /* Disable IDLE interrupt */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+          if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) == SET)
+          {
+            /* Clear IDLE Flag */
+            __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+          }
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered Rx Event callback*/
+          huart->RxEventCallback(huart, huart->RxXferSize);
+#else
+          /*Call legacy weak Rx Event callback*/
+          HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+        }
+        else
+        {
+          /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered Rx complete callback*/
+          huart->RxCpltCallback(huart);
+#else
+          /*Call legacy weak Rx complete callback*/
+          HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+        }
+        break;
       }
     }
 
@@ -3960,13 +4690,13 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
     if ((rxdatacount != 0U) && (rxdatacount < huart->NbRxDataToProcess))
     {
       /* Disable the UART RXFT interrupt*/
-      CLEAR_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
+      ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
 
       /* Update the RxISR function pointer */
       huart->RxISR = UART_RxISR_8BIT;
 
       /* Enable the UART Data Register Not Empty interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
     }
   }
   else
@@ -3977,7 +4707,7 @@ static void UART_RxISR_8BIT_FIFOEN(UART_HandleTypeDef *huart)
 }
 
 /**
-  * @brief RX interrrupt handler for 9 bits data word length and FIFO mode is enabled.
+  * @brief RX interrupt handler for 9 bits data word length and FIFO mode is enabled.
   * @note   Function is called under interruption only, once
   *         interruptions have been enabled by HAL_UART_Receive_IT()
   * @param huart UART handle.
@@ -3988,27 +4718,76 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
   uint16_t *tmp;
   uint16_t  uhMask = huart->Mask;
   uint16_t  uhdata;
-  uint16_t   nb_rx_data;
+  uint16_t  nb_rx_data;
   uint16_t  rxdatacount;
+  uint32_t  isrflags = READ_REG(huart->Instance->ISR);
+  uint32_t  cr1its   = READ_REG(huart->Instance->CR1);
+  uint32_t  cr3its   = READ_REG(huart->Instance->CR3);
 
   /* Check that a Rx process is ongoing */
   if (huart->RxState == HAL_UART_STATE_BUSY_RX)
   {
-    for (nb_rx_data = huart->NbRxDataToProcess ; nb_rx_data > 0U ; nb_rx_data--)
+    nb_rx_data = huart->NbRxDataToProcess;
+    while ((nb_rx_data > 0U) && ((isrflags & USART_ISR_RXNE_RXFNE) != 0U))
     {
       uhdata = (uint16_t) READ_REG(huart->Instance->RDR);
       tmp = (uint16_t *) huart->pRxBuffPtr ;
       *tmp = (uint16_t)(uhdata & uhMask);
       huart->pRxBuffPtr += 2U;
       huart->RxXferCount--;
+      isrflags = READ_REG(huart->Instance->ISR);
+
+      /* If some non blocking errors occurred */
+      if ((isrflags & (USART_ISR_PE | USART_ISR_FE | USART_ISR_NE)) != 0U)
+      {
+        /* UART parity error interrupt occurred -------------------------------------*/
+        if (((isrflags & USART_ISR_PE) != 0U) && ((cr1its & USART_CR1_PEIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_PE;
+        }
+
+        /* UART frame error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_FE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_FEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_FE;
+        }
+
+        /* UART noise error interrupt occurred --------------------------------------*/
+        if (((isrflags & USART_ISR_NE) != 0U) && ((cr3its & USART_CR3_EIE) != 0U))
+        {
+          __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_NEF);
+
+          huart->ErrorCode |= HAL_UART_ERROR_NE;
+        }
+
+        /* Call UART Error Call back function if need be ----------------------------*/
+        if (huart->ErrorCode != HAL_UART_ERROR_NONE)
+        {
+          /* Non Blocking error : transfer could go on.
+          Error is notified to user through user error callback */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered error callback*/
+          huart->ErrorCallback(huart);
+#else
+          /*Call legacy weak error callback*/
+          HAL_UART_ErrorCallback(huart);
+#endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+          huart->ErrorCode = HAL_UART_ERROR_NONE;
+        }
+      }
 
       if (huart->RxXferCount == 0U)
       {
         /* Disable the UART Parity Error Interrupt and RXFT interrupt*/
-        CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
+        ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_PEIE);
 
-        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
-        CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
+        /* Disable the UART Error Interrupt: (Frame error, noise error, overrun error)
+           and RX FIFO Threshold interrupt */
+        ATOMIC_CLEAR_BIT(huart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
         /* Rx process is completed, restore huart->RxState to Ready */
         huart->RxState = HAL_UART_STATE_READY;
@@ -4016,13 +4795,64 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
         /* Clear RxISR function pointer */
         huart->RxISR = NULL;
 
-#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
-        /*Call registered Rx complete callback*/
-        huart->RxCpltCallback(huart);
+        /* Initialize type of RxEvent to Transfer Complete */
+        huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+#if defined(LPUART1)
+        if (!(IS_LPUART_INSTANCE(huart->Instance)))
+        {
+          /* Check that USART RTOEN bit is set */
+          if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+          {
+            /* Enable the UART Receiver Timeout Interrupt */
+            ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+          }
+        }
 #else
-        /*Call legacy weak Rx complete callback*/
-        HAL_UART_RxCpltCallback(huart);
+        /* Check that USART RTOEN bit is set */
+        if (READ_BIT(huart->Instance->CR2, USART_CR2_RTOEN) != 0U)
+        {
+          /* Enable the UART Receiver Timeout Interrupt */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_RTOIE);
+        }
+#endif /* LPUART1 */
+
+        /* Check current reception Mode :
+           If Reception till IDLE event has been selected : */
+        if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+        {
+          /* Set reception type to Standard */
+          huart->ReceptionType = HAL_UART_RECEPTION_STANDARD;
+
+          /* Disable IDLE interrupt */
+          ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+
+          if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE) == SET)
+          {
+            /* Clear IDLE Flag */
+            __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+          }
+
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered Rx Event callback*/
+          huart->RxEventCallback(huart, huart->RxXferSize);
+#else
+          /*Call legacy weak Rx Event callback*/
+          HAL_UARTEx_RxEventCallback(huart, huart->RxXferSize);
+#endif /* (USE_HAL_UART_REGISTER_CALLBACKS) */
+        }
+        else
+        {
+          /* Standard reception API called */
+#if (USE_HAL_UART_REGISTER_CALLBACKS == 1)
+          /*Call registered Rx complete callback*/
+          huart->RxCpltCallback(huart);
+#else
+          /*Call legacy weak Rx complete callback*/
+          HAL_UART_RxCpltCallback(huart);
 #endif /* USE_HAL_UART_REGISTER_CALLBACKS */
+        }
+        break;
       }
     }
 
@@ -4034,13 +4864,13 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
     if ((rxdatacount != 0U) && (rxdatacount < huart->NbRxDataToProcess))
     {
       /* Disable the UART RXFT interrupt*/
-      CLEAR_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
+      ATOMIC_CLEAR_BIT(huart->Instance->CR3, USART_CR3_RXFTIE);
 
       /* Update the RxISR function pointer */
       huart->RxISR = UART_RxISR_16BIT;
 
       /* Enable the UART Data Register Not Empty interrupt */
-      SET_BIT(huart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
     }
   }
   else
@@ -4063,4 +4893,3 @@ static void UART_RxISR_16BIT_FIFOEN(UART_HandleTypeDef *huart)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_uart_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_uart_ex.c
@@ -9,11 +9,22 @@
   *           + Peripheral Control functions
   *
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                ##### UART peripheral extended features  #####
   ==============================================================================
-
+  [..]
     (#) Declare a UART_HandleTypeDef handle structure.
 
     (#) For the UART RS485 Driver Enable mode, initialize the UART registers
@@ -26,17 +37,6 @@
             configured prior starting RX/TX transfers.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -211,15 +211,17 @@ HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t Polarity,
   /* Disable the Peripheral */
   __HAL_UART_DISABLE(huart);
 
+  /* Perform advanced settings configuration */
+  /* For some items, configuration requires to be done prior TE and RE bits are set */
+  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
+  {
+    UART_AdvFeatureConfig(huart);
+  }
+
   /* Set the UART Communication parameters */
   if (UART_SetConfig(huart) == HAL_ERROR)
   {
     return HAL_ERROR;
-  }
-
-  if (huart->AdvancedInit.AdvFeatureInit != UART_ADVFEATURE_NO_INIT)
-  {
-    UART_AdvFeatureConfig(huart);
   }
 
   /* Enable the Driver Enable mode by setting the DEM bit in the CR3 register */
@@ -251,15 +253,13 @@ HAL_StatusTypeDef HAL_RS485Ex_Init(UART_HandleTypeDef *huart, uint32_t Polarity,
  ===============================================================================
                       ##### IO operation functions #####
  ===============================================================================
+    [..]
     This subsection provides a set of Wakeup and FIFO mode related callback functions.
-
     (#) Wakeup from Stop mode Callback:
-        (+) HAL_UARTEx_WakeupCallback()
-
+        (++) HAL_UARTEx_WakeupCallback()
     (#) TX/RX Fifos Callbacks:
-        (+) HAL_UARTEx_RxFifoFullCallback()
-        (+) HAL_UARTEx_TxFifoEmptyCallback()
-
+        (++) HAL_UARTEx_RxFifoFullCallback()
+        (++) HAL_UARTEx_TxFifoEmptyCallback()
 @endverbatim
   * @{
   */
@@ -331,6 +331,41 @@ __weak void HAL_UARTEx_TxFifoEmptyCallback(UART_HandleTypeDef *huart)
      (+) HAL_UARTEx_DisableFifoMode() API disables the FIFO mode
      (+) HAL_UARTEx_SetTxFifoThreshold() API sets the TX FIFO threshold
      (+) HAL_UARTEx_SetRxFifoThreshold() API sets the RX FIFO threshold
+
+    [..] This subsection also provides a set of additional functions providing enhanced reception
+    services to user. (For example, these functions allow application to handle use cases
+    where number of data to be received is unknown).
+
+    (#) Compared to standard reception services which only consider number of received
+        data elements as reception completion criteria, these functions also consider additional events
+        as triggers for updating reception status to caller :
+       (++) Detection of inactivity period (RX line has not been active for a given period).
+          (+++) RX inactivity detected by IDLE event, i.e. RX line has been in idle state (normally high state)
+               for 1 frame time, after last received byte.
+          (+++) RX inactivity detected by RTO, i.e. line has been in idle state
+               for a programmable time, after last received byte.
+       (++) Detection that a specific character has been received.
+
+    (#) There are two modes of transfer:
+       (++) Blocking mode: The reception is performed in polling mode, until either expected number of data is received,
+           or till IDLE event occurs. Reception is handled only during function execution.
+           When function exits, no data reception could occur. HAL status and number of actually received data elements,
+           are returned by function after finishing transfer.
+       (++) Non-Blocking mode: The reception is performed using Interrupts or DMA.
+           These API's return the HAL status.
+           The end of the data processing will be indicated through the
+           dedicated UART IRQ when using Interrupt mode or the DMA IRQ when using DMA mode.
+           The HAL_UARTEx_RxEventCallback() user callback will be executed during Receive process
+           The HAL_UART_ErrorCallback()user callback will be executed when a reception error is detected.
+
+    (#) Blocking mode API:
+        (++) HAL_UARTEx_ReceiveToIdle()
+
+    (#) Non-Blocking mode API with Interrupt:
+        (++) HAL_UARTEx_ReceiveToIdle_IT()
+
+    (#) Non-Blocking mode API with DMA:
+        (++) HAL_UARTEx_ReceiveToIdle_DMA()
 
 @endverbatim
   * @{
@@ -416,7 +451,7 @@ HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huar
   /* Enable the Peripheral */
   __HAL_UART_ENABLE(huart);
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Wait until REACK flag is set */
@@ -448,7 +483,7 @@ HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart)
   __HAL_LOCK(huart);
 
   /* Set UESM bit */
-  SET_BIT(huart->Instance->CR1, USART_CR1_UESM);
+  ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_UESM);
 
   /* Process Unlocked */
   __HAL_UNLOCK(huart);
@@ -467,7 +502,7 @@ HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart)
   __HAL_LOCK(huart);
 
   /* Clear UESM bit */
-  CLEAR_BIT(huart->Instance->CR1, USART_CR1_UESM);
+  ATOMIC_CLEAR_BIT(huart->Instance->CR1, USART_CR1_UESM);
 
   /* Process Unlocked */
   __HAL_UNLOCK(huart);
@@ -539,7 +574,7 @@ HAL_StatusTypeDef HAL_UARTEx_DisableFifoMode(UART_HandleTypeDef *huart)
   /* Disable UART */
   __HAL_UART_DISABLE(huart);
 
-  /* Enable FIFO mode */
+  /* Disable FIFO mode */
   CLEAR_BIT(tmpcr1, USART_CR1_FIFOEN);
   huart->FifoMode = UART_FIFOMODE_DISABLE;
 
@@ -653,6 +688,303 @@ HAL_StatusTypeDef HAL_UARTEx_SetRxFifoThreshold(UART_HandleTypeDef *huart, uint3
 }
 
 /**
+  * @brief Receive an amount of data in blocking mode till either the expected number of data
+  *        is received or an IDLE event occurs.
+  * @note  HAL_OK is returned if reception is completed (expected number of data has been received)
+  *        or if reception is stopped after IDLE event (less than the expected number of data has been received)
+  *        In this case, RxLen output parameter indicates number of data available in reception buffer.
+  * @note  When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *        the received data is handled as a set of uint16_t. In this case, Size must indicate the number
+  *        of uint16_t available through pData.
+  * @note When FIFO mode is enabled, the RXFNE flag is set as long as the RXFIFO
+  *       is not empty. Read operations from the RDR register are performed when
+  *       RXFNE flag is set. From hardware perspective, RXFNE flag and
+  *       RXNE are mapped on the same bit-field.
+#if defined(CORE_CM0PLUS)
+  * @note   Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *         When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *         (16 bits) address of user data buffer for storing data to be received, should be aligned on a half
+  *         word frontier (as received data will be handled using uint16_t pointer cast).
+  *         Depending on compilation chain, use of specific alignment compilation directives or pragmas
+  *         might be required to ensure proper alignment for pData.
+#endif
+  * @param huart   UART handle.
+  * @param pData   Pointer to data buffer (uint8_t or uint16_t data elements).
+  * @param Size    Amount of data elements (uint8_t or uint16_t) to be received.
+  * @param RxLen   Number of data elements finally received
+  *                (could be lower than Size, in case reception ends on IDLE event)
+  * @param Timeout Timeout duration expressed in ms (covers the whole reception sequence).
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size, uint16_t *RxLen,
+                                           uint32_t Timeout)
+{
+  uint8_t  *pdata8bits;
+  uint16_t *pdata16bits;
+  uint16_t uhMask;
+  uint32_t tickstart;
+
+  /* Check that a Rx process is not already ongoing */
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    if ((pData == NULL) || (Size == 0U))
+    {
+      return  HAL_ERROR;
+    }
+
+    huart->ErrorCode = HAL_UART_ERROR_NONE;
+    huart->RxState = HAL_UART_STATE_BUSY_RX;
+    huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
+    huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+    /* Init tickstart for timeout management */
+    tickstart = HAL_GetTick();
+
+    huart->RxXferSize  = Size;
+    huart->RxXferCount = Size;
+
+    /* Computation of UART mask to apply to RDR register */
+    UART_MASK_COMPUTATION(huart);
+    uhMask = huart->Mask;
+
+    /* In case of 9bits/No Parity transfer, pRxData needs to be handled as a uint16_t pointer */
+    if ((huart->Init.WordLength == UART_WORDLENGTH_9B) && (huart->Init.Parity == UART_PARITY_NONE))
+    {
+      pdata8bits  = NULL;
+      pdata16bits = (uint16_t *) pData;
+    }
+    else
+    {
+      pdata8bits  = pData;
+      pdata16bits = NULL;
+    }
+
+    /* Initialize output number of received elements */
+    *RxLen = 0U;
+
+    /* as long as data have to be received */
+    while (huart->RxXferCount > 0U)
+    {
+      /* Check if IDLE flag is set */
+      if (__HAL_UART_GET_FLAG(huart, UART_FLAG_IDLE))
+      {
+        /* Clear IDLE flag in ISR */
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+
+        /* If Set, but no data ever received, clear flag without exiting loop */
+        /* If Set, and data has already been received, this means Idle Event is valid : End reception */
+        if (*RxLen > 0U)
+        {
+          huart->RxEventType = HAL_UART_RXEVENT_IDLE;
+          huart->RxState = HAL_UART_STATE_READY;
+
+          return HAL_OK;
+        }
+      }
+
+      /* Check if RXNE flag is set */
+      if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE))
+      {
+        if (pdata8bits == NULL)
+        {
+          *pdata16bits = (uint16_t)(huart->Instance->RDR & uhMask);
+          pdata16bits++;
+        }
+        else
+        {
+          *pdata8bits = (uint8_t)(huart->Instance->RDR & (uint8_t)uhMask);
+          pdata8bits++;
+        }
+        /* Increment number of received elements */
+        *RxLen += 1U;
+        huart->RxXferCount--;
+      }
+
+      /* Check for the Timeout */
+      if (Timeout != HAL_MAX_DELAY)
+      {
+        if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0U))
+        {
+          huart->RxState = HAL_UART_STATE_READY;
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+
+    /* Set number of received elements in output parameter : RxLen */
+    *RxLen = huart->RxXferSize - huart->RxXferCount;
+    /* At end of Rx process, restore huart->RxState to Ready */
+    huart->RxState = HAL_UART_STATE_READY;
+
+    return HAL_OK;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in interrupt mode till either the expected number of data
+  *        is received or an IDLE event occurs.
+  * @note  Reception is initiated by this function call. Further progress of reception is achieved thanks
+  *        to UART interrupts raised by RXNE and IDLE events. Callback is called at end of reception indicating
+  *        number of received data elements.
+  * @note  When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *        the received data is handled as a set of uint16_t. In this case, Size must indicate the number
+  *        of uint16_t available through pData.
+#if defined(CORE_CM0PLUS)
+  * @note  Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *        When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *        address of user data buffer for storing data to be received, should be aligned on a half word frontier
+  *        (16 bits) (as received data will be handled using uint16_t pointer cast). Depending on compilation chain,
+  *        use of specific alignment compilation directives or pragmas might be required
+  *        to ensure proper alignment for pData.
+#endif
+  * @param huart UART handle.
+  * @param pData Pointer to data buffer (uint8_t or uint16_t data elements).
+  * @param Size  Amount of data elements (uint8_t or uint16_t) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_IT(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check that a Rx process is not already ongoing */
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    if ((pData == NULL) || (Size == 0U))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Set Reception type to reception till IDLE Event*/
+    huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
+    huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+    (void)UART_Start_Receive_IT(huart, pData, Size);
+
+    if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+    {
+      __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+      ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+    }
+    else
+    {
+      /* In case of errors already pending when reception is started,
+         Interrupts may have already been raised and lead to reception abortion.
+         (Overrun error for instance).
+         In such case Reception Type has been reset to HAL_UART_RECEPTION_STANDARD. */
+      status = HAL_ERROR;
+    }
+
+    return status;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Receive an amount of data in DMA mode till either the expected number
+  *        of data is received or an IDLE event occurs.
+  * @note  Reception is initiated by this function call. Further progress of reception is achieved thanks
+  *        to DMA services, transferring automatically received data elements in user reception buffer and
+  *        calling registered callbacks at half/end of reception. UART IDLE events are also used to consider
+  *        reception phase as ended. In all cases, callback execution will indicate number of received data elements.
+  * @note  When the UART parity is enabled (PCE = 1), the received data contain
+  *        the parity bit (MSB position).
+  * @note  When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *        the received data is handled as a set of uint16_t. In this case, Size must indicate the number
+  *        of uint16_t available through pData.
+#if defined(CORE_CM0PLUS)
+  * @note  Dual core specific: there is no support for unaligned accesses on the Cortex-M0+ processor.
+  *        When UART parity is not enabled (PCE = 0), and Word Length is configured to 9 bits (M1-M0 = 01),
+  *        address of user data buffer for storing data to be received, should be aligned on a half word frontier
+  *        (16 bits) (as received data will be handled by DMA from halfword frontier). Depending on compilation chain,
+  *        use of specific alignment compilation directives or pragmas might be required
+  *        to ensure proper alignment for pData.
+#endif
+  * @param huart UART handle.
+  * @param pData Pointer to data buffer (uint8_t or uint16_t data elements).
+  * @param Size  Amount of data elements (uint8_t or uint16_t) to be received.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_ReceiveToIdle_DMA(UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+{
+  HAL_StatusTypeDef status;
+
+  /* Check that a Rx process is not already ongoing */
+  if (huart->RxState == HAL_UART_STATE_READY)
+  {
+    if ((pData == NULL) || (Size == 0U))
+    {
+      return HAL_ERROR;
+    }
+
+    /* Set Reception type to reception till IDLE Event*/
+    huart->ReceptionType = HAL_UART_RECEPTION_TOIDLE;
+    huart->RxEventType = HAL_UART_RXEVENT_TC;
+
+    status =  UART_Start_Receive_DMA(huart, pData, Size);
+
+    /* Check Rx process has been successfully started */
+    if (status == HAL_OK)
+    {
+      if (huart->ReceptionType == HAL_UART_RECEPTION_TOIDLE)
+      {
+        __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_IDLEF);
+        ATOMIC_SET_BIT(huart->Instance->CR1, USART_CR1_IDLEIE);
+      }
+      else
+      {
+        /* In case of errors already pending when reception is started,
+           Interrupts may have already been raised and lead to reception abortion.
+           (Overrun error for instance).
+           In such case Reception Type has been reset to HAL_UART_RECEPTION_STANDARD. */
+        status = HAL_ERROR;
+      }
+    }
+
+    return status;
+  }
+  else
+  {
+    return HAL_BUSY;
+  }
+}
+
+/**
+  * @brief Provide Rx Event type that has lead to RxEvent callback execution.
+  * @note  When HAL_UARTEx_ReceiveToIdle_IT() or HAL_UARTEx_ReceiveToIdle_DMA() API are called, progress
+  *        of reception process is provided to application through calls of Rx Event callback (either default one
+  *        HAL_UARTEx_RxEventCallback() or user registered one). As several types of events could occur (IDLE event,
+  *        Half Transfer, or Transfer Complete), this function allows to retrieve the Rx Event type that has lead
+  *        to Rx Event callback execution.
+  * @note  This function is expected to be called within the user implementation of Rx Event Callback,
+  *        in order to provide the accurate value.
+  * @note  In Interrupt Mode:
+  *        - HAL_UART_RXEVENT_TC : when Reception has been completed (expected nb of data has been received).
+  *        - HAL_UART_RXEVENT_IDLE : when Idle event occurred prior reception has been completed.
+  * @note  In DMA Mode:
+  *        - HAL_UART_RXEVENT_TC : when Reception has been completed (expected nb of data has been received).
+  *        - HAL_UART_RXEVENT_HT : when half of expected nb of data has been received.
+  *        - HAL_UART_RXEVENT_IDLE : when Idle event occurred prior reception has been completed.
+  * @note  In DMA mode, RxEvent callback could be called several times;
+  *        When DMA is configured in Normal Mode, HT event does not stop Reception process;
+  *        When DMA is configured in Circular Mode, HT, TC or IDLE events don't stop Reception process;
+  * @param  huart UART handle.
+  * @retval Rx Event Type (return vale will be a value of @ref UART_RxEvent_Type_Values)
+  */
+HAL_UART_RxEventTypeTypeDef HAL_UARTEx_GetRxEventType(const UART_HandleTypeDef *huart)
+{
+  /* Return Rx Event type value, as stored in UART handle */
+  return (huart->RxEventType);
+}
+
+/**
   * @}
   */
 
@@ -694,8 +1026,8 @@ static void UARTEx_SetNbDataToProcess(UART_HandleTypeDef *huart)
   uint8_t tx_fifo_depth;
   uint8_t rx_fifo_threshold;
   uint8_t tx_fifo_threshold;
-  uint8_t numerator[] = {1U, 1U, 1U, 3U, 7U, 1U, 0U, 0U};
-  uint8_t denominator[] = {8U, 4U, 2U, 4U, 8U, 1U, 1U, 1U};
+  static const uint8_t numerator[] = {1U, 1U, 1U, 3U, 7U, 1U, 0U, 0U};
+  static const uint8_t denominator[] = {8U, 4U, 2U, 4U, 8U, 1U, 1U, 1U};
 
   if (huart->FifoMode == UART_FIFOMODE_DISABLE)
   {
@@ -708,8 +1040,10 @@ static void UARTEx_SetNbDataToProcess(UART_HandleTypeDef *huart)
     tx_fifo_depth = TX_FIFO_DEPTH;
     rx_fifo_threshold = (uint8_t)(READ_BIT(huart->Instance->CR3, USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos);
     tx_fifo_threshold = (uint8_t)(READ_BIT(huart->Instance->CR3, USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos);
-    huart->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) / (uint16_t)denominator[tx_fifo_threshold];
-    huart->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) / (uint16_t)denominator[rx_fifo_threshold];
+    huart->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) /
+                               (uint16_t)denominator[tx_fifo_threshold];
+    huart->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) /
+                               (uint16_t)denominator[rx_fifo_threshold];
   }
 }
 /**
@@ -726,4 +1060,3 @@ static void UARTEx_SetNbDataToProcess(UART_HandleTypeDef *huart)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_usart.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_usart.c
@@ -11,6 +11,17 @@
   *           + Peripheral Control functions
   *           + Peripheral State and Error functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
  ===============================================================================
                         ##### How to use this driver #####
@@ -39,7 +50,8 @@
             (+++) Configure the declared DMA handle structure with the required Tx/Rx parameters.
             (+++) Configure the DMA Tx/Rx channel.
             (+++) Associate the initialized DMA handle to the USART DMA Tx/Rx handle.
-            (+++) Configure the priority and enable the NVIC for the transfer complete interrupt on the DMA Tx/Rx channel.
+            (+++) Configure the priority and enable the NVIC for the transfer
+                  complete interrupt on the DMA Tx/Rx channel.
 
       (#) Program the Baud Rate, Word Length, Stop Bit, Parity, and Mode
           (Receiver/Transmitter) in the husart handle Init structure.
@@ -61,8 +73,8 @@
     allows the user to configure dynamically the driver callbacks.
 
     [..]
-    Use Function @ref HAL_USART_RegisterCallback() to register a user callback.
-    Function @ref HAL_USART_RegisterCallback() allows to register following callbacks:
+    Use Function HAL_USART_RegisterCallback() to register a user callback.
+    Function HAL_USART_RegisterCallback() allows to register following callbacks:
     (+) TxHalfCpltCallback        : Tx Half Complete Callback.
     (+) TxCpltCallback            : Tx Complete Callback.
     (+) RxHalfCpltCallback        : Rx Half Complete Callback.
@@ -78,9 +90,9 @@
     and a pointer to the user callback function.
 
     [..]
-    Use function @ref HAL_USART_UnRegisterCallback() to reset a callback to the default
-    weak (surcharged) function.
-    @ref HAL_USART_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+    Use function HAL_USART_UnRegisterCallback() to reset a callback to the default
+    weak function.
+    HAL_USART_UnRegisterCallback() takes as parameters the HAL peripheral handle,
     and the Callback ID.
     This function allows to reset following callbacks:
     (+) TxHalfCpltCallback        : Tx Half Complete Callback.
@@ -96,13 +108,13 @@
     (+) MspDeInitCallback         : USART MspDeInit.
 
     [..]
-    By default, after the @ref HAL_USART_Init() and when the state is HAL_USART_STATE_RESET
-    all callbacks are set to the corresponding weak (surcharged) functions:
-    examples @ref HAL_USART_TxCpltCallback(), @ref HAL_USART_RxHalfCpltCallback().
+    By default, after the HAL_USART_Init() and when the state is HAL_USART_STATE_RESET
+    all callbacks are set to the corresponding weak functions:
+    examples HAL_USART_TxCpltCallback(), HAL_USART_RxHalfCpltCallback().
     Exception done for MspInit and MspDeInit functions that are respectively
-    reset to the legacy weak (surcharged) functions in the @ref HAL_USART_Init()
-    and @ref HAL_USART_DeInit() only when these callbacks are null (not registered beforehand).
-    If not, MspInit or MspDeInit are not null, the @ref HAL_USART_Init() and @ref HAL_USART_DeInit()
+    reset to the legacy weak functions in the HAL_USART_Init()
+    and HAL_USART_DeInit() only when these callbacks are null (not registered beforehand).
+    If not, MspInit or MspDeInit are not null, the HAL_USART_Init() and HAL_USART_DeInit()
     keep and use the user MspInit/MspDeInit callbacks (registered beforehand).
 
     [..]
@@ -111,27 +123,16 @@
     in HAL_USART_STATE_READY or HAL_USART_STATE_RESET state, thus registered (user)
     MspInit/DeInit callbacks can be used during the Init/DeInit.
     In that case first register the MspInit/MspDeInit user callbacks
-    using @ref HAL_USART_RegisterCallback() before calling @ref HAL_USART_DeInit()
-    or @ref HAL_USART_Init() function.
+    using HAL_USART_RegisterCallback() before calling HAL_USART_DeInit()
+    or HAL_USART_Init() function.
 
     [..]
     When The compilation define USE_HAL_USART_REGISTER_CALLBACKS is set to 0 or
     not defined, the callback registration feature is not available
-    and weak (surcharged) callbacks are used.
+    and weak callbacks are used.
 
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -403,7 +404,9 @@ __weak void HAL_USART_MspDeInit(USART_HandleTypeDef *husart)
 #if (USE_HAL_USART_REGISTER_CALLBACKS == 1)
 /**
   * @brief  Register a User USART Callback
-  *         To be used instead of the weak predefined callback
+  *         To be used to override the weak predefined callback
+  * @note   The HAL_USART_RegisterCallback() may be called before HAL_USART_Init() in HAL_USART_STATE_RESET
+  *         to register callbacks for HAL_USART_MSPINIT_CB_ID and HAL_USART_MSPDEINIT_CB_ID
   * @param  husart usart handle
   * @param  CallbackID ID of the callback to be registered
   *         This parameter can be one of the following values:
@@ -421,7 +424,8 @@ __weak void HAL_USART_MspDeInit(USART_HandleTypeDef *husart)
   * @param  pCallback pointer to the Callback function
   * @retval HAL status
 +  */
-HAL_StatusTypeDef HAL_USART_RegisterCallback(USART_HandleTypeDef *husart, HAL_USART_CallbackIDTypeDef CallbackID, pUSART_CallbackTypeDef pCallback)
+HAL_StatusTypeDef HAL_USART_RegisterCallback(USART_HandleTypeDef *husart, HAL_USART_CallbackIDTypeDef CallbackID,
+                                             pUSART_CallbackTypeDef pCallback)
 {
   HAL_StatusTypeDef status = HAL_OK;
 
@@ -432,8 +436,6 @@ HAL_StatusTypeDef HAL_USART_RegisterCallback(USART_HandleTypeDef *husart, HAL_US
 
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(husart);
 
   if (husart->State == HAL_USART_STATE_READY)
   {
@@ -522,15 +524,14 @@ HAL_StatusTypeDef HAL_USART_RegisterCallback(USART_HandleTypeDef *husart, HAL_US
     status =  HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(husart);
-
   return status;
 }
 
 /**
   * @brief  Unregister an USART Callback
   *         USART callaback is redirected to the weak predefined callback
+  * @note   The HAL_USART_UnRegisterCallback() may be called before HAL_USART_Init() in HAL_USART_STATE_RESET
+  *         to un-register callbacks for HAL_USART_MSPINIT_CB_ID and HAL_USART_MSPDEINIT_CB_ID
   * @param  husart usart handle
   * @param  CallbackID ID of the callback to be unregistered
   *         This parameter can be one of the following values:
@@ -551,55 +552,52 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Process locked */
-  __HAL_LOCK(husart);
-
   if (HAL_USART_STATE_READY == husart->State)
   {
     switch (CallbackID)
     {
       case HAL_USART_TX_HALFCOMPLETE_CB_ID :
-        husart->TxHalfCpltCallback = HAL_USART_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback       */
+        husart->TxHalfCpltCallback = HAL_USART_TxHalfCpltCallback;               /* Legacy weak  TxHalfCpltCallback  */
         break;
 
       case HAL_USART_TX_COMPLETE_CB_ID :
-        husart->TxCpltCallback = HAL_USART_TxCpltCallback;                       /* Legacy weak TxCpltCallback            */
+        husart->TxCpltCallback = HAL_USART_TxCpltCallback;                       /* Legacy weak TxCpltCallback       */
         break;
 
       case HAL_USART_RX_HALFCOMPLETE_CB_ID :
-        husart->RxHalfCpltCallback = HAL_USART_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback        */
+        husart->RxHalfCpltCallback = HAL_USART_RxHalfCpltCallback;               /* Legacy weak RxHalfCpltCallback   */
         break;
 
       case HAL_USART_RX_COMPLETE_CB_ID :
-        husart->RxCpltCallback = HAL_USART_RxCpltCallback;                       /* Legacy weak RxCpltCallback            */
+        husart->RxCpltCallback = HAL_USART_RxCpltCallback;                       /* Legacy weak RxCpltCallback       */
         break;
 
       case HAL_USART_TX_RX_COMPLETE_CB_ID :
-        husart->TxRxCpltCallback = HAL_USART_TxRxCpltCallback;                   /* Legacy weak TxRxCpltCallback            */
+        husart->TxRxCpltCallback = HAL_USART_TxRxCpltCallback;                   /* Legacy weak TxRxCpltCallback     */
         break;
 
       case HAL_USART_ERROR_CB_ID :
-        husart->ErrorCallback = HAL_USART_ErrorCallback;                         /* Legacy weak ErrorCallback             */
+        husart->ErrorCallback = HAL_USART_ErrorCallback;                         /* Legacy weak ErrorCallback        */
         break;
 
       case HAL_USART_ABORT_COMPLETE_CB_ID :
-        husart->AbortCpltCallback = HAL_USART_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback         */
+        husart->AbortCpltCallback = HAL_USART_AbortCpltCallback;                 /* Legacy weak AbortCpltCallback    */
         break;
 
       case HAL_USART_RX_FIFO_FULL_CB_ID :
-        husart->RxFifoFullCallback = HAL_USARTEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback        */
+        husart->RxFifoFullCallback = HAL_USARTEx_RxFifoFullCallback;             /* Legacy weak RxFifoFullCallback   */
         break;
 
       case HAL_USART_TX_FIFO_EMPTY_CB_ID :
-        husart->TxFifoEmptyCallback = HAL_USARTEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback       */
+        husart->TxFifoEmptyCallback = HAL_USARTEx_TxFifoEmptyCallback;           /* Legacy weak TxFifoEmptyCallback  */
         break;
 
       case HAL_USART_MSPINIT_CB_ID :
-        husart->MspInitCallback = HAL_USART_MspInit;                             /* Legacy weak MspInitCallback           */
+        husart->MspInitCallback = HAL_USART_MspInit;                             /* Legacy weak MspInitCallback      */
         break;
 
       case HAL_USART_MSPDEINIT_CB_ID :
-        husart->MspDeInitCallback = HAL_USART_MspDeInit;                         /* Legacy weak MspDeInitCallback         */
+        husart->MspDeInitCallback = HAL_USART_MspDeInit;                         /* Legacy weak MspDeInitCallback    */
         break;
 
       default :
@@ -640,9 +638,6 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
     /* Return error status */
     status =  HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(husart);
 
   return status;
 }
@@ -718,13 +713,16 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
     (#) In Non-Blocking mode transfers, possible errors are split into 2 categories.
         Errors are handled as follows :
         (++) Error is considered as Recoverable and non blocking : Transfer could go till end, but error severity is
-             to be evaluated by user : this concerns Frame Error, Parity Error or Noise Error in Interrupt mode reception .
-             Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify error type,
-             and HAL_USART_ErrorCallback() user callback is executed. Transfer is kept ongoing on USART side.
+             to be evaluated by user : this concerns Frame Error,
+             Parity Error or Noise Error in Interrupt mode reception .
+             Received character is then retrieved and stored in Rx buffer, Error code is set to allow user to identify
+             error type, and HAL_USART_ErrorCallback() user callback is executed.
+             Transfer is kept ongoing on USART side.
              If user wants to abort it, Abort services should be called by user.
         (++) Error is considered as Blocking : Transfer could not be completed properly and is aborted.
              This concerns Overrun Error In Interrupt mode reception and all errors in DMA mode.
-             Error code is set to allow user to identify error type, and HAL_USART_ErrorCallback() user callback is executed.
+             Error code is set to allow user to identify error type,
+             and HAL_USART_ErrorCallback() user callback is executed.
 
 @endverbatim
   * @{
@@ -741,10 +739,10 @@ HAL_StatusTypeDef HAL_USART_UnRegisterCallback(USART_HandleTypeDef *husart, HAL_
   * @param  Timeout Timeout duration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint16_t Size, uint32_t Timeout)
 {
-  uint8_t  *ptxdata8bits;
-  uint16_t *ptxdata16bits;
+  const uint8_t  *ptxdata8bits;
+  const uint16_t *ptxdata16bits;
   uint32_t tickstart;
 
 
@@ -761,7 +759,7 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_TX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     husart->TxXferSize = Size;
@@ -771,7 +769,7 @@ HAL_StatusTypeDef HAL_USART_Transmit(USART_HandleTypeDef *husart, uint8_t *pTxDa
     if ((husart->Init.WordLength == USART_WORDLENGTH_9B) && (husart->Init.Parity == USART_PARITY_NONE))
     {
       ptxdata8bits  = NULL;
-      ptxdata16bits = (uint16_t *) pTxData;
+      ptxdata16bits = (const uint16_t *) pTxData;
     }
     else
     {
@@ -860,7 +858,7 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     husart->RxXferSize = Size;
@@ -952,12 +950,13 @@ HAL_StatusTypeDef HAL_USART_Receive(USART_HandleTypeDef *husart, uint8_t *pRxDat
   * @param  Timeout Timeout duration.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size, uint32_t Timeout)
+HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint8_t *pRxData,
+                                            uint16_t Size, uint32_t Timeout)
 {
   uint8_t  *prxdata8bits;
   uint16_t *prxdata16bits;
-  uint8_t  *ptxdata8bits;
-  uint16_t *ptxdata16bits;
+  const uint8_t  *ptxdata8bits;
+  const uint16_t *ptxdata16bits;
   uint16_t uhMask;
   uint16_t rxdatacount;
   uint32_t tickstart;
@@ -976,7 +975,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
     husart->ErrorCode = HAL_USART_ERROR_NONE;
     husart->State = HAL_USART_STATE_BUSY_RX;
 
-    /* Init tickstart for timeout managment*/
+    /* Init tickstart for timeout management */
     tickstart = HAL_GetTick();
 
     husart->RxXferSize = Size;
@@ -993,7 +992,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
     {
       prxdata8bits  = NULL;
       ptxdata8bits  = NULL;
-      ptxdata16bits = (uint16_t *) pTxData;
+      ptxdata16bits = (const uint16_t *) pTxData;
       prxdata16bits = (uint16_t *) pRxData;
     }
     else
@@ -1099,7 +1098,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive(USART_HandleTypeDef *husart, uint8_t
   * @param  Size amount of data elements (u8 or u16) to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size)
+HAL_StatusTypeDef HAL_USART_Transmit_IT(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint16_t Size)
 {
 
   if (husart->State == HAL_USART_STATE_READY)
@@ -1228,7 +1227,10 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
       __HAL_UNLOCK(husart);
 
       /* Enable the USART Parity Error interrupt and RX FIFO Threshold interrupt */
-      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      if (husart->Init.Parity != USART_PARITY_NONE)
+      {
+       SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      }
       SET_BIT(husart->Instance->CR3, USART_CR3_RXFTIE);
     }
     else
@@ -1247,7 +1249,14 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
       __HAL_UNLOCK(husart);
 
       /* Enable the USART Parity Error and Data Register not empty Interrupts */
-      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+      if (husart->Init.Parity != USART_PARITY_NONE)
+      {
+        SET_BIT(husart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+      }
+      else
+      {
+        SET_BIT(husart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
+      }
     }
 
     if (husart->SlaveMode == USART_SLAVEMODE_DISABLE)
@@ -1288,7 +1297,8 @@ HAL_StatusTypeDef HAL_USART_Receive_IT(USART_HandleTypeDef *husart, uint8_t *pRx
   * @param  Size amount of data elements (u8 or u16) to be sent (same amount to be received).
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData,  uint16_t Size)
+HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint8_t *pRxData,
+                                               uint16_t Size)
 {
 
   if (husart->State == HAL_USART_STATE_READY)
@@ -1335,8 +1345,11 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
       /* Enable the USART Error Interrupt: (Frame error, noise error, overrun error) */
       SET_BIT(husart->Instance->CR3, USART_CR3_EIE);
 
-      /* Enable the USART Parity Error interrupt  */
-      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      if (husart->Init.Parity != USART_PARITY_NONE)
+      {
+        /* Enable the USART Parity Error interrupt  */
+        SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      }
 
       /* Enable the TX and  RX FIFO Threshold interrupts */
       SET_BIT(husart->Instance->CR3, (USART_CR3_TXFTIE | USART_CR3_RXFTIE));
@@ -1361,7 +1374,14 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
       SET_BIT(husart->Instance->CR3, USART_CR3_EIE);
 
       /* Enable the USART Parity Error and USART Data Register not empty Interrupts */
-      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+      if (husart->Init.Parity != USART_PARITY_NONE)
+      {
+        SET_BIT(husart->Instance->CR1, USART_CR1_PEIE | USART_CR1_RXNEIE_RXFNEIE);
+      }
+      else
+      {
+        SET_BIT(husart->Instance->CR1, USART_CR1_RXNEIE_RXFNEIE);
+      }
 
       /* Enable the USART Transmit Data Register Empty Interrupt */
       SET_BIT(husart->Instance->CR1, USART_CR1_TXEIE_TXFNFIE);
@@ -1385,10 +1405,10 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_IT(USART_HandleTypeDef *husart, uint
   * @param  Size amount of data elements (u8 or u16) to be sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint16_t Size)
+HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint16_t Size)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  uint32_t *tmp;
+  const uint32_t *tmp;
 
 
   if (husart->State == HAL_USART_STATE_READY)
@@ -1420,11 +1440,11 @@ HAL_StatusTypeDef HAL_USART_Transmit_DMA(USART_HandleTypeDef *husart, uint8_t *p
       husart->hdmatx->XferErrorCallback = USART_DMAError;
 
       /* Enable the USART transmit DMA channel */
-      tmp = (uint32_t *)&pTxData;
-      status = HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t *)tmp, (uint32_t)&husart->Instance->TDR, Size);
+      tmp = (const uint32_t *)&pTxData;
+      status = HAL_DMA_Start_IT(husart->hdmatx, *(const uint32_t *)tmp, (uint32_t)&husart->Instance->TDR, Size);
     }
 
-    if(status == HAL_OK)
+    if (status == HAL_OK)
     {
       /* Clear the TC flag in the ICR register */
       __HAL_USART_CLEAR_FLAG(husart, USART_CLEAR_TCF);
@@ -1528,13 +1548,16 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
       }
     }
 
-    if(status == HAL_OK)
+    if (status == HAL_OK)
     {
       /* Process Unlocked */
       __HAL_UNLOCK(husart);
 
-      /* Enable the USART Parity Error Interrupt */
-      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      if (husart->Init.Parity != USART_PARITY_NONE)
+      {
+        /* Enable the USART Parity Error Interrupt */
+        SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      }
 
       /* Enable the USART Error Interrupt: (Frame error, noise error, overrun error) */
       SET_BIT(husart->Instance->CR3, USART_CR3_EIE);
@@ -1551,7 +1574,7 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
     }
     else
     {
-      if(husart->hdmarx != NULL)
+      if (husart->hdmarx != NULL)
       {
         status = HAL_DMA_Abort(husart->hdmarx);
       }
@@ -1589,10 +1612,11 @@ HAL_StatusTypeDef HAL_USART_Receive_DMA(USART_HandleTypeDef *husart, uint8_t *pR
   * @param  Size amount of data elements (u8 or u16) to be received/sent.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uint8_t *pTxData, uint8_t *pRxData, uint16_t Size)
+HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, const uint8_t *pTxData, uint8_t *pRxData,
+                                                uint16_t Size)
 {
   HAL_StatusTypeDef status;
-  uint32_t *tmp;
+  const uint32_t *tmp;
 
 
   if (husart->State == HAL_USART_STATE_READY)
@@ -1634,14 +1658,14 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uin
       husart->hdmarx->XferErrorCallback = USART_DMAError;
 
       /* Enable the USART receive DMA channel */
-      tmp = (uint32_t *)&pRxData;
-      status = HAL_DMA_Start_IT(husart->hdmarx, (uint32_t)&husart->Instance->RDR, *(uint32_t *)tmp, Size);
+      tmp = (const uint32_t *)&pRxData;
+      status = HAL_DMA_Start_IT(husart->hdmarx, (uint32_t)&husart->Instance->RDR, *(const uint32_t *)tmp, Size);
 
       /* Enable the USART transmit DMA channel */
-      if(status == HAL_OK)
+      if (status == HAL_OK)
       {
         tmp = (uint32_t *)&pTxData;
-        status = HAL_DMA_Start_IT(husart->hdmatx, *(uint32_t *)tmp, (uint32_t)&husart->Instance->TDR, Size);
+        status = HAL_DMA_Start_IT(husart->hdmatx, *(const uint32_t *)tmp, (uint32_t)&husart->Instance->TDR, Size);
       }
     }
     else
@@ -1649,13 +1673,16 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uin
       status = HAL_ERROR;
     }
 
-    if(status == HAL_OK)
+    if (status == HAL_OK)
     {
       /* Process Unlocked */
       __HAL_UNLOCK(husart);
 
-      /* Enable the USART Parity Error Interrupt */
-      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      if (husart->Init.Parity != USART_PARITY_NONE)
+      {
+        /* Enable the USART Parity Error Interrupt */
+        SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+      }
 
       /* Enable the USART Error Interrupt: (Frame error, noise error, overrun error) */
       SET_BIT(husart->Instance->CR3, USART_CR3_EIE);
@@ -1675,7 +1702,7 @@ HAL_StatusTypeDef HAL_USART_TransmitReceive_DMA(USART_HandleTypeDef *husart, uin
     }
     else
     {
-      if(husart->hdmarx != NULL)
+      if (husart->hdmarx != NULL)
       {
         status = HAL_DMA_Abort(husart->hdmarx);
       }
@@ -1771,8 +1798,11 @@ HAL_StatusTypeDef HAL_USART_DMAResume(USART_HandleTypeDef *husart)
     /* Clear the Overrun flag before resuming the Rx transfer*/
     __HAL_USART_CLEAR_FLAG(husart, USART_CLEAR_OREF);
 
-    /* Reenable PE and ERR (Frame error, noise error, overrun error) interrupts */
-    SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+    /* Re-enable PE and ERR (Frame error, noise error, overrun error) interrupts */
+    if (husart->Init.Parity != USART_PARITY_NONE)
+    {
+      SET_BIT(husart->Instance->CR1, USART_CR1_PEIE);
+    }
     SET_BIT(husart->Instance->CR3, USART_CR3_EIE);
 
     /* Enable the USART DMA Rx request  before the DMA Tx request */
@@ -1820,9 +1850,6 @@ HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart)
         /* Set error code to DMA */
         husart->ErrorCode = HAL_USART_ERROR_DMA;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(husart);
-
         return HAL_TIMEOUT;
       }
     }
@@ -1836,9 +1863,6 @@ HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart)
       {
         /* Set error code to DMA */
         husart->ErrorCode = HAL_USART_ERROR_DMA;
-
-        /* Process Unlocked */
-        __HAL_UNLOCK(husart);
 
         return HAL_TIMEOUT;
       }
@@ -1862,11 +1886,12 @@ HAL_StatusTypeDef HAL_USART_DMAStop(USART_HandleTypeDef *husart)
   *           - Set handle State to READY
   * @note   This procedure is executed in blocking mode : when exiting function, Abort is considered as completed.
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_USART_Abort(USART_HandleTypeDef *husart)
 {
   /* Disable TXEIE, TCIE, RXNE, RXFT, TXFT, PE and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(husart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  CLEAR_BIT(husart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE |
+                                    USART_CR1_TCIE));
   CLEAR_BIT(husart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE));
 
   /* Disable the USART DMA Tx request if enabled */
@@ -1887,9 +1912,6 @@ HAL_StatusTypeDef HAL_USART_Abort(USART_HandleTypeDef *husart)
         {
           /* Set error code to DMA */
           husart->ErrorCode = HAL_USART_ERROR_DMA;
-
-          /* Process Unlocked */
-          __HAL_UNLOCK(husart);
 
           return HAL_TIMEOUT;
         }
@@ -1915,9 +1937,6 @@ HAL_StatusTypeDef HAL_USART_Abort(USART_HandleTypeDef *husart)
         {
           /* Set error code to DMA */
           husart->ErrorCode = HAL_USART_ERROR_DMA;
-
-          /* Process Unlocked */
-          __HAL_UNLOCK(husart);
 
           return HAL_TIMEOUT;
         }
@@ -1963,13 +1982,14 @@ HAL_StatusTypeDef HAL_USART_Abort(USART_HandleTypeDef *husart)
   * @note   This procedure is executed in Interrupt mode, meaning that abort procedure could be
   *         considered as completed only when user abort complete callback is executed (not when exiting function).
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef HAL_USART_Abort_IT(USART_HandleTypeDef *husart)
 {
   uint32_t abortcplt = 1U;
 
   /* Disable TXEIE, TCIE, RXNE, RXFT, TXFT, PE and ERR (Frame error, noise error, overrun error) interrupts */
-  CLEAR_BIT(husart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE | USART_CR1_TCIE));
+  CLEAR_BIT(husart->Instance->CR1, (USART_CR1_RXNEIE_RXFNEIE | USART_CR1_PEIE | USART_CR1_TXEIE_TXFNFIE |
+                                    USART_CR1_TCIE));
   CLEAR_BIT(husart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE | USART_CR3_TXFTIE));
 
   /* If DMA Tx and/or DMA Rx Handles are associated to USART Handle, DMA Abort complete callbacks should be initialised
@@ -2104,7 +2124,7 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
   uint32_t errorcode;
 
   /* If no error occurs */
-  errorflags = (isrflags & (uint32_t)(USART_ISR_PE | USART_ISR_FE | USART_ISR_ORE | USART_ISR_NE | USART_ISR_UDR));
+  errorflags = (isrflags & (uint32_t)(USART_ISR_PE | USART_ISR_FE | USART_ISR_ORE | USART_ISR_NE | USART_ISR_RTOF | USART_ISR_UDR));
   if (errorflags == 0U)
   {
     /* USART in mode Receiver ---------------------------------------------------*/
@@ -2157,6 +2177,14 @@ void HAL_USART_IRQHandler(USART_HandleTypeDef *husart)
       __HAL_USART_CLEAR_IT(husart, USART_CLEAR_OREF);
 
       husart->ErrorCode |= HAL_USART_ERROR_ORE;
+    }
+
+    /* USART Receiver Timeout interrupt occurred ---------------------------------*/
+    if (((isrflags & USART_ISR_RTOF) != 0U) && ((cr1its & USART_CR1_RTOIE) != 0U))
+    {
+      __HAL_UART_CLEAR_FLAG(husart, UART_CLEAR_RTOF);
+
+      husart->ErrorCode |= HAL_USART_ERROR_RTO;
     }
 
     /* USART SPI slave underrun error interrupt occurred -------------------------*/
@@ -2429,8 +2457,8 @@ __weak void HAL_USART_AbortCpltCallback(USART_HandleTypeDef *husart)
   */
 
 /** @defgroup USART_Exported_Functions_Group4 Peripheral State and Error functions
- *  @brief   USART Peripheral State and Error functions
- *
+  *  @brief   USART Peripheral State and Error functions
+  *
 @verbatim
   ==============================================================================
             ##### Peripheral State and Error functions #####
@@ -2451,7 +2479,7 @@ __weak void HAL_USART_AbortCpltCallback(USART_HandleTypeDef *husart)
   *              the configuration information for the specified USART.
   * @retval USART handle state
   */
-HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart)
+HAL_USART_StateTypeDef HAL_USART_GetState(const USART_HandleTypeDef *husart)
 {
   return husart->State;
 }
@@ -2462,7 +2490,7 @@ HAL_USART_StateTypeDef HAL_USART_GetState(USART_HandleTypeDef *husart)
   *              the configuration information for the specified USART.
   * @retval USART handle Error Code
   */
-uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart)
+uint32_t HAL_USART_GetError(const USART_HandleTypeDef *husart)
 {
   return husart->ErrorCode;
 }
@@ -2476,8 +2504,8 @@ uint32_t HAL_USART_GetError(USART_HandleTypeDef *husart)
   */
 
 /** @defgroup USART_Private_Functions USART Private Functions
- * @{
- */
+  * @{
+  */
 
 /**
   * @brief  Initialize the callbacks to their default values.
@@ -2808,7 +2836,8 @@ static void USART_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
 
 
 /**
-  * @brief  Handle USART Communication Timeout.
+  * @brief  Handle USART Communication Timeout. It waits
+  *         until a flag is no longer in the specified status.
   * @param  husart USART handle.
   * @param  Flag Specifies the USART flag to check.
   * @param  Status the Flag status (SET or RESET).
@@ -2816,7 +2845,8 @@ static void USART_DMARxAbortCallback(DMA_HandleTypeDef *hdma)
   * @param  Timeout timeout duration.
   * @retval HAL status
   */
-static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status, uint32_t Tickstart, uint32_t Timeout)
+static HAL_StatusTypeDef USART_WaitOnFlagUntilTimeout(USART_HandleTypeDef *husart, uint32_t Flag, FlagStatus Status,
+                                                      uint32_t Tickstart, uint32_t Timeout)
 {
   /* Wait until flag is set */
   while ((__HAL_USART_GET_FLAG(husart, Flag) ? SET : RESET) == Status)
@@ -2950,7 +2980,7 @@ static HAL_StatusTypeDef USART_CheckIdleState(USART_HandleTypeDef *husart)
   /* Initialize the USART ErrorCode */
   husart->ErrorCode = HAL_USART_ERROR_NONE;
 
-  /* Init tickstart for timeout managment*/
+  /* Init tickstart for timeout management */
   tickstart = HAL_GetTick();
 
   /* Check if the Transmitter is enabled */
@@ -3031,7 +3061,7 @@ static void USART_TxISR_8BIT(USART_HandleTypeDef *husart)
 static void USART_TxISR_16BIT(USART_HandleTypeDef *husart)
 {
   const HAL_USART_StateTypeDef state = husart->State;
-  uint16_t *tmp;
+  const uint16_t *tmp;
 
   if ((state == HAL_USART_STATE_BUSY_TX) ||
       (state == HAL_USART_STATE_BUSY_TX_RX))
@@ -3046,7 +3076,7 @@ static void USART_TxISR_16BIT(USART_HandleTypeDef *husart)
     }
     else
     {
-      tmp = (uint16_t *) husart->pTxBuffPtr;
+      tmp = (const uint16_t *) husart->pTxBuffPtr;
       husart->Instance->TDR = (uint16_t)(*tmp & 0x01FFU);
       husart->pTxBuffPtr += 2U;
       husart->TxXferCount--;
@@ -3112,7 +3142,7 @@ static void USART_TxISR_8BIT_FIFOEN(USART_HandleTypeDef *husart)
 static void USART_TxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart)
 {
   const HAL_USART_StateTypeDef state = husart->State;
-  uint16_t *tmp;
+  const uint16_t *tmp;
   uint16_t  nb_tx_data;
 
   /* Check that a Tx process is ongoing */
@@ -3133,7 +3163,7 @@ static void USART_TxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart)
       }
       else if (__HAL_USART_GET_FLAG(husart, USART_FLAG_TXFNF) == SET)
       {
-        tmp = (uint16_t *) husart->pTxBuffPtr;
+        tmp = (const uint16_t *) husart->pTxBuffPtr;
         husart->Instance->TDR = (uint16_t)(*tmp & 0x01FFU);
         husart->pTxBuffPtr += 2U;
         husart->TxXferCount--;
@@ -3214,6 +3244,7 @@ static void USART_RxISR_8BIT(USART_HandleTypeDef *husart)
   const HAL_USART_StateTypeDef state = husart->State;
   uint16_t txdatacount;
   uint16_t uhMask = husart->Mask;
+  uint32_t txftie;
 
   if ((state == HAL_USART_STATE_BUSY_RX) ||
       (state == HAL_USART_STATE_BUSY_TX_RX))
@@ -3233,7 +3264,8 @@ static void USART_RxISR_8BIT(USART_HandleTypeDef *husart)
       /* Clear RxISR function pointer */
       husart->RxISR = NULL;
 
-      /* txdatacount is a temporary variable for MISRAC2012-Rule-13.5 */
+      /* txftie and txdatacount are temporary variables for MISRAC2012-Rule-13.5 */
+      txftie = READ_BIT(husart->Instance->CR3, USART_CR3_TXFTIE);
       txdatacount = husart->TxXferCount;
 
       if (state == HAL_USART_STATE_BUSY_RX)
@@ -3257,6 +3289,7 @@ static void USART_RxISR_8BIT(USART_HandleTypeDef *husart)
 #endif /* USE_HAL_USART_REGISTER_CALLBACKS */
       }
       else if ((READ_BIT(husart->Instance->CR1, USART_CR1_TCIE) != USART_CR1_TCIE) &&
+               (txftie != USART_CR3_TXFTIE) &&
                (txdatacount == 0U))
       {
         /* TxRx process is completed, restore husart->State to Ready */
@@ -3303,6 +3336,7 @@ static void USART_RxISR_16BIT(USART_HandleTypeDef *husart)
   uint16_t txdatacount;
   uint16_t *tmp;
   uint16_t uhMask = husart->Mask;
+  uint32_t txftie;
 
   if ((state == HAL_USART_STATE_BUSY_RX) ||
       (state == HAL_USART_STATE_BUSY_TX_RX))
@@ -3323,7 +3357,8 @@ static void USART_RxISR_16BIT(USART_HandleTypeDef *husart)
       /* Clear RxISR function pointer */
       husart->RxISR = NULL;
 
-      /* txdatacount is a temporary variable for MISRAC2012-Rule-13.5 */
+      /* txftie and txdatacount are temporary variables for MISRAC2012-Rule-13.5 */
+      txftie = READ_BIT(husart->Instance->CR3, USART_CR3_TXFTIE);
       txdatacount = husart->TxXferCount;
 
       if (state == HAL_USART_STATE_BUSY_RX)
@@ -3347,6 +3382,7 @@ static void USART_RxISR_16BIT(USART_HandleTypeDef *husart)
 #endif /* USE_HAL_USART_REGISTER_CALLBACKS */
       }
       else if ((READ_BIT(husart->Instance->CR1, USART_CR1_TCIE) != USART_CR1_TCIE) &&
+               (txftie != USART_CR3_TXFTIE) &&
                (txdatacount == 0U))
       {
         /* TxRx process is completed, restore husart->State to Ready */
@@ -3394,6 +3430,7 @@ static void USART_RxISR_8BIT_FIFOEN(USART_HandleTypeDef *husart)
   uint16_t rxdatacount;
   uint16_t uhMask = husart->Mask;
   uint16_t nb_rx_data;
+  uint32_t txftie;
 
   /* Check that a Rx process is ongoing */
   if ((state == HAL_USART_STATE_BUSY_RX) ||
@@ -3412,13 +3449,15 @@ static void USART_RxISR_8BIT_FIFOEN(USART_HandleTypeDef *husart)
           /* Disable the USART Parity Error Interrupt */
           CLEAR_BIT(husart->Instance->CR1, USART_CR1_PEIE);
 
-          /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
+          /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error)
+             and RX FIFO Threshold interrupt */
           CLEAR_BIT(husart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
           /* Clear RxISR function pointer */
           husart->RxISR = NULL;
 
-          /* txdatacount is a temporary variable for MISRAC2012-Rule-13.5 */
+          /* txftie and txdatacount are temporary variables for MISRAC2012-Rule-13.5 */
+          txftie = READ_BIT(husart->Instance->CR3, USART_CR3_TXFTIE);
           txdatacount = husart->TxXferCount;
 
           if (state == HAL_USART_STATE_BUSY_RX)
@@ -3443,6 +3482,7 @@ static void USART_RxISR_8BIT_FIFOEN(USART_HandleTypeDef *husart)
 #endif /* USE_HAL_USART_REGISTER_CALLBACKS */
           }
           else if ((READ_BIT(husart->Instance->CR1, USART_CR1_TCIE) != USART_CR1_TCIE) &&
+                   (txftie != USART_CR3_TXFTIE) &&
                    (txdatacount == 0U))
           {
             /* TxRx process is completed, restore husart->State to Ready */
@@ -3524,6 +3564,7 @@ static void USART_RxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart)
   uint16_t *tmp;
   uint16_t uhMask = husart->Mask;
   uint16_t nb_rx_data;
+  uint32_t txftie;
 
   /* Check that a Tx process is ongoing */
   if ((state == HAL_USART_STATE_BUSY_RX) ||
@@ -3543,13 +3584,15 @@ static void USART_RxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart)
           /* Disable the USART Parity Error Interrupt */
           CLEAR_BIT(husart->Instance->CR1, USART_CR1_PEIE);
 
-          /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error) and RX FIFO Threshold interrupt */
+          /* Disable the USART Error Interrupt: (Frame error, noise error, overrun error)
+             and RX FIFO Threshold interrupt */
           CLEAR_BIT(husart->Instance->CR3, (USART_CR3_EIE | USART_CR3_RXFTIE));
 
           /* Clear RxISR function pointer */
           husart->RxISR = NULL;
 
-          /* txdatacount is a temporary variable for MISRAC2012-Rule-13.5 */
+          /* txftie and txdatacount are temporary variables for MISRAC2012-Rule-13.5 */
+          txftie = READ_BIT(husart->Instance->CR3, USART_CR3_TXFTIE);
           txdatacount = husart->TxXferCount;
 
           if (state == HAL_USART_STATE_BUSY_RX)
@@ -3574,6 +3617,7 @@ static void USART_RxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart)
 #endif /* USE_HAL_USART_REGISTER_CALLBACKS */
           }
           else if ((READ_BIT(husart->Instance->CR1, USART_CR1_TCIE) != USART_CR1_TCIE) &&
+                   (txftie != USART_CR3_TXFTIE) &&
                    (txdatacount == 0U))
           {
             /* TxRx process is completed, restore husart->State to Ready */
@@ -3651,4 +3695,3 @@ static void USART_RxISR_16BIT_FIFOEN(USART_HandleTypeDef *husart)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_usart_ex.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_usart_ex.c
@@ -8,6 +8,17 @@
   *           + Peripheral Control functions
   *
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                ##### USART peripheral extended features  #####
@@ -25,17 +36,6 @@
             starting RX/TX transfers.
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -503,8 +503,8 @@ static void USARTEx_SetNbDataToProcess(USART_HandleTypeDef *husart)
   uint8_t rx_fifo_threshold;
   uint8_t tx_fifo_threshold;
   /* 2 0U/1U added for MISRAC2012-Rule-18.1_b and MISRAC2012-Rule-18.1_d */
-  uint8_t numerator[]   = {1U, 1U, 1U, 3U, 7U, 1U, 0U, 0U};
-  uint8_t denominator[] = {8U, 4U, 2U, 4U, 8U, 1U, 1U, 1U};
+  static const uint8_t numerator[]   = {1U, 1U, 1U, 3U, 7U, 1U, 0U, 0U};
+  static const uint8_t denominator[] = {8U, 4U, 2U, 4U, 8U, 1U, 1U, 1U};
 
   if (husart->FifoMode == USART_FIFOMODE_DISABLE)
   {
@@ -515,10 +515,14 @@ static void USARTEx_SetNbDataToProcess(USART_HandleTypeDef *husart)
   {
     rx_fifo_depth = RX_FIFO_DEPTH;
     tx_fifo_depth = TX_FIFO_DEPTH;
-    rx_fifo_threshold = (uint8_t)((READ_BIT(husart->Instance->CR3, USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos) & 0xFFU);
-    tx_fifo_threshold = (uint8_t)((READ_BIT(husart->Instance->CR3, USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos) & 0xFFU);
-    husart->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) / (uint16_t)denominator[tx_fifo_threshold];
-    husart->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) / (uint16_t)denominator[rx_fifo_threshold];
+    rx_fifo_threshold = (uint8_t)((READ_BIT(husart->Instance->CR3,
+                                            USART_CR3_RXFTCFG) >> USART_CR3_RXFTCFG_Pos) & 0xFFU);
+    tx_fifo_threshold = (uint8_t)((READ_BIT(husart->Instance->CR3,
+                                            USART_CR3_TXFTCFG) >> USART_CR3_TXFTCFG_Pos) & 0xFFU);
+    husart->NbTxDataToProcess = ((uint16_t)tx_fifo_depth * numerator[tx_fifo_threshold]) /
+                                (uint16_t)denominator[tx_fifo_threshold];
+    husart->NbRxDataToProcess = ((uint16_t)rx_fifo_depth * numerator[rx_fifo_threshold]) /
+                                (uint16_t)denominator[rx_fifo_threshold];
   }
 }
 /**
@@ -535,4 +539,3 @@ static void USARTEx_SetNbDataToProcess(USART_HandleTypeDef *husart)
   * @}
   */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_wwdg.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_wwdg.c
@@ -7,6 +7,17 @@
   *          functionalities of the Window Watchdog (WWDG) peripheral:
   *           + Initialization and Configuration functions
   *           + IO operation functions
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                       ##### WWDG Specific features #####
@@ -111,17 +122,6 @@
       (+) __HAL_WWDG_ENABLE_IT: Enable the WWDG early wakeup interrupt
 
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
   ******************************************************************************
   */
 
@@ -418,5 +418,3 @@ __weak void HAL_WWDG_EarlyWakeupCallback(WWDG_HandleTypeDef *hwwdg)
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_adc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_adc.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -67,12 +66,12 @@
 #define ADC_CLOCK_RATIO_VS_CPU_HIGHEST          (512UL * 16UL * 4UL)
 #define ADC_TIMEOUT_DISABLE_CPU_CYCLES          (ADC_CLOCK_RATIO_VS_CPU_HIGHEST * 1UL)
 #define ADC_TIMEOUT_STOP_CONVERSION_CPU_CYCLES  (ADC_CLOCK_RATIO_VS_CPU_HIGHEST * 1UL)
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 /* Note: CCRDY handshake requires 1APB + 2 ADC + 3 APB cycles                 */
 /*       after the channel configuration has been changed.                    */
 /*       Driver timeout is approximated to 6 CPU cycles.                      */
 #define ADC_TIMEOUT_CCRDY_CPU_CYCLES            (ADC_CLOCK_RATIO_VS_CPU_HIGHEST * 6UL)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /**
   * @}
@@ -86,7 +85,7 @@
 
 /* Check of parameters for configuration of ADC hierarchical scope:           */
 /* common to several ADC instances.                                           */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_COMMON_CLOCK(__CLOCK__)                                      \
   (   ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV1)                                 \
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV2)                                 \
@@ -119,11 +118,11 @@
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV128)                               \
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC_DIV256)                               \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 /* Check of parameters for configuration of ADC hierarchical scope:           */
 /* ADC instance.                                                              */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_CLOCK(__CLOCK__)                                             \
   (   ((__CLOCK__) == LL_ADC_CLOCK_SYNC_PCLK_DIV4)                             \
    || ((__CLOCK__) == LL_ADC_CLOCK_SYNC_PCLK_DIV2)                             \
@@ -131,7 +130,7 @@
    || ((__CLOCK__) == LL_ADC_CLOCK_ASYNC)                                      \
   )
 
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 #define IS_LL_ADC_RESOLUTION(__RESOLUTION__)                                   \
   (   ((__RESOLUTION__) == LL_ADC_RESOLUTION_12B)                              \
    || ((__RESOLUTION__) == LL_ADC_RESOLUTION_10B)                              \
@@ -144,7 +143,7 @@
    || ((__DATA_ALIGN__) == LL_ADC_DATA_ALIGN_LEFT)                             \
   )
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_LOW_POWER(__LOW_POWER__)                                     \
   (   ((__LOW_POWER__) == LL_ADC_LP_MODE_NONE)                                 \
    || ((__LOW_POWER__) == LL_ADC_LP_AUTOWAIT)                                  \
@@ -156,10 +155,10 @@
   (   ((__LOW_POWER__) == LL_ADC_LP_MODE_NONE)                                 \
    || ((__LOW_POWER__) == LL_ADC_LP_AUTOWAIT)                                  \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /* Check of parameters for configuration of ADC hierarchical scope:           */
 /* ADC group regular                                                          */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_REG_TRIG_SOURCE(__REG_TRIG_SOURCE__)                         \
   (   ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_SOFTWARE)                      \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM1_TRGO2)                \
@@ -181,7 +180,7 @@
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_TIM2_CH2)                  \
    || ((__REG_TRIG_SOURCE__) == LL_ADC_REG_TRIG_EXT_EXTI_LINE11)               \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
 #define IS_LL_ADC_REG_CONTINUOUS_MODE(__REG_CONTINUOUS_MODE__)                 \
   (   ((__REG_CONTINUOUS_MODE__) == LL_ADC_REG_CONV_SINGLE)                    \
@@ -199,14 +198,14 @@
    || ((__REG_OVR_DATA_BEHAVIOR__) == LL_ADC_REG_OVR_DATA_OVERWRITTEN)         \
   )
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_REG_SEQ_MODE(__REG_SEQ_MODE__)                               \
   (   ((__REG_SEQ_MODE__) == LL_ADC_REG_SEQ_FIXED)                             \
    || ((__REG_SEQ_MODE__) == LL_ADC_REG_SEQ_CONFIGURABLE)                      \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_REG_SEQ_SCAN_LENGTH(__REG_SEQ_SCAN_LENGTH__)                 \
   (   ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_DISABLE)               \
    || ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_ENABLE_2RANKS)         \
@@ -236,8 +235,8 @@
    || ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS)        \
    || ((__REG_SEQ_SCAN_LENGTH__) == LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS)        \
   )
-#endif
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#endif /* ADC_SUPPORT_2_5_MSPS */
+#if defined(ADC_SUPPORT_2_5_MSPS)
 #define IS_LL_ADC_REG_SEQ_SCAN_DISCONT_MODE(__REG_SEQ_DISCONT_MODE__)          \
   (   ((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_DISABLE)           \
    || ((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_1RANK)             \
@@ -254,7 +253,7 @@
    || ((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_7RANKS)            \
    || ((__REG_SEQ_DISCONT_MODE__) == LL_ADC_REG_SEQ_DISCONT_8RANKS)            \
   )
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 /* Check of parameters for configuration of ADC hierarchical scope:           */
 /* ADC group injected                                                         */
 #define IS_LL_ADC_INJ_TRIG_SOURCE(__INJ_TRIG_SOURCE__)                         \
@@ -322,7 +321,10 @@ ErrorStatus LL_ADC_CommonDeInit(ADC_Common_TypeDef *ADCxy_COMMON)
   /* Check the parameters */
   assert_param(IS_ADC_COMMON_INSTANCE(ADCxy_COMMON));
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+  /* Prevent unused argument compilation warning */
+  (void)(ADCxy_COMMON);
+
+#if defined(ADC_SUPPORT_2_5_MSPS)
   /* Force reset of ADC clock (core clock) */
   LL_APB2_GRP1_ForceReset(LL_APB2_GRP1_PERIPH_ADC);
 
@@ -354,7 +356,7 @@ ErrorStatus LL_ADC_CommonDeInit(ADC_Common_TypeDef *ADCxy_COMMON)
   *          - SUCCESS: ADC common registers are initialized
   *          - ERROR: ADC common registers are not initialized
   */
-ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct)
+ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, const LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct)
 {
   ErrorStatus status = SUCCESS;
 
@@ -364,7 +366,7 @@ ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, LL_ADC_CommonIni
 
   /* Note: Hardware constraint (refer to description of functions             */
   /*       "LL_ADC_SetCommonXXX()":                                           */
-  /*       On this STM32 serie, setting of these features is conditioned to   */
+  /*       On this STM32 series, setting of these features is conditioned to   */
   /*       ADC state:                                                         */
   /*       All ADC instances of the ADC common group must be disabled.        */
   if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(ADCxy_COMMON) == 0UL)
@@ -427,7 +429,7 @@ void LL_ADC_CommonStructInit(LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct)
   /* Set ADC_CommonInitStruct fields to default values */
   /* Set fields of ADC common */
   /* (all ADC instances belonging to the same ADC common instance) */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   ADC_CommonInitStruct->CommonClock = LL_ADC_CLOCK_ASYNC_DIV2;
 #else
   ADC_CommonInitStruct->CommonClock = LL_ADC_CLOCK_SYNC_PCLK_DIV2;
@@ -476,7 +478,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
       }
     }
 
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
     /* Set ADC group injected trigger source to SW start to ensure to not     */
     /* have an external trigger event occurring during the conversion stop    */
     /* ADC disable process.                                                   */
@@ -517,15 +519,15 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
         break;
       }
     }
-#endif /* ADC_SUPPORT_2_5_MSPS */
+#endif /* !ADC_SUPPORT_2_5_MSPS */
 
-#if !defined (ADC_SUPPORT_2_5_MSPS)
+#if !defined(ADC_SUPPORT_2_5_MSPS)
     /* Flush group injected contexts queue (register JSQR):                   */
     /* Note: Bit JQM must be set to empty the contexts queue (otherwise       */
     /*       contexts queue is maintained with the last active context).      */
     LL_ADC_INJ_SetQueueMode(ADCx, LL_ADC_INJ_QUEUE_2CONTEXTS_END_EMPTY);
 
-#endif
+#endif /* !ADC_SUPPORT_2_5_MSPS */
     /* Disable the ADC instance */
     LL_ADC_Disable(ADCx);
 
@@ -544,7 +546,7 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
   }
 
   /* Check whether ADC state is compliant with expected state */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   if (READ_BIT(ADCx->CR,
                (ADC_CR_ADSTP | ADC_CR_ADSTART
                 | ADC_CR_ADDIS | ADC_CR_ADEN   )
@@ -556,52 +558,74 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
                 | ADC_CR_ADDIS | ADC_CR_ADEN)
               )
       == 0UL)
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   {
     /* ========== Reset ADC registers ========== */
     /* Reset register IER */
+#if !defined(ADC_SUPPORT_2_5_MSPS)
     CLEAR_BIT(ADCx->IER,
               (LL_ADC_IT_ADRDY
                | LL_ADC_IT_EOC
                | LL_ADC_IT_EOS
                | LL_ADC_IT_OVR
                | LL_ADC_IT_EOSMP
-#if !defined (ADC_SUPPORT_2_5_MSPS)
                | LL_ADC_IT_JEOC
                | LL_ADC_IT_JEOS
                | LL_ADC_IT_JQOVF
-#endif
                | LL_ADC_IT_AWD1
                | LL_ADC_IT_AWD2
                | LL_ADC_IT_AWD3
-#if defined (ADC_SUPPORT_2_5_MSPS)
-               | LL_ADC_IT_CCRDY
-#endif
               )
              );
+#endif /* !ADC_SUPPORT_2_5_MSPS */
+#if defined(ADC_SUPPORT_2_5_MSPS)
+    CLEAR_BIT(ADCx->IER,
+              (LL_ADC_IT_ADRDY
+               | LL_ADC_IT_EOC
+               | LL_ADC_IT_EOS
+               | LL_ADC_IT_OVR
+               | LL_ADC_IT_EOSMP
+               | LL_ADC_IT_CCRDY
+               | LL_ADC_IT_AWD1
+               | LL_ADC_IT_AWD2
+               | LL_ADC_IT_AWD3
+              )
+             );
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
     /* Reset register ISR */
+#if !defined(ADC_SUPPORT_2_5_MSPS)
     SET_BIT(ADCx->ISR,
             (LL_ADC_FLAG_ADRDY
              | LL_ADC_FLAG_EOC
              | LL_ADC_FLAG_EOS
              | LL_ADC_FLAG_OVR
              | LL_ADC_FLAG_EOSMP
-#if !defined (ADC_SUPPORT_2_5_MSPS)
              | LL_ADC_FLAG_JEOC
              | LL_ADC_FLAG_JEOS
              | LL_ADC_FLAG_JQOVF
-#endif
              | LL_ADC_FLAG_AWD1
              | LL_ADC_FLAG_AWD2
              | LL_ADC_FLAG_AWD3
-#if defined (ADC_SUPPORT_2_5_MSPS)
-             | LL_ADC_FLAG_CCRDY
-#endif
             )
            );
+#endif /* !ADC_SUPPORT_2_5_MSPS */
+#if defined(ADC_SUPPORT_2_5_MSPS)
+    SET_BIT(ADCx->ISR,
+            (LL_ADC_FLAG_ADRDY
+             | LL_ADC_FLAG_EOC
+             | LL_ADC_FLAG_EOS
+             | LL_ADC_FLAG_OVR
+             | LL_ADC_FLAG_EOSMP
+             | LL_ADC_FLAG_CCRDY
+             | LL_ADC_FLAG_AWD1
+             | LL_ADC_FLAG_AWD2
+             | LL_ADC_FLAG_AWD3
+            )
+           );
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     /* Reset register CR */
     /* Bits ADC_CR_ADCAL, ADC_CR_ADSTP, ADC_CR_ADSTART are in access mode     */
     /* "read-set": no direct reset applicable.                                */
@@ -619,9 +643,9 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     /*          already done above.                                           */
     CLEAR_BIT(ADCx->CR, ADC_CR_ADVREGEN | ADC_CR_ADCALDIF);
     SET_BIT(ADCx->CR, ADC_CR_DEEPPWD);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     /* Reset register CFGR1 */
     CLEAR_BIT(ADCx->CFGR1,
               (  ADC_CFGR1_AWD1CH  | ADC_CFGR1_AWD1EN | ADC_CFGR1_AWD1SGL | ADC_CFGR1_DISCEN
@@ -633,8 +657,8 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
     /* Reset register SMPR */
     CLEAR_BIT(ADCx->SMPR, ADC_SMPR_SMP1 | ADC_SMPR_SMP2 | ADC_SMPR_SMPSEL);
 
-    /* Reset register TR1 */
-    MODIFY_REG(ADCx->TR1, ADC_TR1_HT1 | ADC_TR1_LT1, ADC_TR1_HT1);
+    /* Reset register TR */
+    MODIFY_REG(ADCx->TR, ADC_TR_HT | ADC_TR_LT, ADC_TR_HT);
 
     /* Reset register CHSELR */
     CLEAR_BIT(ADCx->CHSELR,
@@ -775,14 +799,14 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
 
     /* Reset register CALFACT */
     CLEAR_BIT(ADCx->CALFACT, ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   }
   else
   {
     /* ADC instance is in an unknown state */
     /* Need to performing a hard reset of ADC instance, using high level      */
     /* clock source RCC ADC reset.                                            */
-    /* Caution: On this STM32 serie, if several ADC instances are available   */
+    /* Caution: On this STM32 series, if several ADC instances are available   */
     /*          on the selected device, RCC ADC reset will reset              */
     /*          all ADC instances belonging to the common ADC instance.       */
     status = ERROR;
@@ -824,16 +848,16 @@ ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx)
   *          - SUCCESS: ADC registers are initialized
   *          - ERROR: ADC registers are not initialized
   */
-ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct)
+ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, const LL_ADC_InitTypeDef *ADC_InitStruct)
 {
   ErrorStatus status = SUCCESS;
 
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(ADCx));
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   assert_param(IS_LL_ADC_CLOCK(ADC_InitStruct->Clock));
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   assert_param(IS_LL_ADC_RESOLUTION(ADC_InitStruct->Resolution));
   assert_param(IS_LL_ADC_DATA_ALIGN(ADC_InitStruct->DataAlignment));
   assert_param(IS_LL_ADC_LOW_POWER(ADC_InitStruct->LowPowerMode));
@@ -847,7 +871,7 @@ ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct)
     /*    - Set ADC data resolution                                           */
     /*    - Set ADC conversion data alignment                                 */
     /*    - Set ADC low power mode                                            */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     MODIFY_REG(ADCx->CFGR1,
                  ADC_CFGR1_RES
                | ADC_CFGR1_ALIGN
@@ -874,7 +898,7 @@ ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct)
                | ADC_InitStruct->DataAlignment
                | ADC_InitStruct->LowPowerMode
               );
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   }
   else
   {
@@ -894,9 +918,9 @@ void LL_ADC_StructInit(LL_ADC_InitTypeDef *ADC_InitStruct)
 {
   /* Set ADC_InitStruct fields to default values */
   /* Set fields of ADC instance */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   ADC_InitStruct->Clock         = LL_ADC_CLOCK_SYNC_PCLK_DIV2;
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   ADC_InitStruct->Resolution    = LL_ADC_RESOLUTION_12B;
   ADC_InitStruct->DataAlignment = LL_ADC_DATA_ALIGN_RIGHT;
   ADC_InitStruct->LowPowerMode  = LL_ADC_LP_MODE_NONE;
@@ -921,7 +945,7 @@ void LL_ADC_StructInit(LL_ADC_InitTypeDef *ADC_InitStruct)
   *         and potentially with ADC in a different state than disabled,
   *         refer to description of each function for setting
   *         conditioned to ADC state.
-  * @note   On devices STM32WB10xx, STM32WB15xx: Before using this function,
+  * @note   On devices STM32WB10xx, STM32WB15xx, STM32WB1Mxx: Before using this function,
   *         ADC group regular sequencer must be configured: refer to function
   *         @ref LL_ADC_REG_SetSequencerConfigurable().
   * @note   After using this function, other features must be configured
@@ -938,14 +962,14 @@ void LL_ADC_StructInit(LL_ADC_InitTypeDef *ADC_InitStruct)
   *          - SUCCESS: ADC registers are initialized
   *          - ERROR: ADC registers are not initialized
   */
-ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct)
+ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, const LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct)
 {
   ErrorStatus status = SUCCESS;
 
   /* Check the parameters */
   assert_param(IS_ADC_ALL_INSTANCE(ADCx));
   assert_param(IS_LL_ADC_REG_TRIG_SOURCE(ADC_REG_InitStruct->TriggerSource));
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
   if (LL_ADC_REG_GetSequencerConfigurable(ADCx) != LL_ADC_REG_SEQ_FIXED)
   {
     assert_param(IS_LL_ADC_REG_SEQ_SCAN_LENGTH(ADC_REG_InitStruct->SequencerLength));
@@ -972,7 +996,7 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
     assert_param((ADC_REG_InitStruct->ContinuousMode == LL_ADC_REG_CONV_SINGLE)
                  || (ADC_REG_InitStruct->SequencerDiscont == LL_ADC_REG_SEQ_DISCONT_DISABLE));
   }
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   assert_param(IS_LL_ADC_REG_CONTINUOUS_MODE(ADC_REG_InitStruct->ContinuousMode));
   assert_param(IS_LL_ADC_REG_DMA_TRANSFER(ADC_REG_InitStruct->DMATransfer));
   assert_param(IS_LL_ADC_REG_OVR_DATA_BEHAVIOR(ADC_REG_InitStruct->Overrun));
@@ -990,9 +1014,9 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
     /*    - Set ADC group regular conversion data transfer: no transfer or    */
     /*      transfer by DMA, and DMA requests mode                            */
     /*    - Set ADC group regular overrun behavior                            */
-    /* Note: On this STM32 serie, ADC trigger edge is set to value 0x0 by     */
+    /* Note: On this STM32 series, ADC trigger edge is set to value 0x0 by     */
     /*       setting of trigger source to SW start.                           */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     if(   (LL_ADC_REG_GetSequencerConfigurable(ADCx) == LL_ADC_REG_SEQ_FIXED)
        || (ADC_REG_InitStruct->SequencerLength != LL_ADC_REG_SEQ_SCAN_DISABLE)
       )
@@ -1079,14 +1103,14 @@ ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_I
 #endif /* ADC_SUPPORT_2_5_MSPS */
 
     /* Set ADC group regular sequencer length and scan direction */
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if defined(ADC_SUPPORT_2_5_MSPS)
     if (LL_ADC_REG_GetSequencerConfigurable(ADCx) != LL_ADC_REG_SEQ_FIXED)
     {
       LL_ADC_REG_SetSequencerLength(ADCx, ADC_REG_InitStruct->SequencerLength);
     }
 #else
     LL_ADC_REG_SetSequencerLength(ADCx, ADC_REG_InitStruct->SequencerLength);
-#endif
+#endif /* ADC_SUPPORT_2_5_MSPS */
   }
   else
   {
@@ -1106,7 +1130,7 @@ void LL_ADC_REG_StructInit(LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct)
 {
   /* Set ADC_REG_InitStruct fields to default values */
   /* Set fields of ADC group regular */
-  /* Note: On this STM32 serie, ADC trigger edge is set to value 0x0 by       */
+  /* Note: On this STM32 series, ADC trigger edge is set to value 0x0 by       */
   /*       setting of trigger source to SW start.                             */
   ADC_REG_InitStruct->TriggerSource    = LL_ADC_REG_TRIG_SOFTWARE;
   ADC_REG_InitStruct->SequencerLength  = LL_ADC_REG_SEQ_SCAN_DISABLE;
@@ -1116,7 +1140,7 @@ void LL_ADC_REG_StructInit(LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct)
   ADC_REG_InitStruct->Overrun          = LL_ADC_REG_OVR_DATA_OVERWRITTEN;
 }
 
-#if defined (ADC_SUPPORT_2_5_MSPS)
+#if  defined(ADC_SUPPORT_2_5_MSPS)
 /* Feature "ADC group injected" not available on ADC peripheral of this STM32WB device */
 #else
 /**
@@ -1157,7 +1181,7 @@ void LL_ADC_REG_StructInit(LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct)
   *          - SUCCESS: ADC registers are initialized
   *          - ERROR: ADC registers are not initialized
   */
-ErrorStatus LL_ADC_INJ_Init(ADC_TypeDef *ADCx, LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct)
+ErrorStatus LL_ADC_INJ_Init(ADC_TypeDef *ADCx, const LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct)
 {
   ErrorStatus status = SUCCESS;
 
@@ -1182,7 +1206,7 @@ ErrorStatus LL_ADC_INJ_Init(ADC_TypeDef *ADCx, LL_ADC_INJ_InitTypeDef *ADC_INJ_I
     /*    - Set ADC group injected sequencer discontinuous mode               */
     /*    - Set ADC group injected conversion trigger: independent or         */
     /*      from ADC group regular                                            */
-    /* Note: On this STM32 serie, ADC trigger edge is set to value 0x0 by     */
+    /* Note: On this STM32 series, ADC trigger edge is set to value 0x0 by     */
     /*       setting of trigger source to SW start.                           */
     if (ADC_INJ_InitStruct->SequencerLength != LL_ADC_REG_SEQ_SCAN_DISABLE)
     {
@@ -1258,5 +1282,3 @@ void LL_ADC_INJ_StructInit(LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_comp.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_comp.c
@@ -6,16 +6,16 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
+
 #if defined(USE_FULL_LL_DRIVER)
 
 /* Includes ------------------------------------------------------------------*/
@@ -25,7 +25,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -50,7 +50,7 @@
 /* COMP instance.                                                             */
 
 #define IS_LL_COMP_POWER_MODE(__POWER_MODE__)                                  \
-  (   ((__POWER_MODE__) == LL_COMP_POWERMODE_HIGHSPEED)                        \
+  (((__POWER_MODE__) == LL_COMP_POWERMODE_HIGHSPEED)                           \
    || ((__POWER_MODE__) == LL_COMP_POWERMODE_MEDIUMSPEED)                      \
    || ((__POWER_MODE__) == LL_COMP_POWERMODE_ULTRALOWPOWER)                    \
   )
@@ -58,16 +58,16 @@
 /* Note: On this STM32 series, comparator input plus parameters are           */
 /*       the same on all COMP instances.                                      */
 /*       However, comparator instance kept as macro parameter for             */
-/*       compatibility with other STM32 families.                             */
+/*       compatibility with other STM32 series.                               */
 #if defined(LL_COMP_INPUT_PLUS_IO1)
 #define IS_LL_COMP_INPUT_PLUS(__COMP_INSTANCE__, __INPUT_PLUS__)               \
-  (   ((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO1)                             \
+  (((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO1)                                \
    || ((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO2)                             \
    || ((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO3)                             \
   )
 #else
 #define IS_LL_COMP_INPUT_PLUS(__COMP_INSTANCE__, __INPUT_PLUS__)               \
-  (   ((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO2)                             \
+  (((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO2)                                \
    || ((__INPUT_PLUS__) == LL_COMP_INPUT_PLUS_IO3)                             \
   )
 #endif
@@ -75,10 +75,10 @@
 /* Note: On this STM32 series, comparator input minus parameters are          */
 /*       the same on all COMP instances.                                      */
 /*       However, comparator instance kept as macro parameter for             */
-/*       compatibility with other STM32 families.                             */
+/*       compatibility with other STM32 series.                               */
 #if defined(LL_COMP_INPUT_MINUS_IO2)
 #define IS_LL_COMP_INPUT_MINUS(__COMP_INSTANCE__, __INPUT_MINUS__)             \
-  (   ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_1_4VREFINT)                    \
+  (((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_1_4VREFINT)                       \
    || ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_1_2VREFINT)                    \
    || ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_3_4VREFINT)                    \
    || ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_VREFINT)                       \
@@ -90,7 +90,7 @@
   )
 #else
 #define IS_LL_COMP_INPUT_MINUS(__COMP_INSTANCE__, __INPUT_MINUS__)             \
-  (   ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_1_4VREFINT)                    \
+  (((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_1_4VREFINT)                       \
    || ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_1_2VREFINT)                    \
    || ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_3_4VREFINT)                    \
    || ((__INPUT_MINUS__) == LL_COMP_INPUT_MINUS_VREFINT)                       \
@@ -102,19 +102,19 @@
 #endif
 
 #define IS_LL_COMP_INPUT_HYSTERESIS(__INPUT_HYSTERESIS__)                      \
-  (   ((__INPUT_HYSTERESIS__) == LL_COMP_HYSTERESIS_NONE)                      \
+  (((__INPUT_HYSTERESIS__) == LL_COMP_HYSTERESIS_NONE)                         \
    || ((__INPUT_HYSTERESIS__) == LL_COMP_HYSTERESIS_LOW)                       \
    || ((__INPUT_HYSTERESIS__) == LL_COMP_HYSTERESIS_MEDIUM)                    \
    || ((__INPUT_HYSTERESIS__) == LL_COMP_HYSTERESIS_HIGH)                      \
   )
 
 #define IS_LL_COMP_OUTPUT_POLARITY(__POLARITY__)                               \
-  (   ((__POLARITY__) == LL_COMP_OUTPUTPOL_NONINVERTED)                        \
+  (((__POLARITY__) == LL_COMP_OUTPUTPOL_NONINVERTED)                           \
    || ((__POLARITY__) == LL_COMP_OUTPUTPOL_INVERTED)                           \
   )
 
 #define IS_LL_COMP_OUTPUT_BLANKING_SOURCE(__OUTPUT_BLANKING_SOURCE__)          \
-  (   ((__OUTPUT_BLANKING_SOURCE__) == LL_COMP_BLANKINGSRC_NONE)               \
+  (((__OUTPUT_BLANKING_SOURCE__) == LL_COMP_BLANKINGSRC_NONE)                  \
    || ((__OUTPUT_BLANKING_SOURCE__) == LL_COMP_BLANKINGSRC_TIM1_OC5)           \
    || ((__OUTPUT_BLANKING_SOURCE__) == LL_COMP_BLANKINGSRC_TIM2_OC3)           \
   )
@@ -183,7 +183,7 @@ ErrorStatus LL_COMP_DeInit(COMP_TypeDef *COMPx)
   *          - SUCCESS: COMP registers are initialized
   *          - ERROR: COMP registers are not initialized
   */
-ErrorStatus LL_COMP_Init(COMP_TypeDef *COMPx, LL_COMP_InitTypeDef *COMP_InitStruct)
+ErrorStatus LL_COMP_Init(COMP_TypeDef *COMPx, const LL_COMP_InitTypeDef *COMP_InitStruct)
 {
   ErrorStatus status = SUCCESS;
 
@@ -276,5 +276,3 @@ void LL_COMP_StructInit(LL_COMP_InitTypeDef *COMP_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_crc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_crc.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -26,7 +25,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -60,7 +59,7 @@
   *          - SUCCESS: CRC registers are de-initialized
   *          - ERROR: CRC registers are not de-initialized
   */
-ErrorStatus LL_CRC_DeInit(CRC_TypeDef *CRCx)
+ErrorStatus LL_CRC_DeInit(const CRC_TypeDef *CRCx)
 {
   ErrorStatus status = SUCCESS;
 
@@ -102,6 +101,3 @@ ErrorStatus LL_CRC_DeInit(CRC_TypeDef *CRCx)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_crs.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_crs.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -82,5 +81,3 @@ ErrorStatus LL_CRS_DeInit(void)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_dma.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_dma.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -25,7 +24,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -77,47 +76,47 @@
 #if defined (DMA2)
 #if defined (DMA2_Channel6) && defined (DMA2_Channel7)
 #define IS_LL_DMA_ALL_CHANNEL_INSTANCE(INSTANCE, CHANNEL)  ((((INSTANCE) == DMA1) && \
-                                                         (((CHANNEL) == LL_DMA_CHANNEL_1) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_2) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_3) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_4) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_5) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_6) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_7))) || \
-                                                         (((INSTANCE) == DMA2) && \
-                                                         (((CHANNEL) == LL_DMA_CHANNEL_1) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_2) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_3) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_4) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_5) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_6) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_7))))
+                                                             (((CHANNEL) == LL_DMA_CHANNEL_1) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_5) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_6) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_7))) || \
+                                                            (((INSTANCE) == DMA2) && \
+                                                             (((CHANNEL) == LL_DMA_CHANNEL_1) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_5) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_6) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_7))))
 #else
 #define IS_LL_DMA_ALL_CHANNEL_INSTANCE(INSTANCE, CHANNEL)  ((((INSTANCE) == DMA1) && \
-                                                         (((CHANNEL) == LL_DMA_CHANNEL_1) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_2) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_3) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_4) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_5) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_6) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_7))) || \
-                                                         (((INSTANCE) == DMA2) && \
-                                                         (((CHANNEL) == LL_DMA_CHANNEL_1) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_2) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_3) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_4) || \
-                                                          ((CHANNEL) == LL_DMA_CHANNEL_5))))
-#endif
+                                                             (((CHANNEL) == LL_DMA_CHANNEL_1) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_5) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_6) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_7))) || \
+                                                            (((INSTANCE) == DMA2) && \
+                                                             (((CHANNEL) == LL_DMA_CHANNEL_1) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_5))))
+#endif /* DMA2_Channel6 && DMA2_Channel7*/
 #else
 #define IS_LL_DMA_ALL_CHANNEL_INSTANCE(INSTANCE, CHANNEL)  ((((INSTANCE) == DMA1) && \
-                                                            (((CHANNEL) == LL_DMA_CHANNEL_1)|| \
-                                                            ((CHANNEL) == LL_DMA_CHANNEL_2) || \
-                                                            ((CHANNEL) == LL_DMA_CHANNEL_3) || \
-                                                            ((CHANNEL) == LL_DMA_CHANNEL_4) || \
-                                                            ((CHANNEL) == LL_DMA_CHANNEL_5) || \
-                                                            ((CHANNEL) == LL_DMA_CHANNEL_6) || \
-                                                            ((CHANNEL) == LL_DMA_CHANNEL_7))))
-#endif
+                                                             (((CHANNEL) == LL_DMA_CHANNEL_1)|| \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_2) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_3) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_4) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_5) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_6) || \
+                                                              ((CHANNEL) == LL_DMA_CHANNEL_7))))
+#endif /* DMA2 */
 /**
   * @}
   */
@@ -176,7 +175,7 @@ ErrorStatus LL_DMA_DeInit(DMA_TypeDef *DMAx, uint32_t Channel)
       /* Release reset of DMA clock */
       LL_AHB1_GRP1_ReleaseReset(LL_AHB1_GRP1_PERIPH_DMA2);
     }
-#endif
+#endif /* DMA2 */
     else
     {
       status = ERROR;
@@ -367,5 +366,3 @@ void LL_DMA_StructInit(LL_DMA_InitTypeDef *DMA_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_exti.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_exti.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -24,7 +23,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -48,14 +47,14 @@
 #define IS_LL_EXTI_LINE_32_63(__VALUE__)             (((__VALUE__) & ~LL_EXTI_LINE_ALL_32_63) == 0x00000000U)
 
 #define IS_LL_EXTI_MODE(__VALUE__)                   (((__VALUE__) == LL_EXTI_MODE_IT)            \
-                                                   || ((__VALUE__) == LL_EXTI_MODE_EVENT)         \
-                                                   || ((__VALUE__) == LL_EXTI_MODE_IT_EVENT))
+                                                      || ((__VALUE__) == LL_EXTI_MODE_EVENT)      \
+                                                      || ((__VALUE__) == LL_EXTI_MODE_IT_EVENT))
 
 
 #define IS_LL_EXTI_TRIGGER(__VALUE__)                (((__VALUE__) == LL_EXTI_TRIGGER_NONE)       \
-                                                   || ((__VALUE__) == LL_EXTI_TRIGGER_RISING)     \
-                                                   || ((__VALUE__) == LL_EXTI_TRIGGER_FALLING)    \
-                                                   || ((__VALUE__) == LL_EXTI_TRIGGER_RISING_FALLING))
+                                                      || ((__VALUE__) == LL_EXTI_TRIGGER_RISING)  \
+                                                      || ((__VALUE__) == LL_EXTI_TRIGGER_FALLING) \
+                                                      || ((__VALUE__) == LL_EXTI_TRIGGER_RISING_FALLING))
 
 /**
   * @}
@@ -295,5 +294,3 @@ void LL_EXTI_StructInit(LL_EXTI_InitTypeDef *EXTI_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_gpio.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_gpio.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -25,7 +24,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -270,6 +269,3 @@ void LL_GPIO_StructInit(LL_GPIO_InitTypeDef *GPIO_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_i2c.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_i2c.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -25,7 +24,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -84,7 +83,7 @@
   *          - SUCCESS: I2C registers are de-initialized
   *          - ERROR: I2C registers are not de-initialized
   */
-ErrorStatus LL_I2C_DeInit(I2C_TypeDef *I2Cx)
+ErrorStatus LL_I2C_DeInit(const I2C_TypeDef *I2Cx)
 {
   ErrorStatus status = SUCCESS;
 
@@ -108,7 +107,7 @@ ErrorStatus LL_I2C_DeInit(I2C_TypeDef *I2Cx)
     /* Release reset of I2C clock */
     LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_I2C3);
   }
-#endif
+#endif /* I2C3 */
   else
   {
     status = ERROR;
@@ -125,7 +124,7 @@ ErrorStatus LL_I2C_DeInit(I2C_TypeDef *I2Cx)
   *          - SUCCESS: I2C registers are initialized
   *          - ERROR: Not applicable
   */
-ErrorStatus LL_I2C_Init(I2C_TypeDef *I2Cx, LL_I2C_InitTypeDef *I2C_InitStruct)
+ErrorStatus LL_I2C_Init(I2C_TypeDef *I2Cx, const LL_I2C_InitTypeDef *I2C_InitStruct)
 {
   /* Check the I2C Instance I2Cx */
   assert_param(IS_I2C_ALL_INSTANCE(I2Cx));
@@ -224,5 +223,3 @@ void LL_I2C_StructInit(LL_I2C_InitTypeDef *I2C_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_lptim.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_lptim.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -28,7 +27,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -48,22 +47,22 @@
   * @{
   */
 #define IS_LL_LPTIM_CLOCK_SOURCE(__VALUE__) (((__VALUE__) == LL_LPTIM_CLK_SOURCE_INTERNAL) \
-                                          || ((__VALUE__) == LL_LPTIM_CLK_SOURCE_EXTERNAL))
+                                             || ((__VALUE__) == LL_LPTIM_CLK_SOURCE_EXTERNAL))
 
 #define IS_LL_LPTIM_CLOCK_PRESCALER(__VALUE__) (((__VALUE__) == LL_LPTIM_PRESCALER_DIV1)   \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV2)   \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV4)   \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV8)   \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV16)  \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV32)  \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV64)  \
-                                             || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV128))
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV2)   \
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV4)   \
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV8)   \
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV16)  \
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV32)  \
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV64)  \
+                                                || ((__VALUE__) == LL_LPTIM_PRESCALER_DIV128))
 
 #define IS_LL_LPTIM_WAVEFORM(__VALUE__) (((__VALUE__) == LL_LPTIM_OUTPUT_WAVEFORM_PWM) \
-                                      || ((__VALUE__) == LL_LPTIM_OUTPUT_WAVEFORM_SETONCE))
+                                         || ((__VALUE__) == LL_LPTIM_OUTPUT_WAVEFORM_SETONCE))
 
 #define IS_LL_LPTIM_OUTPUT_POLARITY(__VALUE__) (((__VALUE__) == LL_LPTIM_OUTPUT_POLARITY_REGULAR) \
-                                             || ((__VALUE__) == LL_LPTIM_OUTPUT_POLARITY_INVERSE))
+                                                || ((__VALUE__) == LL_LPTIM_OUTPUT_POLARITY_INVERSE))
 /**
   * @}
   */
@@ -93,7 +92,7 @@
   *          - SUCCESS: LPTIMx registers are de-initialized
   *          - ERROR: invalid LPTIMx instance
   */
-ErrorStatus LL_LPTIM_DeInit(LPTIM_TypeDef *LPTIMx)
+ErrorStatus LL_LPTIM_DeInit(const LPTIM_TypeDef *LPTIMx)
 {
   ErrorStatus result = SUCCESS;
 
@@ -145,7 +144,7 @@ void LL_LPTIM_StructInit(LL_LPTIM_InitTypeDef *LPTIM_InitStruct)
   *          - SUCCESS: LPTIMx instance has been initialized
   *          - ERROR: LPTIMx instance hasn't been initialized
   */
-ErrorStatus LL_LPTIM_Init(LPTIM_TypeDef *LPTIMx, LL_LPTIM_InitTypeDef *LPTIM_InitStruct)
+ErrorStatus LL_LPTIM_Init(LPTIM_TypeDef *LPTIMx, const LL_LPTIM_InitTypeDef *LPTIM_InitStruct)
 {
   ErrorStatus result = SUCCESS;
   /* Check the parameters */
@@ -196,6 +195,7 @@ void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
   uint32_t tmpCFGR;
   uint32_t tmpCMP;
   uint32_t tmpARR;
+  uint32_t primask_bit;
 #if defined(LPTIM_OR_OR)
   uint32_t tmpOR;
 #endif
@@ -203,7 +203,9 @@ void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
   /* Check the parameters */
   assert_param(IS_LPTIM_INSTANCE(LPTIMx));
 
-  __disable_irq();
+  /* Enter critical section */
+  primask_bit = __get_PRIMASK();
+  __set_PRIMASK(1) ;
 
   /********** Save LPTIM Config *********/
   /* Save LPTIM source clock */
@@ -263,8 +265,7 @@ void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
       do
       {
         rcc_clock.SYSCLK_Frequency--; /* Used for timeout */
-      }
-      while (((LL_LPTIM_IsActiveFlag_CMPOK(LPTIMx) != 1UL)) && ((rcc_clock.SYSCLK_Frequency) > 0UL));
+      } while (((LL_LPTIM_IsActiveFlag_CMPOK(LPTIMx) != 1UL)) && ((rcc_clock.SYSCLK_Frequency) > 0UL));
 
       LL_LPTIM_ClearFlag_CMPOK(LPTIMx);
     }
@@ -279,8 +280,7 @@ void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
       do
       {
         rcc_clock.SYSCLK_Frequency--; /* Used for timeout */
-      }
-      while (((LL_LPTIM_IsActiveFlag_ARROK(LPTIMx) != 1UL)) && ((rcc_clock.SYSCLK_Frequency) > 0UL));
+      } while (((LL_LPTIM_IsActiveFlag_ARROK(LPTIMx) != 1UL)) && ((rcc_clock.SYSCLK_Frequency) > 0UL));
 
       LL_LPTIM_ClearFlag_ARROK(LPTIMx);
     }
@@ -298,7 +298,8 @@ void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
   LPTIMx->OR = tmpOR;
 #endif
 
-  __enable_irq();
+  /* Exit critical section: restore previous priority mask */
+  __set_PRIMASK(primask_bit);
 }
 
 /**
@@ -320,5 +321,3 @@ void LL_LPTIM_Disable(LPTIM_TypeDef *LPTIMx)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_lpuart.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_lpuart.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -44,6 +43,9 @@
 /** @addtogroup LPUART_LL_Private_Constants
   * @{
   */
+
+/* Definition of default baudrate value used for LPUART initialisation */
+#define LPUART_DEFAULT_BAUDRATE          (9600U)
 
 /**
   * @}
@@ -127,7 +129,7 @@
   *          - SUCCESS: LPUART registers are de-initialized
   *          - ERROR: not applicable
   */
-ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx)
+ErrorStatus LL_LPUART_DeInit(const USART_TypeDef *LPUARTx)
 {
   ErrorStatus status = SUCCESS;
 
@@ -153,8 +155,10 @@ ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx)
 /**
   * @brief  Initialize LPUART registers according to the specified
   *         parameters in LPUART_InitStruct.
-  * @note   As some bits in LPUART configuration registers can only be written when the LPUART is disabled (USART_CR1_UE bit =0),
-  *         LPUART Peripheral should be in disabled state prior calling this function. Otherwise, ERROR result will be returned.
+  * @note   As some bits in LPUART configuration registers can only be written when
+  *         the LPUART is disabled (USART_CR1_UE bit =0),
+  *         LPUART Peripheral should be in disabled state prior calling this function.
+  *         Otherwise, ERROR result will be returned.
   * @note   Baud rate value stored in LPUART_InitStruct BaudRate field, should be valid (different from 0).
   * @param  LPUARTx LPUART Instance
   * @param  LPUART_InitStruct pointer to a @ref LL_LPUART_InitTypeDef structure
@@ -163,7 +167,7 @@ ErrorStatus LL_LPUART_DeInit(USART_TypeDef *LPUARTx)
   *          - SUCCESS: LPUART registers are initialized according to LPUART_InitStruct content
   *          - ERROR: Problem occurred during LPUART Registers initialization
   */
-ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, LL_LPUART_InitTypeDef *LPUART_InitStruct)
+ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, const LL_LPUART_InitTypeDef *LPUART_InitStruct)
 {
   ErrorStatus status = ERROR;
   uint32_t periphclk;
@@ -200,7 +204,8 @@ ErrorStatus LL_LPUART_Init(USART_TypeDef *LPUARTx, LL_LPUART_InitTypeDef *LPUART
 
     /*---------------------------- LPUART CR3 Configuration -----------------------
      * Configure LPUARTx CR3 (Hardware Flow Control) with parameters:
-     * - HardwareFlowControl: USART_CR3_RTSE, USART_CR3_CTSE bits according to LPUART_InitStruct->HardwareFlowControl value.
+     * - HardwareFlowControl: USART_CR3_RTSE, USART_CR3_CTSE bits according
+     *   to LPUART_InitStruct->HardwareFlowControl value.
      */
     LL_LPUART_SetHWFlowCtrl(LPUARTx, LPUART_InitStruct->HardwareFlowControl);
 
@@ -251,7 +256,7 @@ void LL_LPUART_StructInit(LL_LPUART_InitTypeDef *LPUART_InitStruct)
 {
   /* Set LPUART_InitStruct fields to default values */
   LPUART_InitStruct->PrescalerValue      = LL_LPUART_PRESCALER_DIV1;
-  LPUART_InitStruct->BaudRate            = 9600U;
+  LPUART_InitStruct->BaudRate            = LPUART_DEFAULT_BAUDRATE;
   LPUART_InitStruct->DataWidth           = LL_LPUART_DATAWIDTH_8B;
   LPUART_InitStruct->StopBits            = LL_LPUART_STOPBITS_1;
   LPUART_InitStruct->Parity              = LL_LPUART_PARITY_NONE ;
@@ -271,13 +276,10 @@ void LL_LPUART_StructInit(LL_LPUART_InitTypeDef *LPUART_InitStruct)
   * @}
   */
 
-#endif /* defined (LPUART1) */
+#endif /* LPUART1 */
 
 /**
   * @}
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_pka.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_pka.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -26,7 +25,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -46,23 +45,23 @@
   * @{
   */
 #define IS_LL_PKA_MODE(__VALUE__)     (((__VALUE__) == LL_PKA_MODE_MONTGOMERY_PARAM_MOD_EXP) ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MONTGOMERY_PARAM)          ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MODULAR_EXP)               ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MONTGOMERY_PARAM_ECC)      ||\
-                                      ((__VALUE__) == LL_PKA_MODE_ECC_KP_PRIMITIVE)          ||\
-                                      ((__VALUE__) == LL_PKA_MODE_ECDSA_SIGNATURE)           ||\
-                                      ((__VALUE__) == LL_PKA_MODE_ECDSA_VERIFICATION)        ||\
-                                      ((__VALUE__) == LL_PKA_MODE_POINT_CHECK)               ||\
-                                      ((__VALUE__) == LL_PKA_MODE_RSA_CRT_EXP)               ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MODULAR_INV)               ||\
-                                      ((__VALUE__) == LL_PKA_MODE_ARITHMETIC_ADD)            ||\
-                                      ((__VALUE__) == LL_PKA_MODE_ARITHMETIC_SUB)            ||\
-                                      ((__VALUE__) == LL_PKA_MODE_ARITHMETIC_MUL)            ||\
-                                      ((__VALUE__) == LL_PKA_MODE_COMPARISON)                ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MODULAR_REDUC)             ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MODULAR_ADD)               ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MODULAR_SUB)               ||\
-                                      ((__VALUE__) == LL_PKA_MODE_MONTGOMERY_MUL))
+                                       ((__VALUE__) == LL_PKA_MODE_MONTGOMERY_PARAM)          ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MODULAR_EXP)               ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MONTGOMERY_PARAM_ECC)      ||\
+                                       ((__VALUE__) == LL_PKA_MODE_ECC_KP_PRIMITIVE)          ||\
+                                       ((__VALUE__) == LL_PKA_MODE_ECDSA_SIGNATURE)           ||\
+                                       ((__VALUE__) == LL_PKA_MODE_ECDSA_VERIFICATION)        ||\
+                                       ((__VALUE__) == LL_PKA_MODE_POINT_CHECK)               ||\
+                                       ((__VALUE__) == LL_PKA_MODE_RSA_CRT_EXP)               ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MODULAR_INV)               ||\
+                                       ((__VALUE__) == LL_PKA_MODE_ARITHMETIC_ADD)            ||\
+                                       ((__VALUE__) == LL_PKA_MODE_ARITHMETIC_SUB)            ||\
+                                       ((__VALUE__) == LL_PKA_MODE_ARITHMETIC_MUL)            ||\
+                                       ((__VALUE__) == LL_PKA_MODE_COMPARISON)                ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MODULAR_REDUC)             ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MODULAR_ADD)               ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MODULAR_SUB)               ||\
+                                       ((__VALUE__) == LL_PKA_MODE_MONTGOMERY_MUL))
 /**
   * @}
   */
@@ -159,6 +158,3 @@ void LL_PKA_StructInit(LL_PKA_InitTypeDef *PKA_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_pwr.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_pwr.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -98,7 +97,7 @@ ErrorStatus LL_PWR_DeInit(void)
 #if defined(GPIOD)
   LL_PWR_WriteReg(PUCRD, PWR_PUCRD_RESET_VALUE);
   LL_PWR_WriteReg(PDCRD, PWR_PDCRD_RESET_VALUE);
-#endif
+#endif /* GPIOD */
   LL_PWR_WriteReg(PUCRE, PWR_PUCRE_RESET_VALUE);
   LL_PWR_WriteReg(PDCRE, PWR_PDCRE_RESET_VALUE);
   LL_PWR_WriteReg(PUCRH, PWR_PUCRH_RESET_VALUE);
@@ -107,24 +106,46 @@ ErrorStatus LL_PWR_DeInit(void)
   LL_PWR_WriteReg(C2CR3, PWR_C2CR3_RESET_VALUE);
 
   /* Clear all flags */
+  #if defined(PWR_CR3_E802A) && defined(PWR_CR5_SMPSEN)
+LL_PWR_WriteReg(SCR,
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_C802AF
+                | LL_PWR_SCR_C802WUF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CBORHF
+                | LL_PWR_SCR_CSMPSFBF
+                | LL_PWR_SCR_CWUF);
+#elif defined(PWR_CR3_E802A)
   LL_PWR_WriteReg(SCR,
-                    LL_PWR_SCR_CC2HF
-                  | LL_PWR_SCR_CBLEAF
-                  | LL_PWR_SCR_CCRPEF
-#if defined(PWR_CR3_E802A)
-                  | LL_PWR_SCR_C802AF
-                  | LL_PWR_SCR_C802WUF
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_C802AF
+                | LL_PWR_SCR_C802WUF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CWUF);
+#elif defined(PWR_CR5_SMPSEN)
+  LL_PWR_WriteReg(SCR,
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CBORHF
+                | LL_PWR_SCR_CSMPSFBF
+                | LL_PWR_SCR_CWUF);
+#else
+  LL_PWR_WriteReg(SCR,
+                LL_PWR_SCR_CC2HF
+                | LL_PWR_SCR_CBLEAF
+                | LL_PWR_SCR_CCRPEF
+                | LL_PWR_SCR_CBLEWUF
+                | LL_PWR_SCR_CWUF);
 #endif
-                  | LL_PWR_SCR_CBLEWUF
-#if defined(PWR_CR5_SMPSEN)
-                  | LL_PWR_SCR_CBORHF
-                  | LL_PWR_SCR_CSMPSFBF
-#endif
-                  | LL_PWR_SCR_CWUF
-                 );
 
   LL_PWR_WriteReg(EXTSCR,
-                    LL_PWR_EXTSCR_CCRPF
+                  LL_PWR_EXTSCR_CCRPF
                   | LL_PWR_EXTSCR_C2CSSF
                   | LL_PWR_EXTSCR_C1CSSF
                  );
@@ -143,11 +164,10 @@ ErrorStatus LL_PWR_DeInit(void)
 /**
   * @}
   */
-#endif /* defined(PWR) */
+#endif /* PWR */
 /**
   * @}
   */
 
 #endif /* USE_FULL_LL_DRIVER */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_rcc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_rcc.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -20,11 +19,12 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32wbxx_ll_rcc.h"
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
+
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
   */
@@ -46,21 +46,21 @@
 
 #if defined(LPUART1)
 #define IS_LL_RCC_LPUART_CLKSOURCE(__VALUE__) ((__VALUE__) == LL_RCC_LPUART1_CLKSOURCE)
-#endif
+#endif /* LPUART1 */
 
 #if defined(I2C3)
 #define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_I2C1_CLKSOURCE) \
-                                            || ((__VALUE__) == LL_RCC_I2C3_CLKSOURCE))
+                                               || ((__VALUE__) == LL_RCC_I2C3_CLKSOURCE))
 #else
 #define IS_LL_RCC_I2C_CLKSOURCE(__VALUE__)    ((__VALUE__) == LL_RCC_I2C1_CLKSOURCE)
-#endif
+#endif /* I2C3 */
 
 #define IS_LL_RCC_LPTIM_CLKSOURCE(__VALUE__)  (((__VALUE__) == LL_RCC_LPTIM1_CLKSOURCE) \
-                                            || ((__VALUE__) == LL_RCC_LPTIM2_CLKSOURCE))
+                                               || ((__VALUE__) == LL_RCC_LPTIM2_CLKSOURCE))
 
 #if defined(SAI1)
 #define IS_LL_RCC_SAI_CLKSOURCE(__VALUE__)    ((__VALUE__) == LL_RCC_SAI1_CLKSOURCE)
-#endif
+#endif /* SAI1 */
 
 #define IS_LL_RCC_RNG_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_RNG_CLKSOURCE))
 
@@ -68,7 +68,7 @@
 
 #if defined(USB)
 #define IS_LL_RCC_USB_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_USB_CLKSOURCE))
-#endif
+#endif /* USB */
 
 #define IS_LL_RCC_ADC_CLKSOURCE(__VALUE__)    (((__VALUE__) == LL_RCC_ADC_CLKSOURCE))
 
@@ -80,31 +80,31 @@
 /** @defgroup RCC_LL_Private_Functions RCC Private functions
   * @{
   */
-uint32_t RCC_PLL_GetFreqDomain_SYS(void);
+static uint32_t RCC_PLL_GetFreqDomain_SYS(void);
 #if defined(SAI1)
-uint32_t RCC_PLL_GetFreqDomain_SAI(void);
-#endif
-uint32_t RCC_PLL_GetFreqDomain_ADC(void);
-uint32_t RCC_PLL_GetFreqDomain_48M(void);
+static uint32_t RCC_PLL_GetFreqDomain_SAI(void);
+#endif /* SAI1 */
+static uint32_t RCC_PLL_GetFreqDomain_ADC(void);
+static uint32_t RCC_PLL_GetFreqDomain_48M(void);
 
 #if defined(SAI1)
-uint32_t RCC_PLLSAI1_GetFreqDomain_SAI(void);
-uint32_t RCC_PLLSAI1_GetFreqDomain_48M(void);
-uint32_t RCC_PLLSAI1_GetFreqDomain_ADC(void);
-#endif
+static uint32_t RCC_PLLSAI1_GetFreqDomain_SAI(void);
+static uint32_t RCC_PLLSAI1_GetFreqDomain_48M(void);
+static uint32_t RCC_PLLSAI1_GetFreqDomain_ADC(void);
+#endif /* SAI1 */
 
 
-uint32_t RCC_GetSystemClockFreq(void);
+static uint32_t RCC_GetSystemClockFreq(void);
 
 
-uint32_t RCC_GetHCLK1ClockFreq(uint32_t SYSCLK_Frequency);
-uint32_t RCC_GetHCLK2ClockFreq(uint32_t SYSCLK_Frequency);
-uint32_t RCC_GetHCLK4ClockFreq(uint32_t SYSCLK_Frequency);
-uint32_t RCC_GetHCLK5ClockFreq(void);
+static uint32_t RCC_GetHCLK1ClockFreq(uint32_t SYSCLK_Frequency);
+static uint32_t RCC_GetHCLK2ClockFreq(uint32_t SYSCLK_Frequency);
+static uint32_t RCC_GetHCLK4ClockFreq(uint32_t SYSCLK_Frequency);
+static uint32_t RCC_GetHCLK5ClockFreq(void);
 
 
-uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency);
-uint32_t RCC_GetPCLK2ClockFreq(uint32_t HCLK_Frequency);
+static uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency);
+static uint32_t RCC_GetPCLK2ClockFreq(uint32_t HCLK_Frequency);
 /**
   * @}
   */
@@ -178,22 +178,22 @@ ErrorStatus LL_RCC_DeInit(void)
 
   /* Reset PLLSAI1CFGR register */
   LL_RCC_WriteReg(PLLSAI1CFGR, 0x22041000U);
-#endif
+#endif /* SAI1 */
 
   /* Disable all interrupts */
   LL_RCC_WriteReg(CIER, 0x00000000U);
 
   /* Clear all interrupt flags */
-  vl_mask = RCC_CICR_LSI1RDYC | RCC_CICR_LSERDYC | RCC_CICR_MSIRDYC | RCC_CICR_HSIRDYC | RCC_CICR_HSERDYC | RCC_CICR_PLLRDYC | \
-            RCC_CICR_CSSC | RCC_CICR_LSECSSC | RCC_CICR_LSI2RDYC;
+  vl_mask = RCC_CICR_LSI1RDYC | RCC_CICR_LSERDYC | RCC_CICR_MSIRDYC | RCC_CICR_HSIRDYC | RCC_CICR_HSERDYC |
+            RCC_CICR_PLLRDYC | RCC_CICR_CSSC | RCC_CICR_LSECSSC | RCC_CICR_LSI2RDYC;
 
 #if defined(SAI1)
   vl_mask |= RCC_CICR_PLLSAI1RDYC;
-#endif
+#endif /* SAI1 */
 
 #if defined(RCC_HSI48_SUPPORT)
   vl_mask |= RCC_CICR_HSI48RDYC;
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
   LL_RCC_WriteReg(CICR, vl_mask);
 
@@ -203,7 +203,7 @@ ErrorStatus LL_RCC_DeInit(void)
 #if defined(RCC_SMPS_SUPPORT)
   /* SMPS reset */
   LL_RCC_WriteReg(SMPSCR, 0x00000301U); /* MSI default clock source */
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
   /* RF Wakeup Clock Source selection */
   LL_RCC_SetRFWKPClockSource(LL_RCC_RFWKP_CLKSOURCE_NONE);
@@ -211,7 +211,7 @@ ErrorStatus LL_RCC_DeInit(void)
 #if defined(RCC_HSI48_SUPPORT)
   /* HSI48 reset */
   LL_RCC_HSI48_Disable();
-#endif
+#endif /* RCC_HSI48_SUPPORT */
 
   /* HSECR register write unlock & then reset*/
   LL_RCC_WriteReg(HSECR, HSE_CONTROL_UNLOCK_KEY);
@@ -358,7 +358,7 @@ uint32_t LL_RCC_GetSMPSClockFreq(void)
 
   return smps_frequency;
 }
-#endif
+#endif /* RCC_SMPS_SUPPORT */
 
 /**
   * @brief  Return USARTx clock frequency
@@ -464,7 +464,7 @@ uint32_t LL_RCC_GetI2CClockFreq(uint32_t I2CxSource)
         break;
     }
   }
-#endif
+#endif /* I2C3 */
 
   return i2c_frequency;
 }
@@ -513,7 +513,7 @@ uint32_t LL_RCC_GetLPUARTClockFreq(uint32_t LPUARTxSource)
 
   return lpuart_frequency;
 }
-#endif
+#endif /* LPUART1 */
 
 /**
   * @brief  Return LPTIMx clock frequency
@@ -625,19 +625,23 @@ uint32_t LL_RCC_GetSAIClockFreq(uint32_t SAIxSource)
       }
       break;
 
-#if defined(SAI1)
     case LL_RCC_SAI1_CLKSOURCE_PLLSAI1:    /* PLLSAI1 clock used as SAI1 clock source */
       if (LL_RCC_PLLSAI1_IsReady() == 1U)
       {
-        sai_frequency = RCC_PLLSAI1_GetFreqDomain_SAI();
+        if (LL_RCC_PLLSAI1_IsEnabledDomain_SAI() == 1U)
+        {
+          sai_frequency = RCC_PLLSAI1_GetFreqDomain_SAI();
+        }
       }
       break;
-#endif
 
     case LL_RCC_SAI1_CLKSOURCE_PLL:        /* PLL clock used as SAI1 clock source */
       if (LL_RCC_PLL_IsReady() == 1U)
       {
-        sai_frequency = RCC_PLL_GetFreqDomain_SAI();
+        if (LL_RCC_PLL_IsEnabledDomain_SAI() == 1U)
+        {
+          sai_frequency = RCC_PLL_GetFreqDomain_SAI();
+        }
       }
       break;
 
@@ -648,14 +652,15 @@ uint32_t LL_RCC_GetSAIClockFreq(uint32_t SAIxSource)
   }
   return sai_frequency;
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Return CLK48x clock frequency
   * @param  CLK48xSource This parameter can be one of the following values:
   *         @arg @ref LL_RCC_CLK48_CLKSOURCE
   * @retval USB clock frequency (in Hz)
-  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (MSI or HSI48) or PLLs (PLL or PLLSAI1) is not ready
+  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (MSI or HSI48) or PLLs (PLL or PLLSAI1)
+  *                 is not ready
   */
 uint32_t LL_RCC_GetCLK48ClockFreq(uint32_t CLK48xSource)
 {
@@ -671,15 +676,21 @@ uint32_t LL_RCC_GetCLK48ClockFreq(uint32_t CLK48xSource)
     case LL_RCC_CLK48_CLKSOURCE_PLLSAI1:       /* PLLSAI1 clock used as CLK48 clock source */
       if (LL_RCC_PLLSAI1_IsReady() == 1U)
       {
-        clk48_frequency = RCC_PLLSAI1_GetFreqDomain_48M();
+        if (LL_RCC_PLLSAI1_IsEnabledDomain_48M() == 1U)
+        {
+          clk48_frequency = RCC_PLLSAI1_GetFreqDomain_48M();
+        }
       }
       break;
-#endif
+#endif /* SAI1 */
 
     case LL_RCC_CLK48_CLKSOURCE_PLL:           /* PLL clock used as CLK48 clock source */
       if (LL_RCC_PLL_IsReady() == 1U)
       {
-        clk48_frequency = RCC_PLL_GetFreqDomain_48M();
+        if (LL_RCC_PLL_IsEnabledDomain_48M() == 1U)
+        {
+          clk48_frequency = RCC_PLL_GetFreqDomain_48M();
+        }
       }
       break;
 
@@ -702,7 +713,7 @@ uint32_t LL_RCC_GetCLK48ClockFreq(uint32_t CLK48xSource)
     default:
       /* Nothing to do */
       break;
-#endif
+#endif /* RCC_HSI48_SUPPORT */
   }
 
   return clk48_frequency;
@@ -714,20 +725,22 @@ uint32_t LL_RCC_GetCLK48ClockFreq(uint32_t CLK48xSource)
   * @param  USBxSource This parameter can be one of the following values:
   *         @arg @ref LL_RCC_CLK48_CLKSOURCE
   * @retval USB clock frequency (in Hz)
-  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (MSI or HSI48) or PLLs (PLL or PLLSAI1) is not ready
+  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (MSI or HSI48) or PLLs (PLL or PLLSAI1)
+  *                 is not ready
   */
 uint32_t LL_RCC_GetUSBClockFreq(uint32_t USBxSource)
 {
   return LL_RCC_GetCLK48ClockFreq(USBxSource);
 }
-#endif
+#endif /* USB */
 
 /**
   * @brief  Return RNGx clock frequency
   * @param  RNGxSource This parameter can be one of the following values:
   *         @arg @ref LL_RCC_RNG_CLKSOURCE
   * @retval RNG clock frequency (in Hz)
-  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (MSI or HSI48) or PLLs (PLL or PLLSAI1) is not ready
+  *         - @ref  LL_RCC_PERIPH_FREQUENCY_NO indicates that oscillator (MSI or HSI48) or PLLs (PLL or PLLSAI1)
+  *                 is not ready
   */
 uint32_t LL_RCC_GetRNGClockFreq(uint32_t RNGxSource)
 {
@@ -784,10 +797,13 @@ uint32_t LL_RCC_GetADCClockFreq(uint32_t ADCxSource)
     case LL_RCC_ADC_CLKSOURCE_PLLSAI1:       /* PLLSAI1 clock used as ADC clock source */
       if (LL_RCC_PLLSAI1_IsReady() == 1U)
       {
-        adc_frequency = RCC_PLLSAI1_GetFreqDomain_ADC();
+        if (LL_RCC_PLLSAI1_IsEnabledDomain_ADC() == 1U)
+        {
+          adc_frequency = RCC_PLLSAI1_GetFreqDomain_ADC();
+        }
       }
       break;
-#endif
+#endif /* SAI1 */
 
     case LL_RCC_ADC_CLKSOURCE_SYSCLK:        /* SYSCLK clock used as ADC clock source */
       adc_frequency = RCC_GetSystemClockFreq();
@@ -796,7 +812,10 @@ uint32_t LL_RCC_GetADCClockFreq(uint32_t ADCxSource)
     case LL_RCC_ADC_CLKSOURCE_PLL:           /* PLL clock used as ADC clock source */
       if (LL_RCC_PLL_IsReady() == 1U)
       {
-        adc_frequency = RCC_PLL_GetFreqDomain_ADC();
+        if (LL_RCC_PLL_IsEnabledDomain_ADC() == 1U)
+        {
+          adc_frequency = RCC_PLL_GetFreqDomain_ADC();
+        }
       }
       break;
 
@@ -838,11 +857,11 @@ uint32_t LL_RCC_GetRTCClockFreq(void)
       }
       break;
 
-    case LL_RCC_RTC_CLKSOURCE_HSE_DIV32:        /* HSE clock used as ADC clock source */
+    case LL_RCC_RTC_CLKSOURCE_HSE_DIV32: /* HSE clock used as ADC clock source */
       rtc_frequency = HSE_VALUE / 32U;
       break;
 
-    case LL_RCC_RTC_CLKSOURCE_NONE:          /* No clock used as RTC clock source */
+    case LL_RCC_RTC_CLKSOURCE_NONE:      /* No clock used as RTC clock source */
     default:
       rtc_frequency = LL_RCC_PERIPH_FREQUENCY_NA;
       break;
@@ -884,7 +903,6 @@ uint32_t LL_RCC_GetRFWKPClockFreq(void)
   return rfwkp_frequency;
 }
 
-
 /**
   * @}
   */
@@ -901,7 +919,7 @@ uint32_t LL_RCC_GetRFWKPClockFreq(void)
   * @brief  Return SYSTEM clock (SYSCLK) frequency
   * @retval SYSTEM clock frequency (in Hz)
   */
-uint32_t RCC_GetSystemClockFreq(void)
+static uint32_t RCC_GetSystemClockFreq(void)
 {
   uint32_t frequency;
 
@@ -944,7 +962,7 @@ uint32_t RCC_GetSystemClockFreq(void)
   * @param  SYSCLK_Frequency SYSCLK clock frequency
   * @retval HCLK1 clock frequency (in Hz)
   */
-uint32_t RCC_GetHCLK1ClockFreq(uint32_t SYSCLK_Frequency)
+static uint32_t RCC_GetHCLK1ClockFreq(uint32_t SYSCLK_Frequency)
 {
   /* HCLK clock frequency */
   return __LL_RCC_CALC_HCLK1_FREQ(SYSCLK_Frequency, LL_RCC_GetAHBPrescaler());
@@ -955,7 +973,7 @@ uint32_t RCC_GetHCLK1ClockFreq(uint32_t SYSCLK_Frequency)
   * @param  SYSCLK_Frequency SYSCLK clock frequency
   * @retval HCLK2 clock frequency (in Hz)
   */
-uint32_t RCC_GetHCLK2ClockFreq(uint32_t SYSCLK_Frequency)
+static uint32_t RCC_GetHCLK2ClockFreq(uint32_t SYSCLK_Frequency)
 {
   /* HCLK clock frequency */
   return __LL_RCC_CALC_HCLK2_FREQ(SYSCLK_Frequency, LL_C2_RCC_GetAHBPrescaler());
@@ -966,7 +984,7 @@ uint32_t RCC_GetHCLK2ClockFreq(uint32_t SYSCLK_Frequency)
   * @param  SYSCLK_Frequency SYSCLK clock frequency
   * @retval HCLK4 clock frequency (in Hz)
   */
-uint32_t RCC_GetHCLK4ClockFreq(uint32_t SYSCLK_Frequency)
+static uint32_t RCC_GetHCLK4ClockFreq(uint32_t SYSCLK_Frequency)
 {
   /* HCLK clock frequency */
   return __LL_RCC_CALC_HCLK4_FREQ(SYSCLK_Frequency, LL_RCC_GetAHB4Prescaler());
@@ -976,7 +994,7 @@ uint32_t RCC_GetHCLK4ClockFreq(uint32_t SYSCLK_Frequency)
   * @brief  Return HCLK5 clock frequency
   * @retval HCLK5 clock frequency (in Hz)
   */
-uint32_t RCC_GetHCLK5ClockFreq(void)
+static uint32_t RCC_GetHCLK5ClockFreq(void)
 {
   uint32_t frequency;
 
@@ -997,16 +1015,14 @@ uint32_t RCC_GetHCLK5ClockFreq(void)
   }
 
   return frequency;
-
 }
-
 
 /**
   * @brief  Return PCLK1 clock frequency
   * @param  HCLK_Frequency HCLK clock frequency
   * @retval PCLK1 clock frequency (in Hz)
   */
-uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency)
+static uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency)
 {
   /* PCLK1 clock frequency */
   return __LL_RCC_CALC_PCLK1_FREQ(HCLK_Frequency, LL_RCC_GetAPB1Prescaler());
@@ -1017,7 +1033,7 @@ uint32_t RCC_GetPCLK1ClockFreq(uint32_t HCLK_Frequency)
   * @param  HCLK_Frequency HCLK clock frequency
   * @retval PCLK2 clock frequency (in Hz)
   */
-uint32_t RCC_GetPCLK2ClockFreq(uint32_t HCLK_Frequency)
+static uint32_t RCC_GetPCLK2ClockFreq(uint32_t HCLK_Frequency)
 {
   /* PCLK2 clock frequency */
   return __LL_RCC_CALC_PCLK2_FREQ(HCLK_Frequency, LL_RCC_GetAPB2Prescaler());
@@ -1027,9 +1043,10 @@ uint32_t RCC_GetPCLK2ClockFreq(uint32_t HCLK_Frequency)
   * @brief  Return PLL clock (PLLRCLK) frequency used for system domain
   * @retval PLLRCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLL_GetFreqDomain_SYS(void)
+static uint32_t RCC_PLL_GetFreqDomain_SYS(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLN
      SYSCLK = PLL_VCO / PLLR
@@ -1070,9 +1087,10 @@ uint32_t RCC_PLL_GetFreqDomain_SYS(void)
   * @brief  Return PLL clock (PLLPCLK) frequency used for SAI domain
   * @retval PLLPCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLL_GetFreqDomain_SAI(void)
+static uint32_t RCC_PLL_GetFreqDomain_SAI(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI Value / PLLM) * PLLN
      SAI Domain clock = PLL_VCO / PLLP
@@ -1107,15 +1125,16 @@ uint32_t RCC_PLL_GetFreqDomain_SAI(void)
   return __LL_RCC_CALC_PLLCLK_SAI_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(),
                                        LL_RCC_PLL_GetN(), LL_RCC_PLL_GetP());
 }
-#endif
+#endif /* SAI1 */
 
 /**
   * @brief  Return PLL clock (PLLPCLK) frequency used for ADC domain
   * @retval PLLPCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLL_GetFreqDomain_ADC(void)
+static uint32_t RCC_PLL_GetFreqDomain_ADC(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI Value / PLLM) * PLLN
      SAI Domain clock = PLL_VCO / PLLP
@@ -1152,14 +1171,14 @@ uint32_t RCC_PLL_GetFreqDomain_ADC(void)
                                        LL_RCC_PLL_GetN(), LL_RCC_PLL_GetP());
 }
 
-
 /**
   * @brief  Return PLL clock (PLLQCLK) frequency used for 48 MHz domain
   * @retval PLLQCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLL_GetFreqDomain_48M(void)
+static uint32_t RCC_PLL_GetFreqDomain_48M(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLL_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLN
      48M Domain clock = PLL_VCO / PLLQ
@@ -1201,9 +1220,10 @@ uint32_t RCC_PLL_GetFreqDomain_48M(void)
   * @brief  Return PLLSAI1 clock (PLLSAI1PCLK) frequency used for SAI domain
   * @retval PLLSAI1PCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLLSAI1_GetFreqDomain_SAI(void)
+static uint32_t RCC_PLLSAI1_GetFreqDomain_SAI(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLLSAI1_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLSAI1N */
   /* SAI Domain clock  = PLLSAI1_VCO / PLLSAI1P */
@@ -1243,9 +1263,10 @@ uint32_t RCC_PLLSAI1_GetFreqDomain_SAI(void)
   * @brief  Return PLLSAI1 clock (PLLSAI1QCLK) frequency used for 48Mhz domain
   * @retval PLLSAI1QCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLLSAI1_GetFreqDomain_48M(void)
+static uint32_t RCC_PLLSAI1_GetFreqDomain_48M(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLLSAI1_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLSAI1N */
   /* 48M Domain clock  = PLLSAI1_VCO / PLLSAI1Q */
@@ -1284,9 +1305,10 @@ uint32_t RCC_PLLSAI1_GetFreqDomain_48M(void)
   * @brief  Return PLLSAI1 clock (PLLSAI1RCLK) frequency used for ADC domain
   * @retval PLLSAI1RCLK clock frequency (in Hz)
   */
-uint32_t RCC_PLLSAI1_GetFreqDomain_ADC(void)
+static uint32_t RCC_PLLSAI1_GetFreqDomain_ADC(void)
 {
-  uint32_t pllinputfreq, pllsource;
+  uint32_t pllinputfreq;
+  uint32_t pllsource;
 
   /* PLLSAI1_VCO = (HSE_VALUE or HSI_VALUE or MSI Value/ PLLM) * PLLSAI1N */
   /* 48M Domain clock  = PLLSAI1_VCO / PLLSAI1R */
@@ -1320,23 +1342,20 @@ uint32_t RCC_PLLSAI1_GetFreqDomain_ADC(void)
   return __LL_RCC_CALC_PLLSAI1_ADC_FREQ(pllinputfreq, LL_RCC_PLL_GetDivider(),
                                         LL_RCC_PLLSAI1_GetN(), LL_RCC_PLLSAI1_GetR());
 }
-#endif
-
-
-/**
-  * @}
-  */
+#endif /* SAI1 */
 
 /**
   * @}
   */
 
-#endif /* defined(RCC) */
+/**
+  * @}
+  */
+
+#endif /* RCC */
 
 /**
   * @}
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_rng.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_rng.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -26,7 +25,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -69,16 +68,26 @@
   *          - SUCCESS: RNG registers are de-initialized
   *          - ERROR: not applicable
   */
-ErrorStatus LL_RNG_DeInit(RNG_TypeDef *RNGx)
+ErrorStatus LL_RNG_DeInit(const RNG_TypeDef *RNGx)
 {
+  ErrorStatus status = SUCCESS;
+
   /* Check the parameters */
   assert_param(IS_RNG_ALL_INSTANCE(RNGx));
-  /* Enable RNG reset state */
-  LL_AHB3_GRP1_ForceReset(LL_AHB3_GRP1_PERIPH_RNG);
+  if (RNGx == RNG)
+  {
+    /* Enable RNG reset state */
+    LL_AHB3_GRP1_ForceReset(LL_AHB3_GRP1_PERIPH_RNG);
 
-  /* Release RNG from reset state */
-  LL_AHB3_GRP1_ReleaseReset(LL_AHB3_GRP1_PERIPH_RNG);
-  return (SUCCESS);
+    /* Release RNG from reset state */
+    LL_AHB3_GRP1_ReleaseReset(LL_AHB3_GRP1_PERIPH_RNG);
+  }
+  else
+  {
+    status = ERROR;
+  }
+
+  return status;
 }
 
 /**
@@ -90,7 +99,7 @@ ErrorStatus LL_RNG_DeInit(RNG_TypeDef *RNGx)
   *          - SUCCESS: RNG registers are initialized according to RNG_InitStruct content
   *          - ERROR: not applicable
   */
-ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, LL_RNG_InitTypeDef *RNG_InitStruct)
+ErrorStatus LL_RNG_Init(RNG_TypeDef *RNGx, const LL_RNG_InitTypeDef *RNG_InitStruct)
 {
   /* Check the parameters */
   assert_param(IS_RNG_ALL_INSTANCE(RNGx));
@@ -133,6 +142,4 @@ void LL_RNG_StructInit(LL_RNG_InitTypeDef *RNG_InitStruct)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_rtc.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_rtc.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -85,22 +84,11 @@
                                    || ((__VALUE__) == LL_RTC_WEEKDAY_SATURDAY) \
                                    || ((__VALUE__) == LL_RTC_WEEKDAY_SUNDAY))
 
-#define IS_LL_RTC_DAY(__DAY__)    (((__DAY__) >= 1U) && ((__DAY__) <= 31U))
+#define IS_LL_RTC_DAY(__DAY__)     (((__DAY__) >= 1U) && ((__DAY__) <= 31U))
 
-#define IS_LL_RTC_MONTH(__VALUE__) (((__VALUE__) == LL_RTC_MONTH_JANUARY) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_FEBRUARY) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_MARCH) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_APRIL) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_MAY) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_JUNE) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_JULY) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_AUGUST) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_SEPTEMBER) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_OCTOBER) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_NOVEMBER) \
-                                 || ((__VALUE__) == LL_RTC_MONTH_DECEMBER))
+#define IS_LL_RTC_MONTH(__MONTH__) (((__MONTH__) >= 1U) && ((__MONTH__) <= 12U))
 
-#define IS_LL_RTC_YEAR(__YEAR__) ((__YEAR__) <= 99U)
+#define IS_LL_RTC_YEAR(__YEAR__)   ((__YEAR__) <= 99U)
 
 #define IS_LL_RTC_ALMA_MASK(__VALUE__) (((__VALUE__) == LL_RTC_ALMA_MASK_NONE) \
                                      || ((__VALUE__) == LL_RTC_ALMA_MASK_DATEWEEKDAY) \
@@ -116,13 +104,11 @@
                                      || ((__VALUE__) == LL_RTC_ALMB_MASK_SECONDS) \
                                      || ((__VALUE__) == LL_RTC_ALMB_MASK_ALL))
 
-
 #define IS_LL_RTC_ALMA_DATE_WEEKDAY_SEL(__SEL__) (((__SEL__) == LL_RTC_ALMA_DATEWEEKDAYSEL_DATE) || \
                                                   ((__SEL__) == LL_RTC_ALMA_DATEWEEKDAYSEL_WEEKDAY))
 
 #define IS_LL_RTC_ALMB_DATE_WEEKDAY_SEL(__SEL__) (((__SEL__) == LL_RTC_ALMB_DATEWEEKDAYSEL_DATE) || \
                                                   ((__SEL__) == LL_RTC_ALMB_DATEWEEKDAYSEL_WEEKDAY))
-
 
 /**
   * @}
@@ -139,7 +125,7 @@
 
 /**
   * @brief  De-Initializes the RTC registers to their default reset values.
-  * @note   This function doesn't reset the RTC Clock source and RTC Backup Data
+  * @note   This function does not reset the RTC Clock source and RTC Backup Data
   *         registers.
   * @param  RTCx RTC Instance
   * @retval An ErrorStatus enumeration value:
@@ -160,33 +146,29 @@ ErrorStatus LL_RTC_DeInit(RTC_TypeDef *RTCx)
   if (LL_RTC_EnterInitMode(RTCx) != ERROR)
   {
     /* Reset TR, DR and CR registers */
-    WRITE_REG(RTCx->TR,       0x00000000U);
-#if defined(RTC_WAKEUP_SUPPORT)
-    WRITE_REG(RTCx->WUTR,     RTC_WUTR_WUT);
-#endif /* RTC_WAKEUP_SUPPORT */
-    WRITE_REG(RTCx->DR  ,     (RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0));
+    LL_RTC_WriteReg(RTCx, TR,       0x00000000U);
+    LL_RTC_WriteReg(RTCx, WUTR,     RTC_WUTR_WUT);
+    LL_RTC_WriteReg(RTCx, DR,      (RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0));
+
     /* Reset All CR bits except CR[2:0] */
-#if defined(RTC_WAKEUP_SUPPORT)
-    WRITE_REG(RTCx->CR, (READ_REG(RTCx->CR) & RTC_CR_WUCKSEL));
-#else
-    WRITE_REG(RTCx, CR, 0x00000000U);
-#endif /* RTC_WAKEUP_SUPPORT */
-    WRITE_REG(RTCx->PRER,     (RTC_PRER_PREDIV_A | RTC_SYNCH_PRESC_DEFAULT));
-    WRITE_REG(RTCx->ALRMAR,   0x00000000U);
-    WRITE_REG(RTCx->ALRMBR,   0x00000000U);
-    WRITE_REG(RTCx->SHIFTR,   0x00000000U);
-    WRITE_REG(RTCx->CALR,     0x00000000U);
-    WRITE_REG(RTCx->ALRMASSR, 0x00000000U);
-    WRITE_REG(RTCx->ALRMBSSR, 0x00000000U);
+    LL_RTC_WriteReg(RTCx, CR, (LL_RTC_ReadReg(RTCx, CR) & RTC_CR_WUCKSEL));
+
+    LL_RTC_WriteReg(RTCx, PRER,    (RTC_PRER_PREDIV_A | RTC_SYNCH_PRESC_DEFAULT));
+    LL_RTC_WriteReg(RTCx, ALRMAR,   0x00000000U);
+    LL_RTC_WriteReg(RTCx, ALRMBR,   0x00000000U);
+    LL_RTC_WriteReg(RTCx, CALR,     0x00000000U);
+    LL_RTC_WriteReg(RTCx, SHIFTR,   0x00000000U);
+    LL_RTC_WriteReg(RTCx, ALRMASSR, 0x00000000U);
+    LL_RTC_WriteReg(RTCx, ALRMBSSR, 0x00000000U);
 
     /* Reset ISR register and exit initialization mode */
-    WRITE_REG(RTCx->ISR,      0x00000000U);
+    LL_RTC_WriteReg(RTCx, ISR,      0x00000000U);
 
     /* Reset Tamper and alternate functions configuration register */
-    WRITE_REG(RTCx->TAMPCR, 0x00000000U);
+    LL_RTC_WriteReg(RTCx, TAMPCR, 0x00000000U);
 
     /* Reset Option register */
-    WRITE_REG(RTCx->OR, 0x00000000U);
+    LL_RTC_WriteReg(RTCx, OR, 0x00000000U);
 
     /* Wait till the RTC RSF flag is set */
     status = LL_RTC_WaitForSynchro(RTCx);
@@ -328,7 +310,7 @@ ErrorStatus LL_RTC_TIME_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_Time
     }
 
     /* Exit Initialization mode */
-    LL_RTC_DisableInitMode(RTC);
+    LL_RTC_DisableInitMode(RTCx);
 
     /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
     if (LL_RTC_IsShadowRegBypassEnabled(RTCx) == 0U)
@@ -366,7 +348,7 @@ void LL_RTC_TIME_StructInit(LL_RTC_TimeTypeDef *RTC_TimeStruct)
   * @param  RTC_Format This parameter can be one of the following values:
   *         @arg @ref LL_RTC_FORMAT_BIN
   *         @arg @ref LL_RTC_FORMAT_BCD
-  * @param RTC_DateStruct pointer to a RTC_DateTypeDef structure that contains
+  * @param  RTC_DateStruct pointer to a RTC_DateTypeDef structure that contains
   *                         the date configuration information for the RTC.
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: RTC Day register is configured
@@ -382,7 +364,7 @@ ErrorStatus LL_RTC_DATE_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_Date
 
   if ((RTC_Format == LL_RTC_FORMAT_BIN) && ((RTC_DateStruct->Month & 0x10U) == 0x10U))
   {
-    RTC_DateStruct->Month = (RTC_DateStruct->Month & (uint8_t)~(0x10U)) + 0x0AU;
+    RTC_DateStruct->Month = (uint8_t)(RTC_DateStruct->Month & (uint8_t)~(0x10U)) + 0x0AU;
   }
   if (RTC_Format == LL_RTC_FORMAT_BIN)
   {
@@ -416,7 +398,7 @@ ErrorStatus LL_RTC_DATE_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_Date
     }
 
     /* Exit Initialization mode */
-    LL_RTC_DisableInitMode(RTC);
+    LL_RTC_DisableInitMode(RTCx);
 
     /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
     if (LL_RTC_IsShadowRegBypassEnabled(RTCx) == 0U)
@@ -741,7 +723,7 @@ ErrorStatus LL_RTC_EnterInitMode(RTC_TypeDef *RTCx)
 {
   __IO uint32_t timeout = RTC_INITMODE_TIMEOUT;
   ErrorStatus status = SUCCESS;
-  uint32_t tmp;
+  uint32_t tmp = 0U;
 
   /* Check the parameter */
   assert_param(IS_RTC_ALL_INSTANCE(RTCx));
@@ -797,7 +779,7 @@ ErrorStatus LL_RTC_ExitInitMode(RTC_TypeDef *RTCx)
   *         synchronized with RTC APB clock.
   * @note   The RTC Resynchronization mode is write protected, use the
   *         @ref LL_RTC_DisableWriteProtection before calling this function.
-  * @note   To read the calendar through the shadow registers after Calendar
+  * @note   To read the calendar through the shadow registers after calendar
   *         initialization, calendar update or after wakeup from low power modes
   *         the software must first clear the RSF flag.
   *         The software must then wait until it is set again before reading
@@ -812,7 +794,7 @@ ErrorStatus LL_RTC_WaitForSynchro(RTC_TypeDef *RTCx)
 {
   __IO uint32_t timeout = RTC_SYNCHRO_TIMEOUT;
   ErrorStatus status = SUCCESS;
-  uint32_t tmp;
+  uint32_t tmp = 0U;
 
   /* Check the parameter */
   assert_param(IS_RTC_ALL_INSTANCE(RTCx));
@@ -822,7 +804,7 @@ ErrorStatus LL_RTC_WaitForSynchro(RTC_TypeDef *RTCx)
 
   /* Wait the registers to be synchronised */
   tmp = LL_RTC_IsActiveFlag_RS(RTCx);
-  while ((timeout != 0U) && (tmp != 0U))
+  while ((timeout != 0U) && (tmp != 1U))
   {
     if (LL_SYSTICK_IsActiveCounterFlag() == 1U)
     {
@@ -832,24 +814,6 @@ ErrorStatus LL_RTC_WaitForSynchro(RTC_TypeDef *RTCx)
     if (timeout == 0U)
     {
       status = ERROR;
-    }
-  }
-
-  if (status != ERROR)
-  {
-    timeout = RTC_SYNCHRO_TIMEOUT;
-    tmp = LL_RTC_IsActiveFlag_RS(RTCx);
-    while ((timeout != 0U) && (tmp != 1U))
-    {
-      if (LL_SYSTICK_IsActiveCounterFlag() == 1U)
-      {
-        timeout--;
-      }
-      tmp = LL_RTC_IsActiveFlag_RS(RTCx);
-      if (timeout == 0U)
-      {
-        status = ERROR;
-      }
     }
   }
 
@@ -875,5 +839,3 @@ ErrorStatus LL_RTC_WaitForSynchro(RTC_TypeDef *RTCx)
   */
 
 #endif /* USE_FULL_LL_DRIVER */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_spi.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_spi.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -26,7 +25,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -130,7 +129,7 @@
   *          - SUCCESS: SPI registers are de-initialized
   *          - ERROR: SPI registers are not de-initialized
   */
-ErrorStatus LL_SPI_DeInit(SPI_TypeDef *SPIx)
+ErrorStatus LL_SPI_DeInit(const SPI_TypeDef *SPIx)
 {
   ErrorStatus status = ERROR;
 
@@ -167,8 +166,9 @@ ErrorStatus LL_SPI_DeInit(SPI_TypeDef *SPIx)
 
 /**
   * @brief  Initialize the SPI registers according to the specified parameters in SPI_InitStruct.
-  * @note   As some bits in SPI configuration registers can only be written when the SPI is disabled (SPI_CR1_SPE bit =0),
-  *         SPI peripheral should be in disabled state prior calling this function. Otherwise, ERROR result will be returned.
+  * @note   As some bits in SPI configuration registers can only be written when the
+  *         SPI is disabled (SPI_CR1_SPE bit = 0), SPI peripheral should be in disabled state prior
+  *         calling this function. Otherwise, ERROR result will be returned.
   * @param  SPIx SPI Instance
   * @param  SPI_InitStruct pointer to a @ref LL_SPI_InitTypeDef structure
   * @retval An ErrorStatus enumeration value. (Return always SUCCESS)
@@ -219,6 +219,12 @@ ErrorStatus LL_SPI_Init(SPI_TypeDef *SPIx, LL_SPI_InitTypeDef *SPI_InitStruct)
     MODIFY_REG(SPIx->CR2,
                SPI_CR2_DS | SPI_CR2_SSOE,
                SPI_InitStruct->DataWidth | (SPI_InitStruct->NSS >> 16U));
+
+    /* Set Rx FIFO to Quarter (1 Byte) in case of 8 Bits mode. No DataPacking by default */
+    if (SPI_InitStruct->DataWidth < LL_SPI_DATAWIDTH_9BIT)
+    {
+      LL_SPI_SetRxFIFOThreshold(SPIx, LL_SPI_RX_FIFO_TH_QUARTER);
+    }
 
     /*---------------------------- SPIx CRCPR Configuration ----------------------
      * Configure SPIx CRCPR with parameters:
@@ -276,4 +282,3 @@ void LL_SPI_StructInit(LL_SPI_InitTypeDef *SPI_InitStruct)
 
 #endif /* USE_FULL_LL_DRIVER */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_tim.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_tim.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -67,8 +66,8 @@
                                      || ((__VALUE__) == LL_TIM_OCMODE_RETRIG_OPM2) \
                                      || ((__VALUE__) == LL_TIM_OCMODE_COMBINED_PWM1) \
                                      || ((__VALUE__) == LL_TIM_OCMODE_COMBINED_PWM2) \
-                                     || ((__VALUE__) == LL_TIM_OCMODE_ASSYMETRIC_PWM1) \
-                                     || ((__VALUE__) == LL_TIM_OCMODE_ASSYMETRIC_PWM2))
+                                     || ((__VALUE__) == LL_TIM_OCMODE_ASYMMETRIC_PWM1) \
+                                     || ((__VALUE__) == LL_TIM_OCMODE_ASYMMETRIC_PWM2))
 
 #define IS_LL_TIM_OCSTATE(__VALUE__) (((__VALUE__) == LL_TIM_OCSTATE_DISABLE) \
                                       || ((__VALUE__) == LL_TIM_OCSTATE_ENABLE))
@@ -190,16 +189,16 @@
 /** @defgroup TIM_LL_Private_Functions TIM Private Functions
   * @{
   */
-static ErrorStatus OC1Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
-static ErrorStatus OC2Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
-static ErrorStatus OC3Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
-static ErrorStatus OC4Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
-static ErrorStatus OC5Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
-static ErrorStatus OC6Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
-static ErrorStatus IC1Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
-static ErrorStatus IC2Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
-static ErrorStatus IC3Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
-static ErrorStatus IC4Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
+static ErrorStatus OC1Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
+static ErrorStatus OC2Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
+static ErrorStatus OC3Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
+static ErrorStatus OC4Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
+static ErrorStatus OC5Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
+static ErrorStatus OC6Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct);
+static ErrorStatus IC1Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
+static ErrorStatus IC2Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
+static ErrorStatus IC3Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
+static ErrorStatus IC4Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct);
 /**
   * @}
   */
@@ -220,7 +219,7 @@ static ErrorStatus IC4Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: invalid TIMx instance
   */
-ErrorStatus LL_TIM_DeInit(TIM_TypeDef *TIMx)
+ErrorStatus LL_TIM_DeInit(const TIM_TypeDef *TIMx)
 {
   ErrorStatus result = SUCCESS;
 
@@ -278,12 +277,13 @@ void LL_TIM_StructInit(LL_TIM_InitTypeDef *TIM_InitStruct)
 /**
   * @brief  Configure the TIMx time base unit.
   * @param  TIMx Timer Instance
-  * @param  TIM_InitStruct pointer to a @ref LL_TIM_InitTypeDef structure (TIMx time base unit configuration data structure)
+  * @param  TIM_InitStruct pointer to a @ref LL_TIM_InitTypeDef structure
+  *         (TIMx time base unit configuration data structure)
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-ErrorStatus LL_TIM_Init(TIM_TypeDef *TIMx, LL_TIM_InitTypeDef *TIM_InitStruct)
+ErrorStatus LL_TIM_Init(TIM_TypeDef *TIMx, const LL_TIM_InitTypeDef *TIM_InitStruct)
 {
   uint32_t tmpcr1;
 
@@ -331,7 +331,8 @@ ErrorStatus LL_TIM_Init(TIM_TypeDef *TIMx, LL_TIM_InitTypeDef *TIM_InitStruct)
 /**
   * @brief  Set the fields of the TIMx output channel configuration data
   *         structure to their default values.
-  * @param  TIM_OC_InitStruct pointer to a @ref LL_TIM_OC_InitTypeDef structure (the output channel configuration data structure)
+  * @param  TIM_OC_InitStruct pointer to a @ref LL_TIM_OC_InitTypeDef structure
+  *         (the output channel configuration data structure)
   * @retval None
   */
 void LL_TIM_OC_StructInit(LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct)
@@ -357,12 +358,13 @@ void LL_TIM_OC_StructInit(LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct)
   *         @arg @ref LL_TIM_CHANNEL_CH4
   *         @arg @ref LL_TIM_CHANNEL_CH5
   *         @arg @ref LL_TIM_CHANNEL_CH6
-  * @param  TIM_OC_InitStruct pointer to a @ref LL_TIM_OC_InitTypeDef structure (TIMx output channel configuration data structure)
+  * @param  TIM_OC_InitStruct pointer to a @ref LL_TIM_OC_InitTypeDef structure (TIMx output channel configuration
+  *         data structure)
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: TIMx output channel is initialized
   *          - ERROR: TIMx output channel is not initialized
   */
-ErrorStatus LL_TIM_OC_Init(TIM_TypeDef *TIMx, uint32_t Channel, LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct)
+ErrorStatus LL_TIM_OC_Init(TIM_TypeDef *TIMx, uint32_t Channel, const LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct)
 {
   ErrorStatus result = ERROR;
 
@@ -396,7 +398,8 @@ ErrorStatus LL_TIM_OC_Init(TIM_TypeDef *TIMx, uint32_t Channel, LL_TIM_OC_InitTy
 /**
   * @brief  Set the fields of the TIMx input channel configuration data
   *         structure to their default values.
-  * @param  TIM_ICInitStruct pointer to a @ref LL_TIM_IC_InitTypeDef structure (the input channel configuration data structure)
+  * @param  TIM_ICInitStruct pointer to a @ref LL_TIM_IC_InitTypeDef structure (the input channel configuration
+  *         data structure)
   * @retval None
   */
 void LL_TIM_IC_StructInit(LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
@@ -416,12 +419,13 @@ void LL_TIM_IC_StructInit(LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
   *         @arg @ref LL_TIM_CHANNEL_CH2
   *         @arg @ref LL_TIM_CHANNEL_CH3
   *         @arg @ref LL_TIM_CHANNEL_CH4
-  * @param  TIM_IC_InitStruct pointer to a @ref LL_TIM_IC_InitTypeDef structure (TIMx input channel configuration data structure)
+  * @param  TIM_IC_InitStruct pointer to a @ref LL_TIM_IC_InitTypeDef structure (TIMx input channel configuration data
+  *         structure)
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: TIMx output channel is initialized
   *          - ERROR: TIMx output channel is not initialized
   */
-ErrorStatus LL_TIM_IC_Init(TIM_TypeDef *TIMx, uint32_t Channel, LL_TIM_IC_InitTypeDef *TIM_IC_InitStruct)
+ErrorStatus LL_TIM_IC_Init(TIM_TypeDef *TIMx, uint32_t Channel, const LL_TIM_IC_InitTypeDef *TIM_IC_InitStruct)
 {
   ErrorStatus result = ERROR;
 
@@ -448,7 +452,8 @@ ErrorStatus LL_TIM_IC_Init(TIM_TypeDef *TIMx, uint32_t Channel, LL_TIM_IC_InitTy
 
 /**
   * @brief  Fills each TIM_EncoderInitStruct field with its default value
-  * @param  TIM_EncoderInitStruct pointer to a @ref LL_TIM_ENCODER_InitTypeDef structure (encoder interface configuration data structure)
+  * @param  TIM_EncoderInitStruct pointer to a @ref LL_TIM_ENCODER_InitTypeDef structure (encoder interface
+  *         configuration data structure)
   * @retval None
   */
 void LL_TIM_ENCODER_StructInit(LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct)
@@ -468,12 +473,13 @@ void LL_TIM_ENCODER_StructInit(LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct
 /**
   * @brief  Configure the encoder interface of the timer instance.
   * @param  TIMx Timer Instance
-  * @param  TIM_EncoderInitStruct pointer to a @ref LL_TIM_ENCODER_InitTypeDef structure (TIMx encoder interface configuration data structure)
+  * @param  TIM_EncoderInitStruct pointer to a @ref LL_TIM_ENCODER_InitTypeDef structure (TIMx encoder interface
+  *         configuration data structure)
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct)
+ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, const LL_TIM_ENCODER_InitTypeDef *TIM_EncoderInitStruct)
 {
   uint32_t tmpccmr1;
   uint32_t tmpccer;
@@ -532,7 +538,8 @@ ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, LL_TIM_ENCODER_InitTypeDef *T
 /**
   * @brief  Set the fields of the TIMx Hall sensor interface configuration data
   *         structure to their default values.
-  * @param  TIM_HallSensorInitStruct pointer to a @ref LL_TIM_HALLSENSOR_InitTypeDef structure (HALL sensor interface configuration data structure)
+  * @param  TIM_HallSensorInitStruct pointer to a @ref LL_TIM_HALLSENSOR_InitTypeDef structure (HALL sensor interface
+  *         configuration data structure)
   * @retval None
   */
 void LL_TIM_HALLSENSOR_StructInit(LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorInitStruct)
@@ -559,12 +566,13 @@ void LL_TIM_HALLSENSOR_StructInit(LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorI
   * @note LL_TIM_IC_POLARITY_BOTHEDGE must not be used for TI1 when it is used
   *       when TIMx operates in Hall sensor interface mode.
   * @param  TIMx Timer Instance
-  * @param  TIM_HallSensorInitStruct pointer to a @ref LL_TIM_HALLSENSOR_InitTypeDef structure (TIMx HALL sensor interface configuration data structure)
+  * @param  TIM_HallSensorInitStruct pointer to a @ref LL_TIM_HALLSENSOR_InitTypeDef structure (TIMx HALL sensor
+  *         interface configuration data structure)
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-ErrorStatus LL_TIM_HALLSENSOR_Init(TIM_TypeDef *TIMx, LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorInitStruct)
+ErrorStatus LL_TIM_HALLSENSOR_Init(TIM_TypeDef *TIMx, const LL_TIM_HALLSENSOR_InitTypeDef *TIM_HallSensorInitStruct)
 {
   uint32_t tmpcr2;
   uint32_t tmpccmr1;
@@ -639,7 +647,8 @@ ErrorStatus LL_TIM_HALLSENSOR_Init(TIM_TypeDef *TIMx, LL_TIM_HALLSENSOR_InitType
 /**
   * @brief  Set the fields of the Break and Dead Time configuration data structure
   *         to their default values.
-  * @param  TIM_BDTRInitStruct pointer to a @ref LL_TIM_BDTR_InitTypeDef structure (Break and Dead Time configuration data structure)
+  * @param  TIM_BDTRInitStruct pointer to a @ref LL_TIM_BDTR_InitTypeDef structure (Break and Dead Time configuration
+  *         data structure)
   * @retval None
   */
 void LL_TIM_BDTR_StructInit(LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct)
@@ -671,12 +680,13 @@ void LL_TIM_BDTR_StructInit(LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct)
   * @note Macro IS_TIM_BKIN2_INSTANCE(TIMx) can be used to check whether or not
   *       a timer instance provides a second break input.
   * @param  TIMx Timer Instance
-  * @param  TIM_BDTRInitStruct pointer to a @ref LL_TIM_BDTR_InitTypeDef structure (Break and Dead Time configuration data structure)
+  * @param  TIM_BDTRInitStruct pointer to a @ref LL_TIM_BDTR_InitTypeDef structure (Break and Dead Time configuration
+  *         data structure)
   * @retval An ErrorStatus enumeration value:
   *          - SUCCESS: Break and Dead Time is initialized
   *          - ERROR: not applicable
   */
-ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct)
+ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, const LL_TIM_BDTR_InitTypeDef *TIM_BDTRInitStruct)
 {
   uint32_t tmpbdtr = 0;
 
@@ -688,6 +698,8 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDT
   assert_param(IS_LL_TIM_BREAK_STATE(TIM_BDTRInitStruct->BreakState));
   assert_param(IS_LL_TIM_BREAK_POLARITY(TIM_BDTRInitStruct->BreakPolarity));
   assert_param(IS_LL_TIM_AUTOMATIC_OUTPUT_STATE(TIM_BDTRInitStruct->AutomaticOutput));
+  assert_param(IS_LL_TIM_BREAK_FILTER(TIM_BDTRInitStruct->BreakFilter));
+  assert_param(IS_LL_TIM_BREAK_AFMODE(TIM_BDTRInitStruct->BreakAFMode));
 
   /* Set the Lock level, the Break enable Bit and the Polarity, the OSSR State,
   the OSSI State, the dead time value and the Automatic Output Enable Bit */
@@ -700,14 +712,8 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDT
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKE, TIM_BDTRInitStruct->BreakState);
   MODIFY_REG(tmpbdtr, TIM_BDTR_BKP, TIM_BDTRInitStruct->BreakPolarity);
   MODIFY_REG(tmpbdtr, TIM_BDTR_AOE, TIM_BDTRInitStruct->AutomaticOutput);
-  MODIFY_REG(tmpbdtr, TIM_BDTR_MOE, TIM_BDTRInitStruct->AutomaticOutput);
-  if (IS_TIM_ADVANCED_INSTANCE(TIMx))
-  {
-    assert_param(IS_LL_TIM_BREAK_FILTER(TIM_BDTRInitStruct->BreakFilter));
-    assert_param(IS_LL_TIM_BREAK_AFMODE(TIM_BDTRInitStruct->BreakAFMode));
-    MODIFY_REG(tmpbdtr, TIM_BDTR_BKF, TIM_BDTRInitStruct->BreakFilter);
-    MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, TIM_BDTRInitStruct->BreakAFMode);
-  }
+  MODIFY_REG(tmpbdtr, TIM_BDTR_BKF, TIM_BDTRInitStruct->BreakFilter);
+  MODIFY_REG(tmpbdtr, TIM_BDTR_BKBID, TIM_BDTRInitStruct->BreakAFMode);
 
   if (IS_TIM_BKIN2_INSTANCE(TIMx))
   {
@@ -748,7 +754,7 @@ ErrorStatus LL_TIM_BDTR_Init(TIM_TypeDef *TIMx, LL_TIM_BDTR_InitTypeDef *TIM_BDT
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus OC1Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
+static ErrorStatus OC1Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
 {
   uint32_t tmpccmr1;
   uint32_t tmpccer;
@@ -759,8 +765,6 @@ static ErrorStatus OC1Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
 
   /* Disable the Channel 1: Reset the CC1E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC1E);
@@ -788,8 +792,10 @@ static ErrorStatus OC1Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC1NP, TIM_OCInitStruct->OCNPolarity << 2U);
@@ -827,7 +833,7 @@ static ErrorStatus OC1Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus OC2Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
+static ErrorStatus OC2Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
 {
   uint32_t tmpccmr1;
   uint32_t tmpccer;
@@ -838,8 +844,6 @@ static ErrorStatus OC2Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
 
   /* Disable the Channel 2: Reset the CC2E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC2E);
@@ -867,8 +871,10 @@ static ErrorStatus OC2Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC2NP, TIM_OCInitStruct->OCNPolarity << 6U);
@@ -906,7 +912,7 @@ static ErrorStatus OC2Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus OC3Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
+static ErrorStatus OC3Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
 {
   uint32_t tmpccmr2;
   uint32_t tmpccer;
@@ -917,8 +923,6 @@ static ErrorStatus OC3Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
 
   /* Disable the Channel 3: Reset the CC3E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC3E);
@@ -946,8 +950,10 @@ static ErrorStatus OC3Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
+    assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
+    assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
+    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
 
     /* Set the complementary output Polarity */
     MODIFY_REG(tmpccer, TIM_CCER_CC3NP, TIM_OCInitStruct->OCNPolarity << 10U);
@@ -985,7 +991,7 @@ static ErrorStatus OC3Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus OC4Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
+static ErrorStatus OC4Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
 {
   uint32_t tmpccmr2;
   uint32_t tmpccer;
@@ -996,8 +1002,6 @@ static ErrorStatus OC4Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   assert_param(IS_LL_TIM_OCMODE(TIM_OCInitStruct->OCMode));
   assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCState));
   assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCPolarity));
-  assert_param(IS_LL_TIM_OCPOLARITY(TIM_OCInitStruct->OCNPolarity));
-  assert_param(IS_LL_TIM_OCSTATE(TIM_OCInitStruct->OCNState));
 
   /* Disable the Channel 4: Reset the CC4E Bit */
   CLEAR_BIT(TIMx->CCER, TIM_CCER_CC4E);
@@ -1025,7 +1029,6 @@ static ErrorStatus OC4Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
   {
-    assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCNIdleState));
     assert_param(IS_LL_TIM_OCIDLESTATE(TIM_OCInitStruct->OCIdleState));
 
     /* Set the Output Idle state */
@@ -1055,7 +1058,7 @@ static ErrorStatus OC4Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus OC5Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
+static ErrorStatus OC5Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
 {
   uint32_t tmpccmr3;
   uint32_t tmpccer;
@@ -1116,7 +1119,7 @@ static ErrorStatus OC5Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus OC6Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
+static ErrorStatus OC6Config(TIM_TypeDef *TIMx, const LL_TIM_OC_InitTypeDef *TIM_OCInitStruct)
 {
   uint32_t tmpccmr3;
   uint32_t tmpccer;
@@ -1176,7 +1179,7 @@ static ErrorStatus OC6Config(TIM_TypeDef *TIMx, LL_TIM_OC_InitTypeDef *TIM_OCIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus IC1Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
+static ErrorStatus IC1Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
 {
   /* Check the parameters */
   assert_param(IS_TIM_CC1_INSTANCE(TIMx));
@@ -1209,7 +1212,7 @@ static ErrorStatus IC1Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus IC2Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
+static ErrorStatus IC2Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
 {
   /* Check the parameters */
   assert_param(IS_TIM_CC2_INSTANCE(TIMx));
@@ -1242,7 +1245,7 @@ static ErrorStatus IC2Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus IC3Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
+static ErrorStatus IC3Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
 {
   /* Check the parameters */
   assert_param(IS_TIM_CC3_INSTANCE(TIMx));
@@ -1275,7 +1278,7 @@ static ErrorStatus IC3Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
   *          - SUCCESS: TIMx registers are de-initialized
   *          - ERROR: not applicable
   */
-static ErrorStatus IC4Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
+static ErrorStatus IC4Config(TIM_TypeDef *TIMx, const LL_TIM_IC_InitTypeDef *TIM_ICInitStruct)
 {
   /* Check the parameters */
   assert_param(IS_TIM_CC4_INSTANCE(TIMx));
@@ -1292,7 +1295,7 @@ static ErrorStatus IC4Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
              (TIM_CCMR2_CC4S | TIM_CCMR2_IC4F | TIM_CCMR2_IC4PSC),
              (TIM_ICInitStruct->ICActiveInput | TIM_ICInitStruct->ICFilter | TIM_ICInitStruct->ICPrescaler) >> 8U);
 
-  /* Select the Polarity and set the CC2E Bit */
+  /* Select the Polarity and set the CC4E Bit */
   MODIFY_REG(TIMx->CCER,
              (TIM_CCER_CC4P | TIM_CCER_CC4NP),
              ((TIM_ICInitStruct->ICPolarity << 12U) | TIM_CCER_CC4E));
@@ -1317,4 +1320,3 @@ static ErrorStatus IC4Config(TIM_TypeDef *TIMx, LL_TIM_IC_InitTypeDef *TIM_ICIni
 
 #endif /* USE_FULL_LL_DRIVER */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_usart.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_usart.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -22,11 +21,11 @@
 #include "stm32wbxx_ll_usart.h"
 #include "stm32wbxx_ll_rcc.h"
 #include "stm32wbxx_ll_bus.h"
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -45,10 +44,12 @@
   * @{
   */
 
+/* Definition of default baudrate value used for USART initialisation */
+#define USART_DEFAULT_BAUDRATE          (9600U)
+
 /**
   * @}
   */
-
 
 /* Private macros ------------------------------------------------------------*/
 /** @addtogroup USART_LL_Private_Macros
@@ -56,17 +57,17 @@
   */
 
 #define IS_LL_USART_PRESCALER(__VALUE__)  (((__VALUE__) == LL_USART_PRESCALER_DIV1) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV2) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV4) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV6) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV8) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV10) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV12) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV16) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV32) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV64) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV128) \
-                                        || ((__VALUE__) == LL_USART_PRESCALER_DIV256))
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV2) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV4) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV6) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV8) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV10) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV12) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV16) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV32) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV64) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV128) \
+                                           || ((__VALUE__) == LL_USART_PRESCALER_DIV256))
 
 /* __BAUDRATE__ The maximum Baud Rate is derived from the maximum clock available
  *              divided by the smallest oversampling used on the USART (i.e. 8)    */
@@ -75,46 +76,43 @@
 /* __VALUE__ In case of oversampling by 16 and 8, BRR content must be greater than or equal to 16d. */
 #define IS_LL_USART_BRR_MIN(__VALUE__) ((__VALUE__) >= 16U)
 
-/* __VALUE__ BRR content must be lower than or equal to 0xFFFF. */
-#define IS_LL_USART_BRR_MAX(__VALUE__) ((__VALUE__) <= 0x0000FFFFU)
-
 #define IS_LL_USART_DIRECTION(__VALUE__) (((__VALUE__) == LL_USART_DIRECTION_NONE) \
-                                       || ((__VALUE__) == LL_USART_DIRECTION_RX) \
-                                       || ((__VALUE__) == LL_USART_DIRECTION_TX) \
-                                       || ((__VALUE__) == LL_USART_DIRECTION_TX_RX))
+                                          || ((__VALUE__) == LL_USART_DIRECTION_RX) \
+                                          || ((__VALUE__) == LL_USART_DIRECTION_TX) \
+                                          || ((__VALUE__) == LL_USART_DIRECTION_TX_RX))
 
 #define IS_LL_USART_PARITY(__VALUE__) (((__VALUE__) == LL_USART_PARITY_NONE) \
-                                    || ((__VALUE__) == LL_USART_PARITY_EVEN) \
-                                    || ((__VALUE__) == LL_USART_PARITY_ODD))
+                                       || ((__VALUE__) == LL_USART_PARITY_EVEN) \
+                                       || ((__VALUE__) == LL_USART_PARITY_ODD))
 
 #define IS_LL_USART_DATAWIDTH(__VALUE__) (((__VALUE__) == LL_USART_DATAWIDTH_7B) \
-                                       || ((__VALUE__) == LL_USART_DATAWIDTH_8B) \
-                                       || ((__VALUE__) == LL_USART_DATAWIDTH_9B))
+                                          || ((__VALUE__) == LL_USART_DATAWIDTH_8B) \
+                                          || ((__VALUE__) == LL_USART_DATAWIDTH_9B))
 
 #define IS_LL_USART_OVERSAMPLING(__VALUE__) (((__VALUE__) == LL_USART_OVERSAMPLING_16) \
-                                          || ((__VALUE__) == LL_USART_OVERSAMPLING_8))
+                                             || ((__VALUE__) == LL_USART_OVERSAMPLING_8))
 
 #define IS_LL_USART_LASTBITCLKOUTPUT(__VALUE__) (((__VALUE__) == LL_USART_LASTCLKPULSE_NO_OUTPUT) \
-                                              || ((__VALUE__) == LL_USART_LASTCLKPULSE_OUTPUT))
+                                                 || ((__VALUE__) == LL_USART_LASTCLKPULSE_OUTPUT))
 
 #define IS_LL_USART_CLOCKPHASE(__VALUE__) (((__VALUE__) == LL_USART_PHASE_1EDGE) \
-                                        || ((__VALUE__) == LL_USART_PHASE_2EDGE))
+                                           || ((__VALUE__) == LL_USART_PHASE_2EDGE))
 
 #define IS_LL_USART_CLOCKPOLARITY(__VALUE__) (((__VALUE__) == LL_USART_POLARITY_LOW) \
-                                           || ((__VALUE__) == LL_USART_POLARITY_HIGH))
+                                              || ((__VALUE__) == LL_USART_POLARITY_HIGH))
 
 #define IS_LL_USART_CLOCKOUTPUT(__VALUE__) (((__VALUE__) == LL_USART_CLOCK_DISABLE) \
-                                         || ((__VALUE__) == LL_USART_CLOCK_ENABLE))
+                                            || ((__VALUE__) == LL_USART_CLOCK_ENABLE))
 
 #define IS_LL_USART_STOPBITS(__VALUE__) (((__VALUE__) == LL_USART_STOPBITS_0_5) \
-                                      || ((__VALUE__) == LL_USART_STOPBITS_1) \
-                                      || ((__VALUE__) == LL_USART_STOPBITS_1_5) \
-                                      || ((__VALUE__) == LL_USART_STOPBITS_2))
+                                         || ((__VALUE__) == LL_USART_STOPBITS_1) \
+                                         || ((__VALUE__) == LL_USART_STOPBITS_1_5) \
+                                         || ((__VALUE__) == LL_USART_STOPBITS_2))
 
 #define IS_LL_USART_HWCONTROL(__VALUE__) (((__VALUE__) == LL_USART_HWCONTROL_NONE) \
-                                       || ((__VALUE__) == LL_USART_HWCONTROL_RTS) \
-                                       || ((__VALUE__) == LL_USART_HWCONTROL_CTS) \
-                                       || ((__VALUE__) == LL_USART_HWCONTROL_RTS_CTS))
+                                          || ((__VALUE__) == LL_USART_HWCONTROL_RTS) \
+                                          || ((__VALUE__) == LL_USART_HWCONTROL_CTS) \
+                                          || ((__VALUE__) == LL_USART_HWCONTROL_RTS_CTS))
 
 /**
   * @}
@@ -138,7 +136,7 @@
   *          - SUCCESS: USART registers are de-initialized
   *          - ERROR: USART registers are not de-initialized
   */
-ErrorStatus LL_USART_DeInit(USART_TypeDef *USARTx)
+ErrorStatus LL_USART_DeInit(const USART_TypeDef *USARTx)
 {
   ErrorStatus status = SUCCESS;
 
@@ -164,8 +162,9 @@ ErrorStatus LL_USART_DeInit(USART_TypeDef *USARTx)
 /**
   * @brief  Initialize USART registers according to the specified
   *         parameters in USART_InitStruct.
-  * @note   As some bits in USART configuration registers can only be written when the USART is disabled (USART_CR1_UE bit =0),
-  *         USART IP should be in disabled state prior calling this function. Otherwise, ERROR result will be returned.
+  * @note   As some bits in USART configuration registers can only be written when
+  *         the USART is disabled (USART_CR1_UE bit =0), USART Peripheral should be in disabled state prior calling
+  *         this function. Otherwise, ERROR result will be returned.
   * @note   Baud rate value stored in USART_InitStruct BaudRate field, should be valid (different from 0).
   * @param  USARTx USART Instance
   * @param  USART_InitStruct pointer to a LL_USART_InitTypeDef structure
@@ -174,7 +173,7 @@ ErrorStatus LL_USART_DeInit(USART_TypeDef *USARTx)
   *          - SUCCESS: USART registers are initialized according to USART_InitStruct content
   *          - ERROR: Problem occurred during USART Registers initialization
   */
-ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, LL_USART_InitTypeDef *USART_InitStruct)
+ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, const LL_USART_InitTypeDef *USART_InitStruct)
 {
   ErrorStatus status = ERROR;
   uint32_t periphclk = LL_RCC_PERIPH_FREQUENCY_NO;
@@ -216,7 +215,8 @@ ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, LL_USART_InitTypeDef *USART_Ini
 
     /*---------------------------- USART CR3 Configuration ---------------------
      * Configure USARTx CR3 (Hardware Flow Control) with parameters:
-     * - HardwareFlowControl: USART_CR3_RTSE, USART_CR3_CTSE bits according to USART_InitStruct->HardwareFlowControl value.
+     * - HardwareFlowControl: USART_CR3_RTSE, USART_CR3_CTSE bits according to
+     *   USART_InitStruct->HardwareFlowControl value.
      */
     LL_USART_SetHWFlowCtrl(USARTx, USART_InitStruct->HardwareFlowControl);
 
@@ -249,9 +249,6 @@ ErrorStatus LL_USART_Init(USART_TypeDef *USARTx, LL_USART_InitTypeDef *USART_Ini
 
       /* Check BRR is greater than or equal to 16d */
       assert_param(IS_LL_USART_BRR_MIN(USARTx->BRR));
-
-      /* Check BRR is lower than or equal to 0xFFFF */
-      assert_param(IS_LL_USART_BRR_MAX(USARTx->BRR));
     }
 
     /*---------------------------- USART PRESC Configuration -----------------------
@@ -276,7 +273,7 @@ void LL_USART_StructInit(LL_USART_InitTypeDef *USART_InitStruct)
 {
   /* Set USART_InitStruct fields to default values */
   USART_InitStruct->PrescalerValue      = LL_USART_PRESCALER_DIV1;
-  USART_InitStruct->BaudRate            = 9600U;
+  USART_InitStruct->BaudRate            = USART_DEFAULT_BAUDRATE;
   USART_InitStruct->DataWidth           = LL_USART_DATAWIDTH_8B;
   USART_InitStruct->StopBits            = LL_USART_STOPBITS_1;
   USART_InitStruct->Parity              = LL_USART_PARITY_NONE ;
@@ -288,16 +285,18 @@ void LL_USART_StructInit(LL_USART_InitTypeDef *USART_InitStruct)
 /**
   * @brief  Initialize USART Clock related settings according to the
   *         specified parameters in the USART_ClockInitStruct.
-  * @note   As some bits in USART configuration registers can only be written when the USART is disabled (USART_CR1_UE bit =0),
-  *         USART IP should be in disabled state prior calling this function. Otherwise, ERROR result will be returned.
+  * @note   As some bits in USART configuration registers can only be written when
+  *         the USART is disabled (USART_CR1_UE bit =0), USART Peripheral should be in disabled state prior calling
+  *         this function. Otherwise, ERROR result will be returned.
   * @param  USARTx USART Instance
   * @param  USART_ClockInitStruct pointer to a @ref LL_USART_ClockInitTypeDef structure
   *         that contains the Clock configuration information for the specified USART peripheral.
   * @retval An ErrorStatus enumeration value:
-  *          - SUCCESS: USART registers related to Clock settings are initialized according to USART_ClockInitStruct content
+  *          - SUCCESS: USART registers related to Clock settings are initialized according
+  *                     to USART_ClockInitStruct content
   *          - ERROR: Problem occurred during USART Registers initialization
   */
-ErrorStatus LL_USART_ClockInit(USART_TypeDef *USARTx, LL_USART_ClockInitTypeDef *USART_ClockInitStruct)
+ErrorStatus LL_USART_ClockInit(USART_TypeDef *USARTx, const LL_USART_ClockInitTypeDef *USART_ClockInitStruct)
 {
   ErrorStatus status = SUCCESS;
 
@@ -309,37 +308,25 @@ ErrorStatus LL_USART_ClockInit(USART_TypeDef *USARTx, LL_USART_ClockInitTypeDef 
      CRx registers */
   if (LL_USART_IsEnabled(USARTx) == 0U)
   {
-    /*---------------------------- USART CR2 Configuration -----------------------*/
-    /* If Clock signal has to be output */
-    if (USART_ClockInitStruct->ClockOutput == LL_USART_CLOCK_DISABLE)
-    {
-      /* Deactivate Clock signal delivery :
-       * - Disable Clock Output:        USART_CR2_CLKEN cleared
-       */
-      LL_USART_DisableSCLKOutput(USARTx);
-    }
-    else
-    {
-      /* Ensure USART instance is USART capable */
-      assert_param(IS_USART_INSTANCE(USARTx));
+    /* Ensure USART instance is USART capable */
+    assert_param(IS_USART_INSTANCE(USARTx));
 
-      /* Check clock related parameters */
-      assert_param(IS_LL_USART_CLOCKPOLARITY(USART_ClockInitStruct->ClockPolarity));
-      assert_param(IS_LL_USART_CLOCKPHASE(USART_ClockInitStruct->ClockPhase));
-      assert_param(IS_LL_USART_LASTBITCLKOUTPUT(USART_ClockInitStruct->LastBitClockPulse));
+    /* Check clock related parameters */
+    assert_param(IS_LL_USART_CLOCKPOLARITY(USART_ClockInitStruct->ClockPolarity));
+    assert_param(IS_LL_USART_CLOCKPHASE(USART_ClockInitStruct->ClockPhase));
+    assert_param(IS_LL_USART_LASTBITCLKOUTPUT(USART_ClockInitStruct->LastBitClockPulse));
 
-      /*---------------------------- USART CR2 Configuration -----------------------
-       * Configure USARTx CR2 (Clock signal related bits) with parameters:
-       * - Enable Clock Output:         USART_CR2_CLKEN set
-       * - Clock Polarity:              USART_CR2_CPOL bit according to USART_ClockInitStruct->ClockPolarity value
-       * - Clock Phase:                 USART_CR2_CPHA bit according to USART_ClockInitStruct->ClockPhase value
-       * - Last Bit Clock Pulse Output: USART_CR2_LBCL bit according to USART_ClockInitStruct->LastBitClockPulse value.
-       */
-      MODIFY_REG(USARTx->CR2,
-                 USART_CR2_CLKEN | USART_CR2_CPHA | USART_CR2_CPOL | USART_CR2_LBCL,
-                 USART_CR2_CLKEN | USART_ClockInitStruct->ClockPolarity |
-                 USART_ClockInitStruct->ClockPhase | USART_ClockInitStruct->LastBitClockPulse);
-    }
+    /*---------------------------- USART CR2 Configuration -----------------------
+     * Configure USARTx CR2 (Clock signal related bits) with parameters:
+     * - Clock Output:                USART_CR2_CLKEN bit according to USART_ClockInitStruct->ClockOutput value
+     * - Clock Polarity:              USART_CR2_CPOL bit according to USART_ClockInitStruct->ClockPolarity value
+     * - Clock Phase:                 USART_CR2_CPHA bit according to USART_ClockInitStruct->ClockPhase value
+     * - Last Bit Clock Pulse Output: USART_CR2_LBCL bit according to USART_ClockInitStruct->LastBitClockPulse value.
+     */
+    MODIFY_REG(USARTx->CR2,
+               USART_CR2_CLKEN | USART_CR2_CPHA | USART_CR2_CPOL | USART_CR2_LBCL,
+               USART_ClockInitStruct->ClockOutput | USART_ClockInitStruct->ClockPolarity |
+               USART_ClockInitStruct->ClockPhase | USART_ClockInitStruct->LastBitClockPulse);
   }
   /* Else (USART not in Disabled state => return ERROR */
   else
@@ -360,9 +347,12 @@ void LL_USART_ClockStructInit(LL_USART_ClockInitTypeDef *USART_ClockInitStruct)
 {
   /* Set LL_USART_ClockInitStruct fields with default values */
   USART_ClockInitStruct->ClockOutput       = LL_USART_CLOCK_DISABLE;
-  USART_ClockInitStruct->ClockPolarity     = LL_USART_POLARITY_LOW;            /* Not relevant when ClockOutput = LL_USART_CLOCK_DISABLE */
-  USART_ClockInitStruct->ClockPhase        = LL_USART_PHASE_1EDGE;             /* Not relevant when ClockOutput = LL_USART_CLOCK_DISABLE */
-  USART_ClockInitStruct->LastBitClockPulse = LL_USART_LASTCLKPULSE_NO_OUTPUT;  /* Not relevant when ClockOutput = LL_USART_CLOCK_DISABLE */
+  USART_ClockInitStruct->ClockPolarity     = LL_USART_POLARITY_LOW;            /* Not relevant when ClockOutput =
+                                                                                  LL_USART_CLOCK_DISABLE */
+  USART_ClockInitStruct->ClockPhase        = LL_USART_PHASE_1EDGE;             /* Not relevant when ClockOutput =
+                                                                                  LL_USART_CLOCK_DISABLE */
+  USART_ClockInitStruct->LastBitClockPulse = LL_USART_LASTCLKPULSE_NO_OUTPUT;  /* Not relevant when ClockOutput =
+                                                                                  LL_USART_CLOCK_DISABLE */
 }
 
 /**
@@ -385,5 +375,4 @@ void LL_USART_ClockStructInit(LL_USART_ClockInitTypeDef *USART_ClockInitStruct)
 
 #endif /* USE_FULL_LL_DRIVER */
 
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
 

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_usb.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_usb.c
@@ -11,29 +11,33 @@
   *           + Peripheral Control functions
   *           + Peripheral State functions
   *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
   @verbatim
   ==============================================================================
                     ##### How to use this driver #####
   ==============================================================================
     [..]
-      (#) Fill parameters of Init structure in USB_OTG_CfgTypeDef structure.
+      (#) Fill parameters of Init structure in USB_CfgTypeDef structure.
 
       (#) Call USB_CoreInit() API to initialize the USB Core peripheral.
 
       (#) The upper HAL HCD/PCD driver will call the right routines for its internal processes.
 
+      (#)NOTE: For applications not using double buffer mode, define the symbol
+                'USE_USB_DOUBLE_BUFFER' as 0 to reduce the driver's memory footprint.
+
   @endverbatim
-  ******************************************************************************
-  * @attention
-  *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
-  *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
-  *
+
   ******************************************************************************
   */
 
@@ -53,11 +57,10 @@
 /* Private function prototypes -----------------------------------------------*/
 /* Private functions ---------------------------------------------------------*/
 
-
 /**
   * @brief  Initializes the USB Core
-  * @param  USBx: USB Instance
-  * @param  cfg : pointer to a USB_CfgTypeDef structure that contains
+  * @param  USBx USB Instance
+  * @param  cfg pointer to a USB_CfgTypeDef structure that contains
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
@@ -78,12 +81,15 @@ HAL_StatusTypeDef USB_CoreInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
 /**
   * @brief  USB_EnableGlobalInt
   *         Enables the controller's Global Int in the AHB Config reg
-  * @param  USBx : Selected device
+  * @param  USBx Selected device
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx)
 {
   uint32_t winterruptmask;
+
+  /* Clear pending interrupts */
+  USBx->ISTR = 0U;
 
   /* Set winterruptmask variable */
   winterruptmask = USB_CNTR_CTRM  | USB_CNTR_WKUPM |
@@ -92,7 +98,7 @@ HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx)
                    USB_CNTR_RESETM | USB_CNTR_L1REQM;
 
   /* Set interrupt mask */
-  USBx->CNTR |= (uint16_t)winterruptmask;
+  USBx->CNTR = (uint16_t)winterruptmask;
 
   return HAL_OK;
 }
@@ -100,9 +106,9 @@ HAL_StatusTypeDef USB_EnableGlobalInt(USB_TypeDef *USBx)
 /**
   * @brief  USB_DisableGlobalInt
   *         Disable the controller's Global Int in the AHB Config reg
-  * @param  USBx : Selected device
+  * @param  USBx Selected device
   * @retval HAL status
-*/
+  */
 HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx)
 {
   uint32_t winterruptmask;
@@ -120,11 +126,11 @@ HAL_StatusTypeDef USB_DisableGlobalInt(USB_TypeDef *USBx)
 }
 
 /**
-  * @brief  USB_SetCurrentMode : Set functional mode
-  * @param  USBx : Selected device
-  * @param  mode :  current core mode
+  * @brief  USB_SetCurrentMode Set functional mode
+  * @param  USBx Selected device
+  * @param  mode current core mode
   *          This parameter can be one of the these values:
-  *            @arg USB_DEVICE_MODE: Peripheral mode mode
+  *            @arg USB_DEVICE_MODE Peripheral mode
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode)
@@ -141,10 +147,10 @@ HAL_StatusTypeDef USB_SetCurrentMode(USB_TypeDef *USBx, USB_ModeTypeDef mode)
 }
 
 /**
-  * @brief  USB_DevInit : Initializes the USB controller registers
+  * @brief  USB_DevInit Initializes the USB controller registers
   *         for device mode
-  * @param  USBx : Selected device
-  * @param  cfg  : pointer to a USB_CfgTypeDef structure that contains
+  * @param  USBx Selected device
+  * @param  cfg  pointer to a USB_CfgTypeDef structure that contains
   *         the configuration information for the specified USBx peripheral.
   * @retval HAL status
   */
@@ -154,41 +160,17 @@ HAL_StatusTypeDef USB_DevInit(USB_TypeDef *USBx, USB_CfgTypeDef cfg)
   UNUSED(cfg);
 
   /* Init Device */
-  /*CNTR_FRES = 1*/
+  /* CNTR_FRES = 1 */
   USBx->CNTR = (uint16_t)USB_CNTR_FRES;
 
-  /*CNTR_FRES = 0*/
+  /* CNTR_FRES = 0 */
   USBx->CNTR = 0U;
 
-  /*Clear pending interrupts*/
+  /* Clear pending interrupts */
   USBx->ISTR = 0U;
 
   /*Set Btable Address*/
   USBx->BTABLE = BTABLE_ADDRESS;
-
-  /* Enable USB Device Interrupt mask */
-  (void)USB_EnableGlobalInt(USBx);
-
-  return HAL_OK;
-}
-
-/**
-  * @brief  USB_SetDevSpeed :Initializes the device speed
-  *         depending on the PHY type and the enumeration speed of the device.
-  * @param  USBx  Selected device
-  * @param  speed  device speed
-  * @retval  Hal status
-  */
-HAL_StatusTypeDef USB_SetDevSpeed(USB_TypeDef *USBx, uint8_t speed)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(speed);
-
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
 
   return HAL_OK;
 }
@@ -201,7 +183,7 @@ HAL_StatusTypeDef USB_SetDevSpeed(USB_TypeDef *USBx, uint8_t speed)
             15 means Flush all Tx FIFOs
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_FlushTxFifo(USB_TypeDef *USBx, uint32_t num)
+HAL_StatusTypeDef USB_FlushTxFifo(USB_TypeDef const *USBx, uint32_t num)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(USBx);
@@ -220,7 +202,7 @@ HAL_StatusTypeDef USB_FlushTxFifo(USB_TypeDef *USBx, uint32_t num)
   * @param  USBx : Selected device
   * @retval HAL status
   */
-HAL_StatusTypeDef USB_FlushRxFifo(USB_TypeDef *USBx)
+HAL_StatusTypeDef USB_FlushRxFifo(USB_TypeDef const *USBx)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(USBx);
@@ -233,10 +215,12 @@ HAL_StatusTypeDef USB_FlushRxFifo(USB_TypeDef *USBx)
   return HAL_OK;
 }
 
+
+#if defined (HAL_PCD_MODULE_ENABLED)
 /**
   * @brief  Activate and configure an endpoint
-  * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
@@ -295,20 +279,40 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
     }
     else
     {
-      /*Set the endpoint Receive buffer address */
+      /* Set the endpoint Receive buffer address */
       PCD_SET_EP_RX_ADDRESS(USBx, ep->num, ep->pmaadress);
-      /*Set the endpoint Receive buffer counter*/
+
+      /* Set the endpoint Receive buffer counter */
       PCD_SET_EP_RX_CNT(USBx, ep->num, ep->maxpacket);
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
-      /* Configure VALID status for the Endpoint*/
-      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+
+      if (ep->num == 0U)
+      {
+        /* Configure VALID status for EP0 */
+        PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+      }
+      else
+      {
+        /* Configure NAK status for OUT Endpoint */
+        PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_NAK);
+      }
     }
   }
-  /*Double Buffer*/
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+  /* Double Buffer */
   else
   {
-    /* Set the endpoint as double buffered */
-    PCD_SET_EP_DBUF(USBx, ep->num);
+    if (ep->type == EP_TYPE_BULK)
+    {
+      /* Set bulk endpoint as double buffered */
+      PCD_SET_BULK_EP_DBUF(USBx, ep->num);
+    }
+    else
+    {
+      /* Set the ISOC endpoint in double buffer mode */
+      PCD_CLEAR_EP_KIND(USBx, ep->num);
+    }
+
     /* Set buffer address for double buffered mode */
     PCD_SET_EP_DBUF_ADDR(USBx, ep->num, ep->pmaaddr0, ep->pmaaddr1);
 
@@ -318,9 +322,10 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
 
-      /* Reset value of the data toggle bits for the endpoint out */
-      PCD_TX_DTOG(USBx, ep->num);
+      /* Set endpoint RX count */
+      PCD_SET_EP_DBUF_CNT(USBx, ep->num, ep->is_in, ep->maxpacket);
 
+      /* Set endpoint RX to valid state */
       PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
       PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
     }
@@ -329,7 +334,6 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       /* Clear the data toggle bits for the endpoint IN/OUT */
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      PCD_RX_DTOG(USBx, ep->num);
 
       if (ep->type != EP_TYPE_ISOC)
       {
@@ -345,14 +349,15 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
     }
   }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
   return ret;
 }
 
 /**
   * @brief  De-activate and de-initialize an endpoint
-  * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
@@ -362,17 +367,21 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
     if (ep->is_in != 0U)
     {
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
-      /* Configure DISABLE status for the Endpoint*/
+
+      /* Configure DISABLE status for the Endpoint */
       PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
     }
+
     else
     {
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
-      /* Configure DISABLE status for the Endpoint*/
+
+      /* Configure DISABLE status for the Endpoint */
       PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
     }
   }
-  /*Double Buffer*/
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+  /* Double Buffer */
   else
   {
     if (ep->is_in == 0U)
@@ -393,39 +402,42 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       PCD_CLEAR_RX_DTOG(USBx, ep->num);
       PCD_CLEAR_TX_DTOG(USBx, ep->num);
       PCD_RX_DTOG(USBx, ep->num);
+
       /* Configure DISABLE status for the Endpoint*/
       PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
       PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
     }
   }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
   return HAL_OK;
 }
 
 /**
-  * @brief  USB_EPStartXfer : setup and starts a transfer over an EP
-  * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure
+  * @brief  USB_EPStartXfer setup and starts a transfer over an EP
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx, USB_EPTypeDef *ep)
 {
-  uint16_t pmabuffer;
   uint32_t len;
+#if (USE_USB_DOUBLE_BUFFER == 1U)
+  uint16_t pmabuffer;
+  uint16_t wEPVal;
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
   /* IN endpoint */
   if (ep->is_in == 1U)
   {
-    /*Multi packet transfer*/
+    /* Multi packet transfer */
     if (ep->xfer_len > ep->maxpacket)
     {
       len = ep->maxpacket;
-      ep->xfer_len -= len;
     }
     else
     {
       len = ep->xfer_len;
-      ep->xfer_len = 0U;
     }
 
     /* configure and validate Tx endpoint */
@@ -434,52 +446,179 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx, USB_EPTypeDef *ep)
       USB_WritePMA(USBx, ep->xfer_buff, ep->pmaadress, (uint16_t)len);
       PCD_SET_EP_TX_CNT(USBx, ep->num, len);
     }
+#if (USE_USB_DOUBLE_BUFFER == 1U)
     else
     {
-      /* Write the data to the USB endpoint */
-      if ((PCD_GET_ENDPOINT(USBx, ep->num) & USB_EP_DTOG_TX) != 0U)
+      /* double buffer bulk management */
+      if (ep->type == EP_TYPE_BULK)
       {
-        /* Set the Double buffer counter for pmabuffer1 */
-        PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
-        pmabuffer = ep->pmaaddr1;
+        if (ep->xfer_len_db > ep->maxpacket)
+        {
+          /* enable double buffer */
+          PCD_SET_BULK_EP_DBUF(USBx, ep->num);
+
+          /* each Time to write in PMA xfer_len_db will */
+          ep->xfer_len_db -= len;
+
+          /* Fill the two first buffer in the Buffer0 & Buffer1 */
+          if ((PCD_GET_ENDPOINT(USBx, ep->num) & USB_EP_DTOG_TX) != 0U)
+          {
+            /* Set the Double buffer counter for pmabuffer1 */
+            PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr1;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+            ep->xfer_buff += len;
+
+            if (ep->xfer_len_db > ep->maxpacket)
+            {
+              ep->xfer_len_db -= len;
+            }
+            else
+            {
+              len = ep->xfer_len_db;
+              ep->xfer_len_db = 0U;
+            }
+
+            /* Set the Double buffer counter for pmabuffer0 */
+            PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr0;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+          }
+          else
+          {
+            /* Set the Double buffer counter for pmabuffer0 */
+            PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr0;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+            ep->xfer_buff += len;
+
+            if (ep->xfer_len_db > ep->maxpacket)
+            {
+              ep->xfer_len_db -= len;
+            }
+            else
+            {
+              len = ep->xfer_len_db;
+              ep->xfer_len_db = 0U;
+            }
+
+            /* Set the Double buffer counter for pmabuffer1 */
+            PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
+            pmabuffer = ep->pmaaddr1;
+
+            /* Write the user buffer to USB PMA */
+            USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+          }
+        }
+        /* auto Switch to single buffer mode when transfer <Mps no need to manage in double buffer */
+        else
+        {
+          len = ep->xfer_len_db;
+
+          /* disable double buffer mode for Bulk endpoint */
+          PCD_CLEAR_BULK_EP_DBUF(USBx, ep->num);
+
+          /* Set Tx count with nbre of byte to be transmitted */
+          PCD_SET_EP_TX_CNT(USBx, ep->num, len);
+          pmabuffer = ep->pmaaddr0;
+
+          /* Write the user buffer to USB PMA */
+          USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+        }
       }
-      else
+      else /* Manage isochronous double buffer IN mode */
       {
-        /* Set the Double buffer counter for pmabuffer0 */
-        PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
-        pmabuffer = ep->pmaaddr0;
+        /* Each Time to write in PMA xfer_len_db will */
+        ep->xfer_len_db -= len;
+
+        /* Fill the data buffer */
+        if ((PCD_GET_ENDPOINT(USBx, ep->num) & USB_EP_DTOG_TX) != 0U)
+        {
+          /* Set the Double buffer counter for pmabuffer1 */
+          PCD_SET_EP_DBUF1_CNT(USBx, ep->num, ep->is_in, len);
+          pmabuffer = ep->pmaaddr1;
+
+          /* Write the user buffer to USB PMA */
+          USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+        }
+        else
+        {
+          /* Set the Double buffer counter for pmabuffer0 */
+          PCD_SET_EP_DBUF0_CNT(USBx, ep->num, ep->is_in, len);
+          pmabuffer = ep->pmaaddr0;
+
+          /* Write the user buffer to USB PMA */
+          USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
+        }
       }
-      USB_WritePMA(USBx, ep->xfer_buff, pmabuffer, (uint16_t)len);
-      PCD_FreeUserBuffer(USBx, ep->num, ep->is_in);
     }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
     PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_VALID);
   }
   else /* OUT endpoint */
   {
-    /* Multi packet transfer*/
-    if (ep->xfer_len > ep->maxpacket)
-    {
-      len = ep->maxpacket;
-      ep->xfer_len -= len;
-    }
-    else
-    {
-      len = ep->xfer_len;
-      ep->xfer_len = 0U;
-    }
-
-    /* configure and validate Rx endpoint */
     if (ep->doublebuffer == 0U)
     {
-      /*Set RX buffer count*/
-      PCD_SET_EP_RX_CNT(USBx, ep->num, len);
+      if ((ep->xfer_len == 0U) && (ep->type == EP_TYPE_CTRL))
+      {
+        /* This is a status out stage set the OUT_STATUS */
+        PCD_SET_OUT_STATUS(USBx, ep->num);
+      }
+      else
+      {
+        PCD_CLEAR_OUT_STATUS(USBx, ep->num);
+      }
+
+      /* Multi packet transfer */
+      if (ep->xfer_len > ep->maxpacket)
+      {
+        ep->xfer_len -= ep->maxpacket;
+      }
+      else
+      {
+        ep->xfer_len = 0U;
+      }
     }
+#if (USE_USB_DOUBLE_BUFFER == 1U)
     else
     {
-      /*Set the Double buffer counter*/
-      PCD_SET_EP_DBUF_CNT(USBx, ep->num, ep->is_in, len);
+      /* First Transfer Coming From HAL_PCD_EP_Receive & From ISR */
+      /* Set the Double buffer counter */
+      if (ep->type == EP_TYPE_BULK)
+      {
+        /* Coming from ISR */
+        if (ep->xfer_count != 0U)
+        {
+          /* Update last value to check if there is blocking state */
+          wEPVal = PCD_GET_ENDPOINT(USBx, ep->num);
+
+          /* Blocking State */
+          if ((((wEPVal & USB_EP_DTOG_RX) != 0U) && ((wEPVal & USB_EP_DTOG_TX) != 0U)) ||
+              (((wEPVal & USB_EP_DTOG_RX) == 0U) && ((wEPVal & USB_EP_DTOG_TX) == 0U)))
+          {
+            PCD_FREE_USER_BUFFER(USBx, ep->num, 0U);
+          }
+        }
+      }
+      /* iso out double */
+      else if (ep->type == EP_TYPE_ISOC)
+      {
+        /* Only single packet transfer supported in FS */
+        ep->xfer_len = 0U;
+      }
+      else
+      {
+        return HAL_ERROR;
+      }
     }
+#endif /* (USE_USB_DOUBLE_BUFFER == 1U) */
 
     PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
   }
@@ -487,54 +626,11 @@ HAL_StatusTypeDef USB_EPStartXfer(USB_TypeDef *USBx, USB_EPTypeDef *ep)
   return HAL_OK;
 }
 
-/**
-  * @brief  USB_WritePacket : Writes a packet into the Tx FIFO associated
-  *         with the EP/channel
-  * @param  USBx : Selected device
-  * @param  src :  pointer to source buffer
-  * @param  ch_ep_num : endpoint or host channel number
-  * @param  len : Number of bytes to write
-  * @retval HAL status
-  */
-HAL_StatusTypeDef USB_WritePacket(USB_TypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(src);
-  UNUSED(ch_ep_num);
-  UNUSED(len);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return HAL_OK;
-}
 
 /**
-  * @brief  USB_ReadPacket : read a packet from the Tx FIFO associated
-  *         with the EP/channel
-  * @param  USBx : Selected device
-  * @param  dest : destination pointer
-  * @param  len : Number of bytes to read
-  * @retval pointer to destination buffer
-  */
-void *USB_ReadPacket(USB_TypeDef *USBx, uint8_t *dest, uint16_t len)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(dest);
-  UNUSED(len);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return ((void *)NULL);
-}
-
-/**
-  * @brief  USB_EPSetStall : set a stall condition over an EP
-  * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure
+  * @brief  USB_EPSetStall set a stall condition over an EP
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EPSetStall(USB_TypeDef *USBx, USB_EPTypeDef *ep)
@@ -552,40 +648,83 @@ HAL_StatusTypeDef USB_EPSetStall(USB_TypeDef *USBx, USB_EPTypeDef *ep)
 }
 
 /**
-  * @brief  USB_EPClearStall : Clear a stall condition over an EP
-  * @param  USBx : Selected device
-  * @param  ep: pointer to endpoint structure
+  * @brief  USB_EPClearStall Clear a stall condition over an EP
+  * @param  USBx Selected device
+  * @param  ep pointer to endpoint structure
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_EPClearStall(USB_TypeDef *USBx, USB_EPTypeDef *ep)
 {
-  if (ep->doublebuffer == 0U)
+  if (ep->is_in != 0U)
   {
-    if (ep->is_in != 0U)
-    {
-      PCD_CLEAR_TX_DTOG(USBx, ep->num);
+    PCD_CLEAR_TX_DTOG(USBx, ep->num);
 
-      if (ep->type != EP_TYPE_ISOC)
-      {
-        /* Configure NAK status for the Endpoint */
-        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
-      }
-    }
-    else
+    if (ep->type != EP_TYPE_ISOC)
     {
-      PCD_CLEAR_RX_DTOG(USBx, ep->num);
-
-      /* Configure VALID status for the Endpoint*/
-      PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
+      /* Configure NAK status for the Endpoint */
+      PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
     }
+  }
+  else
+  {
+    PCD_CLEAR_RX_DTOG(USBx, ep->num);
+
+    /* Configure VALID status for the Endpoint */
+    PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_VALID);
   }
 
   return HAL_OK;
 }
 
 /**
-  * @brief  USB_StopDevice : Stop the usb device mode
-  * @param  USBx : Selected device
+   * @brief  USB_EPStoptXfer  Stop transfer on an EP
+   * @param  USBx  usb device instance
+   * @param  ep pointer to endpoint structure
+   * @retval HAL status
+   */
+HAL_StatusTypeDef USB_EPStopXfer(USB_TypeDef *USBx, USB_EPTypeDef *ep)
+{
+  /* IN endpoint */
+  if (ep->is_in == 1U)
+  {
+    if (ep->doublebuffer == 0U)
+    {
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Configure NAK status for the Endpoint */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_NAK);
+      }
+      else
+      {
+        /* Configure TX Endpoint to disabled state */
+        PCD_SET_EP_TX_STATUS(USBx, ep->num, USB_EP_TX_DIS);
+      }
+    }
+  }
+  else /* OUT endpoint */
+  {
+    if (ep->doublebuffer == 0U)
+    {
+      if (ep->type != EP_TYPE_ISOC)
+      {
+        /* Configure NAK status for the Endpoint */
+        PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_NAK);
+      }
+      else
+      {
+        /* Configure RX Endpoint to disabled state */
+        PCD_SET_EP_RX_STATUS(USBx, ep->num, USB_EP_RX_DIS);
+      }
+    }
+  }
+
+  return HAL_OK;
+}
+#endif /* defined (HAL_PCD_MODULE_ENABLED) */
+
+/**
+  * @brief  USB_StopDevice Stop the usb device mode
+  * @param  USBx Selected device
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_StopDevice(USB_TypeDef *USBx)
@@ -603,9 +742,9 @@ HAL_StatusTypeDef USB_StopDevice(USB_TypeDef *USBx)
 }
 
 /**
-  * @brief  USB_SetDevAddress : Stop the usb device mode
-  * @param  USBx : Selected device
-  * @param  address : new device address to be assigned
+  * @brief  USB_SetDevAddress Stop the usb device mode
+  * @param  USBx Selected device
+  * @param  address new device address to be assigned
   *          This parameter can be a value from 0 to 255
   * @retval HAL status
   */
@@ -621,8 +760,8 @@ HAL_StatusTypeDef  USB_SetDevAddress(USB_TypeDef *USBx, uint8_t address)
 }
 
 /**
-  * @brief  USB_DevConnect : Connect the USB device by enabling the pull-up/pull-down
-  * @param  USBx : Selected device
+  * @brief  USB_DevConnect Connect the USB device by enabling the pull-up/pull-down
+  * @param  USBx Selected device
   * @retval HAL status
   */
 HAL_StatusTypeDef  USB_DevConnect(USB_TypeDef *USBx)
@@ -634,8 +773,8 @@ HAL_StatusTypeDef  USB_DevConnect(USB_TypeDef *USBx)
 }
 
 /**
-  * @brief  USB_DevDisconnect : Disconnect the USB device by disabling the pull-up/pull-down
-  * @param  USBx : Selected device
+  * @brief  USB_DevDisconnect Disconnect the USB device by disabling the pull-up/pull-down
+  * @param  USBx Selected device
   * @retval HAL status
   */
 HAL_StatusTypeDef  USB_DevDisconnect(USB_TypeDef *USBx)
@@ -647,11 +786,11 @@ HAL_StatusTypeDef  USB_DevDisconnect(USB_TypeDef *USBx)
 }
 
 /**
-  * @brief  USB_ReadInterrupts: return the global USB interrupt status
-  * @param  USBx : Selected device
-  * @retval HAL status
+  * @brief  USB_ReadInterrupts return the global USB interrupt status
+  * @param  USBx Selected device
+  * @retval USB Global Interrupt status
   */
-uint32_t  USB_ReadInterrupts(USB_TypeDef *USBx)
+uint32_t USB_ReadInterrupts(USB_TypeDef const *USBx)
 {
   uint32_t tmpreg;
 
@@ -660,113 +799,8 @@ uint32_t  USB_ReadInterrupts(USB_TypeDef *USBx)
 }
 
 /**
-  * @brief  USB_ReadDevAllOutEpInterrupt: return the USB device OUT endpoints interrupt status
-  * @param  USBx : Selected device
-  * @retval HAL status
-  */
-uint32_t USB_ReadDevAllOutEpInterrupt(USB_TypeDef *USBx)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return (0);
-}
-
-/**
-  * @brief  USB_ReadDevAllInEpInterrupt: return the USB device IN endpoints interrupt status
-  * @param  USBx : Selected device
-  * @retval HAL status
-  */
-uint32_t USB_ReadDevAllInEpInterrupt(USB_TypeDef *USBx)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return (0);
-}
-
-/**
-  * @brief  Returns Device OUT EP Interrupt register
-  * @param  USBx : Selected device
-  * @param  epnum : endpoint number
-  *          This parameter can be a value from 0 to 15
-  * @retval Device OUT EP Interrupt register
-  */
-uint32_t USB_ReadDevOutEPInterrupt(USB_TypeDef *USBx, uint8_t epnum)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(epnum);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return (0);
-}
-
-/**
-  * @brief  Returns Device IN EP Interrupt register
-  * @param  USBx : Selected device
-  * @param  epnum : endpoint number
-  *          This parameter can be a value from 0 to 15
-  * @retval Device IN EP Interrupt register
-  */
-uint32_t USB_ReadDevInEPInterrupt(USB_TypeDef *USBx, uint8_t epnum)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(epnum);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return (0);
-}
-
-/**
-  * @brief  USB_ClearInterrupts: clear a USB interrupt
-  * @param  USBx  Selected device
-  * @param  interrupt  interrupt flag
-  * @retval None
-  */
-void  USB_ClearInterrupts(USB_TypeDef *USBx, uint32_t interrupt)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(interrupt);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-}
-
-/**
-  * @brief  Prepare the EP0 to start the first control setup
-  * @param  USBx  Selected device
-  * @param  psetup  pointer to setup packet
-  * @retval HAL status
-  */
-HAL_StatusTypeDef USB_EP0_OutStart(USB_TypeDef *USBx, uint8_t *psetup)
-{
-  /* Prevent unused argument(s) compilation warning */
-  UNUSED(USBx);
-  UNUSED(psetup);
-  /* NOTE : - This function is not required by USB Device FS peripheral, it is used
-              only by USB OTG FS peripheral.
-            - This function is added to ensure compatibility across platforms.
-   */
-  return HAL_OK;
-}
-
-/**
   * @brief  USB_ActivateRemoteWakeup : active remote wakeup signalling
-  * @param  USBx  Selected device
+  * @param  USBx Selected device
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_ActivateRemoteWakeup(USB_TypeDef *USBx)
@@ -777,13 +811,14 @@ HAL_StatusTypeDef USB_ActivateRemoteWakeup(USB_TypeDef *USBx)
 }
 
 /**
-  * @brief  USB_DeActivateRemoteWakeup : de-active remote wakeup signalling
-  * @param  USBx  Selected device
+  * @brief  USB_DeActivateRemoteWakeup de-active remote wakeup signalling
+  * @param  USBx Selected device
   * @retval HAL status
   */
 HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_TypeDef *USBx)
 {
   USBx->CNTR &= (uint16_t)(~USB_CNTR_RESUME);
+
   return HAL_OK;
 }
 
@@ -792,71 +827,73 @@ HAL_StatusTypeDef USB_DeActivateRemoteWakeup(USB_TypeDef *USBx)
   * @param   USBx USB peripheral instance register address.
   * @param   pbUsrBuf pointer to user memory area.
   * @param   wPMABufAddr address into PMA.
-  * @param   wNBytes: no. of bytes to be copied.
+  * @param   wNBytes no. of bytes to be copied.
   * @retval None
   */
-void USB_WritePMA(USB_TypeDef *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+void USB_WritePMA(USB_TypeDef const *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
 {
   uint32_t n = ((uint32_t)wNBytes + 1U) >> 1;
   uint32_t BaseAddr = (uint32_t)USBx;
-  uint32_t i, temp1, temp2;
+  uint32_t count;
+  uint16_t WrVal;
   __IO uint16_t *pdwVal;
   uint8_t *pBuf = pbUsrBuf;
 
   pdwVal = (__IO uint16_t *)(BaseAddr + 0x400U + ((uint32_t)wPMABufAddr * PMA_ACCESS));
 
-  for (i = n; i != 0U; i--)
+  for (count = n; count != 0U; count--)
   {
-    temp1 = *pBuf;
-    pBuf++;
-    temp2 = temp1 | ((uint16_t)((uint16_t) *pBuf << 8));
-    *pdwVal = (uint16_t)temp2;
+    WrVal = pBuf[0];
+    WrVal |= (uint16_t)pBuf[1] << 8;
+    *pdwVal = (WrVal & 0xFFFFU);
     pdwVal++;
 
 #if PMA_ACCESS > 1U
     pdwVal++;
-#endif
+#endif /* PMA_ACCESS */
 
+    pBuf++;
     pBuf++;
   }
 }
 
 /**
-  * @brief Copy a buffer from user memory area to packet memory area (PMA)
-  * @param   USBx: USB peripheral instance register address.
+  * @brief Copy data from packet memory area (PMA) to user memory buffer
+  * @param   USBx USB peripheral instance register address.
   * @param   pbUsrBuf pointer to user memory area.
   * @param   wPMABufAddr address into PMA.
-  * @param   wNBytes: no. of bytes to be copied.
+  * @param   wNBytes no. of bytes to be copied.
   * @retval None
   */
-void USB_ReadPMA(USB_TypeDef *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
+void USB_ReadPMA(USB_TypeDef const *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
 {
   uint32_t n = (uint32_t)wNBytes >> 1;
   uint32_t BaseAddr = (uint32_t)USBx;
-  uint32_t i, temp;
+  uint32_t count;
+  uint32_t RdVal;
   __IO uint16_t *pdwVal;
   uint8_t *pBuf = pbUsrBuf;
 
   pdwVal = (__IO uint16_t *)(BaseAddr + 0x400U + ((uint32_t)wPMABufAddr * PMA_ACCESS));
 
-  for (i = n; i != 0U; i--)
+  for (count = n; count != 0U; count--)
   {
-    temp = *(__IO uint16_t *)pdwVal;
+    RdVal = *(__IO uint16_t *)pdwVal;
     pdwVal++;
-    *pBuf = (uint8_t)((temp >> 0) & 0xFFU);
+    *pBuf = (uint8_t)((RdVal >> 0) & 0xFFU);
     pBuf++;
-    *pBuf = (uint8_t)((temp >> 8) & 0xFFU);
+    *pBuf = (uint8_t)((RdVal >> 8) & 0xFFU);
     pBuf++;
 
 #if PMA_ACCESS > 1U
     pdwVal++;
-#endif
+#endif /* PMA_ACCESS */
   }
 
   if ((wNBytes % 2U) != 0U)
   {
-    temp = *pdwVal;
-    *pBuf = (uint8_t)((temp >> 0) & 0xFFU);
+    RdVal = *pdwVal;
+    *pBuf = (uint8_t)((RdVal >> 0) & 0xFFU);
   }
 }
 
@@ -874,5 +911,3 @@ void USB_ReadPMA(USB_TypeDef *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uin
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_utils.c
+++ b/STM32WBxx_HAL_Driver/Src/stm32wbxx_ll_utils.c
@@ -6,13 +6,12 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; Copyright (c) 2019 STMicroelectronics.
-  * All rights reserved.</center></h2>
+  * Copyright (c) 2019 STMicroelectronics.
+  * All rights reserved.
   *
-  * This software component is licensed by ST under BSD 3-Clause license,
-  * the "License"; You may not use this file except in compliance with the
-  * License. You may obtain a copy of the License at:
-  *                        opensource.org/licenses/BSD-3-Clause
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
   */
@@ -25,7 +24,7 @@
 #include "stm32_assert.h"
 #else
 #define assert_param(expr) ((void)0U)
-#endif
+#endif /* USE_FULL_ASSERT */
 
 /** @addtogroup STM32WBxx_LL_Driver
   * @{
@@ -44,7 +43,7 @@
 #define UTILS_MAX_FREQUENCY_SCALE1  64000000U        /*!< Maximum frequency for system clock at power scale1, in Hz */
 #if defined(PWR_CR1_VOS)
 #define UTILS_MAX_FREQUENCY_SCALE2  16000000U        /*!< Maximum frequency for system clock at power scale2, in Hz */
-#endif
+#endif /* PWR_CR1_VOS */
 
 /* Defines used for PLL range */
 #define UTILS_PLLVCO_INPUT_MIN        2660000U       /*!< Frequency min for PLLVCO input, in Hz   */
@@ -64,64 +63,66 @@
   * @{
   */
 #define IS_LL_UTILS_SYSCLK_DIV(__VALUE__) (((__VALUE__) == LL_RCC_SYSCLK_DIV_1)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_2)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_3)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_4)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_5)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_6)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_8)   \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_10)  \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_16)  \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_32)  \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_64)  \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_128) \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_256) \
-                                        || ((__VALUE__) == LL_RCC_SYSCLK_DIV_512))
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_2)   \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_3)   \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_4)   \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_5)   \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_6)   \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_8)   \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_10)  \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_16)  \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_32)  \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_64)  \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_128) \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_256) \
+                                           || ((__VALUE__) == LL_RCC_SYSCLK_DIV_512))
 
 #define IS_LL_UTILS_APB1_DIV(__VALUE__) (((__VALUE__) == LL_RCC_APB1_DIV_1) \
-                                      || ((__VALUE__) == LL_RCC_APB1_DIV_2) \
-                                      || ((__VALUE__) == LL_RCC_APB1_DIV_4) \
-                                      || ((__VALUE__) == LL_RCC_APB1_DIV_8) \
-                                      || ((__VALUE__) == LL_RCC_APB1_DIV_16))
+                                         || ((__VALUE__) == LL_RCC_APB1_DIV_2) \
+                                         || ((__VALUE__) == LL_RCC_APB1_DIV_4) \
+                                         || ((__VALUE__) == LL_RCC_APB1_DIV_8) \
+                                         || ((__VALUE__) == LL_RCC_APB1_DIV_16))
 
 #define IS_LL_UTILS_APB2_DIV(__VALUE__) (((__VALUE__) == LL_RCC_APB2_DIV_1) \
-                                      || ((__VALUE__) == LL_RCC_APB2_DIV_2) \
-                                      || ((__VALUE__) == LL_RCC_APB2_DIV_4) \
-                                      || ((__VALUE__) == LL_RCC_APB2_DIV_8) \
-                                      || ((__VALUE__) == LL_RCC_APB2_DIV_16))
+                                         || ((__VALUE__) == LL_RCC_APB2_DIV_2) \
+                                         || ((__VALUE__) == LL_RCC_APB2_DIV_4) \
+                                         || ((__VALUE__) == LL_RCC_APB2_DIV_8) \
+                                         || ((__VALUE__) == LL_RCC_APB2_DIV_16))
 
 #define IS_LL_UTILS_PLLM_VALUE(__VALUE__) (((__VALUE__) == LL_RCC_PLLM_DIV_1) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_2) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_3) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_4) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_5) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_6) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_7) \
-                                        || ((__VALUE__) == LL_RCC_PLLM_DIV_8))
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_2) \
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_3) \
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_4) \
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_5) \
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_6) \
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_7) \
+                                           || ((__VALUE__) == LL_RCC_PLLM_DIV_8))
 
 #define IS_LL_UTILS_PLLN_VALUE(__VALUE__) ((6U <= (__VALUE__)) && ((__VALUE__) <= 127U))
 
 #define IS_LL_UTILS_PLLR_VALUE(__VALUE__) (((__VALUE__) == LL_RCC_PLLR_DIV_2) \
-                                        || ((__VALUE__) == LL_RCC_PLLR_DIV_3) \
-                                        || ((__VALUE__) == LL_RCC_PLLR_DIV_4) \
-                                        || ((__VALUE__) == LL_RCC_PLLR_DIV_5) \
-                                        || ((__VALUE__) == LL_RCC_PLLR_DIV_6) \
-                                        || ((__VALUE__) == LL_RCC_PLLR_DIV_7) \
-                                        || ((__VALUE__) == LL_RCC_PLLR_DIV_8))
+                                           || ((__VALUE__) == LL_RCC_PLLR_DIV_3) \
+                                           || ((__VALUE__) == LL_RCC_PLLR_DIV_4) \
+                                           || ((__VALUE__) == LL_RCC_PLLR_DIV_5) \
+                                           || ((__VALUE__) == LL_RCC_PLLR_DIV_6) \
+                                           || ((__VALUE__) == LL_RCC_PLLR_DIV_7) \
+                                           || ((__VALUE__) == LL_RCC_PLLR_DIV_8))
 
-#define IS_LL_UTILS_PLLVCO_INPUT(__VALUE__)  ((UTILS_PLLVCO_INPUT_MIN <= (__VALUE__)) && ((__VALUE__) <= UTILS_PLLVCO_INPUT_MAX))
+#define IS_LL_UTILS_PLLVCO_INPUT(__VALUE__)  ((UTILS_PLLVCO_INPUT_MIN <= (__VALUE__)) &&\
+                                              ((__VALUE__) <= UTILS_PLLVCO_INPUT_MAX))
 
-#define IS_LL_UTILS_PLLVCO_OUTPUT(__VALUE__) ((UTILS_PLLVCO_OUTPUT_MIN <= (__VALUE__)) && ((__VALUE__) <= UTILS_PLLVCO_OUTPUT_MAX))
+#define IS_LL_UTILS_PLLVCO_OUTPUT(__VALUE__) ((UTILS_PLLVCO_OUTPUT_MIN <= (__VALUE__)) &&\
+                                              ((__VALUE__) <= UTILS_PLLVCO_OUTPUT_MAX))
 
 #if defined(PWR_CR1_VOS)
 #define IS_LL_UTILS_PLL_FREQUENCY(__VALUE__) ((LL_PWR_GetRegulVoltageScaling() == LL_PWR_REGU_VOLTAGE_SCALE1) ? ((__VALUE__) <= UTILS_MAX_FREQUENCY_SCALE1) : \
-                                             ((__VALUE__) <= UTILS_MAX_FREQUENCY_SCALE2))
+                                              ((__VALUE__) <= UTILS_MAX_FREQUENCY_SCALE2))
 #else
 #define IS_LL_UTILS_PLL_FREQUENCY(__VALUE__) ((__VALUE__) <= UTILS_MAX_FREQUENCY_SCALE1)
-#endif
+#endif /* PWR_CR1_VOS */
 
 #define IS_LL_UTILS_HSE_BYPASS(__STATE__) (((__STATE__) == LL_UTILS_HSEBYPASS_ON) \
-                                        || ((__STATE__) == LL_UTILS_HSEBYPASS_OFF))
+                                           || ((__STATE__) == LL_UTILS_HSEBYPASS_OFF))
 
 #define countof(a)   (sizeof(a) / sizeof(*(a)))
 /**
@@ -131,8 +132,10 @@
 /** @defgroup UTILS_LL_Private_Functions UTILS Private functions
   * @{
   */
-static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency, LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
-static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
+static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
+                                               LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
+static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency,
+                                                  LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 
 /**
@@ -268,7 +271,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK4Frequency)
   uint32_t maxfreq = (voltagescaling == LL_PWR_REGU_VOLTAGE_SCALE1) ? UTILS_MAX_FREQUENCY_SCALE1 : UTILS_MAX_FREQUENCY_SCALE2;
 #else
   uint32_t maxfreq = UTILS_MAX_FREQUENCY_SCALE1;
-#endif
+#endif /* PWR_CR1_VOS */
 
   /* Array used for FLASH latency according to HCLK4 Frequency */
   /* Flash Clock source (HCLK4) range in MHz with a VCORE is range1 */
@@ -277,7 +280,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK4Frequency)
 #if defined(PWR_CR1_VOS)
   /* Flash Clock source (HCLK4) range in MHz with a VCORE is range2 */
   const uint32_t UTILS_CLK_SRC_RANGE_VOS2[] = {6000000U, 12000000U, UTILS_MAX_FREQUENCY_SCALE2};
-#endif
+#endif /* PWR_CR1_VOS */
 
   /* Flash Latency range */
   const uint32_t UTILS_LATENCY_RANGE[] = {LL_FLASH_LATENCY_0, LL_FLASH_LATENCY_1, LL_FLASH_LATENCY_2, LL_FLASH_LATENCY_3};
@@ -320,7 +323,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK4Frequency)
         break;
       }
     }
-#endif
+#endif /* PWR_CR1_VOS */
   }
 
   if (status != ERROR)
@@ -335,8 +338,7 @@ ErrorStatus LL_SetFlashLatency(uint32_t HCLK4Frequency)
       /* Wait for Flash latency to be updated */
       getlatency = LL_FLASH_GetLatency();
       timeout--;
-    }
-    while ((getlatency != latency) && (timeout > 0U));
+    } while ((getlatency != latency) && (timeout > 0U));
 
     if (getlatency != latency)
     {
@@ -532,7 +534,8 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
   *          - SUCCESS: Max frequency configuration done
   *          - ERROR: Max frequency configuration not done
   */
-ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass, LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct)
+ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass, LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct,
+                                         LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct)
 {
   ErrorStatus status;
   uint32_t pllrfreq, hclk2freq;
@@ -569,7 +572,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEBypass, LL_UTILS_PLLInitTyp
         {
           LL_RCC_HSE_DisableBypass();
         }
-#endif
+#endif /* RCC_CR_HSEBYP */
         /* Enable HSE */
         LL_RCC_HSE_Enable();
         while (LL_RCC_HSE_IsReady() != 1U)
@@ -663,7 +666,7 @@ static ErrorStatus UTILS_PLL_IsBusy(void)
     /* PLLSAI1 configuration cannot be modified */
     status = ERROR;
   }
-#endif
+#endif /* SAI1 */
 
   return status;
 }
@@ -677,7 +680,8 @@ static ErrorStatus UTILS_PLL_IsBusy(void)
   *          - SUCCESS: No problem to switch system to PLL
   *          - ERROR: Problem to switch system to PLL
   */
-static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct)
+static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency,
+                                                  LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct)
 {
   ErrorStatus status = SUCCESS;
   uint32_t hclks_frequency_target, hclks_frequency_current, sysclk_current;
@@ -757,5 +761,3 @@ static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_
 /**
   * @}
   */
-
-/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
From https://github.com/STMicroelectronics/STM32CubeWB.git tag v1.23.0

This PR replaces https://github.com/micropython/stm32lib/pull/27 as just bringing in the current release of WB onto vendor branch.